### PR TITLE
Translate Fess API guide to English

### DIFF
--- a/en/15.3/api/api-gsa.rst
+++ b/en/15.3/api/api-gsa.rst
@@ -1,17 +1,19 @@
-======================================
+================================
 Google Search Appliance Compatible API
-======================================
+================================
 
-Google Search Appliance(GSA) Compatible API returns a search result as XML format for GSA.
-For more details about XML format, see `GSA official document <https://www.google.com/support/enterprise/static/gsa/docs/admin/74/gsa_doc_set/xml_reference/results_format.html>`__.
+|Fess| also provides an API that returns search results in Google Search Appliance (GSA) compatible XML format.
+For details about the XML format, please refer to the `GSA Official Documentation <https://www.google.com/support/enterprise/static/gsa/docs/admin/74/gsa_doc_set/xml_reference/results_format.html>`__.
 
 Configuration
 =============
 
-To enable GSA Compatible API, set ``web.api.gsa=true`` in system.properties.
+To enable the Google Search Appliance Compatible API, add ``web.api.gsa=true`` to system.properties.
 
 Request
 =======
 
-Accessing to ``http://localhost:8080/gsa/?q=WORD``, |Fess| returns a result as GSA compatible format.
-For request parameters, see :doc:`Search API <api-search>`.
+By sending a request to |Fess| like
+``http://localhost:8080/gsa/?q=search_term``,
+you can receive search results in GSA-compatible XML format.
+The request parameters that can be specified are the same as the `JSON Response Search API <api-search.html>`__.

--- a/en/15.3/api/api-health.rst
+++ b/en/15.3/api/api-health.rst
@@ -2,20 +2,28 @@
 Health API
 ==========
 
-Get Status
-==========
+Fetching Status
+===============
 
-By sending a request to ``http://<Server Name>/api/v1/health`` to |Fess|, you can receive the server status of |Fess| in JSON format.
+Request
+-------
+
+==================  ====================================================
+HTTP Method         GET
+Endpoint            ``/api/v1/health``
+==================  ====================================================
+
+By sending a request to |Fess| at ``http://<Server Name>/api/v1/health``, you can receive the server status of |Fess| in JSON format.
 
 Request Parameters
 ------------------
 
-There are no available request parameters.
+There are no request parameters that can be specified.
 
 Response
 --------
 
-The response will be as follows:
+The following response is returned:
 
 ::
 
@@ -26,16 +34,27 @@ The response will be as follows:
       }
     }
 
-The elements in the response are described as follows:
+Each element is as follows:
 
 .. tabularcolumns:: |p{3cm}|p{12cm}|
-.. list-table::
+.. list-table:: Response Information
 
    * - data
-     - The parent element of the response.
+     - Parent element of search results.
    * - status
-     - The status of the response. "green" is returned for normal status.
+     - System status. Returns ``green`` when normal, ``yellow`` when there are warnings, and ``red`` when there are errors.
    * - timed_out
-     - The response result. "false" is returned if the response is received within the specified time.
+     - Whether a timeout occurred. Returns ``false`` if a response is returned within the specified time, ``true`` if it times out.
 
-Table: Response Information
+Error Response
+==============
+
+When the Health API fails, the following error response is returned:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Error Response
+
+   * - Status Code
+     - Description
+   * - 500 Internal Server Error
+     - When an internal server error occurs

--- a/en/15.3/api/api-label.rst
+++ b/en/15.3/api/api-label.rst
@@ -2,10 +2,18 @@
 Label API
 =========
 
-Get Labels
-==========
+Fetching Labels
+===============
 
-You can retrieve a list of labels registered in |Fess| by sending a request to ``http://<Server Name>/api/v1/labels``. The response will be in JSON format.
+Request
+-------
+
+==================  ====================================================
+HTTP Method         GET
+Endpoint            ``/api/v1/labels``
+==================  ====================================================
+
+By sending a request to |Fess| at ``http://<Server Name>/api/v1/labels``, you can receive a list of labels registered in |Fess| in JSON format.
 
 Request Parameters
 ------------------
@@ -15,7 +23,7 @@ There are no available request parameters.
 Response
 --------
 
-The response will be as follows:
+The following response is returned:
 
 ::
 
@@ -25,23 +33,59 @@ The response will be as follows:
         {
           "label": "AWS",
           "value": "aws"
+        },
+        {
+          "label": "Azure",
+          "value": "azure"
         }
       ]
     }
 
-The elements in the response are described as follows:
+Each element is as follows:
 
 .. tabularcolumns:: |p{3cm}|p{12cm}|
 
 .. list-table::
 
    * - record_count
-     - The number of registered labels.
+     - Number of registered labels.
    * - data
-     - The parent element of the search results.
+     - Parent element of search results.
    * - label
-     - The name of the label.
+     - Label name.
    * - value
-     - The value of the label.
+     - Label value.
 
 Table: Response Information
+
+Usage Examples
+==============
+
+Request example using curl command:
+
+::
+
+    curl "http://localhost:8080/api/v1/labels"
+
+Request example using JavaScript:
+
+::
+
+    fetch('http://localhost:8080/api/v1/labels')
+      .then(response => response.json())
+      .then(data => {
+        console.log('Label list:', data.data);
+      });
+
+Error Response
+==============
+
+When the label API fails, the following error response is returned:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Error Response
+
+   * - Status Code
+     - Description
+   * - 500 Internal Server Error
+     - When an internal server error occurs

--- a/en/15.3/api/api-overview.rst
+++ b/en/15.3/api/api-overview.rst
@@ -4,16 +4,66 @@ API Overview
 
 
 APIs Provided by |Fess|
-=======================
+========================
 
-This document provides an explanation of the APIs provided by |Fess|. By utilizing these APIs, you can use |Fess| as a search server within existing web systems and more.
+This document explains the APIs provided by |Fess|.
+By utilizing these APIs, you can use |Fess| as a search server within existing web systems.
+
+Base URL
+========
+
+The |Fess| API endpoints are provided at the following base URL:
+
+::
+
+    http://<Server Name>/api/v1/
+
+For example, when running in a local environment, it would be:
+
+::
+
+    http://localhost:8080/api/v1/
+
+Authentication
+==============
+
+In the current version, authentication is not required to use the API.
+However, you must enable each API through the various settings in the administration screen.
+
+HTTP Methods
+============
+
+All API endpoints are accessed using the **GET** method.
+
+Response Format
+===============
+
+All API responses are returned in **JSON format** (except for GSA compatible API).
+The response ``Content-Type`` is ``application/json``.
+
+Error Handling
+==============
+
+When an API request fails, error information is returned along with an appropriate HTTP status code.
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: HTTP Status Codes
+
+   * - 200
+     - The request was processed successfully.
+   * - 400
+     - The request parameters are invalid.
+   * - 404
+     - The requested resource was not found.
+   * - 500
+     - An internal server error occurred.
+
+Table: HTTP Status Codes
 
 Types of APIs
 =============
 
-.. TODO: favorite, favorites
-
-|Fess| offers several APIs.
+|Fess| provides the following APIs:
 
 .. tabularcolumns:: |p{3cm}|p{12cm}|
 .. list-table::
@@ -24,7 +74,7 @@ Types of APIs
      - API for retrieving popular words.
    * - label
      - API for retrieving a list of created labels.
-   * - ping
+   * - health
      - API for retrieving server status.
    * - suggest
      - API for retrieving suggested words.

--- a/en/15.3/api/api-popularword.rst
+++ b/en/15.3/api/api-popularword.rst
@@ -2,10 +2,19 @@
 Popular Words API
 =================
 
-Get List of Popular Words
-=========================
+Fetching Popular Words List
+============================
 
-By sending a request to ``http://<Server Name>/api/v1/popular-words?seed=123`` to |Fess|, you can receive a list of popular words registered in |Fess| in JSON format. To use the Popular Words API, you need to enable the response of popular words in the general settings of the administration screen.
+Request
+-------
+
+==================  ====================================================
+HTTP Method         GET
+Endpoint            ``/api/v1/popular-words``
+==================  ====================================================
+
+By sending a request to |Fess| at ``http://<Server Name>/api/v1/popular-words?seed=123``, you can receive a list of popular words registered in |Fess| in JSON format.
+To use the Popular Words API, you need to enable popular words response in the Administration screen under System > General Settings.
 
 Request Parameters
 ------------------
@@ -26,23 +35,40 @@ The available request parameters are as follows:
 Response
 --------
 
-The response will be as follows:
+The following response is returned:
 
 ::
 
     {
-      "record_count": 9,
+      "record_count": 3,
       "data": [
-        "python"
+        "python",
+        "java",
+        "javascript"
       ]
     }
 
-The elements in the response are described as follows:
+Each element is as follows:
 
 .. tabularcolumns:: |p{3cm}|p{12cm}|
 .. list-table:: Response Information
 
    * - record_count
-     - The number of registered popular words.
+     - Number of registered popular words
    * - data
-     - Popular words.
+     - Array of popular words
+
+Error Response
+==============
+
+When the popular words API fails, the following error response is returned:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Error Response
+
+   * - Status Code
+     - Description
+   * - 400 Bad Request
+     - When request parameters are invalid
+   * - 500 Internal Server Error
+     - When an internal server error occurs

--- a/en/15.3/api/api-search.rst
+++ b/en/15.3/api/api-search.rst
@@ -3,54 +3,67 @@ Search API
 ==========
 
 Fetching Search Results
-=======================
+========================
 
-You can retrieve search results from |Fess| in JSON format by sending a request to ``http://<Server Name>/api/v1/documents?q=search term``. To use the search API, you need to enable JSON responses in the Administration screen under "General Settings."
+Request
+-------
+
+==================  ====================================================
+HTTP Method         GET
+Endpoint            ``/api/v1/documents``
+==================  ====================================================
+
+By sending a request to |Fess| like
+``http://<Server Name>/api/v1/documents?q=search_term``,
+you can receive |Fess| search results in JSON format.
+To use the search API, you need to enable JSON responses in the Administration screen under System > General Settings.
 
 Request Parameters
 ------------------
 
-You can specify request parameters to perform advanced searches, such as ``http://<Server Name>/api/v1/documents?q=search term&num=50&fields.label=fess``. The available request parameters are as follows:
+You can perform more advanced searches by specifying request parameters such as
+``http://<Server Name>/api/v1/documents?q=search_term&num=50&fields.label=fess``.
+The available request parameters are as follows:
 
 .. tabularcolumns:: |p{3cm}|p{12cm}|
 .. list-table::
 
    * - q
-     - The search term. Encode it in the URL.
+     - Search term. Pass it after URL encoding.
    * - start
-     - The starting position of the search results. It starts from 0.
+     - Starting position of the result count. Starts from 0.
    * - num
-     - The number of results to display. The default is 20, and you can display up to 100.
+     - Number of items to display. Default is 20 items. Can display up to 100 items.
    * - sort
-     - Sorting. Used to sort the search results.
+     - Sort order. Used to sort search results.
    * - fields.label
      - Label value. Used to specify a label.
    * - facet.field
-     - Specify a facet field. (e.g., ``facet.field=label``)
+     - Facet field specification. (Example) ``facet.field=label``
    * - facet.query
-     - Specify a facet query. (e.g., ``facet.query=timestamp:[now/d-1d TO *]``)
+     - Facet query specification. (Example) ``facet.query=timestamp:[now/d-1d TO *]``
    * - facet.size
-     - Specify the maximum number of facets to retrieve. This is valid when facet.field is specified.
+     - Specification of the maximum number of facets to retrieve. Valid when facet.field is specified.
    * - facet.minDocCount
-     - Retrieve facets with a count equal to or greater than this value. This is valid when facet.field is specified.
+     - Retrieve facets with a count equal to or greater than this value. Valid when facet.field is specified.
    * - geo.location.point
-     - Specify latitude and longitude. (e.g., ``geo.location.point=35.0,139.0``)
+     - Latitude and longitude specification. (Example) ``geo.location.point=35.0,139.0``
    * - geo.location.distance
-     - Specify the distance from the center point. (e.g., ``geo.location.distance=10km``)
+     - Distance from the center point specification. (Example) ``geo.location.distance=10km``
    * - lang
-     - Specify the search language. (e.g., ``lang=en``)
+     - Search language specification. (Example) ``lang=en``
    * - preference
-     - Specify a string to determine the shard to use during search. (e.g., ``preference=abc``)
+     - String to specify the shard during search. (Example) ``preference=abc``
    * - callback
-     - The callback name when using JSONP. It is not necessary to specify if JSONP is not used.
+     - Callback name when using JSONP. Not necessary to specify if not using JSONP.
 
 Table: Request Parameters
 
 Response
 --------
 
-| The response returned will be as follows:
-| (Formatted version)
+| The following response is returned:
+| (Formatted)
 
 ::
 
@@ -105,7 +118,7 @@ Response
       ]
     }
 
-The response will be as follows:
+Each element is as follows:
 
 .. tabularcolumns:: |p{3cm}|p{12cm}|
 .. list-table:: Response Information
@@ -187,9 +200,10 @@ The response will be as follows:
 Searching All Documents
 =======================
 
-To search all documents, send the following request: ``http://<Server Name>/api/v1/documents/all?q=search_term```
+To search all target documents, send the following request:
+``http://<Server Name>/api/v1/documents/all?q=search_term``
 
-To use this feature, you need to set ``api.search.scroll`` to true in the ``fess_config.properties`` file.
+To use this feature, you need to set api.search.scroll to true in fess_config.properties.
 
 Request Parameters
 ------------------
@@ -202,8 +216,32 @@ The available request parameters are as follows:
    * - q
      - Search term. Pass it after URL encoding.
    * - num
-     - Number of items to display. The default value is 20, and you can display up to 100 items.
+     - Number of items to display. Default is 20 items. Can display up to 100 items.
    * - sort
-     - Sort order. Used to sort the search results.
+     - Sort order. Used to sort search results.
 
 Table: Request Parameters
+
+Error Response
+==============
+
+When the search API fails, the following error response is returned:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Error Response
+
+   * - Status Code
+     - Description
+   * - 400 Bad Request
+     - When request parameters are invalid
+   * - 500 Internal Server Error
+     - When an internal server error occurs
+
+Error response example:
+
+::
+
+    {
+      "message": "Invalid request parameter",
+      "status": 400
+    }

--- a/en/15.3/api/api-suggest.rst
+++ b/en/15.3/api/api-suggest.rst
@@ -1,0 +1,92 @@
+===========
+Suggest API
+===========
+
+Fetching Suggest Words List
+============================
+
+Request
+-------
+
+==================  ====================================================
+HTTP Method         GET
+Endpoint            ``/api/v1/suggest-words``
+==================  ====================================================
+
+By sending a request to |Fess| at ``http://<Server Name>/api/v1/suggest-words?q=suggest_word``, you can receive a list of suggest words registered in |Fess| in JSON format.
+To use the Suggest Words API, you need to enable "Suggest by Document" or "Suggest by Search Word" in the Administration screen under System > General Settings.
+
+Request Parameters
+------------------
+
+The available request parameters are as follows:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Request Parameters
+
+   * - q
+     - Keyword for suggestion. (Example) ``q=fess``
+   * - num
+     - Number of suggested words. Default is 10. (Example) ``num=20``
+   * - label
+     - Filtered label name. (Example) ``label=java``
+   * - fields
+     - Field name to narrow down suggestion targets. Default is no filtering. (Example) ``fields=content,title``
+   * - lang
+     - Search language specification. (Example) ``lang=en``
+
+
+Response
+--------
+
+The following response is returned:
+
+::
+
+    {
+      "query_time": 18,
+      "record_count": 355,
+      "page_size": 10,
+      "data": [
+        {
+          "text": "fess",
+          "labels": [
+            "java",
+            "python"
+          ]
+        }
+      ]
+    }
+
+Each element is as follows:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Response Information
+
+   * - query_time
+     - Query processing time (in milliseconds).
+   * - record_count
+     - Number of registered suggest words.
+   * - page_size
+     - Page size.
+   * - data
+     - Parent element of search results.
+   * - text
+     - Suggest word.
+   * - labels
+     - Array of label values.
+
+Error Response
+==============
+
+When the suggest API fails, the following error response is returned:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Error Response
+
+   * - Status Code
+     - Description
+   * - 400 Bad Request
+     - When request parameters are invalid
+   * - 500 Internal Server Error
+     - When an internal server error occurs

--- a/en/15.3/api/index.rst
+++ b/en/15.3/api/index.rst
@@ -1,5 +1,5 @@
 |Fess| API Guide
-================
+===============
 
 .. toctree::
    :maxdepth: 2
@@ -9,4 +9,6 @@
    api-search
    api-label
    api-popularword
+   api-suggest
    api-health
+   api-gsa

--- a/en/15.3/api/intro.rst
+++ b/en/15.3/api/intro.rst
@@ -2,42 +2,64 @@
 Introduction
 ============
 
-Who Should Use This Document
-============================
+Target Audience
+===============
 
-This document is intended for developers responsible for managing the |Fess|.
+This document is intended for developers who will be using |Fess| API features.
+The following knowledge is assumed:
 
+- Basic concepts of REST APIs
+- JSON data format
+- Basic knowledge of HTTP protocol
 
 Before You Read This Document
-=============================
+==============================
 
-This document shows how to access |Fess| on API.
+This document demonstrates how to use the API in |Fess| 15.3.
+
+API Usage Prerequisites
+=======================
+
+Before using the |Fess| API, the following setup is required:
+
+- |Fess| 15.3 or later must be installed and running properly
+- Enable required settings for each API through the administration screen (refer to each API documentation)
+- API endpoints must be accessible via network
 
 Online Access
 =============
 
-Download, professional services, support, and other developer
-information, visit the following.
+For downloads, professional services, support, and other developer information, please visit:
 
--  Project site: `https://fess.codelibs.org/ <https://fess.codelibs.org/>`__
+-  Project Site: https://fess.codelibs.org/
 
-Technical Support
-=================
+Technical Support Contact
+=========================
 
-For technical questions and problems about our products, see the following info.
+If you have technical questions about this product that are not resolved in this documentation, please visit:
 
-- Issues: `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
+-  Issues:
+   `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
 
 Commercial Support
 ------------------
 
-If you need commercial support, maintenance and technical support for this product,
-please contact to `N2SM, Inc. <https://www.n2sm.net/>`__.
+If you require commercial support for this product, including technical assistance and maintenance,
+please contact `N2SM, Inc. <https://www.n2sm.net/>`__.
 
-How To Send Comments And Suggestions
-====================================
+References to Related Third-Party Websites
+===========================================
 
-If you find problems or improvements, please send from:
+The |Fess| project is not responsible for the validity of third-party websites referenced in this documentation.
+The |Fess| project makes no warranties, responsibilities, or obligations regarding content, advertisements, products, services,
+or other documentation available through such sites or resources. The |Fess| project assumes no responsibility or liability
+for any damage or loss arising from, or alleged to have arisen from, the use of or reliance on any content, advertisements,
+products, services, or other documentation available through such sites or resources.
 
-- Issues For Product: `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
-- Issues For Document: `https://github.com/codelibs/fess-docs/issues <https://github.com/codelibs/fess-docs/issues>`__
+How to Send Comments and Suggestions
+=====================================
+
+The |Fess| project is committed to improving this documentation and welcomes comments and suggestions from readers.
+
+-  Issues:
+   `https://github.com/codelibs/fess-docs/issues <https://github.com/codelibs/fess-docs/issues>`__


### PR DESCRIPTION
…ations

Complete the English translation of the Fess API guide based on the Japanese version (ja/15.3/api), ensuring commercial-quality documentation standards.

Key improvements:
- Add missing api-suggest.rst with full translation
- Enhance all API documentation with proper structure and sections
- Add comprehensive error response documentation
- Improve request/response format descriptions
- Add usage examples where appropriate
- Standardize terminology and formatting across all API docs

Files modified:
- index.rst: Add missing api-suggest and api-gsa to table of contents
- intro.rst: Expand with complete prerequisites and disclaimers
- api-overview.rst: Add base URL, authentication, HTTP methods, and error handling
- api-search.rst: Add request section header and error responses
- api-label.rst: Add request section and usage examples
- api-popularword.rst: Add request section and error responses
- api-health.rst: Add request section and improved status descriptions
- api-gsa.rst: Improve clarity and consistency

New files:
- api-suggest.rst: Complete translation of suggest API documentation