### PR TITLE
Create German translation of Fess configuration guide

### DIFF
--- a/de/15.3/config/admin-analyzer.rst
+++ b/de/15.3/config/admin-analyzer.rst
@@ -1,0 +1,22 @@
+=============
+Analyzer-Konfiguration
+=============
+
+Über Analyzer
+==============
+
+Bei Erstellung eines Index für die Suche müssen Dokumente für Registrierung als Index aufgeteilt werden.
+In |Fess| ist die Funktion zum Zerlegen von Dokumenten in Wörter als Analyzer registriert.
+Analyzer besteht aus CharFilter, Tokenizer und TokenFilter.
+
+Grundsätzlich können Einheiten kleiner als die vom Analyzer aufgeteilten Einheiten bei Suche nicht gefunden werden.
+Betrachten Sie zum Beispiel den Satz "Wohnen in Tokyo".
+Angenommen, dieser Satz wurde vom Analyzer in "Tokyo", "in", "wohnen" aufgeteilt.
+In diesem Fall wird eine Suche nach "Tokyo" einen Treffer ergeben.
+Eine Suche nach "Kyoto" ergibt jedoch keinen Treffer.
+
+Analyzer-Konfiguration wird beim Start von |Fess| registriert, indem fess-Index mit app/WEB-INF/classes/fess_indices/fess.json erstellt wird, wenn fess-Index nicht existiert.
+Für Zusammensetzungsmethode des Analyzers siehe OpenSearch-Analyzer-Dokumentation.
+
+Analyzer-Konfiguration hat großen Einfluss auf Suche.
+Bei Änderung des Analyzers führen Sie dies nach Verständnis der Funktionsweise des Lucene-Analyzers durch oder konsultieren Sie kommerziellen Support.

--- a/de/15.3/config/admin-index-backup.rst
+++ b/de/15.3/config/admin-index-backup.rst
@@ -1,0 +1,135 @@
+==================
+Index-Verwaltung
+==================
+
+Übersicht
+====
+
+Von |Fess| verwaltete Daten werden als OpenSearch-Indizes verwaltet.
+Backup und Wiederherstellung von Suchindizes sind für stabilen Systembetrieb unerlässlich.
+Dieser Abschnitt beschreibt Backup-, Wiederherstellungs- und Migrationsverfahren für Indizes.
+
+Index-Struktur
+==================
+
+|Fess| verwendet folgende Indizes:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Indexname
+     - Beschreibung
+   * - ``fess.{Datum}``
+     - Index für zu durchsuchende Dokumente (täglich erstellt)
+   * - ``fess_log``
+     - Suchprotokolle und Klickprotokolle
+   * - ``fess_user``
+     - Benutzerinformationen
+   * - ``fess_config``
+     - Systemkonfigurationsinformationen
+   * - ``configsync``
+     - Konfigurationssynchronisierungsinformationen
+
+Index-Backup und -Wiederherstellung
+====================================
+
+Mit OpenSearch-Snapshot-Funktion können Sie Index-Backup und -Wiederherstellung durchführen.
+
+Konfiguration des Snapshot-Repositorys
+--------------------------------
+
+Konfigurieren Sie zuerst ein Repository zum Speichern von Backup-Daten.
+
+**Bei Dateisystem-Repository:**
+
+1. Fügen Sie Repository-Pfad zur OpenSearch-Konfigurationsdatei (``config/opensearch.yml``) hinzu.
+
+::
+
+    path.repo: ["/var/opensearch/backup"]
+
+2. Starten Sie OpenSearch neu.
+
+3. Registrieren Sie Repository.
+
+::
+
+    curl -X PUT "localhost:9201/_snapshot/fess_backup" -H 'Content-Type: application/json' -d'
+    {
+      "type": "fs",
+      "settings": {
+        "location": "/var/opensearch/backup",
+        "compress": true
+      }
+    }'
+
+.. note::
+   In Standardkonfiguration von |Fess| startet OpenSearch auf Port 9201.
+
+Snapshot-Erstellung (Backup)
+------------------------------------
+
+Backup aller Indizes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Alle Indizes sichern.
+
+::
+
+    curl -X PUT "localhost:9201/_snapshot/fess_backup/snapshot_1?wait_for_completion=true" -H 'Content-Type: application/json' -d'
+    {
+      "indices": "*",
+      "ignore_unavailable": true,
+      "include_global_state": false
+    }'
+
+Wiederherstellung aus Snapshot
+------------------------------
+
+Wiederherstellung aller Indizes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    curl -X POST "localhost:9201/_snapshot/fess_backup/snapshot_1/_restore?wait_for_completion=true" -H 'Content-Type: application/json' -d'
+    {
+      "indices": "*",
+      "ignore_unavailable": true,
+      "include_global_state": false
+    }'
+
+Backup von Konfigurationsdateien
+==========================
+
+Zusätzlich zu OpenSearch-Indizes sichern Sie auch folgende Konfigurationsdateien.
+
+Zu sichernde Dateien
+--------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Datei/Verzeichnis
+     - Beschreibung
+   * - ``app/WEB-INF/conf/system.properties``
+     - Systemkonfiguration (bei Zip-Installation)
+   * - ``/etc/fess/system.properties``
+     - Systemkonfiguration (bei RPM/DEB-Paketen)
+   * - ``app/WEB-INF/classes/fess_config.properties``
+     - Detaillierte Fess-Konfiguration
+   * - ``/etc/fess/fess_config.properties``
+     - Detaillierte Fess-Konfiguration (RPM/DEB-Pakete)
+   * - ``app/WEB-INF/classes/log4j2.xml``
+     - Protokollkonfiguration
+   * - ``/etc/fess/log4j2.xml``
+     - Protokollkonfiguration (RPM/DEB-Pakete)
+
+Referenzinformationen
+========
+
+Für detaillierte Informationen siehe offizielle OpenSearch-Dokumentation.
+
+- `Snapshot-Funktion <https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/snapshots/index/>`_
+- `Repository-Konfiguration <https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/>`_

--- a/de/15.3/config/admin-logging.rst
+++ b/de/15.3/config/admin-logging.rst
@@ -1,0 +1,167 @@
+============
+Protokollkonfiguration
+============
+
+Übersicht
+====
+
+|Fess| gibt mehrere Protokolldateien aus, um Systembetriebsstatus und Fehlerinformationen aufzuzeichnen.
+Durch angemessene Protokollkonfiguration werden Fehlersuche und Systemüberwachung erleichtert.
+
+Arten von Protokolldateien
+==================
+
+Hauptprotokoll
+
+dateien
+------------------
+
+Hauptprotokolldateien, die |Fess| ausgibt:
+
+.. list-table:: Liste der Protokolldateien
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Dateiname
+     - Inhalt
+   * - ``fess.log``
+     - Betriebsprotokolle in Verwaltungs- und Suchoberfläche, Anwendungsfehler, Systemereignisse
+   * - ``fess_crawler.log``
+     - Protokolle bei Crawler-Ausführung, Ziel-URLs, abgerufene Dokumentinformationen, Fehler
+   * - ``fess_suggest.log``
+     - Protokolle bei Vorschlags-Generierung, Index-Aktualisierungsinformationen
+   * - ``server_?.log``
+     - Systemprotokolle des Anwendungsservers wie Tomcat
+   * - ``audit.log``
+     - Audit-Protokolle für Benutzerauthentifizierung, An-/Abmeldung, wichtige Operationen
+
+Speicherort der Protokolldateien
+------------------
+
+**Bei Zip-Installation:**
+
+::
+
+    {FESS_HOME}/logs/
+
+**Bei RPM/DEB-Paketen:**
+
+::
+
+    /var/log/fess/
+
+Protokollüberprüfung bei Fehlersuche
+----------------------------------
+
+Bei Problemen überprüfen Sie Protokolle wie folgt:
+
+1. **Fehlertyp identifizieren**
+
+   - Anwendungsfehler → ``fess.log``
+   - Crawler-Fehler → ``fess_crawler.log``
+   - Authentifizierungsfehler → ``audit.log``
+   - Serverfehler → ``server_?.log``
+
+2. **Neueste Fehler überprüfen**
+
+   ::
+
+       tail -f /var/log/fess/fess.log
+
+3. **Nach bestimmten Fehlern suchen**
+
+   ::
+
+       grep -i "error" /var/log/fess/fess.log
+       grep -i "exception" /var/log/fess/fess.log
+
+Konfiguration der Protokollebenen
+================
+
+Was sind Protokollebenen?
+--------------
+
+Protokollebenen steuern Detailgrad der auszugebenden Protokolle.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Ebene
+     - Beschreibung
+   * - ``FATAL``
+     - Kritische Fehler (Anwendung kann nicht fortgesetzt werden)
+   * - ``ERROR``
+     - Fehler (Teil der Funktionalität funktioniert nicht)
+   * - ``WARN``
+     - Warnung (potenzielle Probleme)
+   * - ``INFO``
+     - Information (wichtige Ereignisse)
+   * - ``DEBUG``
+     - Debug-Informationen (detaillierte Betriebsprotokolle)
+   * - ``TRACE``
+     - Trace-Informationen (am detailliertesten)
+
+Empfohlene Protokollebenen
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Umgebung
+     - Empfohlene Ebene
+     - Begründung
+   * - Produktionsumgebung
+     - ``WARN``
+     - Fokus auf Leistung und Speicherplatz
+   * - Staging-Umgebung
+     - ``INFO``
+     - Aufzeichnung wichtiger Ereignisse
+   * - Entwicklungsumgebung
+     - ``DEBUG``
+     - Detaillierte Debug-Informationen erforderlich
+   * - Bei Problemuntersuchung
+     - ``DEBUG`` oder ``TRACE``
+     - Temporär detaillierte Protokolle aktivieren
+
+Protokollrotation
+==================
+
+Übersicht
+----
+
+Protokolldateien wachsen mit der Zeit, daher ist regelmäßige Rotation (Generationsverwaltung) erforderlich.
+
+Automatische Rotation durch Log4j2
+-------------------------------
+
+|Fess| verwendet RollingFileAppender von Log4j2 für automatische Protokollrotation.
+
+Standardkonfiguration
+~~~~~~~~~~~~~~~~
+
+- **Dateigröße**: Rotation bei über 10 MB
+- **Aufbewahrungsgenerationen**: Maximal 10 Dateien
+
+Beispiel für Konfigurationsdatei (``log4j2.xml``):
+
+::
+
+    <RollingFile name="FessFile"
+                 fileName="${log.dir}/fess.log"
+                 filePattern="${log.dir}/fess.log.%i">
+        <PatternLayout pattern="%d{ISO8601} [%t] %-5p %c - %m%n"/>
+        <Policies>
+            <SizeBasedTriggeringPolicy size="10MB"/>
+        </Policies>
+        <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
+Referenzinformationen
+========
+
+- :doc:`setup-memory` - Speicherkonfiguration
+- :doc:`crawler-advanced` - Erweiterte Crawler-Konfiguration
+- :doc:`admin-index-backup` - Index-Backup
+- `Log4j2 Documentation <https://logging.apache.org/log4j/2.x/>`_

--- a/de/15.3/config/admin-opensearch-dashboards.rst
+++ b/de/15.3/config/admin-opensearch-dashboards.rst
@@ -1,0 +1,127 @@
+=======================
+Konfiguration der Suchprotokoll-Visualisierung
+=======================
+
+Über Suchprotokoll-Visualisierung
+========================
+
+|Fess| erfasst Suchprotokolle und Klickprotokolle von Benutzern.
+Erfasste Suchprotokolle können mit `OpenSearch Dashboards <https://opensearch.org/docs/latest/dashboards/index/>`__ analysiert und visualisiert werden.
+
+Visualisierbare Informationen
+----------------
+
+Mit Standardkonfiguration können folgende Informationen visualisiert werden:
+
+-  Durchschnittliche Zeit für Anzeige von Suchergebnissen
+-  Anzahl Suchen pro Sekunde
+-  User-Agent-Ranking zugreifender Benutzer
+-  Ranking der Suchschlüsselwörter
+-  Ranking der Suchschlüsselwörter ohne Suchergebnisse
+-  Gesamtzahl der Suchergebnisse
+-  Suchtrends in Zeitreihen
+
+Mit Visualize-Funktion können Sie neue Diagramme erstellen und zum Dashboard hinzufügen, um eigene Überwachungsdashboards zu erstellen.
+
+Konfiguration der Datenvisualisierung mit OpenSearch Dashboards
+==============================================
+
+Installation von OpenSearch Dashboards
+------------------------------------
+
+OpenSearch Dashboards ist ein Tool zur Visualisierung von in |Fess| verwendeten OpenSearch-Daten.
+Installieren Sie OpenSearch Dashboards gemäß `offizieller OpenSearch-Dokumentation <https://opensearch.org/docs/latest/install-and-configure/install-dashboards/index/>`__.
+
+Bearbeitung der Konfigurationsdatei
+------------------
+
+Bearbeiten Sie Konfigurationsdatei ``config/opensearch_dashboards.yml``, damit OpenSearch Dashboards in |Fess| verwendetes OpenSearch erkennt.
+
+::
+
+    opensearch.hosts: ["http://localhost:9201"]
+
+Ändern Sie ``localhost`` entsprechend Ihrer Umgebung zu geeignetem Hostnamen oder IP-Adresse.
+In Standardkonfiguration von |Fess| startet OpenSearch auf Port 9201.
+
+.. note::
+   Wenn OpenSearch-Portnummer abweicht, ändern Sie zu entsprechender Portnummer.
+
+Start von OpenSearch Dashboards
+-----------------------------
+
+Nach Bearbeitung der Konfigurationsdatei starten Sie OpenSearch Dashboards.
+
+::
+
+    $ cd /path/to/opensearch-dashboards
+    $ ./bin/opensearch-dashboards
+
+Nach Start greifen Sie im Browser auf ``http://localhost:5601`` zu.
+
+Konfiguration von Index-Mustern
+--------------------------
+
+1. Wählen Sie aus Home-Bildschirm von OpenSearch Dashboards das Menü "Management".
+2. Wählen Sie "Index Patterns".
+3. Klicken Sie auf "Create index pattern".
+4. Geben Sie ``fess_log*`` als Index pattern name ein.
+5. Klicken Sie auf "Next step".
+6. Wählen Sie ``requestedAt`` als Time field.
+7. Klicken Sie auf "Create index pattern".
+
+Damit ist Vorbereitung zur Visualisierung von |Fess|-Suchprotokollen abgeschlossen.
+
+Hauptfelder der Suchprotokolle
+----------------------
+
+|Fess|-Suchprotokolle enthalten folgende Informationen:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Feldname
+     - Beschreibung
+   * - ``queryId``
+     - Eindeutige Kennung der Suchabfrage
+   * - ``searchWord``
+     - Suchschlüsselwort
+   * - ``requestedAt``
+     - Datum und Uhrzeit der Suchausführung
+   * - ``responseTime``
+     - Antwortzeit der Suchergebnisse (Millisekunden)
+   * - ``queryTime``
+     - Abfrageausführungszeit (Millisekunden)
+   * - ``hitCount``
+     - Trefferanzahl der Suchergebnisse
+   * - ``userAgent``
+     - Browser-Informationen des Benutzers
+   * - ``clientIp``
+     - IP-Adresse des Clients
+   * - ``languages``
+     - Verwendete Sprache
+   * - ``roles``
+     - Rolleninformationen des Benutzers
+   * - ``user``
+     - Benutzername (bei Anmeldung)
+
+Mit diesen Feldern können Sie Suchprotokolle aus verschiedenen Perspektiven analysieren.
+
+Fehlersuche
+----------------------
+
+Wenn Daten nicht angezeigt werden
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Überprüfen Sie, ob OpenSearch korrekt gestartet ist.
+- Überprüfen Sie, ob ``opensearch.hosts``-Einstellung in ``opensearch_dashboards.yml`` korrekt ist.
+- Überprüfen Sie, ob in |Fess| Suchen ausgeführt und Protokolle aufgezeichnet werden.
+- Überprüfen Sie, ob Zeitbereich des Index-Musters angemessen konfiguriert ist.
+
+Bei Verbindungsfehlern
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Überprüfen Sie, ob OpenSearch-Portnummer korrekt ist.
+- Überprüfen Sie Firewall- oder Sicherheitsgruppen-Einstellungen.
+- Überprüfen Sie OpenSearch-Protokolldateien auf Fehler.

--- a/de/15.3/config/crawler-advanced.rst
+++ b/de/15.3/config/crawler-advanced.rst
@@ -1,0 +1,955 @@
+========================
+Erweiterte Crawler-Konfiguration
+========================
+
+Übersicht
+====
+
+Dieser Leitfaden beschreibt erweiterte Konfigurationen für den |Fess|-Crawler.
+Für grundlegende Crawler-Konfigurationen siehe :doc:`crawler-basic`.
+
+.. warning::
+   Die Einstellungen auf dieser Seite können systemweite Auswirkungen haben.
+   Testen Sie Konfigurationsänderungen gründlich, bevor Sie sie in Produktionsumgebungen anwenden.
+
+Allgemeine Konfiguration
+========
+
+Speicherort der Konfigurationsdateien
+------------------
+
+Erweiterte Crawler-Konfigurationen werden in folgenden Dateien vorgenommen:
+
+- **Hauptkonfiguration**: ``/etc/fess/fess_config.properties`` (oder ``app/WEB-INF/classes/fess_config.properties``)
+- **Inhaltslängen-Konfiguration**: ``app/WEB-INF/classes/crawler/contentlength.xml``
+- **Komponenten-Konfiguration**: ``app/WEB-INF/classes/crawler/container.xml``
+
+Standard-Skriptsprache
+--------------------
+
+Legt die Standard-Skriptsprache für den Crawler fest.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.default.script``
+     - Crawler-Skriptsprache
+     - ``groovy``
+
+::
+
+    crawler.default.script=groovy
+
+HTTP-Thread-Pool
+------------------
+
+Thread-Pool-Konfiguration für den HTTP-Crawler.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.http.thread_pool.size``
+     - HTTP-Thread-Pool-Größe
+     - ``0``
+
+::
+
+    # Bei 0 automatische Konfiguration
+    crawler.http.thread_pool.size=0
+
+Dokumentverarbeitungs-Konfiguration
+====================
+
+Grundkonfiguration
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.document.max.site.length``
+     - Maximale Zeilenanzahl für Dokumentsite
+     - ``100``
+   * - ``crawler.document.site.encoding``
+     - Codierung der Dokumentsite
+     - ``UTF-8``
+   * - ``crawler.document.unknown.hostname``
+     - Ersatzwert für unbekannte Hostnamen
+     - ``unknown``
+   * - ``crawler.document.use.site.encoding.on.english``
+     - Site-Codierung für englische Dokumente verwenden
+     - ``false``
+   * - ``crawler.document.append.data``
+     - Daten zum Dokument hinzufügen
+     - ``true``
+   * - ``crawler.document.append.filename``
+     - Dateinamen zum Dokument hinzufügen
+     - ``false``
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    crawler.document.max.site.length=100
+    crawler.document.site.encoding=UTF-8
+    crawler.document.unknown.hostname=unknown
+    crawler.document.use.site.encoding.on.english=false
+    crawler.document.append.data=true
+    crawler.document.append.filename=false
+
+Wortverarbeitungs-Konfiguration
+------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.document.max.alphanum.term.size``
+     - Maximale Länge alphanumerischer Wörter
+     - ``20``
+   * - ``crawler.document.max.symbol.term.size``
+     - Maximale Länge von Symbol-Wörtern
+     - ``10``
+   * - ``crawler.document.duplicate.term.removed``
+     - Entfernung doppelter Wörter
+     - ``false``
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    # Maximale Länge alphanumerischer Zeichen auf 50 ändern
+    crawler.document.max.alphanum.term.size=50
+
+    # Maximale Länge von Symbolen auf 20 ändern
+    crawler.document.max.symbol.term.size=20
+
+    # Doppelte Wörter entfernen
+    crawler.document.duplicate.term.removed=true
+
+.. note::
+   Das Erhöhen von ``max.alphanum.term.size`` ermöglicht die vollständige Indizierung langer IDs, Tokens, URLs usw., erhöht jedoch die Indexgröße.
+
+Zeichenverarbeitungs-Konfiguration
+------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.document.space.chars``
+     - Definition von Leerzeichen
+     - ``\u0009\u000A...``
+   * - ``crawler.document.fullstop.chars``
+     - Definition von Satzendzeichen
+     - ``\u002e\u06d4...``
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    # Standardwerte (einschließlich Unicode-Zeichen)
+    crawler.document.space.chars=\u0009\u000A\u000B\u000C\u000D\u001C\u001D\u001E\u001F\u0020\u00A0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u200B\u200C\u202F\u205F\u3000\uFEFF\uFFFD\u00B6
+
+    crawler.document.fullstop.chars=\u002e\u06d4\u2e3c\u3002
+
+Protokoll-Konfiguration
+==============
+
+Unterstützte Protokolle
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.web.protocols``
+     - Protokolle für Web-Crawling
+     - ``http,https``
+   * - ``crawler.file.protocols``
+     - Protokolle für Datei-Crawling
+     - ``file,smb,smb1,ftp,storage``
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    crawler.web.protocols=http,https
+    crawler.file.protocols=file,smb,smb1,ftp,storage
+
+Umgebungsvariablen-Parameter
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.data.env.param.key.pattern``
+     - Muster für Umgebungsvariablen-Parameterschlüssel
+     - ``^FESS_ENV_.*``
+
+::
+
+    # Umgebungsvariablen beginnend mit FESS_ENV_ können in Crawl-Konfigurationen verwendet werden
+    crawler.data.env.param.key.pattern=^FESS_ENV_.*
+
+robots.txt-Konfiguration
+===============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.ignore.robots.txt``
+     - robots.txt ignorieren
+     - ``false``
+   * - ``crawler.ignore.robots.tags``
+     - Zu ignorierende Robots-Tags
+     - (leer)
+   * - ``crawler.ignore.content.exception``
+     - Inhaltsausnahmen ignorieren
+     - ``true``
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    # robots.txt ignorieren (nicht empfohlen)
+    crawler.ignore.robots.txt=false
+
+    # Bestimmte Robots-Tags ignorieren
+    crawler.ignore.robots.tags=
+
+    # Inhaltsausnahmen ignorieren
+    crawler.ignore.content.exception=true
+
+.. warning::
+   Die Einstellung ``crawler.ignore.robots.txt=true`` kann gegen Nutzungsbedingungen von Websites verstoßen. Seien Sie vorsichtig beim Crawlen externer Sites.
+
+Fehlerbehandlungs-Konfiguration
+==============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.failure.url.status.codes``
+     - Als Fehler behandelte HTTP-Statuscodes
+     - ``404``
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    # Zusätzlich zu 404 auch 403 als Fehler behandeln
+    crawler.failure.url.status.codes=404,403
+
+Systemüberwachungs-Konfiguration
+================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.system.monitor.interval``
+     - Systemüberwachungsintervall (Sekunden)
+     - ``60``
+
+::
+
+    # System alle 30 Sekunden überwachen
+    crawler.system.monitor.interval=30
+
+Hot-Thread-Konfiguration
+------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.hotthread.ignore_idle_threads``
+     - Leerlaufende Threads ignorieren
+     - ``true``
+   * - ``crawler.hotthread.interval``
+     - Snapshot-Intervall
+     - ``500ms``
+   * - ``crawler.hotthread.snapshots``
+     - Anzahl Snapshots
+     - ``10``
+   * - ``crawler.hotthread.threads``
+     - Anzahl überwachter Threads
+     - ``3``
+   * - ``crawler.hotthread.timeout``
+     - Timeout
+     - ``30s``
+   * - ``crawler.hotthread.type``
+     - Überwachungstyp
+     - ``cpu``
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    crawler.hotthread.ignore_idle_threads=true
+    crawler.hotthread.interval=500ms
+    crawler.hotthread.snapshots=10
+    crawler.hotthread.threads=3
+    crawler.hotthread.timeout=30s
+    crawler.hotthread.type=cpu
+
+Metadaten-Konfiguration
+==============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.metadata.content.excludes``
+     - Auszuschließende Metadaten
+     - ``resourceName,X-Parsed-By...``
+   * - ``crawler.metadata.name.mapping``
+     - Metadaten-Namen-Mapping
+     - ``title=title:string...``
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    # Auszuschließende Metadaten
+    crawler.metadata.content.excludes=resourceName,X-Parsed-By,Content-Encoding.*,Content-Type.*,X-TIKA.*,X-FESS.*
+
+    # Metadaten-Namen-Mapping
+    crawler.metadata.name.mapping=\
+        title=title:string\n\
+        Title=title:string\n\
+        dc:title=title:string
+
+HTML-Crawler-Konfiguration
+===================
+
+XPath-Konfiguration
+----------
+
+XPath-Konfiguration zum Extrahieren von HTML-Elementen.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.document.html.content.xpath``
+     - XPath für Inhalt
+     - ``//BODY``
+   * - ``crawler.document.html.lang.xpath``
+     - XPath für Sprache
+     - ``//HTML/@lang``
+   * - ``crawler.document.html.digest.xpath``
+     - XPath für Digest
+     - ``//META[@name='description']/@content``
+   * - ``crawler.document.html.canonical.xpath``
+     - XPath für kanonische URL
+     - ``//LINK[@rel='canonical'][1]/@href``
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    # Standardkonfiguration
+    crawler.document.html.content.xpath=//BODY
+    crawler.document.html.lang.xpath=//HTML/@lang
+    crawler.document.html.digest.xpath=//META[@name='description']/@content
+    crawler.document.html.canonical.xpath=//LINK[@rel='canonical'][1]/@href
+
+Beispiele für benutzerdefinierte XPath
+~~~~~~~~~~~~~~~~~~~
+
+::
+
+    # Nur bestimmte div-Elemente als Inhalt extrahieren
+    crawler.document.html.content.xpath=//DIV[@id='main-content']
+
+    # Auch Meta-Keywords in Digest einbeziehen
+    crawler.document.html.digest.xpath=//META[@name='description']/@content|//META[@name='keywords']/@content
+
+HTML-Tag-Verarbeitung
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.document.html.pruned.tags``
+     - Zu entfernende HTML-Tags
+     - ``noscript,script,style,header,footer,aside,nav,a[rel=nofollow]``
+   * - ``crawler.document.html.max.digest.length``
+     - Maximale Digest-Länge
+     - ``120``
+   * - ``crawler.document.html.default.lang``
+     - Standardsprache
+     - (leer)
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    # Tags zum Entfernen hinzufügen
+    crawler.document.html.pruned.tags=noscript,script,style,header,footer,aside,nav,a[rel=nofollow],form
+
+    # Digest-Länge auf 200 Zeichen
+    crawler.document.html.max.digest.length=200
+
+    # Standardsprache auf Deutsch
+    crawler.document.html.default.lang=de
+
+URL-Musterfilter
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.document.html.default.include.index.patterns``
+     - In Index einzuschließende URL-Muster
+     - (leer)
+   * - ``crawler.document.html.default.exclude.index.patterns``
+     - Aus Index auszuschließende URL-Muster
+     - ``(?i).*(css|js|jpeg...)``
+   * - ``crawler.document.html.default.include.search.patterns``
+     - In Suchergebnisse einzuschließende URL-Muster
+     - (leer)
+   * - ``crawler.document.html.default.exclude.search.patterns``
+     - Aus Suchergebnissen auszuschließende URL-Muster
+     - (leer)
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    # Standard-Ausschlussmuster
+    crawler.document.html.default.exclude.index.patterns=(?i).*(css|js|jpeg|jpg|gif|png|bmp|wmv|xml|ico|exe)
+
+    # Nur bestimmte Pfade indizieren
+    crawler.document.html.default.include.index.patterns=https://example\\.com/docs/.*
+
+Datei-Crawler-Konfiguration
+======================
+
+Grundkonfiguration
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.document.file.name.encoding``
+     - Dateinamen-Codierung
+     - (leer)
+   * - ``crawler.document.file.no.title.label``
+     - Label für Dateien ohne Titel
+     - ``No title.``
+   * - ``crawler.document.file.ignore.empty.content``
+     - Leere Inhalte ignorieren
+     - ``false``
+   * - ``crawler.document.file.max.title.length``
+     - Maximale Titellänge
+     - ``100``
+   * - ``crawler.document.file.max.digest.length``
+     - Maximale Digest-Länge
+     - ``200``
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    # Windows-31J-Dateinamen verarbeiten
+    crawler.document.file.name.encoding=Windows-31J
+
+    # Label für Dateien ohne Titel
+    crawler.document.file.no.title.label=Kein Titel
+
+    # Leere Dateien ignorieren
+    crawler.document.file.ignore.empty.content=true
+
+    # Titel- und Digest-Länge
+    crawler.document.file.max.title.length=200
+    crawler.document.file.max.digest.length=500
+
+Inhaltsverarbeitung
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.document.file.append.meta.content``
+     - Metadaten zum Inhalt hinzufügen
+     - ``true``
+   * - ``crawler.document.file.append.body.content``
+     - Haupttext zum Inhalt hinzufügen
+     - ``true``
+   * - ``crawler.document.file.default.lang``
+     - Standardsprache
+     - (leer)
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    crawler.document.file.append.meta.content=true
+    crawler.document.file.append.body.content=true
+    crawler.document.file.default.lang=de
+
+Datei-URL-Musterfilter
+------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.document.file.default.include.index.patterns``
+     - In Index einzuschließende Muster
+     - (leer)
+   * - ``crawler.document.file.default.exclude.index.patterns``
+     - Aus Index auszuschließende Muster
+     - (leer)
+   * - ``crawler.document.file.default.include.search.patterns``
+     - In Suchergebnisse einzuschließende Muster
+     - (leer)
+   * - ``crawler.document.file.default.exclude.search.patterns``
+     - Aus Suchergebnissen auszuschließende Muster
+     - (leer)
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    # Nur bestimmte Erweiterungen indizieren
+    crawler.document.file.default.include.index.patterns=.*\\.(pdf|docx|xlsx|pptx)$
+
+    # Temp-Ordner ausschließen
+    crawler.document.file.default.exclude.index.patterns=.*/temp/.*
+
+Cache-Konfiguration
+==============
+
+Dokumenten-Cache
+----------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.document.cache.enabled``
+     - Dokumenten-Cache aktivieren
+     - ``true``
+   * - ``crawler.document.cache.max.size``
+     - Maximale Cache-Größe (Bytes)
+     - ``2621440`` (2,5 MB)
+   * - ``crawler.document.cache.supported.mimetypes``
+     - Zu cachende MIME-Typen
+     - ``text/html``
+   * - ``crawler.document.cache.html.mimetypes``
+     - Als HTML zu behandelnde MIME-Typen
+     - ``text/html``
+
+Konfigurationsbeispiel
+~~~~~~
+
+::
+
+    # Dokumenten-Cache aktivieren
+    crawler.document.cache.enabled=true
+
+    # Cache-Größe auf 5 MB
+    crawler.document.cache.max.size=5242880
+
+    # Zu cachende MIME-Typen
+    crawler.document.cache.supported.mimetypes=text/html,application/xhtml+xml
+
+    # Als HTML zu behandelnde MIME-Typen
+    crawler.document.cache.html.mimetypes=text/html,application/xhtml+xml
+
+.. note::
+   Bei aktiviertem Cache wird in Suchergebnissen ein Cache-Link angezeigt,
+   über den Benutzer den Inhalt zum Zeitpunkt des Crawlings einsehen können.
+
+JVM-Optionen
+==============
+
+Sie können JVM-Optionen für den Crawler-Prozess konfigurieren.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``jvm.crawler.options``
+     - JVM-Optionen für Crawler
+     - ``-Xms128m -Xmx512m...``
+
+Standardkonfiguration
+--------------
+
+::
+
+    jvm.crawler.options=-Xms128m -Xmx512m \
+        -XX:MaxMetaspaceSize=128m \
+        -XX:+UseG1GC \
+        -XX:MaxGCPauseMillis=60000 \
+        -XX:-HeapDumpOnOutOfMemoryError
+
+Erklärung wichtiger Optionen
+----------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Option
+     - Beschreibung
+   * - ``-Xms128m``
+     - Initiale Heap-Größe (128 MB)
+   * - ``-Xmx512m``
+     - Maximale Heap-Größe (512 MB)
+   * - ``-XX:MaxMetaspaceSize=128m``
+     - Maximale Metaspace-Größe (128 MB)
+   * - ``-XX:+UseG1GC``
+     - G1-Garbage-Collector verwenden
+   * - ``-XX:MaxGCPauseMillis=60000``
+     - Ziel für GC-Pausenzeit (60 Sekunden)
+   * - ``-XX:-HeapDumpOnOutOfMemoryError``
+     - Heap-Dumps bei OutOfMemory deaktivieren
+
+Beispiele für benutzerdefinierte Konfiguration
+--------------
+
+**Beim Crawlen großer Dateien:**
+
+::
+
+    jvm.crawler.options=-Xms256m -Xmx2g \
+        -XX:MaxMetaspaceSize=256m \
+        -XX:+UseG1GC \
+        -XX:MaxGCPauseMillis=60000
+
+**Beim Debuggen:**
+
+::
+
+    jvm.crawler.options=-Xms128m -Xmx512m \
+        -XX:MaxMetaspaceSize=128m \
+        -XX:+UseG1GC \
+        -XX:+HeapDumpOnOutOfMemoryError \
+        -XX:HeapDumpPath=/tmp/crawler_dump.hprof
+
+Details siehe :doc:`setup-memory`.
+
+Leistungsoptimierung
+==========================
+
+Optimierung der Crawl-Geschwindigkeit
+--------------------
+
+**1. Thread-Anzahl anpassen**
+
+Durch Erhöhung der Anzahl paralleler Crawls kann die Crawl-Geschwindigkeit verbessert werden.
+
+::
+
+    # Thread-Anzahl in Crawl-Konfiguration der Verwaltungsoberfläche anpassen
+    Thread-Anzahl: 10
+
+Beachten Sie jedoch die Last auf dem Zielserver.
+
+**2. Timeout anpassen**
+
+Bei langsamen Sites passen Sie Timeouts an.
+
+::
+
+    # Zu „Konfigurationsparametern" der Crawl-Konfiguration hinzufügen
+    client.connectionTimeout=10000
+    client.socketTimeout=30000
+
+**3. Unnötige Inhalte ausschließen**
+
+Durch Ausschluss von Bildern, CSS, JavaScript-Dateien usw. wird die Crawl-Geschwindigkeit verbessert.
+
+::
+
+    # URL-Ausschlussmuster
+    .*\.(jpg|jpeg|png|gif|css|js|ico)$
+
+**4. Retry-Einstellungen**
+
+Passen Sie Anzahl und Intervall von Wiederholungsversuchen bei Fehlern an.
+
+::
+
+    # Zu „Konfigurationsparametern" der Crawl-Konfiguration hinzufügen
+    client.maxRetry=3
+    client.retryInterval=1000
+
+Optimierung der Speichernutzung
+--------------------
+
+**1. Heap-Größe anpassen**
+
+::
+
+    jvm.crawler.options=-Xms256m -Xmx1g
+
+**2. Cache-Größe anpassen**
+
+::
+
+    crawler.document.cache.max.size=1048576  # 1 MB
+
+**3. Große Dateien ausschließen**
+
+::
+
+    # Zu „Konfigurationsparametern" der Crawl-Konfiguration hinzufügen
+    client.maxContentLength=10485760  # 10 MB
+
+Details siehe :doc:`setup-memory`.
+
+Verbesserung der Indexqualität
+----------------------
+
+**1. XPath optimieren**
+
+Schließen Sie unnötige Elemente (Navigation, Werbung usw.) aus.
+
+::
+
+    crawler.document.html.content.xpath=//DIV[@id='main-content']
+    crawler.document.html.pruned.tags=noscript,script,style,header,footer,aside,nav,form,iframe
+
+**2. Digest optimieren**
+
+::
+
+    crawler.document.html.max.digest.length=200
+
+**3. Metadaten-Mapping**
+
+::
+
+    crawler.metadata.name.mapping=\
+        title=title:string\n\
+        description=digest:string\n\
+        keywords=label:string
+
+Fehlersuche
+======================
+
+Speichermangel
+----------
+
+**Symptome:**
+
+- ``OutOfMemoryError`` in ``fess_crawler.log`` aufgezeichnet
+- Crawling stoppt mittendrin
+
+**Gegenmaßnahmen:**
+
+1. Crawler-Heap-Größe erhöhen
+
+   ::
+
+       jvm.crawler.options=-Xms256m -Xmx2g
+
+2. Anzahl paralleler Threads reduzieren
+
+3. Große Dateien ausschließen
+
+Details siehe :doc:`setup-memory`.
+
+Crawling ist langsam
+--------------
+
+**Symptome:**
+
+- Crawling dauert zu lange
+- Häufige Timeouts
+
+**Gegenmaßnahmen:**
+
+1. Thread-Anzahl erhöhen (Last auf Zielserver beachten)
+
+2. Timeouts anpassen
+
+   ::
+
+       client.connectionTimeout=5000
+       client.socketTimeout=10000
+
+3. Unnötige URLs ausschließen
+
+Bestimmte Inhalte können nicht extrahiert werden
+------------------------------
+
+**Symptome:**
+
+- Seitentext wird nicht korrekt extrahiert
+- Wichtige Informationen fehlen in Suchergebnissen
+
+**Gegenmaßnahmen:**
+
+1. XPath überprüfen und anpassen
+
+   ::
+
+       crawler.document.html.content.xpath=//DIV[@class='content']
+
+2. Zu entfernende Tags überprüfen
+
+   ::
+
+       crawler.document.html.pruned.tags=script,style
+
+3. Bei dynamisch durch JavaScript generierten Inhalten alternative Methoden (z. B. API-Crawling) in Betracht ziehen
+
+Zeichenkodierungsprobleme treten auf
+------------------
+
+**Symptome:**
+
+- Zeichenkodierungsprobleme in Suchergebnissen
+- Bestimmte Sprachen werden nicht korrekt angezeigt
+
+**Gegenmaßnahmen:**
+
+1. Codierungseinstellungen überprüfen
+
+   ::
+
+       crawler.document.site.encoding=UTF-8
+       crawler.crawling.data.encoding=UTF-8
+
+2. Dateinamen-Codierung konfigurieren
+
+   ::
+
+       crawler.document.file.name.encoding=Windows-31J
+
+3. Codierungsfehler im Protokoll überprüfen
+
+   ::
+
+       grep -i "encoding" /var/log/fess/fess_crawler.log
+
+Best Practices
+==================
+
+1. **In Testumgebung validieren**
+
+   Validieren Sie gründlich in Testumgebung, bevor Sie in Produktionsumgebung anwenden.
+
+2. **Schrittweise Anpassung**
+
+   Ändern Sie Konfigurationen nicht auf einmal stark, sondern passen Sie schrittweise an und überprüfen Sie die Wirkung.
+
+3. **Protokolle überwachen**
+
+   Überwachen Sie nach Konfigurationsänderungen Protokolle auf Fehler oder Leistungsprobleme.
+
+   ::
+
+       tail -f /var/log/fess/fess_crawler.log
+
+4. **Backup**
+
+   Erstellen Sie vor Änderung von Konfigurationsdateien unbedingt ein Backup.
+
+   ::
+
+       cp /etc/fess/fess_config.properties /etc/fess/fess_config.properties.bak
+
+5. **Dokumentation**
+
+   Dokumentieren Sie geänderte Konfigurationen und deren Begründung.
+
+Referenzinformationen
+========
+
+- :doc:`crawler-basic` - Grundlegende Crawler-Konfiguration
+- :doc:`crawler-thumbnail` - Thumbnail-Konfiguration
+- :doc:`setup-memory` - Speicherkonfiguration
+- :doc:`admin-logging` - Protokollkonfiguration
+- :doc:`search-advanced` - Erweiterte Suchkonfiguration

--- a/de/15.3/config/crawler-basic.rst
+++ b/de/15.3/config/crawler-basic.rst
@@ -1,0 +1,635 @@
+====================
+Grundlegende Crawler-Konfiguration
+====================
+
+Übersicht
+====
+
+Der Crawler von |Fess| ist eine Funktion, die automatisch Inhalte von Websites, Dateisystemen usw. sammelt und im Suchindex registriert.
+Dieser Leitfaden erläutert die grundlegenden Konzepte und Konfigurationsmethoden des Crawlers.
+
+Grundlegende Crawler-Konzepte
+====================
+
+Was ist ein Crawler?
+--------------
+
+Ein Crawler ist ein Programm, das automatisch Inhalte sammelt, indem es von angegebenen URLs oder Dateipfaden ausgehend Links folgt.
+
+Der Crawler von |Fess| hat folgende Merkmale:
+
+- **Multi-Protokoll-Unterstützung**: HTTP/HTTPS, Dateisystem, SMB, FTP usw.
+- **Geplante Ausführung**: Regelmäßiges automatisches Crawlen
+- **Inkrementelles Crawlen**: Aktualisierung nur geänderter Inhalte
+- **Parallele Verarbeitung**: Gleichzeitiges Crawlen mehrerer URLs
+- **Einhaltung von Roboter-Regeln**: Einhaltung von robots.txt
+
+Crawler-Typen
+----------------
+
+|Fess| bietet folgende Crawler-Typen je nach Ziel.
+
+.. list-table:: Crawler-Typen
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * - Typ
+     - Ziel
+     - Verwendungszweck
+   * - **Web-Crawler**
+     - Websites (HTTP/HTTPS)
+     - Öffentliche Websites, Intranet-Websites
+   * - **Datei-Crawler**
+     - Dateisystem, SMB, FTP
+     - Dateiserver, freigegebene Ordner
+   * - **Datenspeicher-Crawler**
+     - Datenbanken
+     - RDB, CSV, JSON und andere Datenquellen
+
+Erstellen von Crawl-Konfigurationen
+==================
+
+Hinzufügen grundlegender Crawl-Konfigurationen
+--------------------------
+
+1. **Zugriff auf Verwaltungsoberfläche**
+
+   Öffnen Sie ``http://localhost:8080/admin`` im Browser und melden Sie sich als Administrator an.
+
+2. **Crawler-Konfigurationsbildschirm öffnen**
+
+   Wählen Sie im linken Menü „Crawler" → „Web" oder „Dateisystem".
+
+3. **Neue Konfiguration erstellen**
+
+   Klicken Sie auf die Schaltfläche „Neu erstellen".
+
+4. **Grundinformationen eingeben**
+
+   - **Name**: Identifikationsname der Crawl-Konfiguration (z. B. Firmen-Wiki)
+   - **URL**: Start-URL für das Crawling (z. B. ``https://wiki.example.com/``)
+   - **Crawl-Intervall**: Häufigkeit der Crawl-Ausführung (z. B. jede Stunde)
+   - **Thread-Anzahl**: Anzahl paralleler Crawls (z. B. 5)
+   - **Tiefe**: Hierarchietiefe für das Folgen von Links (z. B. 3)
+
+5. **Speichern**
+
+   Klicken Sie auf „Erstellen", um die Konfiguration zu speichern.
+
+Beispiele für Web-Crawler-Konfiguration
+---------------------
+
+Crawlen von Firmen-Intranet-Sites
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    Name: Firmenportal
+    URL: http://intranet.example.com/
+    Crawl-Intervall: Einmal täglich
+    Thread-Anzahl: 10
+    Tiefe: Unbegrenzt (-1)
+    Maximale Zugriffszahl: 10000
+
+Crawlen öffentlicher Websites
+~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    Name: Produkt-Site
+    URL: https://www.example.com/products/
+    Crawl-Intervall: Einmal wöchentlich
+    Thread-Anzahl: 5
+    Tiefe: 5
+    Maximale Zugriffszahl: 1000
+
+Beispiele für Datei-Crawler-Konfiguration
+--------------------------
+
+Lokales Dateisystem
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    Name: Dokumentenordner
+    URL: file:///home/share/documents/
+    Crawl-Intervall: Einmal täglich
+    Thread-Anzahl: 3
+    Tiefe: Unbegrenzt (-1)
+
+SMB/CIFS (Windows-Dateifreigabe)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    Name: Dateiserver
+    URL: smb://fileserver.example.com/share/
+    Crawl-Intervall: Einmal täglich
+    Thread-Anzahl: 5
+    Tiefe: Unbegrenzt (-1)
+
+Konfiguration von Authentifizierungsinformationen
+--------------
+
+Für Sites oder Dateiserver, die Authentifizierung erfordern, konfigurieren Sie Authentifizierungsinformationen.
+
+1. Wählen Sie in der Verwaltungsoberfläche „Crawler" → „Authentifizierung"
+2. Klicken Sie auf „Neu erstellen"
+3. Geben Sie Authentifizierungsinformationen ein:
+
+   ::
+
+       Hostname: wiki.example.com
+       Port: 443
+       Authentifizierungsmethode: Basic-Authentifizierung
+       Benutzername: crawler_user
+       Passwort: ********
+
+4. Klicken Sie auf „Erstellen"
+
+Ausführung des Crawlings
+==============
+
+Manuelle Ausführung
+--------
+
+Um einen konfigurierten Crawl sofort auszuführen:
+
+1. Wählen Sie die Zielkonfiguration in der Crawl-Konfigurationsliste
+2. Klicken Sie auf die Schaltfläche „Starten"
+3. Überprüfen Sie den Job-Ausführungsstatus im Menü „Scheduler"
+
+Geplante Ausführung
+----------------
+
+Um Crawls regelmäßig auszuführen:
+
+1. Öffnen Sie das Menü „Scheduler"
+2. Wählen Sie den Job „Default Crawler"
+3. Konfigurieren Sie den Zeitplanausdruck (Cron-Format)
+
+   ::
+
+       # Täglich um 2 Uhr morgens ausführen
+       0 0 2 * * ?
+
+       # Jede Stunde zur vollen Stunde ausführen
+       0 0 * * * ?
+
+       # Montag bis Freitag um 18 Uhr ausführen
+       0 0 18 ? * MON-FRI
+
+4. Klicken Sie auf „Aktualisieren"
+
+Überprüfung des Crawl-Status
+------------------
+
+Überprüfung des Status laufender Crawls:
+
+1. Öffnen Sie das Menü „Scheduler"
+2. Überprüfen Sie laufende Jobs
+3. Überprüfen Sie Details im Protokoll:
+
+   ::
+
+       tail -f /var/log/fess/fess_crawler.log
+
+Grundlegende Konfigurationselemente
+================
+
+Beschränkung von Crawl-Zielen
+------------------
+
+Beschränkung nach URL-Muster
+~~~~~~~~~~~~~~~~~~~~~
+
+Sie können bestimmte URL-Muster als Crawl-Ziele einschließen oder ausschließen.
+
+**Einzuschließende URL-Muster (regulärer Ausdruck):**
+
+::
+
+    # Nur unter /docs/ crawlen
+    https://example\.com/docs/.*
+
+**Auszuschließende URL-Muster (regulärer Ausdruck):**
+
+::
+
+    # Bestimmte Verzeichnisse ausschließen
+    .*/admin/.*
+    .*/private/.*
+
+    # Bestimmte Dateierweiterungen ausschließen
+    .*\.(jpg|png|gif|css|js)$
+
+Tiefenbeschränkung
+~~~~~~~~~~
+
+Beschränkung der Hierarchietiefe für das Folgen von Links:
+
+- **0**: Nur Start-URL
+- **1**: Start-URL und von dort verlinkte Seiten
+- **-1**: Unbegrenzt (allen Links folgen)
+
+Maximale Zugriffszahl
+~~~~~~~~~~~~~~
+
+Obergrenze für die Anzahl zu crawlender Seiten:
+
+::
+
+    Maximale Zugriffszahl: 1000
+
+Stoppt nach dem Crawlen von 1000 Seiten.
+
+Anzahl paralleler Crawls (Thread-Anzahl)
+--------------------------
+
+Gibt die Anzahl gleichzeitig zu crawlender URLs an.
+
+.. list-table:: Empfohlene Thread-Anzahl
+   :header-rows: 1
+   :widths: 40 30 30
+
+   * - Umgebung
+     - Empfohlener Wert
+     - Beschreibung
+   * - Kleine Site (~10.000 Seiten)
+     - 3–5
+     - Last auf Zielserver begrenzen
+   * - Mittlere Site (10.000–100.000 Seiten)
+     - 5–10
+     - Ausgewogene Einstellung
+   * - Große Site (über 100.000 Seiten)
+     - 10–20
+     - Schnelles Crawling erforderlich
+   * - Dateiserver
+     - 3–5
+     - Datei-I/O-Last berücksichtigen
+
+.. warning::
+   Zu hohe Thread-Anzahlen belasten den Zielserver übermäßig.
+   Konfigurieren Sie angemessene Werte.
+
+Crawl-Intervall
+------------
+
+Gibt die Häufigkeit der Crawl-Ausführung an.
+
+::
+
+    # Zeitangabe
+    Crawl-Intervall: 3600000  # Millisekunden (1 Stunde)
+
+    # Oder im Scheduler konfigurieren
+    0 0 2 * * ?  # Täglich um 2 Uhr morgens
+
+Konfiguration der Dateigröße
+====================
+
+Sie können die Obergrenze für zu crawlende Dateigrößen konfigurieren.
+
+Obergrenze für abzurufende Dateigrößen
+----------------------------
+
+Fügen Sie Folgendes zu den „Konfigurationsparametern" der Crawler-Konfiguration hinzu:
+
+::
+
+    client.maxContentLength=10485760
+
+Ruft Dateien bis zu 10 MB ab. Standardmäßig keine Beschränkung.
+
+.. note::
+   Beim Crawlen großer Dateien passen Sie auch die Speichereinstellungen an.
+   Details siehe :doc:`setup-memory`.
+
+Obergrenze für zu indizierende Dateigrößen
+------------------------------------
+
+Sie können Obergrenzen für zu indizierende Größen nach Dateityp festlegen.
+
+**Standardwerte:**
+
+- HTML-Dateien: 2,5 MB
+- Andere Dateien: 10 MB
+
+**Konfigurationsdatei:** ``app/WEB-INF/classes/crawler/contentlength.xml``
+
+::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+            "http://dbflute.org/meta/lastadi10.dtd">
+    <components namespace="fessCrawler">
+            <include path="crawler/container.xml" />
+
+            <component name="contentLengthHelper"
+                    class="org.codelibs.fess.crawler.helper.ContentLengthHelper" instance="singleton">
+                    <property name="defaultMaxLength">10485760</property><!-- 10M -->
+                    <postConstruct name="addMaxLength">
+                            <arg>"text/html"</arg>
+                            <arg>2621440</arg><!-- 2.5M -->
+                    </postConstruct>
+                    <postConstruct name="addMaxLength">
+                            <arg>"application/pdf"</arg>
+                            <arg>5242880</arg><!-- 5M -->
+                    </postConstruct>
+            </component>
+    </components>
+
+Fügt Konfiguration für PDF-Dateien bis zu 5 MB hinzu.
+
+.. warning::
+   Bei größeren Dateigrößen erhöhen Sie auch die Crawler-Speichereinstellungen.
+
+Längenbeschränkung für Wörter
+==============
+
+Übersicht
+----
+
+Lange Zeichenfolgen nur aus alphanumerischen Zeichen oder aufeinanderfolgende Symbole verursachen Indexgrößen-Zunahme und Leistungsverschlechterung.
+Daher setzt |Fess| standardmäßig folgende Beschränkungen:
+
+- **Aufeinanderfolgende alphanumerische Zeichen**: Bis zu 20 Zeichen
+- **Aufeinanderfolgende Symbole**: Bis zu 10 Zeichen
+
+Konfigurationsmethode
+--------
+
+Bearbeiten Sie ``fess_config.properties``.
+
+**Standardkonfiguration:**
+
+::
+
+    crawler.document.max.alphanum.term.size=20
+    crawler.document.max.symbol.term.size=10
+
+**Beispiel: Lockerung der Beschränkung**
+
+::
+
+    crawler.document.max.alphanum.term.size=50
+    crawler.document.max.symbol.term.size=20
+
+.. note::
+   Wenn Sie nach langen alphanumerischen Zeichenfolgen suchen müssen (z. B. Seriennummern, Tokens),
+   erhöhen Sie diesen Wert. Beachten Sie jedoch, dass die Indexgröße zunimmt.
+
+Proxy-Konfiguration
+==============
+
+Übersicht
+----
+
+Beim Crawlen externer Sites aus einem Intranet kann die Verbindung durch eine Firewall blockiert werden.
+In diesem Fall crawlen Sie über einen Proxy-Server.
+
+Konfigurationsmethode
+--------
+
+Fügen Sie in der Verwaltungsoberfläche in der Crawl-Konfiguration unter „Konfigurationsparameter" Folgendes hinzu.
+
+**Grundlegende Proxy-Konfiguration:**
+
+::
+
+    client.proxyHost=proxy.example.com
+    client.proxyPort=8080
+
+**Proxy mit Authentifizierung:**
+
+::
+
+    client.proxyHost=proxy.example.com
+    client.proxyPort=8080
+    client.proxyUsername=proxyuser
+    client.proxyPassword=proxypass
+
+**Bestimmte Hosts vom Proxy ausschließen:**
+
+::
+
+    client.nonProxyHosts=localhost|127.0.0.1|*.example.com
+
+Systemweite Proxy-Konfiguration
+--------------------------
+
+Wenn alle Crawl-Konfigurationen denselben Proxy verwenden, können Sie dies über Umgebungsvariablen konfigurieren.
+
+::
+
+    export http_proxy=http://proxy.example.com:8080
+    export https_proxy=http://proxy.example.com:8080
+    export no_proxy=localhost,127.0.0.1,.example.com
+
+Konfiguration von robots.txt
+=================
+
+Übersicht
+----
+
+robots.txt ist eine Datei, die Crawlern anweist, ob das Crawlen erlaubt ist.
+|Fess| befolgt standardmäßig robots.txt.
+
+Konfigurationsmethode
+--------
+
+Um robots.txt zu ignorieren, bearbeiten Sie ``fess_config.properties``.
+
+::
+
+    crawler.ignore.robots.txt=true
+
+.. warning::
+   Beim Crawlen externer Sites befolgen Sie robots.txt.
+   Das Ignorieren kann übermäßige Last auf Server ausüben oder gegen Nutzungsbedingungen verstoßen.
+
+Konfiguration des User-Agent
+=================
+
+Sie können den User-Agent des Crawlers ändern.
+
+Konfiguration in der Verwaltungsoberfläche
+----------------
+
+Fügen Sie zu den „Konfigurationsparametern" der Crawl-Konfiguration hinzu:
+
+::
+
+    client.userAgent=MyCompanyCrawler/1.0
+
+Systemweite Konfiguration
+------------------
+
+Konfigurieren Sie in ``fess_config.properties``:
+
+::
+
+    crawler.user.agent=MyCompanyCrawler/1.0
+
+Codierungs-Konfiguration
+====================
+
+Codierung von Crawl-Daten
+--------------------------------
+
+Konfigurieren Sie in ``fess_config.properties``:
+
+::
+
+    crawler.crawling.data.encoding=UTF-8
+
+Codierung von Dateinamen
+----------------------------
+
+Codierung von Dateinamen im Dateisystem:
+
+::
+
+    crawler.document.file.name.encoding=UTF-8
+
+Fehlersuche beim Crawling
+================================
+
+Crawling startet nicht
+----------------------
+
+**Überprüfungspunkte:**
+
+1. Überprüfen Sie, ob der Scheduler aktiviert ist
+
+   - Überprüfen Sie im Menü „Scheduler", ob der Job „Default Crawler" aktiviert ist
+
+2. Überprüfen Sie, ob die Crawl-Konfiguration aktiviert ist
+
+   - Überprüfen Sie in der Crawl-Konfigurationsliste, ob die Zielkonfiguration aktiviert ist
+
+3. Überprüfen Sie Protokolle
+
+   ::
+
+       tail -f /var/log/fess/fess.log
+       tail -f /var/log/fess/fess_crawler.log
+
+Crawling stoppt mittendrin
+------------------------
+
+**Mögliche Ursachen:**
+
+1. **Speichermangel**
+
+   - Überprüfen Sie ``fess_crawler.log`` auf ``OutOfMemoryError``
+   - Erhöhen Sie den Crawler-Speicher (Details siehe :doc:`setup-memory`)
+
+2. **Netzwerkfehler**
+
+   - Passen Sie Timeout-Einstellungen an
+   - Überprüfen Sie Retry-Einstellungen
+
+3. **Fehler im Crawl-Ziel**
+
+   - Überprüfen Sie, ob viele 404-Fehler auftreten
+   - Überprüfen Sie Fehlerdetails im Protokoll
+
+Bestimmte Seiten werden nicht gecrawlt
+------------------------------
+
+**Überprüfungspunkte:**
+
+1. **URL-Muster überprüfen**
+
+   - Überprüfen Sie, ob URL dem Ausschlussmuster entspricht
+
+2. **robots.txt überprüfen**
+
+   - Überprüfen Sie ``/robots.txt`` der Ziel-Site
+
+3. **Authentifizierung überprüfen**
+
+   - Bei Seiten, die Authentifizierung erfordern, überprüfen Sie Authentifizierungseinstellungen
+
+4. **Tiefenbeschränkung**
+
+   - Überprüfen Sie, ob Hierarchietiefe der Links die Tiefenbeschränkung überschreitet
+
+5. **Maximale Zugriffszahl**
+
+   - Überprüfen Sie, ob maximale Zugriffszahl erreicht wurde
+
+Crawling ist langsam
+--------------
+
+**Gegenmaßnahmen:**
+
+1. **Thread-Anzahl erhöhen**
+
+   - Erhöhen Sie Anzahl paralleler Crawls (beachten Sie jedoch Last auf Zielserver)
+
+2. **Unnötige URLs ausschließen**
+
+   - Fügen Sie Bilder, CSS-Dateien usw. zu Ausschlussmustern hinzu
+
+3. **Timeout-Einstellungen anpassen**
+
+   - Bei langsamen Sites verkürzen Sie Timeout
+
+4. **Crawler-Speicher erhöhen**
+
+   - Details siehe :doc:`setup-memory`
+
+Best Practices
+==================
+
+Empfehlungen für Crawl-Konfiguration
+----------------------
+
+1. **Angemessene Thread-Anzahl konfigurieren**
+
+   Konfigurieren Sie angemessene Thread-Anzahl, um Zielserver nicht übermäßig zu belasten.
+
+2. **URL-Muster optimieren**
+
+   Durch Ausschluss unnötiger Dateien (Bilder, CSS, JavaScript usw.)
+   verkürzen Sie Crawl-Zeit und verbessern Indexqualität.
+
+3. **Tiefenbeschränkung konfigurieren**
+
+   Konfigurieren Sie angemessene Tiefe entsprechend der Site-Struktur.
+   Unbegrenzt (-1) nur zum Crawlen der gesamten Site verwenden.
+
+4. **Maximale Zugriffszahl konfigurieren**
+
+   Legen Sie Obergrenze fest, um unerwartetes Crawlen großer Seitenmengen zu vermeiden.
+
+5. **Crawl-Intervall anpassen**
+
+   Konfigurieren Sie angemessenes Intervall entsprechend der Aktualisierungshäufigkeit.
+   - Häufig aktualisierte Sites: Jede Stunde bis alle paar Stunden
+   - Selten aktualisierte Sites: Täglich bis wöchentlich
+
+Empfehlungen für Zeitplankonfiguration
+--------------------------
+
+1. **Nächtliche Ausführung**
+
+   Führen Sie zu Zeiten niedriger Serverlast aus (z. B. 2 Uhr nachts).
+
+2. **Vermeidung doppelter Ausführung**
+
+   Konfigurieren Sie, dass der nächste Crawl erst nach Abschluss des vorherigen startet.
+
+3. **Benachrichtigung bei Fehlern**
+
+   Konfigurieren Sie E-Mail-Benachrichtigung bei Crawl-Fehlern.
+
+Referenzinformationen
+========
+
+- :doc:`crawler-advanced` - Erweiterte Crawler-Konfiguration
+- :doc:`crawler-thumbnail` - Thumbnail-Konfiguration
+- :doc:`setup-memory` - Speicherkonfiguration
+- :doc:`admin-logging` - Protokollkonfiguration

--- a/de/15.3/config/crawler-thumbnail.rst
+++ b/de/15.3/config/crawler-thumbnail.rst
@@ -1,0 +1,64 @@
+===============
+Konfiguration von Thumbnail-Bildern
+===============
+
+Anzeige von Thumbnail-Bildern
+===============
+
+|Fess| kann Thumbnail-Bilder in Suchergebnissen anzeigen.
+Thumbnail-Bilder werden basierend auf dem MIME-Typ der Suchergebnisse generiert.
+Bei unterstützten MIME-Typen werden Thumbnail-Bilder bei der Anzeige von Suchergebnissen generiert.
+Die Verarbeitung zur Generierung von Thumbnail-Bildern kann für jeden MIME-Typ konfiguriert und hinzugefügt werden.
+
+Um Thumbnail-Bilder anzuzeigen, melden Sie sich als Administrator an, aktivieren Sie die Thumbnail-Anzeige in den allgemeinen Einstellungen und speichern Sie.
+
+Thumbnail-Bilder für HTML-Dateien
+======================
+
+Für HTML-Thumbnails werden im HTML angegebene oder enthaltene Bilder verwendet.
+Thumbnail-Bilder werden in folgender Reihenfolge gesucht und angezeigt, wenn angegeben:
+
+- Der Wert des content-Attributs eines meta-Tags mit name-Attribut thumbnail
+- Der Wert des content-Attributs eines meta-Tags mit property-Attribut og:image
+- Bilder in geeigneter Größe für Thumbnails in img-Tags
+
+
+Thumbnail-Bilder für MS Office-Dateien
+===========================
+
+Thumbnail-Bilder für MS Office-Dateien werden mit LibreOffice und ImageMagick generiert.
+Wenn die Befehle unoconv und convert installiert sind, werden Thumbnail-Bilder generiert.
+
+Installation von Paketen
+------------------
+
+Bei Redhat-basierten Betriebssystemen installieren Sie folgende Pakete zur Bildgenerierung:
+
+::
+
+    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick
+
+Generierungsskript
+-----------
+
+Bei Installation über RPM/DEB-Paket wird das Thumbnail-Generierungsskript für MS Office unter /usr/share/fess/bin/generate-thumbnail installiert.
+
+Thumbnail-Bilder für PDF-Dateien
+=====================
+
+Thumbnail-Bilder für PDF werden mit ImageMagick generiert.
+Wenn der Befehl convert installiert ist, werden Thumbnail-Bilder generiert.
+
+Deaktivierung des Thumbnail-Jobs
+==================
+
+Um den Thumbnail-Job zu deaktivieren, konfigurieren Sie Folgendes:
+
+1. Entfernen Sie in der Verwaltungsoberfläche unter System > Allgemein das Häkchen bei „Thumbnail-Anzeige" und klicken Sie auf „Aktualisieren".
+2. Setzen Sie ``thumbnail.crawler.enabled`` in ``app/WEB-INF/classes/fess_config.properties`` oder ``/etc/fess/fess_config.properties`` auf ``false``.
+
+::
+
+    thumbnail.crawler.enabled=false
+
+3. Starten Sie den Fess-Dienst neu.

--- a/de/15.3/config/index.rst
+++ b/de/15.3/config/index.rst
@@ -1,0 +1,52 @@
+|Fess| Konfigurationsleitfaden
+================================
+
+Ein umfassender Leitfaden zur Konfiguration von |Fess|. Jeder Abschnitt ist nach Zweck organisiert.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Erste Schritte
+
+   intro
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Grundkonfiguration
+
+   setup-port-network
+   setup-memory
+   setup-windows-service
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Crawler-Konfiguration
+
+   crawler-basic
+   crawler-advanced
+   crawler-thumbnail
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Suchfunktionen-Konfiguration
+
+   search-basic
+   search-advanced
+   search-geosearch
+   search-scroll
+   search-form-integration
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Sicherheitskonfiguration
+
+   security-role
+   security-virtual-host
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Systemverwaltung
+
+   admin-logging
+   admin-index-backup
+   admin-analyzer
+   admin-opensearch-dashboards

--- a/de/15.3/config/intro.rst
+++ b/de/15.3/config/intro.rst
@@ -1,0 +1,49 @@
+======
+Einführung
+======
+
+Zielgruppe
+======
+
+Dieses Dokument richtet sich an Benutzer, die für die Konfiguration von |Fess| verantwortlich sind.
+
+Bevor Sie beginnen
+============
+
+Dieses Dokument beschreibt die Konfiguration von |Fess|.
+Grundlegende Kenntnisse im Umgang mit Computern sind erforderlich.
+
+Online-Zugriff
+=================
+
+Für Downloads, professionelle Dienstleistungen, Support und weitere Entwicklerinformationen besuchen Sie bitte:
+
+-  Projekt-Website: https://fess.codelibs.org/
+
+Technischer Support
+==================
+
+Bei technischen Fragen zu diesem Produkt, die sich nicht durch die Dokumentation lösen lassen, besuchen Sie bitte:
+
+-  Issues:
+   `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
+
+Kommerzieller Support
+---------
+
+Wenn Sie kommerziellen Support für technische Betreuung oder Wartung dieses Produkts benötigen, wenden Sie sich bitte an `N2SM, Inc. <https://www.n2sm.net/>`__.
+
+Hinweise zu Drittanbieter-Websites
+=============================
+
+Das |Fess|-Projekt übernimmt keine Verantwortung für die Gültigkeit von in diesem Dokument erwähnten Drittanbieter-Websites.
+Das |Fess|-Projekt übernimmt keine Gewährleistung, Verantwortung oder Verpflichtung für über solche Websites oder Ressourcen verfügbare Inhalte, Werbung, Produkte, Dienstleistungen oder andere Materialien.
+Das |Fess|-Projekt übernimmt keine Haftung oder Verantwortung für Schäden oder Verluste, die durch die Nutzung oder das Vertrauen auf über solche Websites oder Ressourcen verfügbare Inhalte, Werbung, Produkte, Dienstleistungen oder andere Materialien entstehen oder geltend gemacht werden.
+
+Kommentare und Vorschläge
+=====================
+
+Das |Fess|-Projekt ist bestrebt, diese Dokumentation zu verbessern, und begrüßt Kommentare und Vorschläge von Lesern.
+
+-  Mailingliste: `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
+

--- a/de/15.3/config/search-advanced.rst
+++ b/de/15.3/config/search-advanced.rst
@@ -1,0 +1,169 @@
+===========
+Suchbezogene Konfigurationen
+===========
+
+Die nachfolgend beschriebenen Einstellungen werden in fess_config.properties angegeben.
+Nach Änderungen ist ein Neustart von |Fess| erforderlich.
+
+Fuzzy-Suche
+=========
+
+Für 4 oder mehr Zeichen wird Fuzzy-Suche angewendet, die auch bei einem Zeichenunterschied Treffer erzielt.
+Um diese Einstellung zu deaktivieren, geben Sie `-1` an.
+::
+
+    query.boost.fuzzy.min.length=-1
+
+Such-Timeout-Wert
+=================
+
+Sie können den Timeout-Wert für Suchen angeben.
+Standardwert ist 10 Sekunden.
+::
+
+    query.timeout=10000
+
+Maximale Zeichenanzahl bei Suche
+==============
+
+Sie können die maximale Zeichenanzahl bei Suchen angeben.
+Standardwert ist 1000 Zeichen.
+::
+
+    query.max.length=1000
+
+Protokollierung von Such-Timeouts
+=======================
+
+Protokollierungseinstellung für den Fall von Such-Timeouts.
+Standardwert ist `true (aktiviert)`.
+::
+
+    query.timeout.logging=true
+
+Anzeige der Trefferzahl
+===========
+
+Geben Sie dies an, wenn Anzeige der Trefferzahl von über 10.000 Treffern erforderlich ist.
+Bei Standardeinstellung erfolgt bei über 10.000 Treffern folgende Anzeige:
+
+`Suchergebnisse für xxxxx ca. 10.000 oder mehr Treffer 1 - 10 von (4,94 Sekunden)`
+
+::
+
+    query.track.total.hits=10000
+
+Indexname für Standortsuche
+=======================
+
+Gibt den Indexnamen für Standortsuche an.
+Standardwert ist `location`.
+::
+
+    query.geo.fields=location
+
+Sprachspezifikation über Request-Parameter
+=======================
+
+Gibt den Parameternamen für Sprachspezifikation über Request-Parameter an.
+Beispielsweise wechselt die Anzeigesprache des Bildschirms zu Englisch, wenn der Request-Parameter als `browser_lang=en` in der URL übergeben wird.
+::
+
+    query.browser.lang.parameter.name=browser_lang
+
+Spezifikation der Präfixsuche
+==============
+
+Bei exakter Suche mit Angabe von `~\*` wird als Präfixsuche gesucht.
+Standardwert ist `true (aktiviert)`.
+::
+
+    query.replace.term.with.prefix.query=true
+
+Hervorhebungszeichen
+==============
+
+Sätze werden mit den hier angegebenen Zeichenfolgen getrennt, um natürliche Hervorhebung zu realisieren.
+Angegebene Zeichenfolgen werden als Unicode-Zeichen mit u als Anfangstrennzeichen angegeben.
+::
+
+    query.highlight.terminal.chars=u0021u002Cu002Eu003Fu0589u061Fu06D4u0700u0701u0702u0964u104Au104Bu1362u1367u1368u166Eu1803u1809u203Cu203Du2047u2048u2049u3002uFE52uFE57uFF01uFF0EuFF1FuFF61
+
+Standardwerte sind wie folgt konfiguriert (dekodiert konvertiert):
+
+``! , . ? ։ ؟ ۔ ܀ ܁ ܂ । ၊ ။ ። ፧ ፨ ᙮ ᠃ ᠉ ‼ ‽ ⁇ ⁈ ⁉ 。 ﹒ ﹗ ！ ． ？ ｡``
+
+Hervorhebungsfragmente
+==================
+
+Gibt Anzahl Zeichen und Anzahl Fragmente für Hervorhebungsfragmente an, die von OpenSearch abgerufen werden.
+::
+
+    query.highlight.fragment.size=60
+    query.highlight.number.of.fragments=2
+
+Hervorhebungs-Generierungsmethode
+==============
+
+Gibt die Hervorhebungs-Generierungsmethode von OpenSearch an.
+::
+
+    query.highlight.type=fvh
+
+Tags für Hervorhebung
+===============
+
+Gibt Start- und End-Tags für Hervorhebung an.
+::
+
+    query.highlight.tag.pre=<strong>
+    query.highlight.tag.post=</strong>
+
+An OpenSearch-Highlighter übergebene Werte
+===========================
+
+Gibt an OpenSearch-Highlighter übergebene Werte an.
+::
+
+    query.highlight.boundary.chars=u0009u000Au0013u0020
+    query.highlight.boundary.max.scan=20
+    query.highlight.boundary.scanner=chars
+    query.highlight.encoder=default
+
+Zu Response hinzuzufügende Feldnamen
+========================
+
+Gibt Feldnamen an, die zu Response bei normaler Suche oder API-Suche hinzugefügt werden.
+::
+
+    query.additional.response.fields=
+    query.additional.api.response.fields=
+
+Hinzufügen von Feldnamen
+==============
+
+Gibt an, wenn Suchfeldnamen oder Facetten-Feldnamen hinzugefügt werden.
+::
+
+    query.additional.search.fields=
+    query.additional.facet.fields=
+
+Konfiguration für GSA-kompatibles XML-Format bei Suchergebnissen
+===================================
+
+Wird beim Abrufen von Suchergebnissen im GSA-kompatiblen XML-Format verwendet.
+
+Gibt Feldnamen an, die zu Response bei Verwendung von GSA-kompatiblem XML-Format hinzugefügt werden.
+    ::
+
+        query.gsa.response.fields=UE,U,T,RK,S,LANG
+
+Gibt Sprache bei Verwendung von GSA-kompatiblem XML-Format an.
+    ::
+
+        query.gsa.default.lang=en
+
+Gibt Standard-Sortierung bei Verwendung von GSA-kompatiblem XML-Format an.
+    ::
+
+        query.gsa.default.sort=

--- a/de/15.3/config/search-basic.rst
+++ b/de/15.3/config/search-basic.rst
@@ -1,0 +1,234 @@
+========
+Suchfunktionen
+========
+
+Übersicht
+====
+
+|Fess| bietet leistungsstarke Volltextsuchfunktionen.
+Dieser Abschnitt beschreibt detaillierte Konfigurationen und Verwendungsmethoden der Suchfunktionen.
+
+Anzeige der Anzahl Suchergebnisse
+==================
+
+Standardverhalten
+----------------
+
+Wenn Suchergebnisse 10.000 Treffer überschreiten, wird auf dem Suchergebnisbildschirm „ca. 10.000 oder mehr Treffer" angezeigt.
+Dies ist die Standardeinstellung unter Berücksichtigung der OpenSearch-Leistung.
+
+Suchbeispiel
+
+|image0|
+
+.. |image0| image:: ../../../resources/images/ja/15.3/config/search-result.png
+
+Anzeige der genauen Trefferzahl
+----------------------
+
+Um die genaue Trefferzahl von über 10.000 Treffern anzuzeigen, ändern Sie in ``fess_config.properties`` folgende Einstellung:
+
+::
+
+    query.track.total.hits=100000
+
+Mit dieser Einstellung können Sie die genaue Trefferzahl bis zu maximal 100.000 Treffern abrufen.
+Beachten Sie jedoch, dass große Werte die Leistung beeinträchtigen können.
+
+.. warning::
+   Zu große Werte können die Suchleistung beeinträchtigen.
+   Konfigurieren Sie angemessene Werte entsprechend der tatsächlichen Nutzung.
+
+Suchoptionen
+==============
+
+Grundlegende Suche
+------------
+
+In |Fess| wird durch einfache Eingabe von Schlüsselwörtern in das Suchfeld eine Volltextsuche ausgeführt.
+Bei Eingabe mehrerer Schlüsselwörter wird eine UND-Suche ausgeführt.
+
+::
+
+    Suche Engine
+
+Im obigen Beispiel werden Dokumente gesucht, die sowohl „Suche" als auch „Engine" enthalten.
+
+ODER-Suche
+------
+
+Für ODER-Suchen fügen Sie ``OR`` zwischen Schlüsselwörtern ein.
+
+::
+
+    Suche OR Engine
+
+NICHT-Suche
+-------
+
+Um bestimmte Schlüsselwörter auszuschließen, setzen Sie ein ``-`` (Minuszeichen) vor das Schlüsselwort.
+
+::
+
+    Suche -Engine
+
+Phrasensuche
+------------
+
+Für exakte Phrasensuchen setzen Sie die Phrase in Anführungszeichen.
+
+::
+
+    "Suchmaschine"
+
+Feldspezifische Suche
+------------------
+
+Sie können nach bestimmten Feldern suchen.
+
+::
+
+    title:Suchmaschine
+    url:https://fess.codelibs.org/
+
+Hauptfelder:
+
+- ``title``: Dokumenttitel
+- ``content``: Dokumenthaupttext
+- ``url``: Dokument-URL
+- ``filetype``: Dateityp (z. B. pdf, html, doc)
+- ``label``: Label (Kategorie)
+
+Platzhaltersuche
+------------------
+
+Platzhaltersuche ist möglich.
+
+- ``*``: Beliebige Zeichenfolge (0 oder mehr Zeichen)
+- ``?``: Beliebiges einzelnes Zeichen
+
+::
+
+    Such*
+    Such?ine
+
+Fuzzy-Suche
+------------
+
+Fuzzy-Suche für Rechtschreibfehler und Schreibvarianten ist verfügbar.
+Standardmäßig wird Fuzzy-Suche automatisch auf Schlüsselwörter mit 4 oder mehr Zeichen angewendet.
+
+::
+
+    Suchmaschine~
+
+Durch Angabe einer Zahl nach ``~`` kann die Editierdistanz angegeben werden.
+
+Sortierung der Suchergebnisse
+================
+
+Suchergebnisse werden standardmäßig nach Relevanz sortiert.
+In den Verwaltungseinstellungen oder API-Parametern können Sie folgende Sortierreihenfolgen angeben:
+
+- Nach Relevanz (Standard)
+- Nach Aktualisierungsdatum
+- Nach Erstellungsdatum
+- Nach Dateigröße
+
+Facettensuche
+==============
+
+Mit Facettensuche können Sie Suchergebnisse nach Kategorien filtern.
+Standardmäßig ist das Label-Feld (label) als Facette konfiguriert.
+
+Durch Klicken auf Facetten links im Suchbildschirm können Sie Suchergebnisse eingrenzen.
+
+Hervorhebung von Suchergebnissen
+====================
+
+Suchschlüsselwörter werden in Titel und Zusammenfassung der Suchergebnisse hervorgehoben.
+Hervorhebungseinstellungen können in ``fess_config.properties`` angepasst werden.
+
+::
+
+    query.highlight.tag.pre=<strong>
+    query.highlight.tag.post=</strong>
+    query.highlight.fragment.size=60
+    query.highlight.number.of.fragments=2
+
+Vorschlagsfunktion
+==============
+
+Bei Eingabe in das Suchfeld werden Vorschläge (Autovervollständigung) angezeigt.
+Vorschläge basieren auf früheren Suchschlüsselwörtern oder beliebten Suchschlüsselwörtern.
+
+Die Vorschlagsfunktion kann in den allgemeinen Einstellungen der Verwaltungsoberfläche aktiviert/deaktiviert werden.
+
+Suchprotokoll
+========
+
+|Fess| protokolliert alle Suchabfragen und Klickprotokolle.
+Diese Protokolle können für folgende Zwecke verwendet werden:
+
+- Analyse und Verbesserung der Suchqualität
+- Analyse des Benutzerverhaltens
+- Identifizierung beliebter Suchschlüsselwörter
+- Identifizierung von Schlüsselwörtern ohne Suchergebnisse
+
+Suchprotokolle werden im ``fess_log``-Index von OpenSearch gespeichert
+und können in OpenSearch Dashboards visualisiert und analysiert werden.
+Details siehe :doc:`kibana`.
+
+Leistungsoptimierung
+==========================
+
+Konfiguration des Such-Timeouts
+----------------------
+
+Sie können die Such-Timeout-Zeit konfigurieren. Standard ist 10 Sekunden.
+
+::
+
+    query.timeout=10000
+
+Maximale Anzahl Zeichen für Suchabfragen
+----------------------
+
+Aus Sicherheits- und Leistungsgründen können Sie die maximale Anzahl Zeichen für Suchabfragen begrenzen.
+
+::
+
+    query.max.length=1000
+
+Cache-Nutzung
+----------------
+
+Durch Aktivierung des Caching von Suchergebnissen kann die Antwortzeit für identische Suchabfragen verkürzt werden.
+Passen Sie Cache-Einstellungen entsprechend den Systemanforderungen an.
+
+Fehlersuche
+======================
+
+Keine Suchergebnisse angezeigt
+----------------------
+
+1. Überprüfen Sie, ob der Index korrekt erstellt wurde.
+2. Überprüfen Sie, ob das Crawling erfolgreich abgeschlossen wurde.
+3. Überprüfen Sie, ob keine Zugriffsberechtigungen für Zieldokumente konfiguriert sind.
+4. Überprüfen Sie, ob OpenSearch ordnungsgemäß funktioniert.
+
+Langsame Suchgeschwindigkeit
+--------------
+
+1. Überprüfen Sie die Heap-Speichergröße von OpenSearch.
+2. Optimieren Sie Anzahl Shards und Replikate des Index.
+3. Überprüfen Sie die Komplexität der Suchabfrage.
+4. Überprüfen Sie Hardwareressourcen (CPU, Speicher, Disk-I/O).
+
+Ergebnisse mit geringer Relevanz angezeigt
+----------------------------
+
+1. Passen Sie Boost-Einstellungen an (``query.boost.title``, ``query.boost.content`` usw.).
+2. Überprüfen Sie Fuzzy-Such-Einstellungen.
+3. Überprüfen Sie Analyzer-Konfiguration.
+4. Konsultieren Sie bei Bedarf kommerziellen Support.

--- a/de/15.3/config/search-form-integration.rst
+++ b/de/15.3/config/search-form-integration.rst
@@ -1,0 +1,65 @@
+==============
+Platzierung von Suchformularen
+==============
+
+Methode zur Platzierung von Suchformularen
+=================
+
+Durch Platzierung eines Suchformulars auf einer bestehenden Website können Sie zu |Fess|-Suchergebnissen leiten.
+Hier wird am Beispiel erklärt, wie |Fess| unter https://search.n2sm.co.jp/ aufgebaut wird und Suchformulare auf einzelnen Seiten einer bestehenden Website platziert werden.
+
+Suchformular
+---------
+
+Platzieren Sie an der Stelle auf der Seite, wo Sie das Suchformular einfügen möchten, folgenden Code:
+
+::
+
+    <form id="searchForm" method="get" action="https://search.n2sm.co.jp/search/">
+    <input id="query" type="text" name="q" maxlength="1000" autocomplete="off">
+    <input type="submit" name="search" value="Suche">
+    </form>
+
+Passen Sie das Design entsprechend Ihrer Website an, indem Sie z. B. Klassennamen per class-Attribut hinzufügen und mit CSS nach Bedarf anpassen.
+Ändern Sie die URL https://search.n2sm.co.jp/ zur URL Ihres aufgebauten |Fess|-Servers.
+
+
+Vorschläge
+--------
+
+Sie können auch Vorschlagsfunktion für platzierte Suchformulare konfigurieren.
+Zur Konfiguration fügen Sie folgenden Code vor </body> hinzu:
+
+::
+
+    <script type="text/javascript" src="https://search.n2sm.co.jp/js/jquery-3.6.3.min.js"></script>
+    <script type="text/javascript" src="https://search.n2sm.co.jp/js/suggestor.js"></script>
+    <script>
+    $(function() {
+      $('#query').suggestor({
+        ajaxinfo : {
+          url : 'https://search.n2sm.co.jp/api/v1/suggest-words',
+          fn :  ["_default", "content", "title"],
+          num : 10
+        },
+        boxCssInfo: {
+          border: "1px solid rgba(82, 168, 236, 0.5)",
+          "-webkit-box-shadow":
+            "0 1px 1px 0px rgba(0, 0, 0, 0.1), 0 3px 2px 0px rgba(82, 168, 236, 0.2)",
+          "-moz-box-shadow":
+            "0 1px 1px 0px rgba(0, 0, 0, 0.1), 0 3px 2px 0px rgba(82, 168, 236, 0.2)",
+          "box-shadow":
+            "0 1px 1px 0px rgba(0, 0, 0, 0.1), 0 3px 2px 0px rgba(82, 168, 236, 0.2)",
+          "background-color": "#fff",
+          "z-index": "10000"
+        },
+        minterm: 2,
+        adjustWidthVal : 11,
+        searchForm : $('#searchForm')
+      });
+    });
+    </script>
+
+Falls Ihre Website bereits jQuery verwendet, müssen Sie das jQuery-script-Element nicht hinzufügen.
+
+Geben Sie für "z-index" einen Wert an, der sich nicht mit anderen Elementen überschneidet.

--- a/de/15.3/config/search-geosearch.rst
+++ b/de/15.3/config/search-geosearch.rst
@@ -1,0 +1,281 @@
+============
+Standortsuche
+============
+
+Übersicht
+====
+
+|Fess| kann geografische Bereichssuchen für Dokumente mit Breiten- und Längengraden durchführen.
+Mit dieser Funktion können Sie Dokumente innerhalb einer bestimmten Entfernung von einem bestimmten Punkt suchen
+oder Suchsysteme in Verbindung mit Kartendiensten wie Google Maps erstellen.
+
+Anwendungsfälle
+============
+
+Standortsuche kann für folgende Zwecke genutzt werden:
+
+- Geschäftssuche: Suche nach Geschäften in der Nähe des aktuellen Standorts des Benutzers
+- Immobiliensuche: Suche nach Immobilien innerhalb einer bestimmten Entfernung von einem bestimmten Bahnhof oder einer Einrichtung
+- Veranstaltungssuche: Suche nach Veranstaltungsinformationen in der Umgebung eines bestimmten Ortes
+- Einrichtungssuche: Suche nach Sehenswürdigkeiten oder öffentlichen Einrichtungen in der Nähe
+
+Konfigurationsmethode
+========
+
+Konfiguration bei Indexgenerierung
+------------------------
+
+Definition des Standortfeldes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+In |Fess| ist ``location`` als Standardfeld für Standortinformationen definiert.
+Dieses Feld ist als OpenSearch-Typ ``geo_point`` konfiguriert.
+
+Registrierungsformat für Standortinformationen
+~~~~~~~~~~~~~~~~~~
+
+Bei Indexgenerierung werden Breiten- und Längengrad durch Komma getrennt im ``location``-Feld festgelegt.
+
+**Format:**
+
+::
+
+    Breitengrad,Längengrad
+
+**Beispiel:**
+
+::
+
+    45.17614,-93.87341
+
+.. note::
+   Breitengrad wird im Bereich von -90 bis 90, Längengrad im Bereich von -180 bis 180 angegeben.
+
+Konfigurationsbeispiel für Datenspeicher-Crawling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bei Verwendung von Datenspeicher-Crawling werden Breiten- und Längengrade
+aus einer Datenquelle mit Standortinformationen im ``location``-Feld festgelegt.
+
+**Beispiel: Abruf aus Datenbank**
+
+::
+
+    SELECT
+        id,
+        name,
+        address,
+        CONCAT(latitude, ',', longitude) as location
+    FROM stores
+
+Hinzufügen von Standortinformationen per Skript
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sie können auch dynamisch Standortinformationen zu Dokumenten hinzufügen, indem Sie die Skriptfunktion der Crawl-Konfiguration verwenden.
+
+::
+
+    // Breiten- und Längengrad im location-Feld festlegen
+    doc.location = "35.681236,139.767125";
+
+Konfiguration bei Suche
+------------
+
+Für Standortsuche geben Sie Mittelpunkt und Bereich der Suche über Request-Parameter an.
+
+Request-Parameter
+~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Parametername
+     - Beschreibung
+   * - ``geo.location.point``
+     - Breiten-/Längengrad des Suchmittelpunkts (durch Komma getrennt)
+   * - ``geo.location.distance``
+     - Suchradius vom Mittelpunkt (mit Einheit)
+
+Entfernungseinheiten
+~~~~~~~~~~
+
+Für Entfernungen können folgende Einheiten verwendet werden:
+
+- ``km``: Kilometer
+- ``m``: Meter
+- ``mi``: Meilen
+- ``yd``: Yards
+
+Suchbeispiele
+======
+
+Grundlegende Suche
+------------
+
+Suche nach Dokumenten innerhalb eines Radius von 10 km vom Bahnhof Tokyo (35.681236, 139.767125):
+
+::
+
+    http://localhost:8080/search?q=Suchschlüsselwort&geo.location.point=35.681236,139.767125&geo.location.distance=10km
+
+Suche in der Nähe des aktuellen Standorts
+----------------
+
+Suche innerhalb 1 km vom aktuellen Standort des Benutzers:
+
+::
+
+    http://localhost:8080/search?q=Ramen&geo.location.point=35.681236,139.767125&geo.location.distance=1km
+
+Sortierung nach Entfernung
+----------------
+
+Um Suchergebnisse nach Entfernung zu sortieren, verwenden Sie den ``sort``-Parameter.
+
+::
+
+    http://localhost:8080/search?q=Convenience&geo.location.point=35.681236,139.767125&geo.location.distance=5km&sort=location.distance
+
+Verwendung in API
+-----------
+
+Standortsuche kann auch in JSON-API verwendet werden.
+
+::
+
+    curl -X POST "http://localhost:8080/json/?q=Hotel" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "geo.location.point": "35.681236,139.767125",
+        "geo.location.distance": "5km"
+      }'
+
+Anpassung von Feldnamen
+==========================
+
+Änderung des Standard-Feldnamens
+----------------------------
+
+Um den für Standortsuche verwendeten Feldnamen zu ändern,
+ändern Sie in ``fess_config.properties`` folgende Einstellung:
+
+::
+
+    query.geo.fields=location
+
+Zur Angabe mehrerer Feldnamen trennen Sie diese durch Kommas.
+
+::
+
+    query.geo.fields=location,geo_point,coordinates
+
+Implementierungsbeispiele
+======
+
+Implementierung in Webanwendung
+---------------------------
+
+Beispiel für Suche mit JavaScript unter Abruf des aktuellen Standorts:
+
+.. code-block:: javascript
+
+    // Aktuellen Standort mit Browser-Geolocation-API abrufen
+    navigator.geolocation.getCurrentPosition(function(position) {
+        const latitude = position.coords.latitude;
+        const longitude = position.coords.longitude;
+        const distance = "5km";
+
+        // Such-URL erstellen
+        const searchUrl = `/search?q=&geo.location.point=${latitude},${longitude}&geo.location.distance=${distance}`;
+
+        // Suche ausführen
+        window.location.href = searchUrl;
+    });
+
+Integration mit Google Maps
+--------------------
+
+Beispiel für Anzeige von Suchergebnissen als Marker auf Google Maps:
+
+.. code-block:: javascript
+
+    // Karte initialisieren
+    const map = new google.maps.Map(document.getElementById('map'), {
+        center: {lat: 35.681236, lng: 139.767125},
+        zoom: 13
+    });
+
+    // Standortsuche mit Fess-API ausführen
+    fetch('/json/?q=Geschäfte&geo.location.point=35.681236,139.767125&geo.location.distance=5km')
+        .then(response => response.json())
+        .then(data => {
+            // Suchergebnisse als Marker anzeigen
+            data.response.result.forEach(doc => {
+                if (doc.location) {
+                    const [lat, lng] = doc.location.split(',').map(Number);
+                    new google.maps.Marker({
+                        position: {lat: lat, lng: lng},
+                        map: map,
+                        title: doc.title
+                    });
+                }
+            });
+        });
+
+Leistungsoptimierung
+====================
+
+Optimierung der Indexeinstellungen
+------------------------
+
+Bei Umgang mit großen Mengen an Standortdaten optimieren Sie Indexeinstellungen.
+
+Überprüfen Sie Standortfeld-Einstellungen in ``app/WEB-INF/classes/fess_indices/fess.json``.
+
+::
+
+    "location": {
+        "type": "geo_point"
+    }
+
+Beschränkung des Suchbereichs
+--------------
+
+Aus Leistungsgründen wird empfohlen, den Suchbereich auf das notwendige Minimum zu beschränken.
+
+- Weitreichende Suchen (50 km oder mehr) können längere Verarbeitungszeiten erfordern
+- Konfigurieren Sie angemessene Bereiche je nach Verwendungszweck
+
+Fehlersuche
+======================
+
+Standortsuche funktioniert nicht
+------------------------
+
+1. Überprüfen Sie, ob Daten korrekt im ``location``-Feld gespeichert sind.
+2. Überprüfen Sie, ob das Breiten-/Längengrad-Format korrekt ist (durch Komma getrennt).
+3. Überprüfen Sie, ob ``location`` im OpenSearch-Index-Mapping als ``geo_point``-Typ definiert ist.
+
+Keine Suchergebnisse zurückgegeben
+----------------------
+
+1. Überprüfen Sie, ob Dokumente innerhalb der angegebenen Entfernung existieren.
+2. Überprüfen Sie, ob Breiten-/Längengradwerte im korrekten Bereich liegen (Breitengrad: -90~90, Längengrad: -180~180).
+3. Überprüfen Sie, ob Entfernungseinheit korrekt angegeben ist.
+
+Standortinformationen werden nicht korrekt angezeigt
+----------------------------
+
+1. Überprüfen Sie, ob ``location``-Feld beim Crawling korrekt festgelegt wurde.
+2. Überprüfen Sie, ob Breiten-/Längengrad-Datentyp in der Datenquelle numerisch ist.
+3. Bei Festlegung von Standortinformationen per Skript überprüfen Sie, ob das Zeichenfolgen-Konkatenationsformat korrekt ist.
+
+Referenzinformationen
+========
+
+Für Details zur Standortsuche siehe folgende Ressourcen:
+
+- `OpenSearch Geo Queries <https://opensearch.org/docs/latest/query-dsl/geo-and-xy/index/>`_
+- `OpenSearch Geo Point <https://opensearch.org/docs/latest/field-types/supported-field-types/geo-point/>`_
+- `Geolocation API (MDN) <https://developer.mozilla.org/de/docs/Web/API/Geolocation_API>`_

--- a/de/15.3/config/search-scroll.rst
+++ b/de/15.3/config/search-scroll.rst
@@ -1,0 +1,387 @@
+==================
+Massen-Abruf von Suchergebnissen
+==================
+
+Übersicht
+====
+
+Bei normaler Suche in |Fess| wird durch Paging-Funktion nur eine bestimmte Anzahl von Suchergebnissen angezeigt.
+Wenn Sie alle Suchergebnisse auf einmal abrufen möchten, verwenden Sie die Scroll-Search-Funktion.
+
+Diese Funktion ist nützlich, wenn alle Suchergebnisse verarbeitet werden müssen,
+z. B. für Massen-Datenexport, Backup oder Analyse großer Datenmengen.
+
+Anwendungsfälle
+============
+
+Scroll-Suche eignet sich für folgende Zwecke:
+
+- Vollständiger Export von Suchergebnissen
+- Abruf großer Datenmengen für Datenanalyse
+- Datenabruf in Batch-Verarbeitung
+- Datensynchronisation mit externen Systemen
+- Datenerfassung für Berichtsgenerierung
+
+.. warning::
+   Scroll-Suche gibt große Datenmengen zurück und verbraucht daher mehr
+   Serverressourcen im Vergleich zur normalen Suche. Aktivieren Sie nur bei Bedarf.
+
+Konfigurationsmethode
+========
+
+Aktivierung der Scroll-Suche
+----------------------
+
+Standardmäßig ist Scroll-Suche aus Sicherheits- und Leistungsgründen deaktiviert.
+Zur Aktivierung ändern Sie in ``fess_config.properties`` oder ``/etc/fess/fess_config.properties``
+folgende Einstellung:
+
+::
+
+    api.search.scroll=true
+
+.. note::
+   Nach Konfigurationsänderung muss |Fess| neu gestartet werden.
+
+Konfiguration von Response-Feldern
+--------------------------
+
+Sie können Felder anpassen, die in Suchergebnissen enthalten sind.
+Standardmäßig werden nur Grundfelder zurückgegeben, Sie können jedoch zusätzliche Felder angeben.
+
+::
+
+    query.additional.scroll.response.fields=content,mimetype,filename,created,last_modified
+
+Bei Angabe mehrerer Felder trennen Sie diese durch Kommas.
+
+Timeout-Einstellung für Scroll
+----------------------------
+
+Sie können die Gültigkeitsdauer des Scroll-Kontexts konfigurieren.
+Standard ist 1 Minute.
+
+::
+
+    api.search.scroll.timeout=1m
+
+Einheiten:
+- ``s``: Sekunden
+- ``m``: Minuten
+- ``h``: Stunden
+
+Verwendungsmethode
+========
+
+Grundlegende Verwendung
+----------------
+
+Zugriff auf Scroll-Suche erfolgt über folgende URL:
+
+::
+
+    http://localhost:8080/json/scroll?q=Suchschlüsselwort
+
+Suchergebnisse werden im NDJSON-Format (Newline Delimited JSON) zurückgegeben.
+Pro Zeile wird ein Dokument im JSON-Format ausgegeben.
+
+**Beispiel:**
+
+::
+
+    curl "http://localhost:8080/json/scroll?q=Fess"
+
+Request-Parameter
+--------------------
+
+Für Scroll-Suche können folgende Parameter verwendet werden:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Parametername
+     - Beschreibung
+   * - ``q``
+     - Suchabfrage (erforderlich)
+   * - ``size``
+     - Anzahl pro Scroll-Abruf (Standard: 100)
+   * - ``scroll``
+     - Gültigkeitszeit des Scroll-Kontexts (Standard: 1m)
+   * - ``fields.label``
+     - Filterung nach Label
+
+Angabe von Suchabfragen
+----------------
+
+Sie können Suchabfragen wie bei normaler Suche angeben.
+
+**Beispiel: Schlüsselwortsuche**
+
+::
+
+    curl "http://localhost:8080/json/scroll?q=Suchmaschine"
+
+**Beispiel: Feldspezifische Suche**
+
+::
+
+    curl "http://localhost:8080/json/scroll?q=title:Fess"
+
+**Beispiel: Vollständiger Abruf (ohne Suchbedingung)**
+
+::
+
+    curl "http://localhost:8080/json/scroll?q=*:*"
+
+Angabe der Abrufanzahl
+--------------
+
+Sie können die Anzahl pro Scroll-Abruf ändern.
+
+::
+
+    curl "http://localhost:8080/json/scroll?q=Fess&size=500"
+
+.. note::
+   Zu großer ``size``-Parameter erhöht Speichernutzung.
+   Normalerweise wird Bereich von 100–1000 empfohlen.
+
+Filterung nach Label
+--------------------------
+
+Sie können nur Dokumente bestimmter Labels abrufen.
+
+::
+
+    curl "http://localhost:8080/json/scroll?q=*:*&fields.label=public"
+
+Bei erforderlicher Authentifizierung
+----------------
+
+Bei Verwendung rollenbasierter Suche müssen Sie Authentifizierungsinformationen einschließen.
+
+::
+
+    curl -u username:password "http://localhost:8080/json/scroll?q=Fess"
+
+Oder mit API-Token:
+
+::
+
+    curl -H "Authorization: Bearer YOUR_API_TOKEN" \
+         "http://localhost:8080/json/scroll?q=Fess"
+
+Response-Format
+==============
+
+NDJSON-Format
+----------
+
+Scroll-Such-Response wird im NDJSON-Format (Newline Delimited JSON) zurückgegeben.
+Jede Zeile repräsentiert ein Dokument.
+
+**Beispiel:**
+
+::
+
+    {"url":"http://example.com/page1","title":"Page 1","content":"..."}
+    {"url":"http://example.com/page2","title":"Page 2","content":"..."}
+    {"url":"http://example.com/page3","title":"Page 3","content":"..."}
+
+Response-Felder
+--------------------
+
+Standardmäßig enthaltene Hauptfelder:
+
+- ``url``: Dokument-URL
+- ``title``: Titel
+- ``content``: Haupttext (Auszug)
+- ``score``: Such-Score
+- ``boost``: Boost-Wert
+- ``created``: Erstellungsdatum
+- ``last_modified``: Letztes Änderungsdatum
+
+Datenverarbeitungsbeispiele
+============
+
+Verarbeitungsbeispiel mit Python
+----------------
+
+.. code-block:: python
+
+    import requests
+    import json
+
+    # Scroll-Suche ausführen
+    url = "http://localhost:8080/json/scroll"
+    params = {
+        "q": "Fess",
+        "size": 100
+    }
+
+    response = requests.get(url, params=params, stream=True)
+
+    # NDJSON-Response zeilenweise verarbeiten
+    for line in response.iter_lines():
+        if line:
+            doc = json.loads(line)
+            print(f"Title: {doc.get('title')}")
+            print(f"URL: {doc.get('url')}")
+            print("---")
+
+Speichern in Datei
+----------------
+
+Beispiel zum Speichern von Suchergebnissen in Datei:
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/json/scroll?q=*:*" > all_documents.ndjson
+
+Konvertierung zu CSV
+-----------
+
+Beispiel für Konvertierung zu CSV mit jq-Befehl:
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/json/scroll?q=Fess" | \
+        jq -r '[.url, .title, .score] | @csv' > results.csv
+
+Datenanalyse
+----------
+
+Beispiel für Analyse abgerufener Daten:
+
+.. code-block:: python
+
+    import json
+    import pandas as pd
+    from collections import Counter
+
+    # NDJSON-Datei einlesen
+    documents = []
+    with open('all_documents.ndjson', 'r') as f:
+        for line in f:
+            documents.append(json.loads(line))
+
+    # In DataFrame konvertieren
+    df = pd.DataFrame(documents)
+
+    # Grundstatistik
+    print(f"Total documents: {len(df)}")
+    print(f"Average score: {df['score'].mean()}")
+
+    # URL-Domain-Analyse
+    df['domain'] = df['url'].apply(lambda x: x.split('/')[2])
+    print(df['domain'].value_counts())
+
+Leistung und Best Practices
+==================================
+
+Effiziente Verwendung
+----------------
+
+1. **Angemessene size-Parameter-Einstellung**
+
+   - Zu klein erhöht Kommunikations-Overhead
+   - Zu groß erhöht Speichernutzung
+   - Empfohlen: 100–1000
+
+2. **Optimierung von Suchbedingungen**
+
+   - Suchbedingungen so angeben, dass nur benötigte Dokumente abgerufen werden
+   - Vollständigen Abruf nur bei wirklichem Bedarf ausführen
+
+3. **Nutzung von Off-Peak-Zeiten**
+
+   - Abruf großer Datenmengen in Zeiten niedriger Systemlast ausführen
+
+4. **Verwendung in Batch-Verarbeitung**
+
+   - Regelmäßige Datensynchronisation als Batch-Job ausführen
+
+Optimierung der Speichernutzung
+--------------------
+
+Bei Verarbeitung großer Datenmengen verwenden Sie Streaming-Verarbeitung zur Reduzierung der Speichernutzung.
+
+.. code-block:: python
+
+    import requests
+    import json
+
+    url = "http://localhost:8080/json/scroll"
+    params = {"q": "*:*", "size": 100}
+
+    # Mit Streaming verarbeiten
+    with requests.get(url, params=params, stream=True) as response:
+        for line in response.iter_lines(decode_unicode=True):
+            if line:
+                doc = json.loads(line)
+                # Dokumentverarbeitung
+                process_document(doc)
+
+Sicherheitsüberlegungen
+====================
+
+Zugriffsbeschränkung
+------------
+
+Da Scroll-Suche große Datenmengen zurückgibt, konfigurieren Sie angemessene Zugriffsbeschränkungen.
+
+1. **IP-Adressen-Beschränkung**
+
+   Zugriff nur von bestimmten IP-Adressen erlauben
+
+2. **API-Authentifizierung**
+
+   API-Token oder Basic-Authentifizierung verwenden
+
+3. **Rollenbasierte Beschränkung**
+
+   Zugriff nur für Benutzer mit bestimmten Rollen erlauben
+
+Rate-Limiting
+----------
+
+Zur Vermeidung übermäßigen Zugriffs wird Konfiguration von Rate-Limiting im Reverse-Proxy empfohlen.
+
+Fehlersuche
+======================
+
+Scroll-Suche nicht verfügbar
+----------------------------
+
+1. Überprüfen Sie, ob ``api.search.scroll`` auf ``true`` gesetzt ist.
+2. Überprüfen Sie, ob |Fess| neu gestartet wurde.
+3. Überprüfen Sie Fehlerprotokolle.
+
+Timeout-Fehler tritt auf
+----------------------------
+
+1. Erhöhen Sie Wert von ``api.search.scroll.timeout``.
+2. Verkleinern Sie ``size``-Parameter für verteilte Verarbeitung.
+3. Grenzen Sie Suchbedingungen ein, um abzurufende Datenmenge zu reduzieren.
+
+Speichermangel-Fehler
+----------------
+
+1. Verkleinern Sie ``size``-Parameter.
+2. Erhöhen Sie Heap-Speichergröße von |Fess|.
+3. Überprüfen Sie Heap-Speichergröße von OpenSearch.
+
+Response ist leer
+--------------------
+
+1. Überprüfen Sie, ob Suchabfrage korrekt ist.
+2. Überprüfen Sie, ob angegebene Labels oder Filterbedingungen korrekt sind.
+3. Überprüfen Sie Berechtigungseinstellungen für rollenbasierte Suche.
+
+Referenzinformationen
+========
+
+- :doc:`search-basic` - Details zu Suchfunktionen
+- :doc:`search-advanced` - Suchbezogene Konfigurationen
+- `OpenSearch Scroll API <https://opensearch.org/docs/latest/api-reference/scroll/>`_

--- a/de/15.3/config/security-role.rst
+++ b/de/15.3/config/security-role.rst
@@ -1,0 +1,54 @@
+=================
+Konfiguration rollenbasierter Suche
+=================
+
+Über rollenbasierte Suche
+==================
+
+|Fess| kann Suchergebnisse basierend auf Authentifizierungsinformationen von Benutzern differenzieren, die durch beliebige Authentifizierungssysteme authentifiziert wurden.
+Beispielsweise werden für Benutzer A mit Rolle a Suchergebnisse mit Informationen für Rolle a angezeigt, aber Benutzer B ohne Rolle a sieht diese bei Suche nicht.
+Mit dieser Funktion können Sie Suche nach Abteilung, Position usw. in Portalen oder Single-Sign-On-Umgebungen für angemeldete Benutzer realisieren.
+
+Bei rollenbasierter Suche in |Fess| können Rolleninformationen aus folgenden Quellen abgerufen werden:
+
+-  Request-Parameter
+
+-  Request-Header
+
+-  Cookie
+
+-  |Fess|-Authentifizierungsinformationen
+
+Bei Portal- oder Agent-basierten Single-Sign-On-Systemen können Rolleninformationen abgerufen werden, indem bei Authentifizierung Authentifizierungsinformationen per Cookie für Domain und Pfad gespeichert werden, auf dem |Fess| läuft.
+Bei Reverse-Proxy-basierten Single-Sign-On-Systemen können Rolleninformationen abgerufen werden, indem bei Zugriff auf |Fess| Authentifizierungsinformationen zu Request-Parametern oder Request-Headern hinzugefügt werden.
+
+Konfiguration rollenbasierter Suche
+=================
+
+Hier wird die Konfigurationsmethode für rollenbasierte Suche unter Verwendung von |Fess|-Authentifizierungsinformationen erklärt.
+
+Konfiguration in |Fess|-Verwaltungsoberfläche
+---------------------
+
+Starten Sie |Fess| und melden Sie sich als Administrator an.
+Erstellen Sie Rollen und Benutzer.
+Erstellen Sie beispielsweise Role1 im Rollen-Verwaltungsbildschirm und erstellen Sie im Benutzer-Verwaltungsbildschirm einen Benutzer, der zu Role1 gehört.
+Beschreiben Sie als nächstes in der Crawl-Konfiguration im Berechtigungsfeld {role}Role1 und speichern Sie.
+Für Benutzer-spezifische Angabe können Sie {user}Benutzername schreiben, für Gruppen-spezifische Angabe {group}Gruppenname.
+Danach wird durch Crawlen mit dieser Crawl-Konfiguration ein Index erstellt, der nur für erstellte Benutzer durchsuchbar ist.
+
+Anmeldung
+------
+
+Melden Sie sich von der Verwaltungsoberfläche ab.
+Melden Sie sich mit Benutzer an, der zu Role1 gehört.
+Bei erfolgreicher Anmeldung werden Sie zur Startseite des Suchbildschirms weitergeleitet.
+
+Bei normaler Suche werden nur Einträge angezeigt, für die in der Crawl-Konfiguration Rolleneinstellung Role1 konfiguriert wurde.
+
+Bei Suche ohne Anmeldung erfolgt Suche als Gastbenutzer (guest).
+
+Abmeldung
+--------
+
+Im angemeldeten Zustand mit Benutzer außer Administrator wählen Sie Abmeldung im Suchbildschirm, um sich abzumelden.

--- a/de/15.3/config/security-virtual-host.rst
+++ b/de/15.3/config/security-virtual-host.rst
@@ -1,0 +1,53 @@
+========
+Virtueller Host
+========
+
+Über virtuelle Hosts
+==============
+
+|Fess| kann Suchergebnisse basierend auf dem Hostnamen (Hostteil der URL) differenzieren, mit dem auf |Fess| zugegriffen wird.
+Da Suchergebnisse in jeweiligen JSPs angezeigt werden, kann auch das Design geändert werden.
+
+Systemkonfiguration
+----------
+
+Konfigurieren Sie "Virtueller Host" unter :doc:`Administratorhandbuch > Allgemeine Einstellungen <../admin/general-guide>`. Geben Sie den hier konfigurierten virtuellen Hostnamen in der Crawl-Konfiguration an.
+
+**Format**
+
+::
+
+   Host:Hostname[:Portnummer]=Virtueller Hostname
+
+.. list-table::
+
+   * - *Hostname*
+     - Hostname oder IP-Adresse, die im System aufgelöst werden kann (DNS)
+   * - *Portnummer*
+     - Optional. Standard ist 80.
+   * - *Virtueller Hostname*
+     - Virtueller Hostname, der in Crawl-Konfiguration angegeben wird
+
+**Beispiel**
+
+::
+
+   Host:abc.example.com:8080=host1
+   Host:192.168.1.123:8080=host2
+
+Nach Konfiguration werden JSPs der Suchseite unter ``WEB-INF/view/Virtueller Hostname`` generiert.
+Durch Bearbeitung dieser können Sie Seitendesign für jeden virtuellen Host ändern.
+
+
+Crawl-Konfiguration
+---------
+
+Geben Sie "Virtueller Host" in Web-Crawl-Konfiguration, Datei-Crawl-Konfiguration oder Datenspeicher-Crawl-Konfiguration an.
+"Virtueller Host" gibt einen der in Systemkonfiguration konfigurierten virtuellen Hostnamen an.
+
+**Beispiel**
+
+.. list-table::
+
+   * - *Virtueller Host*
+     - ``host1``

--- a/de/15.3/config/setup-memory.rst
+++ b/de/15.3/config/setup-memory.rst
@@ -1,0 +1,414 @@
+============
+Speicherkonfiguration
+============
+
+Übersicht
+====
+
+Java-Anwendungen erfordern die Konfiguration des maximalen Heap-Speichers pro Prozess.
+Bei |Fess| werden Speichereinstellungen für die folgenden drei Komponenten separat konfiguriert.
+
+- Fess-Webanwendung
+- Crawler-Prozess
+- OpenSearch
+
+Durch angemessene Speicherkonfiguration können Leistungsverbesserungen und stabiler Betrieb erreicht werden.
+
+Speicherkonfiguration der Fess-Webanwendung
+======================================
+
+Situationen, in denen Konfiguration erforderlich ist
+----------------
+
+Erwägen Sie die Anpassung der Speichergröße in folgenden Fällen:
+
+- OutOfMemory-Fehler werden in ``fess.log`` aufgezeichnet
+- Hohe Anzahl gleichzeitiger Zugriffe muss verarbeitet werden
+- Verwaltungsoberfläche ist langsam oder läuft in einen Timeout
+
+Die Standardspeichergröße ist für normale Nutzung ausreichend, aber in Umgebungen mit hoher Last ist eine Erhöhung erforderlich.
+
+Konfiguration über Umgebungsvariablen
+------------------
+
+Setzen Sie die Umgebungsvariable ``FESS_HEAP_SIZE``.
+
+::
+
+    export FESS_HEAP_SIZE=2g
+
+Einheiten:
+
+- ``m``: Megabyte
+- ``g``: Gigabyte
+
+Bei RPM/DEB-Paketen
+------------------------
+
+Bei Installation über RPM-Paket bearbeiten Sie ``/etc/sysconfig/fess``.
+
+::
+
+    FESS_HEAP_SIZE=2g
+
+Bei DEB-Paketen bearbeiten Sie ``/etc/default/fess``.
+
+::
+
+    FESS_HEAP_SIZE=2g
+
+.. warning::
+   Nach Änderung der Speichergröße muss der |Fess|-Dienst neu gestartet werden.
+
+Empfohlene Speichergrößen
+----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Umgebung
+     - Empfohlene Heap-Größe
+     - Anmerkungen
+   * - Entwicklungs-/Testumgebung
+     - 512m–1g
+     - Kleine Indizes
+   * - Kleine Produktionsumgebung
+     - 1g–2g
+     - Zehntausende bis hunderttausende Dokumente
+   * - Mittlere Produktionsumgebung
+     - 2g–4g
+     - Hunderttausende bis Millionen Dokumente
+   * - Große Produktionsumgebung
+     - 4g–8g
+     - Mehrere Millionen Dokumente
+
+Speicherkonfiguration des Crawlers
+======================
+
+Situationen, in denen Konfiguration erforderlich ist
+----------------
+
+In folgenden Fällen muss die Speichergröße des Crawlers erhöht werden:
+
+- Bei Erhöhung der Anzahl paralleler Crawls
+- Beim Crawlen großer Dateien
+- Bei Auftreten von OutOfMemory-Fehlern während der Crawler-Ausführung
+
+Konfigurationsmethode
+--------
+
+Bearbeiten Sie ``app/WEB-INF/classes/fess_config.properties`` oder ``/etc/fess/fess_config.properties``.
+
+::
+
+    jvm.crawler.options=-Xmx512m
+
+Beispiel für Änderung auf 1 GB:
+
+::
+
+    jvm.crawler.options=-Xmx1g
+
+.. note::
+   Diese Einstellung wird pro Crawler-Prozess (pro Scheduler-Job) angewendet.
+   Bei gleichzeitiger Ausführung mehrerer Crawler-Jobs wird für jeden Job der angegebene Speicher verwendet.
+
+Empfohlene Einstellungen
+--------
+
+- **Normales Web-Crawling**: 512m–1g
+- **Massiv paralleles Crawling**: 1g–2g
+- **Crawlen großer Dateien**: 2g–4g
+
+Detaillierte JVM-Optionen
+------------------
+
+Detaillierte JVM-Optionen für den Crawler können über ``jvm.crawler.options`` konfiguriert werden.
+Die Standardkonfiguration umfasst folgende Optimierungen:
+
+**Hauptoptionen:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Option
+     - Beschreibung
+   * - ``-Xms128m -Xmx512m``
+     - Initiale und maximale Heap-Größe
+   * - ``-XX:MaxMetaspaceSize=128m``
+     - Maximale Metaspace-Größe
+   * - ``-XX:+UseG1GC``
+     - Verwendung des G1-Garbage-Collectors
+   * - ``-XX:MaxGCPauseMillis=60000``
+     - Ziel für GC-Pausenzeit (60 Sekunden)
+   * - ``-XX:-HeapDumpOnOutOfMemoryError``
+     - Deaktivierung von Heap-Dumps bei OutOfMemory
+
+Speicherkonfiguration von OpenSearch
+=======================
+
+Wichtige Überlegungen
+--------------
+
+Bei OpenSearch müssen folgende zwei Punkte für die Speicherkonfiguration berücksichtigt werden:
+
+1. **Java-Heap-Speicher**: Verwendet vom OpenSearch-Prozess
+2. **OS-Dateisystem-Cache**: Wichtig für Such-Performance
+
+.. warning::
+   Wenn der Java-Heap-Speicher zu groß eingestellt wird, verringert sich
+   der für den OS-Dateisystem-Cache verfügbare Speicher,
+   was die Such-Performance beeinträchtigt.
+
+Konfigurationsmethode
+--------
+
+Linux-Umgebungen
+~~~~~~~~~
+
+Der Heap-Speicher von OpenSearch wird über Umgebungsvariablen oder die OpenSearch-Konfigurationsdatei angegeben.
+
+Konfiguration über Umgebungsvariable:
+
+::
+
+    export OPENSEARCH_HEAP_SIZE=2g
+
+Oder bearbeiten Sie ``config/jvm.options``:
+
+::
+
+    -Xms2g
+    -Xmx2g
+
+.. note::
+   Es wird empfohlen, die minimale Heap-Größe (``-Xms``) und die maximale Heap-Größe (``-Xmx``) auf denselben Wert zu setzen.
+
+Windows-Umgebungen
+~~~~~~~~~~~
+
+Bearbeiten Sie die Datei ``config\jvm.options``.
+
+::
+
+    -Xms2g
+    -Xmx2g
+
+Empfohlene Speichergrößen
+----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Indexgröße
+     - Empfohlene Heap-Größe
+     - Empfohlener Gesamtspeicher
+   * - ~10 GB
+     - 2g
+     - 4 GB oder mehr
+   * - 10 GB–50 GB
+     - 4g
+     - 8 GB oder mehr
+   * - 50 GB–100 GB
+     - 8g
+     - 16 GB oder mehr
+   * - Über 100 GB
+     - 16g–31g
+     - 32 GB oder mehr
+
+.. warning::
+   Der Heap-Speicher von OpenSearch sollte 32 GB nicht überschreiten.
+   Bei über 32 GB wird Compressed OOP deaktiviert und die Speichereffizienz nimmt ab.
+
+Best Practices
+------------------
+
+1. **50% des physischen Speichers dem Heap zuweisen**
+
+   Weisen Sie etwa 50% des physischen Speichers des Servers dem OpenSearch-Heap zu.
+   Der Rest wird für OS und Dateisystem-Cache verwendet.
+
+2. **Maximum von 31 GB**
+
+   Die Heap-Größe sollte maximal 31 GB betragen. Bei höherem Bedarf sollten zusätzliche Knoten hinzugefügt werden.
+
+3. **Überprüfung in Produktionsumgebungen**
+
+   Konsultieren Sie die offizielle OpenSearch-Dokumentation für optimale umgebungsspezifische Einstellungen.
+
+Speicherkonfiguration für Vorschlag- und Thumbnail-Verarbeitung
+======================================
+
+Vorschlags-Generierungsprozess
+----------------------
+
+Die Speicherkonfiguration für die Vorschlags-Generierung wird über ``jvm.suggest.options`` konfiguriert.
+
+::
+
+    jvm.suggest.options=-Xmx256m
+
+Standardmäßig werden folgende Einstellungen verwendet:
+
+- Initialer Heap: 128 MB
+- Maximaler Heap: 256 MB
+- Maximaler Metaspace: 128 MB
+
+Thumbnail-Generierungsprozess
+----------------------
+
+Die Speicherkonfiguration für die Thumbnail-Generierung wird über ``jvm.thumbnail.options`` konfiguriert.
+
+::
+
+    jvm.thumbnail.options=-Xmx256m
+
+Standardmäßig werden folgende Einstellungen verwendet:
+
+- Initialer Heap: 128 MB
+- Maximaler Heap: 256 MB
+- Maximaler Metaspace: 128 MB
+
+.. note::
+   Bei der Verarbeitung großer Bilder für die Thumbnail-Generierung muss der Speicher erhöht werden.
+
+Speicherüberwachung und -Tuning
+========================
+
+Überprüfung der Speichernutzung
+--------------------
+
+Speichernutzung von Fess
+~~~~~~~~~~~~~~~~~~~~~
+
+Kann in der Verwaltungsoberfläche unter „Systeminformationen" überprüft werden.
+
+Oder verwenden Sie JVM-Überwachungstools:
+
+::
+
+    jps -l  # Fess-Prozesse anzeigen
+    jstat -gcutil <PID> 1000  # GC-Statistiken jede Sekunde anzeigen
+
+Speichernutzung von OpenSearch
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    curl -X GET "localhost:9201/_nodes/stats/jvm?pretty"
+    curl -X GET "localhost:9201/_cat/nodes?v&h=heap.percent,ram.percent"
+
+Anzeichen von Speichermangel
+----------------
+
+Bei folgenden Symptomen besteht möglicherweise Speichermangel.
+
+**Fess-Webanwendung:**
+
+- Langsame Antwortzeiten
+- ``OutOfMemoryError`` in Protokollen aufgezeichnet
+- Prozess beendet sich unerwartet
+
+**Crawler:**
+
+- Crawling stoppt mittendrin
+- ``OutOfMemoryError`` in ``fess_crawler.log`` aufgezeichnet
+- Crawlen großer Dateien schlägt fehl
+
+**OpenSearch:**
+
+- Langsame Suche
+- Langsame Indexerstellung
+- ``circuit_breaker_exception``-Fehler treten auf
+
+Tuning-Verfahren
+----------------
+
+1. **Aktuelle Speichernutzung überprüfen**
+
+   Überwachen Sie die Speichernutzung jeder Komponente.
+
+2. **Engpass identifizieren**
+
+   Identifizieren Sie, welche Komponente Speichermangel hat.
+
+3. **Schrittweise erhöhen**
+
+   Erhöhen Sie nicht auf einmal stark, sondern in Schritten von 25–50% und überprüfen Sie die Wirkung.
+
+4. **Gesamtsystembalance berücksichtigen**
+
+   Stellen Sie sicher, dass die Gesamtsumme des Speichers aller Komponenten den physischen Speicher nicht überschreitet.
+
+5. **Kontinuierliche Überwachung**
+
+   Überwachen Sie kontinuierlich die Speichernutzung und passen Sie bei Bedarf an.
+
+Maßnahmen gegen Speicherlecks
+----------------
+
+Bei Verdacht auf Speicherlecks:
+
+1. **Heap-Dump erstellen**
+
+::
+
+    jmap -dump:format=b,file=heap.bin <PID>
+
+2. **Heap-Dump analysieren**
+
+   Analysieren Sie mit Tools wie Eclipse Memory Analyzer (MAT).
+
+3. **Problem melden**
+
+   Wenn Sie ein Speicherleck entdecken, melden Sie es bitte über GitHub Issues.
+
+Fehlersuche
+======================
+
+OutOfMemoryError tritt auf
+---------------------------
+
+**Fess-Webanwendung:**
+
+1. Erhöhen Sie ``FESS_HEAP_SIZE``.
+2. Beschränken Sie die Anzahl gleichzeitiger Zugriffe.
+3. Senken Sie den Log-Level, um Speichernutzung durch Protokollierung zu reduzieren.
+
+**Crawler:**
+
+1. Erhöhen Sie ``-Xmx`` in ``jvm.crawler.options``.
+2. Reduzieren Sie die Anzahl paralleler Crawls.
+3. Passen Sie die Crawler-Konfiguration an, um große Dateien auszuschließen.
+
+**OpenSearch:**
+
+1. Erhöhen Sie die Heap-Größe (bis maximal 31 GB).
+2. Überprüfen Sie die Anzahl der Index-Shards.
+3. Überprüfen Sie die Komplexität der Abfragen.
+
+Lange Pausenzeiten durch GC
+----------------------
+
+1. Passen Sie die G1GC-Einstellungen an.
+2. Konfigurieren Sie die Heap-Größe angemessen (sowohl zu groß als auch zu klein führt zu häufigen GCs).
+3. Erwägen Sie ein Update auf eine neuere Java-Version.
+
+Leistung verbessert sich nicht trotz Speicherkonfiguration
+------------------------------
+
+1. Überprüfen Sie andere Ressourcen wie CPU, Disk-I/O, Netzwerk.
+2. Führen Sie eine Indexoptimierung durch.
+3. Überprüfen Sie Abfragen und Crawler-Konfigurationen.
+
+Referenzinformationen
+========
+
+- :doc:`setup-port-network` - Port- und Netzwerkkonfiguration
+- :doc:`crawler-advanced` - Erweiterte Crawler-Konfiguration
+- :doc:`admin-logging` - Protokollkonfiguration
+- `OpenSearch Memory Settings <https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/#important-settings>`_
+- `Java GC Tuning <https://docs.oracle.com/en/java/javase/11/gctuning/>`_

--- a/de/15.3/config/setup-port-network.rst
+++ b/de/15.3/config/setup-port-network.rst
@@ -1,0 +1,395 @@
+======================
+Port- und Netzwerkkonfiguration
+======================
+
+Übersicht
+====
+
+Dieser Abschnitt beschreibt die netzwerkbezogenen Konfigurationen von |Fess|.
+Er behandelt Einstellungen für Netzwerkverbindungen wie Änderungen der Portnummer, Proxy-Konfiguration und HTTP-Kommunikationseinstellungen.
+
+Konfiguration der verwendeten Ports
+================
+
+Standard-Ports
+----------------
+
+|Fess| verwendet standardmäßig die folgenden Ports.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Dienst
+     - Portnummer
+   * - Fess-Webanwendung
+     - 8080
+   * - OpenSearch (HTTP)
+     - 9201
+   * - OpenSearch (Transport)
+     - 9301
+
+Ändern des Ports der Fess-Webanwendung
+--------------------------------------
+
+Konfiguration in Linux-Umgebungen
+~~~~~~~~~~~~~~~~~
+
+Um die Portnummer in Linux-Umgebungen zu ändern, bearbeiten Sie ``bin/fess.in.sh``.
+
+::
+
+    FESS_JAVA_OPTS="$FESS_JAVA_OPTS -Dfess.port=8080"
+
+Beispiel für die Verwendung von Port 80:
+
+::
+
+    FESS_JAVA_OPTS="$FESS_JAVA_OPTS -Dfess.port=80"
+
+.. note::
+   Für die Verwendung von Portnummern unter 1024 sind Root-Rechte oder entsprechende Berechtigungen (CAP_NET_BIND_SERVICE) erforderlich.
+
+Konfiguration über Umgebungsvariablen
+~~~~~~~~~~~~~~~~~~
+
+Sie können die Portnummer auch über eine Umgebungsvariable angeben.
+
+::
+
+    export FESS_PORT=8080
+
+Bei RPM/DEB-Paketen
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bei RPM-Paketen bearbeiten Sie ``/etc/sysconfig/fess``, bei DEB-Paketen ``/etc/default/fess``.
+
+::
+
+    FESS_PORT=8080
+
+Konfiguration in Windows-Umgebungen
+~~~~~~~~~~~~~~~~~~~
+
+In Windows-Umgebungen bearbeiten Sie ``bin\fess.in.bat``.
+
+::
+
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.port=8080
+
+Bei Registrierung als Windows-Dienst
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Wenn Sie |Fess| in einer Windows-Umgebung als Dienst registrieren und verwenden möchten, ändern Sie bitte auch die Portkonfiguration in ``bin\service.bat``.
+Weitere Informationen finden Sie unter :doc:`setup-windows-service`.
+
+Konfiguration des Kontextpfads
+----------------------
+
+Wenn Sie |Fess| in einem Unterverzeichnis veröffentlichen möchten, können Sie einen Kontextpfad konfigurieren.
+
+::
+
+    FESS_JAVA_OPTS="$FESS_JAVA_OPTS -Dfess.context.path=/search"
+
+Mit dieser Einstellung wird der Zugriff unter ``http://localhost:8080/search/`` möglich.
+
+.. warning::
+   Wenn Sie den Kontextpfad ändern, müssen Sie auch die Pfade für statische Dateien entsprechend konfigurieren.
+
+Proxy-Konfiguration
+============
+
+Übersicht
+----
+
+Beim Crawlen externer Websites aus einem Intranet oder beim Zugriff auf externe APIs kann die Kommunikation durch eine Firewall blockiert werden.
+In solchen Umgebungen ist eine Konfiguration für die Kommunikation über einen Proxy-Server erforderlich.
+
+Proxy-Konfiguration für den Crawler
+--------------------------
+
+Grundkonfiguration
+~~~~~~~~
+
+Geben Sie in den Crawl-Einstellungen in der Verwaltungsoberfläche die folgenden Konfigurationsparameter an.
+
+::
+
+    client.proxyHost=proxy.example.com
+    client.proxyPort=8080
+
+Konfiguration eines Proxys mit Authentifizierung
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Wenn der Proxy-Server eine Authentifizierung erfordert, fügen Sie Folgendes hinzu.
+
+::
+
+    client.proxyHost=proxy.example.com
+    client.proxyPort=8080
+    client.proxyUsername=proxyuser
+    client.proxyPassword=proxypass
+
+Ausschluss bestimmter Hosts vom Proxy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Um bestimmte Hosts (z. B. Server im Intranet) ohne Proxy zu verbinden:
+
+::
+
+    client.proxyHost=proxy.example.com
+    client.proxyPort=8080
+    client.nonProxyHosts=localhost|*.local|192.168.*
+
+Systemweite HTTP-Proxy-Konfiguration
+------------------------------
+
+Um einen HTTP-Proxy für die gesamte |Fess|-Anwendung zu verwenden, konfigurieren Sie dies in ``fess_config.properties``.
+
+::
+
+    http.proxy.host=proxy.example.com
+    http.proxy.port=8080
+    http.proxy.username=proxyuser
+    http.proxy.password=proxypass
+
+.. warning::
+   Passwörter werden unverschlüsselt gespeichert. Setzen Sie entsprechende Dateiberechtigungen.
+
+HTTP-Kommunikationseinstellungen
+============
+
+Beschränkung von Datei-Uploads
+--------------------------
+
+Sie können die Größe von Datei-Uploads über die Verwaltungsoberfläche beschränken.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Konfigurationselement
+     - Beschreibung
+   * - ``http.fileupload.max.size``
+     - Maximale Datei-Upload-Größe (Standard: 262144000 Bytes = 250 MB)
+   * - ``http.fileupload.threshold.size``
+     - Schwellenwertgröße für die Speicherung im Arbeitsspeicher (Standard: 262144 Bytes = 256 KB)
+   * - ``http.fileupload.max.file.count``
+     - Anzahl der Dateien, die gleichzeitig hochgeladen werden können (Standard: 10)
+
+Konfigurationsbeispiel in ``fess_config.properties``:
+
+::
+
+    http.fileupload.max.size=524288000
+    http.fileupload.threshold.size=524288
+    http.fileupload.max.file.count=20
+
+Einstellungen für Verbindungs-Timeouts
+--------------------
+
+Sie können Verbindungs-Timeouts für OpenSearch konfigurieren.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Konfigurationselement
+     - Beschreibung
+   * - ``search_engine.http.url``
+     - OpenSearch-URL (Standard: http://localhost:9201)
+   * - ``search_engine.heartbeat_interval``
+     - Intervall für Gesundheitsprüfungen (Millisekunden, Standard: 10000)
+
+Ändern der OpenSearch-Verbindung
+----------------------
+
+Für die Verbindung zu einem externen OpenSearch-Cluster:
+
+::
+
+    search_engine.http.url=http://opensearch-cluster.example.com:9200
+
+Verbindung zu mehreren Knoten
+~~~~~~~~~~~~~~~~~~
+
+Um eine Verbindung zu mehreren OpenSearch-Knoten herzustellen, geben Sie diese durch Kommas getrennt an.
+
+::
+
+    search_engine.http.url=http://node1:9200,http://node2:9200,http://node3:9200
+
+Konfiguration von SSL/TLS-Verbindungen
+-----------------
+
+Für HTTPS-Verbindungen zu OpenSearch:
+
+::
+
+    search_engine.http.url=https://opensearch.example.com:9200
+    search_engine.http.ssl.certificate_authorities=/path/to/ca.crt
+    search_engine.username=admin
+    search_engine.password=admin_password
+
+.. note::
+   Für die Zertifikatsvalidierung geben Sie den Pfad zum CA-Zertifikat unter ``certificate_authorities`` an.
+
+Konfiguration virtueller Hosts
+==============
+
+Übersicht
+----
+
+|Fess| kann Suchergebnisse basierend auf dem Hostnamen, über den darauf zugegriffen wird, unterschiedlich darstellen.
+Weitere Informationen finden Sie unter :doc:`security-virtual-host`.
+
+Grundkonfiguration
+--------
+
+Konfigurieren Sie den Header für virtuelle Hosts in ``fess_config.properties``.
+
+::
+
+    virtual.host.headers=X-Forwarded-Host,Host
+
+Integration mit Reverse-Proxys
+========================
+
+Konfigurationsbeispiel für Nginx
+--------------
+
+::
+
+    server {
+        listen 80;
+        server_name search.example.com;
+
+        location / {
+            proxy_pass http://localhost:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+        }
+    }
+
+Konfigurationsbeispiel für Apache
+---------------
+
+::
+
+    <VirtualHost *:80>
+        ServerName search.example.com
+
+        ProxyPreserveHost On
+        ProxyPass / http://localhost:8080/
+        ProxyPassReverse / http://localhost:8080/
+
+        RequestHeader set X-Forwarded-Proto "http"
+        RequestHeader set X-Forwarded-Host "search.example.com"
+    </VirtualHost>
+
+SSL/TLS-Terminierung
+-----------
+
+Konfigurationsbeispiel für SSL/TLS-Terminierung am Reverse-Proxy (Nginx):
+
+::
+
+    server {
+        listen 443 ssl http2;
+        server_name search.example.com;
+
+        ssl_certificate /path/to/cert.pem;
+        ssl_certificate_key /path/to/key.pem;
+
+        location / {
+            proxy_pass http://localhost:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Host $host;
+        }
+    }
+
+Firewall-Konfiguration
+====================
+
+Öffnen erforderlicher Ports
+------------------
+
+Um |Fess| von extern zugänglich zu machen, öffnen Sie die folgenden Ports.
+
+**Konfigurationsbeispiel für iptables:**
+
+::
+
+    # Fess-Webanwendung
+    iptables -A INPUT -p tcp --dport 8080 -j ACCEPT
+
+    # Für HTTPS-Zugriff (über Reverse-Proxy)
+    iptables -A INPUT -p tcp --dport 443 -j ACCEPT
+
+**Konfigurationsbeispiel für firewalld:**
+
+::
+
+    # Fess-Webanwendung
+    firewall-cmd --permanent --add-port=8080/tcp
+    firewall-cmd --reload
+
+Konfiguration von Sicherheitsgruppen (Cloud-Umgebungen)
+------------------------------------------
+
+In Cloud-Umgebungen wie AWS, GCP oder Azure öffnen Sie bitte die entsprechenden Ports über Sicherheitsgruppen oder Netzwerk-ACLs.
+
+Empfohlene Konfiguration:
+- Eingehend: Ports 80/443 (über HTTP-Reverse-Proxy)
+- Port 8080 nur intern zugänglich beschränken
+- OpenSearch-Ports 9201/9301 nur intern zugänglich beschränken
+
+Fehlersuche
+======================
+
+Kein Zugriff nach Portänderung möglich
+------------------------------
+
+1. Überprüfen Sie, ob |Fess| neu gestartet wurde.
+2. Überprüfen Sie, ob der entsprechende Port in der Firewall geöffnet ist.
+3. Überprüfen Sie Fehler in der Protokolldatei (``fess.log``).
+
+Crawlen über Proxy nicht möglich
+------------------------------
+
+1. Überprüfen Sie, ob Hostname und Port des Proxy-Servers korrekt sind.
+2. Wenn der Proxy-Server eine Authentifizierung erfordert, konfigurieren Sie Benutzername und Passwort.
+3. Überprüfen Sie, ob Verbindungsversuche im Protokoll des Proxy-Servers aufgezeichnet werden.
+4. Überprüfen Sie, ob die Konfiguration von ``nonProxyHosts`` korrekt ist.
+
+Keine Verbindung zu OpenSearch möglich
+-------------------------
+
+1. Überprüfen Sie, ob OpenSearch läuft.
+2. Überprüfen Sie, ob die Einstellung ``search_engine.http.url`` korrekt ist.
+3. Überprüfen Sie die Netzwerkverbindung: ``curl http://localhost:9201``
+4. Überprüfen Sie Fehler im OpenSearch-Protokoll.
+
+Fehlfunktion beim Zugriff über Reverse-Proxy
+----------------------------------------------------
+
+1. Überprüfen Sie, ob der Header ``X-Forwarded-Host`` korrekt konfiguriert ist.
+2. Überprüfen Sie, ob der Header ``X-Forwarded-Proto`` korrekt konfiguriert ist.
+3. Überprüfen Sie, ob der Kontextpfad korrekt konfiguriert ist.
+4. Überprüfen Sie Fehler im Reverse-Proxy-Protokoll.
+
+Referenzinformationen
+========
+
+- :doc:`setup-memory` - Speicherkonfiguration
+- :doc:`setup-windows-service` - Windows-Dienst-Konfiguration
+- :doc:`security-virtual-host` - Konfiguration virtueller Hosts
+- :doc:`crawler-advanced` - Erweiterte Crawler-Konfiguration
+- `OpenSearch Configuration <https://opensearch.org/docs/latest/install-and-configure/configuration/>`_

--- a/de/15.3/config/setup-windows-service.rst
+++ b/de/15.3/config/setup-windows-service.rst
@@ -1,0 +1,78 @@
+===================
+Registrierung als Windows-Dienst
+===================
+
+Registrierung als Windows-Dienst
+======================
+
+|Fess| kann als Windows-Dienst registriert werden.
+Zum Betrieb von |Fess| muss OpenSearch gestartet sein.
+In diesem Dokument wird davon ausgegangen, dass |Fess| unter ``c:\opt\fess`` und OpenSearch unter ``c:\opt\opensearch`` installiert sind.
+
+Vorbereitung
+------
+
+Setzen Sie JAVA_HOME als Systemumgebungsvariable.
+
+Registrierung von OpenSearch als Dienst
+-------------------------
+
+Führen Sie ``c:\opt\opensearch\bin\opensearch-service.bat`` als Administrator von der Eingabeaufforderung aus.
+
+::
+
+    > cd c:\opt\opensearch\bin
+    > opensearch-service.bat install
+    ...
+    The service 'opensearch-service-x64' has been installed.
+
+Weitere Informationen finden Sie in der `OpenSearch-Dokumentation <https://opensearch.org/docs/2.4/install-and-configure/install-opensearch/windows/>`_.
+
+Konfiguration
+----
+
+Bearbeiten Sie ``c:\opt\fess\bin\fess.in.bat`` und setzen Sie den Installationspfad von OpenSearch in SEARCH_ENGINE_HOME.
+
+::
+
+    set SEARCH_ENGINE_HOME=c:/opt/opensearch
+
+Die Standardportnummer für Such- und Verwaltungsoberfläche von |Fess| ist 8080. Um auf Port 80 zu ändern, ändern Sie fess.port in ``c:\opt\fess\bin\fess.in.bat``.
+
+::
+
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.port=80
+
+
+Registrierungsmethode
+------
+
+Führen Sie ``c:\opt\fess\bin\service.bat`` als Administrator von der Eingabeaufforderung aus.
+
+::
+
+    > cd c:\opt\fess\bin
+    > service.bat install
+    ...
+    The service 'fess-service-x64' has been installed.
+
+
+Dienstkonfiguration
+-----------
+
+Beim manuellen Start des Dienstes starten Sie zuerst den OpenSearch-Dienst und dann den |Fess|-Dienst.
+Für den automatischen Start fügen Sie eine Abhängigkeit hinzu.
+
+1. Setzen Sie in den allgemeinen Diensteinstellungen den Starttyp auf „Automatisch (verzögerter Start)".
+2. Dienstabhängigkeiten werden in der Registry konfiguriert.
+
+Fügen Sie im Registrierungs-Editor (regedit) den folgenden Schlüssel und Wert hinzu.
+
+.. list-table::
+
+   * - *Schlüssel*
+     - ``Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\fess-service-x64\DependOnService``
+   * - *Wert*
+     - ``opensearch-service-x64``
+
+Nach dem Hinzufügen wird opensearch-service-x64 in den Abhängigkeiten der |Fess|-Diensteigenschaften angezeigt.


### PR DESCRIPTION
- Translate all 19 configuration guide files from ja/15.3/config to de/15.3/config
- Include comprehensive translations for:
  - Introduction and index files
  - Setup guides (port/network, memory, Windows service)
  - Crawler configurations (basic, advanced, thumbnail)
  - Search functionality (basic, advanced, geosearch, scroll, form integration)
  - Security settings (role-based access, virtual hosts)
  - Administration guides (logging, index backup, analyzer, OpenSearch Dashboards)
- All translations maintain commercial product documentation quality in German
- Preserve original RST formatting and structure