### PR TITLE
Translate user guide to English

### DIFF
--- a/en/15.3/user/advanced-search.rst
+++ b/en/15.3/user/advanced-search.rst
@@ -80,4 +80,4 @@ Site or Domain
 
 Filter search results by the site or domain you enter.
 
-.. |image0| image:: ../../../resources/images/ja/15.3/user/advanced-search-1.png
+.. |image0| image:: ../../../resources/images/en/15.3/user/advanced-search-1.png

--- a/en/15.3/user/advanced-search.rst
+++ b/en/15.3/user/advanced-search.rst
@@ -2,81 +2,82 @@
 Advanced Search
 ===============
 
-Advanced Search
-===============
-
-Narrow down search results for complex searches by using Advanced Search.
+The Advanced Search page enables you to perform more complex searches.
 
 Usage
 -----
 
-You can access Advanced Search page by clicking Advance button in Search Options dialog.
+The Advanced Search page can be accessed by clicking the Advanced Search button in the Options section of the search screen.
 
 |image0|
 
-You can search by pressing Search button at the bottom of the page.
+Click the Search button at the bottom of the page to execute your search.
 
-Details
--------
+Field List
+----------
 
-All these words
+All These Words
 :::::::::::::::
 
-All these words provides a search result that contains all search words you type at a text box.
+Search for documents that contain all of the words you enter.
+Words are separated by spaces.
 
-This exact word or phrase
-:::::::::::::::::::::::::
+This Exact Phrase
+:::::::::::::::::
 
-This exact word or phrase provides a search result that contains exact word or phrase you type at a text box.
+Search for documents that contain the exact phrase you enter.
+The phrase cannot be separated by spaces.
 
-Any of these words
+Any of These Words
 ::::::::::::::::::
 
-Any of these words provides a search result that contains some of search words you type at a text box.
+Search for documents that contain any of the words you enter.
+Words are separated by spaces.
 
-None of these words
+None of These Words
 :::::::::::::::::::
 
-None of these words provides a search result that does not contain specified search word. 
+Search for documents that do not contain all of the words you enter.
+Words are separated by spaces.
 
-Results per page
+Results per Page
 ::::::::::::::::
 
-Change the number of documents in search result page to display them.
+Specify the number of search results to display per page.
 
 Sort
 ::::
 
-Sort search results.
+Sort search results by fields such as search date and time.
 
 Preferred Languages
 :::::::::::::::::::
 
-you can select preferred language.
+Specify the preferred language for search results.
 
 Labels
 ::::::
 
-Narrow down search results by labels you select at a pull-down. 
+Filter search results by label. This option is not displayed if no labels are registered.
 
-Last update
-:::::::::::
+Last Modified
+:::::::::::::
 
-Narrow down search results by last update of documents.
+Filter search results by document modification date and time.
 
 File Type
 :::::::::
 
-Narrow down search results by file type you select at a pull down.
+Filter search results by document file type.
 
-Terms appearing
-:::::::::::::::
+Search Target
+:::::::::::::
 
-you can select the search target.
+Specify the search target from among entire page, page title, or page URL.
 
-Site or domain
+Site or Domain
 ::::::::::::::
 
-Narrow down search results by site or domain you type at a text box.
+Filter search results by the site or domain you enter.
 
-.. |image0| image:: ../../../resources/images/en/15.3/user/advanced-search-1.png
+.. |image0| image:: ../../../resources/images/ja/15.3/user/advanced-search-1.png

--- a/en/15.3/user/index.rst
+++ b/en/15.3/user/index.rst
@@ -1,7 +1,5 @@
 |Fess| User Guide
-====================
-
-Contents:
+==================
 
 .. toctree::
    :maxdepth: 2
@@ -19,7 +17,6 @@ Contents:
    search-fuzzy
    search-geo
    search-additional
-   json-response
-   ss
+   role-search
+   special-char
    advanced-search
-   

--- a/en/15.3/user/intro.rst
+++ b/en/15.3/user/intro.rst
@@ -2,35 +2,45 @@
 Introduction
 ============
 
-Who Should Use This Document
-============================
+Intended Audience
+=================
 
-This document is intended for users who search on |Fess|.
+This document is intended for users who use |Fess|.
 
 Before You Read This Document
-=============================
+==============================
 
-This document demonstrates search operations for |Fess|.
-Basic knowledge of computer operation is required.
+This document demonstrates how to search with |Fess|. Basic knowledge of computer operation is required.
 
 Online Access
 =============
 
-Download, professional services, support, and other developer information, visit the following.
+For downloads, professional services, support, and other developer information, please visit:
 
--  Project site:
-   `https://fess.codelibs.org/ <https://fess.codelibs.org/>`__
+-  Project site: https://fess.codelibs.org/
 
-Technical Support
-=================
+Technical Support Contact
+=========================
 
-Technical questions about our products, visit the following.
+If you have technical questions about this product that cannot be resolved through this documentation, please visit:
 
-- Issues:
+-  Issues:
    `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
 
 Commercial Support
 ------------------
 
-If you need commercial technical supports for this product, please contact to `N2SM, Inc. <https://www.n2sm.net/>`__.
+If you require commercial support such as technical assistance or maintenance for this product, please contact `N2SM, Inc. <https://www.n2sm.net/>`__.
 
+Third-Party Website References
+===============================
+
+The |Fess| project is not responsible for the validity of third-party websites listed in this document. The |Fess| project does not provide any warranties, responsibilities, or obligations regarding content, advertisements, products, services, or other materials available through such sites or resources. The |Fess| project shall not be liable or responsible for any damages or losses caused or alleged to be caused by or in connection with the use of or reliance on such content, advertisements, products, services, or other materials available through such sites or resources.
+
+Submitting Comments and Suggestions
+====================================
+
+The |Fess| project strives to improve this documentation and welcomes comments and suggestions from readers.
+
+-  Issues:
+   `https://github.com/codelibs/fess-docs/issues <https://github.com/codelibs/fess-docs/issues>`__

--- a/en/15.3/user/role-search.rst
+++ b/en/15.3/user/role-search.rst
@@ -32,7 +32,7 @@ When logged in, click the username displayed at the top of the search screen and
 
 
 
-.. |image0| image:: ../../../resources/images/ja/15.3/user/role-search-1.png
+.. |image0| image:: ../../../resources/images/en/15.3/user/role-search-1.png
 .. pdf   :width: 200 px
-.. |image1| image:: ../../../resources/images/ja/15.3/user/role-search-2.png
+.. |image1| image:: ../../../resources/images/en/15.3/user/role-search-2.png
 .. pdf   :width: 300 px

--- a/en/15.3/user/role-search.rst
+++ b/en/15.3/user/role-search.rst
@@ -1,0 +1,38 @@
+===========
+Role Search
+===========
+
+|Fess| provides user management functionality, allowing users to utilize role search by logging in. Users managed by |Fess| can change their password and perform role-based searches after logging in.
+
+
+Search Method
+-------------
+
+If roles are configured and the content has been crawled and indexed, search results can be displayed only to users who have the appropriate role.
+When users are logged in, searches are performed based on the roles they belong to.
+
+Changing Password
+-----------------
+
+After logging in, click the username displayed at the top of the search screen to display the password change menu.
+
+|image0|
+
+Clicking "Change Password" displays the password change screen.
+
+|image1|
+
+Enter your current password and new password, then click the Update button to update your password.
+After changing your password, click the Back button to return to the search screen.
+
+Logging Out
+-----------
+
+When logged in, click the username displayed at the top of the search screen and select "Logout" from the menu to log out.
+
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/user/role-search-1.png
+.. pdf   :width: 200 px
+.. |image1| image:: ../../../resources/images/ja/15.3/user/role-search-2.png
+.. pdf   :width: 300 px

--- a/en/15.3/user/search-additional.rst
+++ b/en/15.3/user/search-additional.rst
@@ -1,15 +1,10 @@
-===========
-Extra Query
-===========
+========================
+Hidden Search Conditions
+========================
 
-Extra Query
-===========
-
-If you want to use an additional hidden query, |Fess| provides ex_q request parameter.
-The value of ex_q is kept in search-scope.
+You can use the ex_q parameter to maintain specific search conditions without displaying the condition text on the screen. The value of ex_q is retained even when the screen is refreshed through pagination.
 
 Usage
 -----
 
-To perform this feature, append ex_q=... as a request parameter.
-
+To execute a search with hidden conditions (for example, from a search form), add the ex_q value as a hidden form field when executing the search. This allows you to maintain the condition without displaying it on the screen, even when navigating through pages.

--- a/en/15.3/user/search-and.rst
+++ b/en/15.3/user/search-and.rst
@@ -2,21 +2,17 @@
 AND Search
 ==========
 
-AND Search
-==========
-
-AND search provides a search result that contains all search words you type at a search box.
-For example, "Apple AND Computer" is the search result that contains both Apple and Computer.
-AND operator is optional, so the default operator is AND in |Fess|.
+Use AND search to find documents that contain all of the specified search terms. When multiple words are separated by spaces in the search input field without specifying AND, AND search is performed by default.
 
 Usage
 -----
 
-AND operator is written in capital letters, and is optional.
+To use AND search, specify AND between search terms. AND must be written in uppercase letters with spaces before and after it. AND can also be omitted.
 
-For multiple words, type the following query with AND operator at the search form:
+For example, to search for documents containing both "term1" and "term2", enter the following in the search form:
 
 ::
 
-    "term 1" AND "term 2" AND "term 3"
+    term1 AND term2
 
+Multiple terms can also be connected with AND.

--- a/en/15.3/user/search-boost.rst
+++ b/en/15.3/user/search-boost.rst
@@ -2,21 +2,20 @@
 Boost Search
 ============
 
-Boost Search
-============
+Boost Search (Weighted Search)
+===============================
 
-|Fess| supports Boost search which prioritize specific search words.
+Use boost search to prioritize specific search terms. Boost search enables searching based on the importance of search terms.
 
 Usage
 -----
 
-Boost search syntax is word^number, such as Apple^10.
-The number is boost-weighted value, and higher value is prior.
+To use boost search, specify a boost value (weighting value) in the format "^boost_value" after the search term.
 
-To search document which contains more apples than oranges, 
+For example, to search for "apple orange" with pages containing more instances of "apple" prioritized, enter the following in the search form:
 
 ::
 
-    apples^100 oranges
+    apple^100 orange
 
-Boost value specifies an integer greater than 1.
+Specify an integer greater than or equal to 1 for the boost value.

--- a/en/15.3/user/search-field.rst
+++ b/en/15.3/user/search-field.rst
@@ -1,57 +1,63 @@
-============
-Field Search
-============
+========================
+Field-Specified Search
+========================
 
-Search with field
-=================
+Field-Specified Search
+======================
 
-|Fess| stores crawling data to each field, such as title and content, in the indexed document.
-Since some of fields are searchable, you can search documents by the field.
+Content crawled by |Fess| is stored in separate fields such as title and body. You can search by specifying these fields. By specifying fields, you can define detailed search conditions such as by document type or size.
 
-Available fields
+Available Fields
 ----------------
 
-The default searchable fields are below.
+By default, you can search using the following fields:
 
-.. tabularcolumns:: |p{4cm}|p{8cm}|
 .. list-table::
+   :header-rows: 1
 
-   * - Field name
+   * - Field Name
      - Description
    * - url
      - Crawled URL
    * - host
-     - Crawled host name
+     - Host name contained in the crawled URL
    * - title
-     - Title of document
+     - Title
    * - content
-     - Content of document
+     - Body text
    * - content_length
-     - Document size
+     - Crawled document size
    * - last_modified
-     - Last modified time of document
+     - Last modified date and time of the crawled document
    * - mimetype
-     - The MIME type of document
+     - Document MIME type
 
-Table: Searchable fields
+Table: Available Field List
 
-For HTML document, title field is a value of title tag and content field is a value under body tag without tags.
+
+If no field is specified, the search targets the title and content fields.
+You can also add custom fields to make them searchable.
+
+For HTML files, the title tag is stored in the title field, and the text under the body tag is stored in the content field.
 
 Usage
 -----
 
-The format of Field search is colon-separated query, such as fieldname:searchword.
-If field name is not specified, |Fess| searches documents in values of title and content field.
+To perform a field-specified search, enter "field_name:search_term" in the search form, separating the field name and search term with a colon (:).
 
-To search documents that contains "fess" in title field:
+To search for fess in the title field, enter:
 
 ::
 
     title:fess
 
-To search documents that contains "fess" in url field:
+The above search displays documents containing fess in the title field.
+
+To search the url field, enter:
 
 ::
 
-    url:"*fess*"
+   url:https\:\/\/fess.codelibs.org\/ja\/15.3\/*
+   url:"https://fess.codelibs.org/ja/15.3/*"
 
+The first format allows wildcard queries, so you can also write it as ``url:*\/\/fess.codelibs.org\/*``. The ":" and "/" characters in URLs are reserved words and must be escaped. The second format does not support wildcard queries but supports prefix queries.

--- a/en/15.3/user/search-fuzzy.rst
+++ b/en/15.3/user/search-fuzzy.rst
@@ -2,23 +2,18 @@
 Fuzzy Search
 ============
 
-Fuzzy Search
-============
+Fuzzy Search (Approximate Search)
+==================================
 
-|Fess| supports Fuzzy search based on the Levenshtein Distance or Edit Distance algorithm.
+Fuzzy search is available when you want to search for words that do not exactly match the search term. |Fess| supports fuzzy search based on Levenshtein distance.
 
 Usage
 -----
 
-Fuzzy search syntax is word~number, such as Apple~0.8.
-The number is between 0 and 1, with a value closer to 1 only terms with a higher similarity will be matched.
+Add "~" after the search term to which you want to apply fuzzy search.
 
-
-
-To search documents which contains words close to Solr, the query is as below.
+For example, to perform a fuzzy search for the word "Fess", enter the following in the search form to search for documents containing words similar to "Fess" (such as "Fes"):
 
 ::
 
-    Solr~0.8
-
-If no fuzzy value, the default is 0.5.
+    Fess~

--- a/en/15.3/user/search-geo.rst
+++ b/en/15.3/user/search-geo.rst
@@ -1,26 +1,19 @@
-==========
-Geo Search
-==========
+=========================
+Geolocation-Based Search
+=========================
 
-Geo Search
-==========
-
-|Fess| supports Geo Search to search documents with location information.
-To perform Geo search, indexed document needs to contains values of latitude and longitude in location field.
+By adding latitude and longitude geolocation information to each document during index generation, you can perform searches using geolocation information.
 
 Usage
-----
+-----
 
-Geo information is passed as request parameters.
+By default, the following parameters are available:
 
-.. tabularcolumns:: |p{4cm}|p{8cm}|
 .. list-table::
 
    * - geo.<fieldname>.point
-     - Comma-separated value that is latitude,longitude.
+     - Specify latitude and longitude in degrees as Double type.
    * - geo.<fieldname>.distance
-     - Distance from the above point.
+     - Specify distance from document in kilometers. Example: 10km
 
-Table: Request parameters
-
-
+Table: Request Parameters

--- a/en/15.3/user/search-label.rst
+++ b/en/15.3/user/search-label.rst
@@ -18,5 +18,5 @@ You can select label information when searching. Label information can be select
 
 By creating an index with labels configured, you can search documents by their assigned labels. Searching without specifying a label performs a normal full search. If you change label information, you need to update the index.
 
-.. |image0| image:: ../../../resources/images/ja/15.3/user/search-label-1.png
+.. |image0| image:: ../../../resources/images/en/15.3/user/search-label-1.png
 .. pdf   :width: 300 px

--- a/en/15.3/user/search-label.rst
+++ b/en/15.3/user/search-label.rst
@@ -1,22 +1,22 @@
-============
-Label Search
-============
+=====================
+Label-Specified Search
+=====================
 
-Search with label
-=================
+Label-Specified Search (Category Search)
+=========================================
 
-|Fess| is able to assign labels to documents at the indexing time and Label search categorizes documents into the labels on the search result.
-To register a label at administrative page, you can select the label from Search Options.
+By adding label information to categorize search target documents, you can perform filtered searches by specifying labels at search time.
+
+By registering label information in the administration screen, label-based searching becomes available on the search screen. Available label information can be selected from a dropdown menu when searching. If no labels are registered, the label dropdown box will not be displayed.
 
 Usage
 -----
 
-You can select labels at search time.
-To click Option button at the right of Search button on Search page, Search Options dialog is displayed.
+You can select label information when searching. Label information can be selected in the search options dialog displayed by clicking the Options button.
 
 |image0|
 
-Labels are assigned to documents at the indexing time.
-If you want to update label information, you need to reindex documents.
+By creating an index with labels configured, you can search documents by their assigned labels. Searching without specifying a label performs a normal full search. If you change label information, you need to update the index.
 
-.. |image0| image:: ../../../resources/images/en/15.3/user/search-label-1.png
+.. |image0| image:: ../../../resources/images/ja/15.3/user/search-label-1.png
+.. pdf   :width: 300 px

--- a/en/15.3/user/search-not.rst
+++ b/en/15.3/user/search-not.rst
@@ -2,26 +2,15 @@
 NOT Search
 ==========
 
-NOT Search
-==========
-
-NOT search provides a search result that does not contain specified search word.
-For example, "Apple NOT Compute" is the search result that contains Apple and does not contain Computer.
+NOT search can be used to search for documents that do not contain a specific word.
 
 Usage
 -----
 
-Locate the NOT search as NOT in front of the Word does not contain. Is
-NOT in uppercase characters ago and need space.
+For NOT search, place NOT before the word to exclude. NOT must be in uppercase letters with spaces before and after it.
 
-For example, enter the following if you want to find documents that
-contain the search term 1 does not contain a search term 2 and the
-search.
-
-NOT operator is written in capital letters.
-
-Type the following query with NOT operator at the search form:
+For example, to search for documents that contain "term1" but do not contain "term2", enter the following:
 
 ::
 
-    "term 1" NOT "term 2"
+    term1 NOT term2

--- a/en/15.3/user/search-or.rst
+++ b/en/15.3/user/search-or.rst
@@ -2,21 +2,17 @@
 OR Search
 =========
 
-OR Search
-=========
-
-OR search provides a search result that contains some of search words you type at a search box.
-For example, "Apple OR Computer" is the search result that contains Apple or Computer.
+Use OR search to find documents that contain any of the specified search terms. When multiple words are entered in the search input field, the default is AND search.
 
 Usage
 -----
 
-OR operator is written in capital letters.
+To use OR search, specify OR between search terms. OR must be written in uppercase letters with spaces before and after it.
 
-For multiple words, type the following query with OR operator at the search form:
+For example, to search for documents containing either "term1" or "term2", enter the following in the search form:
 
 ::
 
-    "term 1" OR "term 2" OR "term 3"
+    term1 OR term2
 
-
+Multiple terms can also be connected with OR.

--- a/en/15.3/user/search-range.rst
+++ b/en/15.3/user/search-range.rst
@@ -1,47 +1,37 @@
-============
-Range Search
-============
+====================
+Range-Specified Search
+====================
 
-Range Search
-============
-
-|Fess| supports Range search that specify values between the lower and upper bound by date type or numeric type.
+When data that supports range specification, such as numeric values, is stored in a field, you can perform range-specified searches on that field.
 
 Usage
 -----
 
-The syntax of Range search is "fieldname:[lower TO upper]"
+To perform a range-specified search, enter "field_name:[value TO value]" in the search form.
 
-For example, type to search document content_length field against 1 k to
-10 k bytes is shown below the search form.
-
-To search documents of which size is from 10 bytes to 100 bytes, the query is below.
+For example, to search for documents in the content_length field ranging from 1 kilobyte to 10 kilobytes, enter the following in the search form:
 
 ::
 
-    content_length:[10 TO 100]
+    content_length:[1000 TO 10000]
 
-Date range search is also supported. 
-The syntax is "last_modified:[fromdate TO todate].
-The date format supports ISO 8601 or Date Math syntax.
+To perform a time range-specified search, enter "last_modified:[datetime1 TO datetime2]" (datetime1 < datetime2) in the search form.
 
-.. tabularcolumns:: |p{4cm}|p{8cm}|
+Date and time are based on ISO 8601.
+
 .. list-table::
 
-   * - ISO8601
-     - YYYY-MM-DDThh:mm:ss.sssZ(ex. 2012-12-02T10:45:23.5Z)
-   * - Date Math
-     - now, y(Year), M(Month), d(Day), h(hour), m(minute)
+   * - Date and time with fractional seconds
+     - When based on current date and time
+   * - YYYY-MM-DDThh:mm:sssZ (Example: 2012-12-02T10:45:235Z)
+     - now (current date and time), y (year), M (month), w (week), d (day), h (hour), m (minute), s (second)
 
-For example, if you look for documents updated from 30 days prior to now(2/21/2012), it's as below.
+When based on now or a specific time, you can add symbols such as +, - (addition, subtraction) and / (rounding). However, when based on a specific time, you need to insert || between the time and the symbol.
 
-::
+/ is a symbol that rounds to the unit following /. now-1d/d represents the previous day at 00:00, which is 1 day subtracted from today at 00:00, regardless of what time it is executed today.
 
-    last_modified:[now/d-30d TO now]
-
-or
+For example, to search for documents updated within the last 30 days from February 21, 2016 at 20:00 (current date and time) in the last_modified field, enter the following in the search form:
 
 ::
 
-    last_modified:[2012-11-23T00:00:00Z TO 2012-12-21T20:00:00Z]
-
+    last_modified:[now-30d TO now](=[2016-01-23T00:00:000Z+TO+2016-02-21T20:00:000Z(current date and time)])

--- a/en/15.3/user/search-sort.rst
+++ b/en/15.3/user/search-sort.rst
@@ -1,68 +1,67 @@
-====
-Sort
-====
+===========
+Sort Search
+===========
 
-Sort
-====
+You can sort search results by specifying fields such as search date and time.
 
-To select sort field in Search Options dialog, the search results are sorted by the field.
+Sort Target Fields
+------------------
 
-Sort field
-----------
+By default, you can specify the following fields for sorting:
 
-The following sort fields are available.
-
-.. tabularcolumns:: |p{4cm}|p{8cm}|
 .. list-table::
    :header-rows: 1
 
-   * - Field name
+   * - Field Name
      - Description
    * - created
-     - Time to crawl document
+     - Crawled date and time
    * - content_length
-     - Size of document
+     - Crawled document size
    * - last_modified
-     - Last modified time of document
+     - Last modified date and time of the crawled document
    * - filename
      - File name
    * - score
      - Score value
    * - timestamp
-     - Indexed time
+     - Date and time when the document was indexed
    * - click_count
-     - The number of clicked documents
+     - Number of times the document was clicked
    * - favorite_count
-     - The number of liked documents
+     - Number of times the document was favorited
 
-Table: Sort fields
+Table: Sort Target Field List
+
+
+You can also customize to add your own fields as sort targets.
 
 Usage
 -----
 
-To click Options button, Sort fields are selectable on Search Options dialog.
+You can select sort conditions when searching. Sort conditions can be selected in the search options dialog displayed by clicking the Options button.
 
 |image0|
 
-In addition to selecting sort field on the dialog, sort prefix operator is available in query syntax. 
-The format is colon-separated query, such as sort:fieldname.
+To sort using the search field, enter "sort:field_name" in the search form, separating sort and the field name with a colon (:).
 
-To sort search results which contains fess by content size, the query is below.
+The following sorts documents containing fess by document size in ascending order:
 
 ::
 
     fess sort:content_length
 
-To sort in descending order as below.
+To sort in descending order:
 
 ::
 
     fess sort:content_length.desc
 
-If you want to sort by multiple sort fields, it's below.
+To sort by multiple fields, specify them separated by commas:
 
 ::
 
     fess sort:content_length.desc,last_modified
 
-.. |image0| image:: ../../../resources/images/en/15.3/user/search-sort-1.png
+.. |image0| image:: ../../../resources/images/ja/15.3/user/search-sort-1.png
+.. pdf            :width: 300 px

--- a/en/15.3/user/search-sort.rst
+++ b/en/15.3/user/search-sort.rst
@@ -63,5 +63,5 @@ To sort by multiple fields, specify them separated by commas:
 
     fess sort:content_length.desc,last_modified
 
-.. |image0| image:: ../../../resources/images/ja/15.3/user/search-sort-1.png
+.. |image0| image:: ../../../resources/images/en/15.3/user/search-sort-1.png
 .. pdf            :width: 300 px

--- a/en/15.3/user/search-wildcard.rst
+++ b/en/15.3/user/search-wildcard.rst
@@ -1,40 +1,35 @@
-===============
+================
 Wildcard Search
-===============
+================
 
-Wildcard Search
-===============
-
-|Fess| supports single and multiple character wildcard search.
-Wildcard search performs indexed terms, not phrase.
+You can use single-character or multiple-character wildcards within search terms. ? can be specified as a single-character wildcard, and \* can be specified as a multiple-character wildcard. Wildcards apply to words. Wildcard searches on phrases are not supported.
 
 Usage
 -----
 
-To perform a single character wildcard search, use "?" symbol.
+To use a single-character wildcard, use ? as follows:
 
 ::
 
     te?t
 
-The above search looks for terms that match that with the single character replaced, such as text or test.
+In the above case, it is treated as a single-character wildcard, such as text or test.
 
-To perform a multiple character wildcard search, use "*" symbol.
+To use a multiple-character wildcard, use \* as follows:
 
 ::
 
     test*
 
-Multiple character wildcard search looks for 0 or more characters, such as test, tests or tester.
+In the above case, it is treated as a multiple-character wildcard, such as test, tests, or tester. You can also use it within a search term:
 
-You can also use the wildcard search in the middle of a term.
 ::
 
     te*t
 
-Notice
-------
+Usage Conditions
+----------------
 
-Wildcard search support terms, not phrase.
-If a word is indexed by bi-gram and so on, Wildcard search will not work properly.
-So, to use Wildcard search, a proper morphological analysis needs to be used.
+Wildcards are used on strings registered in the index.
+Therefore, if an index is created with bi-gram or similar methods, Japanese text is treated as fixed-length strings without meaning, so wildcards do not work as expected in Japanese.
+When using wildcards in Japanese, use them in fields that utilize morphological analysis.

--- a/en/15.3/user/special-char.rst
+++ b/en/15.3/user/special-char.rst
@@ -1,0 +1,20 @@
+==================
+Special Characters
+==================
+
+The following characters are treated as special characters in search terms. To use these characters as search characters, you need to escape them.
+
+::
+
+    + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
+
+
+Usage
+-----
+
+Escape with \ or enclose the search term in ".
+
+::
+
+    aaa\/bbb
+    "aaa/bbb"


### PR DESCRIPTION
Complete high-quality English translation of the Fess 15.3 user guide from Japanese source (ja/15.3/user) to English (en/15.3/user).

Changes:
- Updated index.rst table of contents to match Japanese version
- Translated intro.rst with complete sections including third-party references and comments submission
- Improved all search feature documentation files with commercial-quality English
- Added role-search.rst covering role-based search, password changes, and logout
- Added special-char.rst documenting special character handling
- Standardized terminology and formatting across all files
- Enhanced clarity and technical accuracy throughout documentation

All translations maintain commercial product documentation standards with clear, professional English suitable for enterprise users.