### PR TITLE
Create German API documentation translation

### DIFF
--- a/de/15.3/api/api-gsa.rst
+++ b/de/15.3/api/api-gsa.rst
@@ -1,0 +1,19 @@
+====================================
+Google Search Appliance-kompatible API
+====================================
+
+|Fess| bietet auch eine API, die Suchergebnisse im Google Search Appliance (GSA)-kompatiblen XML-Format zurückgibt.
+Informationen zum XML-Format finden Sie in der \ `offiziellen GSA-Dokumentation <https://www.google.com/support/enterprise/static/gsa/docs/admin/74/gsa_doc_set/xml_reference/results_format.html>`__\ .
+
+Konfiguration
+=============
+
+Fügen Sie ``web.api.gsa=true`` zu system.properties hinzu, um die Google Search Appliance-kompatible API zu aktivieren.
+
+Anfrage
+=======
+
+Durch Senden einer Anfrage wie
+``http://localhost:8080/gsa/?q=Suchbegriff``
+an |Fess| können Sie Suchergebnisse im GSA-kompatiblen XML-Format erhalten.
+Die als Anfrageparameter angebbaren Werte sind die gleichen wie bei der \ `Such-API mit JSON-Antwort <api-search.html>`__\ .

--- a/de/15.3/api/api-health.rst
+++ b/de/15.3/api/api-health.rst
@@ -1,0 +1,60 @@
+===========
+Health-API
+===========
+
+Abrufen des Status
+===================
+
+Anfrage
+-------
+
+==================  ====================================================
+HTTP-Methode        GET
+Endpunkt            ``/api/v1/health``
+==================  ====================================================
+
+Durch Senden einer Anfrage wie ``http://<Servername>/api/v1/health`` an |Fess| können Sie den Serverstatus von |Fess| im JSON-Format erhalten.
+
+Anfrageparameter
+----------------
+
+Es sind keine Anfrageparameter verfügbar.
+
+Antwort
+-------
+
+Es wird folgende Antwort zurückgegeben:
+
+::
+
+    {
+      "data": {
+        "status": "green",
+        "timed_out": false
+      }
+    }
+
+Die einzelnen Elemente sind wie folgt definiert:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Antwortinformationen
+
+   * - data
+     - Übergeordnetes Element der Suchergebnisse.
+   * - status
+     - Status des Systems. Bei normalem Betrieb wird ``green`` zurückgegeben, bei Warnungen ``yellow``, bei Fehlern ``red``.
+   * - timed_out
+     - Gibt an, ob eine Zeitüberschreitung aufgetreten ist. ``false`` wird zurückgegeben, wenn die Antwort innerhalb der angegebenen Zeit zurückgegeben wurde, ``true`` bei Zeitüberschreitung.
+
+Fehlerantworten
+===============
+
+Wenn die Health-API fehlschlägt, wird folgende Fehlerantwort zurückgegeben:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Fehlerantworten
+
+   * - Statuscode
+     - Beschreibung
+   * - 500 Internal Server Error
+     - Wenn ein interner Serverfehler aufgetreten ist

--- a/de/15.3/api/api-label.rst
+++ b/de/15.3/api/api-label.rst
@@ -1,0 +1,92 @@
+=========
+Label-API
+=========
+
+Abrufen von Labels
+==================
+
+Anfrage
+-------
+
+==================  ====================================================
+HTTP-Methode        GET
+Endpunkt            ``/api/v1/labels``
+==================  ====================================================
+
+Durch Senden einer Anfrage wie ``http://<Servername>/api/v1/labels`` an |Fess| können Sie die in |Fess| registrierten Labels als Liste im JSON-Format erhalten.
+
+Anfrageparameter
+----------------
+
+Es sind keine Anfrageparameter verfügbar.
+
+
+Antwort
+-------
+
+Es wird folgende Antwort zurückgegeben:
+
+::
+
+    {
+      "record_count": 9,
+      "data": [
+        {
+          "label": "AWS",
+          "value": "aws"
+        },
+        {
+          "label": "Azure",
+          "value": "azure"
+        }
+      ]
+    }
+
+Die einzelnen Elemente sind wie folgt definiert:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+
+.. list-table::
+
+   * - record_count
+     - Anzahl der registrierten Labels.
+   * - data
+     - Übergeordnetes Element der Suchergebnisse.
+   * - label
+     - Name des Labels.
+   * - value
+     - Wert des Labels.
+
+Tabelle: Antwortinformationen
+
+Verwendungsbeispiele
+====================
+
+Beispielanfrage mit curl:
+
+::
+
+    curl "http://localhost:8080/api/v1/labels"
+
+Beispielanfrage mit JavaScript:
+
+::
+
+    fetch('http://localhost:8080/api/v1/labels')
+      .then(response => response.json())
+      .then(data => {
+        console.log('Label-Liste:', data.data);
+      });
+
+Fehlerantworten
+===============
+
+Wenn die Label-API fehlschlägt, wird folgende Fehlerantwort zurückgegeben:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Fehlerantworten
+
+   * - Statuscode
+     - Beschreibung
+   * - 500 Internal Server Error
+     - Wenn ein interner Serverfehler aufgetreten ist

--- a/de/15.3/api/api-overview.rst
+++ b/de/15.3/api/api-overview.rst
@@ -1,0 +1,82 @@
+==============
+API-Übersicht
+==============
+
+
+Von |Fess| bereitgestellte APIs
+================================
+
+Diese Dokumentation beschreibt die von |Fess| bereitgestellten APIs.
+Durch die Verwendung der API können Sie |Fess| auch in bestehenden Websystemen als Suchserver einsetzen.
+
+Basis-URL
+=========
+
+Die API-Endpunkte von |Fess| werden unter folgender Basis-URL bereitgestellt:
+
+::
+
+    http://<Servername>/api/v1/
+
+Beispielsweise sieht die URL bei einem lokal betriebenen System wie folgt aus:
+
+::
+
+    http://localhost:8080/api/v1/
+
+Authentifizierung
+=================
+
+In der aktuellen Version ist für die Nutzung der API keine Authentifizierung erforderlich.
+Allerdings müssen die APIs in den verschiedenen Einstellungen der Administrationsoberfläche aktiviert werden.
+
+HTTP-Methoden
+=============
+
+Auf alle API-Endpunkte wird mit der **GET**-Methode zugegriffen.
+
+Antwortformat
+=============
+
+Alle API-Antworten werden im **JSON-Format** zurückgegeben (mit Ausnahme der GSA-kompatiblen API).
+Der ``Content-Type`` der Antwort ist ``application/json``.
+
+Fehlerbehandlung
+================
+
+Wenn eine API-Anfrage fehlschlägt, werden Fehlerinformationen zusammen mit einem entsprechenden HTTP-Statuscode zurückgegeben.
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: HTTP-Statuscodes
+
+   * - 200
+     - Die Anfrage wurde erfolgreich verarbeitet.
+   * - 400
+     - Die Anfrageparameter sind ungültig.
+   * - 404
+     - Die angeforderte Ressource wurde nicht gefunden.
+   * - 500
+     - Es ist ein interner Serverfehler aufgetreten.
+
+Tabelle: HTTP-Statuscodes
+
+API-Typen
+=========
+
+|Fess| stellt folgende APIs bereit:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table::
+
+   * - search
+     - API zum Abrufen von Suchergebnissen.
+   * - popularword
+     - API zum Abrufen beliebter Suchbegriffe.
+   * - label
+     - API zum Abrufen der Liste erstellter Labels.
+   * - health
+     - API zum Abrufen des Serverstatus.
+   * - suggest
+     - API zum Abrufen von Vorschlagswörtern.
+
+Tabelle: API-Typen

--- a/de/15.3/api/api-popularword.rst
+++ b/de/15.3/api/api-popularword.rst
@@ -1,0 +1,74 @@
+=====================
+Beliebte-Wörter-API
+=====================
+
+Abrufen beliebter Wörter
+=========================
+
+Anfrage
+-------
+
+==================  ====================================================
+HTTP-Methode        GET
+Endpunkt            ``/api/v1/popular-words``
+==================  ====================================================
+
+Durch Senden einer Anfrage wie ``http://<Servername>/api/v1/popular-words?seed=123`` an |Fess| können Sie die in |Fess| registrierten beliebten Wörter als Liste im JSON-Format erhalten.
+Um die Beliebte-Wörter-API zu nutzen, muss in der Administrationsoberfläche unter System > Allgemeine Einstellungen die Antwort für beliebte Wörter aktiviert sein.
+
+Anfrageparameter
+----------------
+
+Die verfügbaren Anfrageparameter sind wie folgt:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Anfrageparameter
+
+   * - seed
+     - Seed zum Abrufen beliebter Wörter (durch diesen Wert können verschiedene Muster von Wörtern abgerufen werden)
+   * - label
+     - Gefilterter Label-Name
+   * - field
+     - Feldname zur Generierung beliebter Wörter
+
+
+Antwort
+-------
+
+Es wird folgende Antwort zurückgegeben:
+
+::
+
+    {
+      "record_count": 3,
+      "data": [
+        "python",
+        "java",
+        "javascript"
+      ]
+    }
+
+Die einzelnen Elemente sind wie folgt definiert:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Antwortinformationen
+
+   * - record_count
+     - Anzahl der registrierten beliebten Wörter
+   * - data
+     - Array der beliebten Wörter
+
+Fehlerantworten
+===============
+
+Wenn die Beliebte-Wörter-API fehlschlägt, wird folgende Fehlerantwort zurückgegeben:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Fehlerantworten
+
+   * - Statuscode
+     - Beschreibung
+   * - 400 Bad Request
+     - Wenn die Anfrageparameter ungültig sind
+   * - 500 Internal Server Error
+     - Wenn ein interner Serverfehler aufgetreten ist

--- a/de/15.3/api/api-search.rst
+++ b/de/15.3/api/api-search.rst
@@ -1,0 +1,249 @@
+==========
+Such-API
+==========
+
+Abrufen von Suchergebnissen
+============================
+
+Anfrage
+-------
+
+==================  ====================================================
+HTTP-Methode        GET
+Endpunkt            ``/api/v1/documents``
+==================  ====================================================
+
+Durch Senden einer Anfrage wie
+``http://<Servername>/api/v1/documents?q=Suchbegriff``
+an |Fess| können Sie die Suchergebnisse von |Fess| im JSON-Format erhalten.
+Um die Such-API zu nutzen, muss die JSON-Antwort in der Administrationsoberfläche unter System > Allgemeine Einstellungen aktiviert sein.
+
+Anfrageparameter
+----------------
+
+Durch Angabe von Anfrageparametern wie
+``http://<Servername>/api/v1/documents?q=Suchbegriff&num=50&fields.label=fess``
+können Sie erweiterte Suchfunktionen durchführen.
+Die verfügbaren Anfrageparameter sind wie folgt:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table::
+
+   * - q
+     - Suchbegriff. Wird URL-codiert übergeben.
+   * - start
+     - Startposition der Ergebnisse. Beginnt bei 0.
+   * - num
+     - Anzahl der Ergebnisse. Standard ist 20. Maximal können 100 Ergebnisse angezeigt werden.
+   * - sort
+     - Sortierung. Wird verwendet, um die Suchergebnisse zu sortieren.
+   * - fields.label
+     - Label-Wert. Wird verwendet, um ein Label anzugeben.
+   * - facet.field
+     - Angabe des Facettenfeldes. (Beispiel) ``facet.field=label``
+   * - facet.query
+     - Angabe der Facettenabfrage. (Beispiel) ``facet.query=timestamp:[now/d-1d TO *]``
+   * - facet.size
+     - Angabe der maximalen Anzahl der abzurufenden Facetten. Gilt, wenn facet.field angegeben ist.
+   * - facet.minDocCount
+     - Ruft Facetten ab, deren Anzahl größer oder gleich diesem Wert ist. Gilt, wenn facet.field angegeben ist.
+   * - geo.location.point
+     - Angabe von Breiten- und Längengrad. (Beispiel) ``geo.location.point=35.0,139.0``
+   * - geo.location.distance
+     - Angabe der Entfernung vom Mittelpunkt. (Beispiel) ``geo.location.distance=10km``
+   * - lang
+     - Angabe der Suchsprache. (Beispiel) ``lang=en``
+   * - preference
+     - Zeichenfolge zur Angabe des Shards bei der Suche. (Beispiel) ``preference=abc``
+   * - callback
+     - Callback-Name bei Verwendung von JSONP. Muss nicht angegeben werden, wenn JSONP nicht verwendet wird.
+
+Tabelle: Anfrageparameter
+
+
+Antwort
+-------
+
+| Es wird folgende Antwort zurückgegeben.
+| (Formatiert dargestellt)
+
+::
+
+    {
+      "q": "Fess",
+      "query_id": "bd60f9579a494dfd8c03db7c8aa905b0",
+      "exec_time": 0.21,
+      "query_time": 0,
+      "page_size": 20,
+      "page_number": 1,
+      "record_count": 31625,
+      "page_count": 1,
+      "highlight_params": "&hq=n2sm&hq=Fess",
+      "next_page": true,
+      "prev_page": false,
+      "start_record_number": 1,
+      "end_record_number": 20,
+      "page_numbers": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5"
+      ],
+      "partial": false,
+      "search_query": "(Fess OR n2sm)",
+      "requested_time": 1507822131845,
+      "related_query": [
+        "aaa"
+      ],
+      "related_contents": [],
+      "data": [
+        {
+          "filetype": "html",
+          "title": "Open Source Enterprise Search Server: Fess — Fess 11.0 documentation",
+          "content_title": "Open Source Enterprise Search Server: Fess — Fe...",
+          "digest": "Docs » Open Source Enterprise Search Server: Fess Commercial Support Open Source Enterprise Search Server: Fess What is Fess ? Fess is very powerful and easily deployable Enterprise Search Server. ...",
+          "host": "fess.codelibs.org",
+          "last_modified": "2017-10-09T22:28:56.000Z",
+          "content_length": "29624",
+          "timestamp": "2017-10-09T22:28:56.000Z",
+          "url_link": "https://fess.codelibs.org/",
+          "created": "2017-10-10T15.30:48.609Z",
+          "site_path": "fess.codelibs.org/",
+          "doc_id": "e79fbfdfb09d4bffb58ec230c68f6f7e",
+          "url": "https://fess.codelibs.org/",
+          "content_description": "Enterprise Search Server: <strong>Fess</strong> Commercial Support Open...Search Server: <strong>Fess</strong> What is <strong>Fess</strong> ? <strong>Fess</strong> is very powerful...You can install and run <strong>Fess</strong> quickly on any platforms...Java runtime environment. <strong>Fess</strong> is provided under Apache...Apache license. Demo <strong>Fess</strong> is OpenSearch-based search",
+          "site": "fess.codelibs.org/",
+          "boost": "10.0",
+          "mimetype": "text/html"
+        }
+      ]
+    }
+
+Die einzelnen Elemente sind wie folgt definiert:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Antwortinformationen
+
+   * - q
+     - Suchbegriff
+   * - exec_time
+     - Antwortzeit (Einheit: Sekunden)
+   * - query_time
+     - Abfrageverarbeitungszeit (Einheit: Millisekunden)
+   * - page_size
+     - Anzahl der Ergebnisse
+   * - page_number
+     - Seitennummer
+   * - record_count
+     - Anzahl der Treffer für den Suchbegriff
+   * - page_count
+     - Anzahl der Seiten der Treffer für den Suchbegriff
+   * - highlight_params
+     - Hervorhebungsparameter
+   * - next_page
+     - true: Nächste Seite existiert. false: Nächste Seite existiert nicht.
+   * - prev_page
+     - true: Vorherige Seite existiert. false: Vorherige Seite existiert nicht.
+   * - start_record_number
+     - Startposition der Datensatznummer
+   * - end_record_number
+     - Endposition der Datensatznummer
+   * - page_numbers
+     - Array der Seitennummern
+   * - partial
+     - Wird true, wenn das Suchergebnis abgebrochen wurde, z.B. bei Zeitüberschreitung.
+   * - search_query
+     - Suchabfrage
+   * - requested_time
+     - Anfragezeitpunkt (Einheit: Epoch-Millisekunden)
+   * - related_query
+     - Verwandte Abfragen
+   * - related_contents
+     - Abfragen für verwandte Inhalte
+   * - facet_field
+     - Informationen über Dokumente, die auf das angegebene Facettenfeld zutreffen (nur wenn ``facet.field`` im Anfrageparameter angegeben wurde)
+   * - facet_query
+     - Anzahl der Dokumente, die auf die angegebene Facettenabfrage zutreffen (nur wenn ``facet.query`` im Anfrageparameter angegeben wurde)
+   * - result
+     - Übergeordnetes Element der Suchergebnisse
+   * - filetype
+     - Dateityp
+   * - created
+     - Erstellungsdatum des Dokuments
+   * - title
+     - Titel des Dokuments
+   * - doc_id
+     - ID des Dokuments
+   * - url
+     - URL des Dokuments
+   * - site
+     - Site-Name
+   * - content_description
+     - Beschreibung des Inhalts
+   * - host
+     - Hostname
+   * - digest
+     - Zusammenfassung des Dokuments
+   * - boost
+     - Boost-Wert des Dokuments
+   * - mimetype
+     - MIME-Typ
+   * - last_modified
+     - Letztes Änderungsdatum
+   * - content_length
+     - Größe des Dokuments
+   * - url_link
+     - URL als Suchergebnis
+   * - timestamp
+     - Aktualisierungszeitpunkt des Dokuments
+
+
+Suche in allen Dokumenten
+==========================
+
+Um alle Zieldokumente zu durchsuchen, senden Sie folgende Anfrage:
+``http://<Servername>/api/v1/documents/all?q=Suchbegriff``
+
+Um diese Funktion zu nutzen, muss in fess_config.properties die Einstellung api.search.scroll auf true gesetzt werden.
+
+Anfrageparameter
+----------------
+
+Die verfügbaren Anfrageparameter sind wie folgt:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table::
+
+   * - q
+     - Suchbegriff. Wird URL-codiert übergeben.
+   * - num
+     - Anzahl der Ergebnisse. Standard ist 20. Maximal können 100 Ergebnisse angezeigt werden.
+   * - sort
+     - Sortierung. Wird verwendet, um die Suchergebnisse zu sortieren.
+
+Tabelle: Anfrageparameter
+
+Fehlerantworten
+===============
+
+Wenn die Such-API fehlschlägt, wird folgende Fehlerantwort zurückgegeben:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Fehlerantworten
+
+   * - Statuscode
+     - Beschreibung
+   * - 400 Bad Request
+     - Wenn die Anfrageparameter ungültig sind
+   * - 500 Internal Server Error
+     - Wenn ein interner Serverfehler aufgetreten ist
+
+Beispiel für eine Fehlerantwort:
+
+::
+
+    {
+      "message": "Invalid request parameter",
+      "status": 400
+    }

--- a/de/15.3/api/api-suggest.rst
+++ b/de/15.3/api/api-suggest.rst
@@ -1,0 +1,92 @@
+=============
+Vorschlags-API
+=============
+
+Abrufen von Vorschlagswörtern
+==============================
+
+Anfrage
+-------
+
+==================  ====================================================
+HTTP-Methode        GET
+Endpunkt            ``/api/v1/suggest-words``
+==================  ====================================================
+
+Durch Senden einer Anfrage wie ``http://<Servername>/api/v1/suggest-words?q=Vorschlagswort`` an |Fess| können Sie die in |Fess| registrierten Vorschlagswörter als Liste im JSON-Format erhalten.
+Um die Vorschlags-API zu nutzen, muss in der Administrationsoberfläche unter System > Allgemeine Einstellungen entweder "Vorschläge aus Dokumenten" oder "Vorschläge aus Suchbegriffen" aktiviert sein.
+
+Anfrageparameter
+----------------
+
+Die verfügbaren Anfrageparameter sind wie folgt:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Anfrageparameter
+
+   * - q
+     - Schlüsselwort für Vorschläge. (Beispiel) ``q=fess``
+   * - num
+     - Anzahl der vorgeschlagenen Wörter. Standard: 10. (Beispiel) ``num=20``
+   * - label
+     - Gefilterter Label-Name. (Beispiel) ``label=java``
+   * - fields
+     - Feldname zur Eingrenzung der Vorschlagsziele. Standard: keine Eingrenzung. (Beispiel) ``fields=content,title``
+   * - lang
+     - Angabe der Suchsprache. (Beispiel) ``lang=en``
+
+
+Antwort
+-------
+
+Es wird folgende Antwort zurückgegeben:
+
+::
+
+    {
+      "query_time": 18,
+      "record_count": 355,
+      "page_size": 10,
+      "data": [
+        {
+          "text": "fess",
+          "labels": [
+            "java",
+            "python"
+          ]
+        }
+      ]
+    }
+
+Die einzelnen Elemente sind wie folgt definiert:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Antwortinformationen
+
+   * - query_time
+     - Abfrageverarbeitungszeit (Einheit: Millisekunden).
+   * - record_count
+     - Anzahl der registrierten Vorschlagswörter.
+   * - page_size
+     - Seitengröße.
+   * - data
+     - Übergeordnetes Element der Suchergebnisse.
+   * - text
+     - Vorschlagswort.
+   * - labels
+     - Array der Label-Werte.
+
+Fehlerantworten
+===============
+
+Wenn die Vorschlags-API fehlschlägt, wird folgende Fehlerantwort zurückgegeben:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Fehlerantworten
+
+   * - Statuscode
+     - Beschreibung
+   * - 400 Bad Request
+     - Wenn die Anfrageparameter ungültig sind
+   * - 500 Internal Server Error
+     - Wenn ein interner Serverfehler aufgetreten ist

--- a/de/15.3/api/index.rst
+++ b/de/15.3/api/index.rst
@@ -1,0 +1,13 @@
+|Fess| API-Leitfaden
+====================
+
+.. toctree::
+   :maxdepth: 2
+
+   intro
+   api-overview
+   api-search
+   api-label
+   api-popularword
+   api-suggest
+   api-health

--- a/de/15.3/api/intro.rst
+++ b/de/15.3/api/intro.rst
@@ -1,0 +1,61 @@
+=========
+Einführung
+=========
+
+Zielgruppe
+==========
+
+Diese Dokumentation richtet sich an Entwickler, die die API-Funktionen von |Fess| nutzen möchten.
+Folgende Kenntnisse werden vorausgesetzt:
+
+- Grundlegende Konzepte von REST-APIs
+- JSON-Datenformat
+- Grundlagen des HTTP-Protokolls
+
+Bevor Sie beginnen
+==================
+
+Diese Dokumentation beschreibt die Verwendung der API in |Fess| 15.3.
+
+Voraussetzungen für die API-Nutzung
+====================================
+
+Bevor Sie die API von |Fess| nutzen können, sind folgende Einstellungen erforderlich:
+
+- |Fess| 15.3 oder höher muss installiert und ordnungsgemäß gestartet sein
+- Die erforderlichen Einstellungen für jede API müssen in der Administrationsoberfläche aktiviert werden (siehe jeweilige API-Dokumentation)
+- Der Zugriff auf die API-Endpunkte muss über das Netzwerk möglich sein
+
+Online-Zugriff
+==============
+
+Für Downloads, professionelle Dienstleistungen, Support und weitere Entwicklerinformationen besuchen Sie:
+
+-  Projekt-Website: https://fess.codelibs.org/
+
+Kontakt für technischen Support
+================================
+
+Wenn Sie technische Fragen zu diesem Produkt haben, für die Sie in der Dokumentation keine Lösung finden, besuchen Sie bitte:
+
+-  Issues:
+   `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
+
+Kommerzieller Support
+---------------------
+
+Wenn Sie für dieses Produkt technischen Support oder Wartungsdienste benötigen, wenden Sie sich bitte an \ `N2SM,
+Inc. <https://www.n2sm.net/>`__\ .
+
+Hinweise zu Drittanbieter-Websites
+===================================
+
+Das |Fess|-Projekt übernimmt keine Verantwortung für die Gültigkeit der in dieser Dokumentation genannten Drittanbieter-Websites. Das |Fess|-Projekt übernimmt keine Gewährleistung, Verantwortung oder Verpflichtung für Inhalte, Werbung, Produkte, Dienstleistungen oder andere auf solchen Websites oder Ressourcen verfügbare Materialien. Das |Fess|-Projekt übernimmt keine Verantwortung oder Haftung für Schäden oder Verluste, die durch die Nutzung oder das Vertrauen auf solche Inhalte, Werbung, Produkte, Dienstleistungen oder andere auf solchen Websites oder Ressourcen verfügbare Materialien entstehen oder geltend gemacht werden.
+
+Übermittlung von Kommentaren und Vorschlägen
+=============================================
+
+Das |Fess|-Projekt ist bestrebt, diese Dokumentation zu verbessern und freut sich über Kommentare und Vorschläge von Lesern.
+
+-  Issues:
+   `https://github.com/codelibs/fess-docs/issues <https://github.com/codelibs/fess-docs/issues>`__


### PR DESCRIPTION
Created comprehensive German translation of the Fess API guide with commercial-grade quality documentation. All API endpoints are now documented in German, including:

- Introduction and overview
- Search API with detailed parameters and responses
- Label API for retrieving label lists
- Suggest API for word suggestions
- Popular Words API
- Health API for server status monitoring
- GSA-compatible API documentation

The translation maintains the same structure as the Japanese original (ja/15.3/api) and follows professional technical documentation standards suitable for commercial products.

Files translated:
- index.rst (main table of contents)
- intro.rst (introduction and prerequisites)
- api-overview.rst (API overview and concepts)
- api-search.rst (search API documentation)
- api-label.rst (label API documentation)
- api-suggest.rst (suggest API documentation)
- api-popularword.rst (popular words API documentation)
- api-health.rst (health API documentation)
- api-gsa.rst (GSA-compatible API documentation)