### PR TITLE
Create German user guide documentation

### DIFF
--- a/de/15.3/user/advanced-search.rst
+++ b/de/15.3/user/advanced-search.rst
@@ -1,0 +1,83 @@
+==================
+Erweiterte Suche
+==================
+
+Der erweiterte Suchbildschirm ermöglicht komplexere Suchen.
+
+Verwendung
+-----------
+
+Der erweiterte Suchbildschirm kann über die Schaltfläche "Erweiterte Suche" in den Optionen des Suchbildschirms aufgerufen werden.
+
+|image0|
+
+Sie können die Suche durchführen, indem Sie auf die Suchschaltfläche unten auf der Seite klicken.
+
+Elementliste
+-------------
+
+Alle Wörter enthalten
+::::::::::::::::::::::
+
+Sie können nach Dokumenten suchen, die alle eingegebenen Wörter enthalten.
+Wörter werden durch Leerzeichen getrennt.
+
+Exakte Übereinstimmung einschließlich Wortreihenfolge
+::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Sie können nach Dokumenten suchen, die die eingegebene Zeichenkette enthalten.
+Trennung durch Leerzeichen usw. ist nicht möglich.
+
+Eines der Wörter enthalten
+::::::::::::::::::::::::::::
+
+Sie können nach Dokumenten suchen, die eines der eingegebenen Wörter enthalten.
+Wörter werden durch Leerzeichen getrennt.
+
+Auszuschließende Wörter
+::::::::::::::::::::::::
+
+Sie können nach Dokumenten suchen, die alle eingegebenen Wörter nicht enthalten.
+Wörter werden durch Leerzeichen getrennt.
+
+Anzahl der Anzeigen
+::::::::::::::::::::
+
+Sie können die Anzahl der Suchergebnisse angeben, die auf einer Seite der Suchergebnisse enthalten sind.
+
+Sortierung
+:::::::::::
+
+Sie können die Suchergebnisse nach Feldern wie dem Suchdatum sortieren.
+
+Bevorzugte Sprache
+:::::::::::::::::::
+
+Sie können die bevorzugte Sprache für die Suchergebnisse angeben.
+
+Label
+::::::
+
+Sie können nach Label-Informationen filtern. Wenn keine Label registriert sind, werden sie nicht angezeigt.
+
+Aktualisierungsdatum
+:::::::::::::::::::::
+
+Sie können nach dem Aktualisierungsdatum des Dokuments filtern.
+
+Dateiformat
+::::::::::::
+
+Sie können nach dem Dateiformat des Dokuments filtern.
+
+Suchziel
+:::::::::
+
+Sie können das Suchziel aus der gesamten Seite, dem Seitentitel oder der Seiten-URL auswählen.
+
+Website oder Domain
+::::::::::::::::::::
+
+Sie können nach der eingegebenen Website oder Domain filtern.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/user/advanced-search-1.png

--- a/de/15.3/user/index.rst
+++ b/de/15.3/user/index.rst
@@ -1,0 +1,22 @@
+|Fess| Benutzerhandbuch
+========================
+
+.. toctree::
+   :maxdepth: 2
+
+   intro
+   search-and
+   search-or
+   search-not
+   search-label
+   search-field
+   search-sort
+   search-wildcard
+   search-range
+   search-boost
+   search-fuzzy
+   search-geo
+   search-additional
+   role-search
+   special-char
+   advanced-search

--- a/de/15.3/user/intro.rst
+++ b/de/15.3/user/intro.rst
@@ -1,0 +1,47 @@
+============
+Einführung
+============
+
+Zielgruppe
+============
+
+Diese Dokumentation richtet sich an Benutzer, die |Fess| verwenden.
+
+Bevor Sie beginnen
+===================
+
+Diese Dokumentation beschreibt die Suchmethoden in |Fess|. Grundlegende Kenntnisse im Umgang mit Computern werden vorausgesetzt.
+
+Online-Zugriff
+===============
+
+Für Downloads, professionelle Dienstleistungen, Support und weitere Entwicklerinformationen besuchen Sie bitte:
+
+-  Projekt-Website: https://fess.codelibs.org/
+
+Kontakt für technischen Support
+=================================
+
+Sollten Sie technische Fragen zu diesem Produkt haben, für die Sie in dieser Dokumentation keine Lösung finden, besuchen Sie bitte:
+
+-  Issues:
+   `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
+
+Kommerzieller Support
+-----------------------
+
+Wenn Sie kommerziellen Support benötigen, wie z. B. technische Unterstützung oder Wartung für dieses Produkt, wenden Sie sich bitte an `N2SM, Inc. <https://www.n2sm.net/>`__.
+
+Haftungsausschluss für Websites Dritter
+==========================================
+
+Das |Fess|-Projekt übernimmt keine Verantwortung für die Verfügbarkeit der in dieser Dokumentation erwähnten Websites Dritter. Das |Fess|-Projekt übernimmt keine Gewährleistung, Verantwortung oder Haftung für Inhalte, Werbung, Produkte, Dienstleistungen oder andere Materialien, die auf oder über solche Websites oder Ressourcen verfügbar sind. Das |Fess|-Projekt haftet nicht für Schäden oder Verluste, die durch die Nutzung oder das Vertrauen auf solche Inhalte, Werbung, Produkte, Dienstleistungen oder andere Materialien entstehen oder geltend gemacht werden, die auf oder über solche Websites oder Ressourcen verfügbar sind.
+
+Einreichen von Kommentaren und Vorschlägen
+===========================================
+
+Das |Fess|-Projekt ist bestrebt, diese Dokumentation zu verbessern, und begrüßt Kommentare und Vorschläge von Lesern.
+
+-  Issues:
+   `https://github.com/codelibs/fess-docs/issues <https://github.com/codelibs/fess-docs/issues>`__
+

--- a/de/15.3/user/role-search.rst
+++ b/de/15.3/user/role-search.rst
@@ -1,0 +1,39 @@
+==================
+Rollenbasierte Suche
+==================
+
+|Fess| bietet Benutzerverwaltungsfunktionen, die es Benutzern ermöglichen, die rollenbasierte Suche durch Anmeldung zu nutzen. Von |Fess| verwaltete Benutzer können nach der Anmeldung die rollenbasierte Suche nutzen und ihr Passwort ändern.
+
+
+Suchmethode
+-------------
+
+Wenn Rollen festgelegt sind und Crawling sowie Indizierung durchgeführt wurden, können Suchergebnisse nur Benutzern angezeigt werden, die die entsprechenden Rollen besitzen.
+Wenn ein Benutzer angemeldet ist, wird die Suche basierend auf den zugehörigen Rollen durchgeführt.
+
+Passwort ändern
+-----------------
+
+Nach der Anmeldung können Sie durch Klicken auf den oben im Suchbildschirm angezeigten Benutzernamen das Menü zur Passwortänderung anzeigen.
+
+|image0|
+
+Durch Klicken auf "Passwort ändern" wird der Bildschirm zur Passwortänderung angezeigt.
+
+|image1|
+
+Geben Sie das aktuelle Passwort und das neue Passwort ein und klicken Sie auf die Schaltfläche "Aktualisieren", um das Passwort zu aktualisieren.
+Nach der Passwortänderung können Sie durch Klicken auf die Schaltfläche "Zurück" zum Suchbildschirm zurückkehren.
+
+Abmelden
+----------
+
+Wenn Sie angemeldet sind, können Sie sich abmelden, indem Sie auf den oben im Suchbildschirm angezeigten Benutzernamen klicken und aus dem Menü "Abmelden" auswählen.
+
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/user/role-search-1.png
+.. pdf   :width: 200 px
+.. |image1| image:: ../../../resources/images/ja/15.3/user/role-search-2.png
+.. pdf   :width: 300 px
+

--- a/de/15.3/user/search-additional.rst
+++ b/de/15.3/user/search-additional.rst
@@ -1,0 +1,10 @@
+=======================
+Versteckte Suchkriterien
+=======================
+
+Wenn Sie bestimmte Suchkriterien weitergeben möchten, ohne die Suchkriterien-Zeichenkette auf dem Bildschirm anzuzeigen, können Sie den Parameter ex_q verwenden. Der Wert von ex_q wird auch bei Seitenaktualisierungen durch Paginierung beibehalten.
+
+Verwendung
+-----------
+
+Wenn eine Suche ausgeführt wird (z. B. über ein Suchformular), können Sie den Wert von ex_q als verstecktes Formularfeld hinzufügen, um die Suche auszuführen. Die Bedingung wird dann bei Seitenübergängen durch Paginierung beibehalten, ohne auf dem Bildschirm angezeigt zu werden.

--- a/de/15.3/user/search-and.rst
+++ b/de/15.3/user/search-and.rst
@@ -1,0 +1,20 @@
+===========
+AND-Suche
+===========
+
+Wenn Sie nach Dokumenten suchen möchten, die mehrere Suchbegriffe enthalten, verwenden Sie die AND-Suche. Wenn Sie mehrere Wörter durch Leerzeichen getrennt in das Suchfeld eingeben und AND weglassen, wird ebenfalls eine AND-Suche durchgeführt.
+
+Verwendung
+-----------
+
+Um eine AND-Suche zu verwenden, fügen Sie AND zwischen den Suchbegriffen ein. AND
+muss in Großbuchstaben geschrieben werden und erfordert Leerzeichen davor und danach. AND
+kann auch weggelassen werden.
+
+Wenn Sie beispielsweise nach Dokumenten suchen möchten, die sowohl "Suchbegriff1" als auch "Suchbegriff2" enthalten, geben Sie Folgendes in das Suchformular ein:
+
+::
+
+    Suchbegriff1 AND Suchbegriff2
+
+Es ist auch möglich, mehrere Begriffe mit AND zu verknüpfen.

--- a/de/15.3/user/search-boost.rst
+++ b/de/15.3/user/search-boost.rst
@@ -1,0 +1,21 @@
+==================
+Boost-Suche
+==================
+
+Boost-Suche (Gewichtete Suche)
+================================
+
+Wenn Sie unter den Suchbegriffen einen bestimmten Begriff bevorzugen möchten, verwenden Sie die Boost-Suche. Durch die Verwendung der Boost-Suche können Sie entsprechend der Wichtigkeit der Suchbegriffe suchen.
+
+Verwendung
+-----------
+
+Um die Boost-Suche zu verwenden, geben Sie nach dem Suchbegriff "^Boost-Wert" in der Form eines Boost-Werts (Gewichtswert) an.
+
+Wenn Sie beispielsweise "Apfel Orange" suchen möchten, aber Seiten bevorzugen, die mehr "Apfel" enthalten, geben Sie Folgendes in das Suchformular ein:
+
+::
+
+    Apfel^100 Orange
+
+Als Boost-Wert geben Sie eine Ganzzahl von 1 oder mehr an.

--- a/de/15.3/user/search-field.rst
+++ b/de/15.3/user/search-field.rst
@@ -1,0 +1,63 @@
+=======================
+Feldspezifische Suche
+=======================
+
+Feldspezifische Suche
+=======================
+
+Die von |Fess| gecrawlten Ergebnisse werden in einzelnen Feldern wie Titel oder Haupttext gespeichert. Sie können nach diesen Feldern suchen. Durch die Angabe von Feldern können Sie detaillierte Suchkriterien wie Dokumenttyp oder Größe festlegen.
+
+Verfügbare Felder
+-------------------
+
+Standardmäßig können die folgenden Felder für die Suche angegeben werden.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Feldname
+     - Beschreibung
+   * - url
+     - Gecrawlte URL
+   * - host
+     - In der gecrawlten URL enthaltener Hostname
+   * - title
+     - Titel
+   * - content
+     - Haupttext
+   * - content_length
+     - Größe des gecrawlten Dokuments
+   * - last_modified
+     - Letztes Änderungsdatum des gecrawlten Dokuments
+   * - mimetype
+     - MIME-Typ des Dokuments
+
+Tabelle: Liste der verfügbaren Felder
+
+
+Wenn kein Feld angegeben ist, werden title und content als Suchziel verwendet.
+Es ist auch möglich, Felder hinzuzufügen und als Suchziel festzulegen.
+
+Wenn HTML-Dateien als Suchziel verwendet werden, wird das title-Tag im title-Feld und die Zeichenkette unter dem body-Tag im content-Feld registriert.
+
+Verwendung
+-----------
+
+Um eine feldspezifische Suche durchzuführen, geben Sie "Feldname:Suchbegriff" in das Suchformular ein, wobei Feldname und Suchbegriff durch einen Doppelpunkt (:) getrennt sind.
+
+Um nach fess im title-Feld zu suchen, geben Sie Folgendes ein:
+
+::
+
+    title:fess
+
+Mit dieser Suche werden Dokumente angezeigt, die fess im title-Feld enthalten.
+
+Um nach dem url-Feld zu suchen, geben Sie Folgendes ein:
+
+::
+
+   url:https\:\/\/fess.codelibs.org\/ja\/15.3\/*
+   url:"https://fess.codelibs.org/ja/15.3/*"
+
+Ersteres ermöglicht Wildcard-Abfragen, sodass Schreibweisen wie ``url:*\/\/fess.codelibs.org\/*`` möglich sind. ":" und "/" in der URL sind reservierte Zeichen und müssen maskiert werden. Letzteres erlaubt keine Wildcard-Abfragen, aber Präfix-Abfragen sind möglich.

--- a/de/15.3/user/search-fuzzy.rst
+++ b/de/15.3/user/search-fuzzy.rst
@@ -1,0 +1,20 @@
+================
+Unscharfe Suche
+================
+
+Unscharfe Suche (Fuzzy-Suche)
+===============================
+
+Wenn Sie auch nach Wörtern suchen möchten, die nicht exakt mit dem Suchbegriff übereinstimmen, können Sie die unscharfe Suche verwenden. |Fess| unterstützt unscharfe Suche (Fuzzy-Suche) basierend auf der Levenshtein-Distanz.
+
+Verwendung
+-----------
+
+Fügen Sie "~" nach dem Suchbegriff hinzu, auf den Sie die unscharfe Suche anwenden möchten.
+
+Wenn Sie beispielsweise das Wort "Fess" unscharf suchen möchten, können Sie durch Eingabe des Folgenden in das Suchformular Dokumente finden, die Wörter enthalten, die "Fess" ähnlich sind (z. B. "Fes").
+
+::
+
+    Fess~
+

--- a/de/15.3/user/search-geo.rst
+++ b/de/15.3/user/search-geo.rst
@@ -1,0 +1,21 @@
+==========================
+Standortbasierte Suche
+==========================
+
+Durch Hinzufügen von Standortinformationen (Breiten- und Längengrad) zu jedem Dokument bei der Indexerstellung können Sie bei der Suche standortbasierte Suchen durchführen.
+
+Verwendung
+-----------
+
+Standardmäßig sind die folgenden Parameter verfügbar.
+
+.. list-table::
+
+   * - geo.<feldname>.point
+     - Geben Sie Breiten- und Längengrad in Grad-Minuten-Sekunden als Double-Typ an.
+   * - geo.<feldname>.distance
+     - Geben Sie die Entfernung zum Dokument in Kilometern an. Beispiel: 10km
+
+Tabelle: Anfrageparameter
+
+

--- a/de/15.3/user/search-label.rst
+++ b/de/15.3/user/search-label.rst
@@ -1,0 +1,22 @@
+===================
+Label-basierte Suche
+===================
+
+Label-basierte Suche (Kategoriesuche)
+========================================
+
+Durch Hinzufügen von Label-Informationen zu den zu durchsuchenden Dokumenten zur Kategorisierung ist es möglich, bei der Suche nach Labeln gefilterte Suchen durchzuführen.
+
+Label-Informationen können in der Verwaltungsoberfläche registriert werden, um eine Suche nach Labeln im Suchbildschirm zu ermöglichen. Verfügbare Label-Informationen können bei der Suche über ein Dropdown-Menü in Mehrfachauswahl ausgewählt werden. Wenn keine Label registriert sind, wird das Label-Dropdown-Feld nicht angezeigt.
+
+Verwendung
+-----------
+
+Bei der Suche können Label-Informationen ausgewählt werden. Label-Informationen können im Suchoptionen-Dialog ausgewählt werden, der durch Klicken auf die Optionsschaltfläche angezeigt wird.
+
+|image0|
+
+Durch Festlegen von Labeln und Erstellen eines Index können Sie nach Dokumenten suchen, für die Label festgelegt wurden. Eine Suche ohne Angabe von Labeln ist eine normale Suche über alle Dokumente. Wenn Label-Informationen geändert werden, muss der Index aktualisiert werden.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/user/search-label-1.png
+.. pdf   :width: 300 px

--- a/de/15.3/user/search-not.rst
+++ b/de/15.3/user/search-not.rst
@@ -1,0 +1,17 @@
+===========
+NOT-Suche
+===========
+
+Wenn Sie nach Dokumenten suchen möchten, die ein bestimmtes Wort nicht enthalten, können Sie die NOT-Suche verwenden.
+
+Verwendung
+-----------
+
+Bei der NOT-Suche wird NOT vor das Wort gesetzt, das nicht enthalten sein soll. NOT
+muss in Großbuchstaben geschrieben werden und erfordert Leerzeichen davor und danach.
+
+Wenn Sie beispielsweise nach Dokumenten suchen möchten, die "Suchbegriff1" enthalten, aber "Suchbegriff2" nicht enthalten, geben Sie Folgendes ein:
+
+::
+
+    Suchbegriff1 NOT Suchbegriff2

--- a/de/15.3/user/search-or.rst
+++ b/de/15.3/user/search-or.rst
@@ -1,0 +1,19 @@
+==========
+OR-Suche
+==========
+
+Wenn Sie nach Dokumenten suchen möchten, die einen der Suchbegriffe enthalten, verwenden Sie die OR-Suche. Wenn Sie mehrere Wörter in das Suchfeld eingeben, wird standardmäßig eine AND-Suche durchgeführt.
+
+Verwendung
+-----------
+
+Um eine OR-Suche zu verwenden, fügen Sie OR zwischen den Suchbegriffen ein. OR
+muss in Großbuchstaben geschrieben werden und erfordert Leerzeichen davor und danach.
+
+Wenn Sie beispielsweise nach Dokumenten suchen möchten, die entweder "Suchbegriff1" oder "Suchbegriff2" enthalten, geben Sie Folgendes in das Suchformular ein:
+
+::
+
+    Suchbegriff1 OR Suchbegriff2
+
+Es ist auch möglich, mehrere Begriffe mit OR zu verknüpfen.

--- a/de/15.3/user/search-range.rst
+++ b/de/15.3/user/search-range.rst
@@ -1,0 +1,37 @@
+==================
+Bereichssuche
+==================
+
+Wenn Sie Daten, für die Bereichsangaben möglich sind, wie z. B. Zahlen, in einem Feld speichern, können Sie eine Bereichssuche für dieses Feld durchführen.
+
+Verwendung
+-----------
+
+Um eine Bereichssuche durchzuführen, geben Sie "Feldname:[Wert TO Wert]" in das Suchformular ein.
+
+Um beispielsweise Dokumente im content_length-Feld zu suchen, die zwischen 1 kByte und 10 kByte liegen, geben Sie Folgendes in das Suchformular ein:
+
+::
+
+    content_length:[1000 TO 10000]
+
+Um eine Zeitbereichssuche durchzuführen, geben Sie "last_modified:[Datum/Zeit1 TO Datum/Zeit2]" (Datum/Zeit1 < Datum/Zeit2) in das Suchformular ein.
+
+Datums-/Zeitangaben basieren auf ISO 8601.
+
+.. list-table::
+
+   * - Jahr, Monat, Tag sowie Stunde, Minute, Sekunde und Bruchteile
+     - Bei Verwendung der aktuellen Zeit als Referenz
+   * - YYYY-MM-DDThh:mm:sssZ (Beispiel: 2012-12-02T10:45:235Z)
+     - now (aktuelle Zeit), y (Jahr), M (Monat), w (Woche), d (Tag), h (Stunde), m (Minute), s (Sekunde)
+
+Bei Verwendung von now oder Zeit als Referenz können Symbole wie +, - (Addition, Subtraktion) und / (Rundung) hinzugefügt werden. Bei Verwendung von Zeit als Referenz muss jedoch || zwischen dem Symbol eingefügt werden.
+
+/ ist ein Symbol zum Runden auf die Einheit nach /. now-1d/d repräsentiert 00:00 Uhr des Vortages, unabhängig davon, zu welcher Uhrzeit es am heutigen Tag ausgeführt wird (heutiger Tag 00:00 Uhr - 1 Tag).
+
+Um beispielsweise Dokumente zu suchen, die im last_modified-Feld innerhalb der letzten 30 Tage ab dem 21. Februar 2016 um 20:00 Uhr (angenommene aktuelle Zeit) aktualisiert wurden, geben Sie Folgendes in das Suchformular ein:
+
+::
+
+    last_modified:[now-30d TO now](=[2016-01-23T00:00:000Z+TO+2016-02-21T20:00:000Z(aktuelle Zeit)])

--- a/de/15.3/user/search-sort.rst
+++ b/de/15.3/user/search-sort.rst
@@ -1,0 +1,67 @@
+==================
+Sortierte Suche
+==================
+
+Sie können Suchergebnisse nach Feldern wie dem Suchdatum sortieren.
+
+Sortierbare Felder
+--------------------
+
+Standardmäßig können die folgenden Felder zum Sortieren angegeben werden.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Feldname
+     - Beschreibung
+   * - created
+     - Crawl-Datum
+   * - content_length
+     - Größe des gecrawlten Dokuments
+   * - last_modified
+     - Letztes Änderungsdatum des gecrawlten Dokuments
+   * - filename
+     - Dateiname
+   * - score
+     - Bewertung
+   * - timestamp
+     - Datum der Dokumentindizierung
+   * - click_count
+     - Anzahl der Klicks auf das Dokument
+   * - favorite_count
+     - Anzahl der Favorisierungen des Dokuments
+
+Tabelle: Liste der sortierbaren Felder
+
+
+Durch Anpassung können Sie auch eigene Felder als Sortierziel hinzufügen.
+
+Verwendung
+-----------
+
+Bei der Suche können Sortierkriterien ausgewählt werden. Sortierkriterien können im Suchoptionen-Dialog ausgewählt werden, der durch Klicken auf die Optionsschaltfläche angezeigt wird.
+
+|image0|
+
+Um im Suchfeld zu sortieren, geben Sie "sort:Feldname" in das Suchformular ein, wobei sort und Feldname durch einen Doppelpunkt (:) getrennt sind.
+
+Das Folgende sucht nach fess und sortiert nach Dokumentgröße in aufsteigender Reihenfolge.
+
+::
+
+    fess sort:content_length
+
+Um in absteigender Reihenfolge zu sortieren, geben Sie Folgendes ein:
+
+::
+
+    fess sort:content_length.desc
+
+Um nach mehreren Feldern zu sortieren, geben Sie diese durch Kommas getrennt an:
+
+::
+
+    fess sort:content_length.desc,last_modified
+
+.. |image0| image:: ../../../resources/images/ja/15.3/user/search-sort-1.png
+.. pdf            :width: 300 px

--- a/de/15.3/user/search-wildcard.rst
+++ b/de/15.3/user/search-wildcard.rst
@@ -1,0 +1,37 @@
+====================
+Wildcard-Suche
+====================
+
+Sie können Wildcards für ein oder mehrere Zeichen innerhalb von Suchbegriffen verwenden. ? kann als Wildcard für ein Zeichen angegeben werden, und \* kann als Wildcard für mehrere Zeichen angegeben werden. Wildcards können für Wörter verwendet werden. Wildcard-Suchen für Sätze sind nicht möglich.
+
+Verwendung
+-----------
+
+Um ein Ein-Zeichen-Wildcard zu verwenden, nutzen Sie ? wie folgt:
+
+::
+
+    te?t
+
+In diesem Fall wird es als Ein-Zeichen-Wildcard behandelt, z. B. text oder test.
+
+Um ein Mehrzeichen-Wildcard zu verwenden, nutzen Sie \* wie folgt:
+
+::
+
+    test*
+
+In diesem Fall wird es als Mehrzeichen-Wildcard behandelt, z. B. test, tests oder tester. Außerdem
+
+::
+
+    te*t
+
+kann innerhalb des Suchbegriffs verwendet werden.
+
+Nutzungsbedingungen
+---------------------
+
+Wildcards werden auf im Index registrierte Zeichenketten angewendet.
+Daher funktionieren Wildcards für Japanisch nicht wie erwartet, wenn der Index mit bi-gram erstellt wurde, da Japanisch als bedeutungslose Zeichenkette mit fester Länge behandelt wird.
+Um Wildcards für Japanisch zu verwenden, nutzen Sie bitte Felder, die morphologische Analyse verwenden.

--- a/de/15.3/user/special-char.rst
+++ b/de/15.3/user/special-char.rst
@@ -1,0 +1,21 @@
+================
+Sonderzeichen
+================
+
+Die folgenden Zeichen werden in Suchbegriffen als Sonderzeichen behandelt. Wenn diese Zeichen als Suchzeichen verwendet werden sollen, müssen sie maskiert werden.
+
+::
+
+    + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
+
+
+Verwendung
+-----------
+
+Maskieren Sie mit \ oder umschließen Sie den Suchbegriff mit ".
+
+::
+
+    aaa\/bbb
+    "aaa/bbb"
+


### PR DESCRIPTION
Create comprehensive German translation of the Fess user guide with commercial documentation quality. All 17 documentation files have been translated from Japanese (ja/15.3/user) to German (de/15.3/user), covering:

- Introduction and getting started
- All search types (AND, OR, NOT, fuzzy, wildcard, range, boost, etc.)
- Field-specific and label-based search
- Role-based search and authentication
- Advanced search features
- Sorting and geo-location search
- Special characters handling

The translation maintains professional terminology and follows German documentation standards for technical products.