### PR TITLE
Create German admin guide translation

### DIFF
--- a/de/15.3/admin/accesstoken-guide.rst
+++ b/de/15.3/admin/accesstoken-guide.rst
@@ -1,0 +1,63 @@
+============
+Zugriffstoken
+============
+
+Übersicht
+=========
+
+Die Konfigurationsseite für Zugriffstoken verwaltet Zugriffstoken.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Konfigurationsübersichtsseite für Zugriffstoken zu öffnen, klicken Sie im linken Menü auf [System > Zugriffstoken].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Konfigurationsseite für Zugriffstoken zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Name
+::::
+
+Geben Sie einen Namen an, um dieses Zugriffstoken zu beschreiben.
+
+Berechtigung
+::::::::::::
+
+Legen Sie die Berechtigung für das Zugriffstoken fest.
+Geben Sie diese im Format „{user|group|role}name" an.
+Um beispielsweise Suchergebnisse für Benutzer anzuzeigen, die zur Gruppe „developer" gehören, legen Sie die Berechtigung auf „{group}developer" fest.
+
+Parametername
+:::::::::::::
+
+Geben Sie den Namen des Anforderungsparameters an, wenn Sie die Berechtigung als Suchabfrage angeben.
+
+Ablaufdatum
+:::::::::::
+
+Geben Sie das Ablaufdatum des Zugriffstokens an.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/accesstoken-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/accesstoken-2.png

--- a/de/15.3/admin/backup-guide.rst
+++ b/de/15.3/admin/backup-guide.rst
@@ -1,0 +1,74 @@
+=========
+Sicherung
+=========
+
+Übersicht
+=========
+
+Auf der Sicherungsseite können Sie Konfigurationsinformationen von |Fess| herunterladen und hochladen.
+
+Download
+--------
+
+|Fess| speichert Konfigurationsinformationen als Index.
+Klicken Sie zum Herunterladen auf den Indexnamen.
+
+|image0|
+
+fess_config.bulk
+::::::::::::::::
+
+fess_config.bulk enthält die Konfigurationsinformationen von |Fess|.
+
+fess_basic_config.bulk
+::::::::::::::::::::::
+
+fess_basic_config.bulk enthält die Konfigurationsinformationen von |Fess| ohne Fehler-URLs.
+
+fess_user.bulk
+::::::::::::::
+
+fess_user.bulk enthält Informationen zu Benutzern, Rollen und Gruppen.
+
+system.properties
+:::::::::::::::::
+
+system.properties enthält allgemeine Konfigurationsinformationen.
+
+fess.json
+:::::::::
+
+fess.json enthält die Konfigurationsinformationen des Fess-Index.
+
+doc.json
+::::::::
+
+doc.json enthält die Mapping-Informationen des Fess-Index.
+
+click_log.ndjson
+::::::::::::::::
+
+click_log.ndjson enthält Klick-Protokollinformationen.
+
+favorite_log.ndjson
+:::::::::::::::::::
+
+favorite_log.ndjson enthält Favoriten-Protokollinformationen.
+
+search_log.ndjson
+:::::::::::::::::
+
+search_log.ndjson enthält Such-Protokollinformationen.
+
+user_info.ndjson
+::::::::::::::::
+
+user_info.ndjson enthält Informationen zu Suchbenutzern.
+
+Upload
+------
+
+Sie können Konfigurationsinformationen hochladen und importieren.
+Dateien, die wiederhergestellt werden können, sind \*.bulk und system.properties.
+
+  .. |image0| image:: ../../../resources/images/ja/15.3/admin/backup-1.png

--- a/de/15.3/admin/badword-guide.rst
+++ b/de/15.3/admin/badword-guide.rst
@@ -1,0 +1,85 @@
+==================
+Ausschlusswörter
+==================
+
+Übersicht
+=========
+
+Hier wird die Konfiguration von Ausschlusswörtern für Vorschläge erläutert.
+Vorschläge werden entsprechend den Suchbegriffen angezeigt, aber Sie können konfigurieren, dass bestimmte Wörter nicht in den Vorschlägen erscheinen.
+
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Konfigurationsübersichtsseite für Ausschlusswörter für Vorschläge zu öffnen, klicken Sie im linken Menü auf [Vorschläge > Ausschlusswörter].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Erstellungsseite für Ausschlusswörter für Vorschläge zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Vorschlagskandidat
+::::::::::::::::::
+
+Registrieren Sie unerwünschte Wörter.
+Wörter, die hier registriert sind, werden nicht in den Vorschlägen angezeigt.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+Download
+========
+
+Laden Sie registrierte Wörter im CSV-Format herunter.
+
+|image2|
+
+CSV-Inhalt
+----------
+
+Zeile 1 ist die Kopfzeile.
+Ab Zeile 2 werden die Ausschlusswörter aufgeführt.
+
+::
+
+"BadWord"
+"検索エンジン"
+
+Upload
+======
+
+Registrieren Sie Wörter im CSV-Format.
+
+|image3|
+
+CSV-Inhalt
+----------
+
+Zeile 1 ist die Kopfzeile.
+Ab Zeile 2 beschreiben Sie die Ausschlusswörter.
+
+::
+
+"BadWord"
+"検索エンジン"
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/badword-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/badword-2.png
+.. |image2| image:: ../../../resources/images/ja/15.3/admin/badword-3.png
+.. |image3| image:: ../../../resources/images/ja/15.3/admin/badword-4.png

--- a/de/15.3/admin/boostdoc-guide.rst
+++ b/de/15.3/admin/boostdoc-guide.rst
@@ -1,0 +1,58 @@
+==================
+Dokument-Boosting
+==================
+
+Übersicht
+=========
+
+Hier wird die Konfiguration für Dokument-Boosting erläutert.
+Durch die Konfiguration von Dokument-Boosting können Sie Dokumente unabhängig vom Suchbegriff in den Suchergebnissen höher positionieren.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Konfigurationsübersichtsseite für Dokument-Boosting zu öffnen, klicken Sie im linken Menü auf [Crawler > Dokument-Boosting].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Konfigurationsseite für Dokument-Boosting zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Bedingung
+:::::::::
+
+Geben Sie die Bedingung für Dokumente an, die höher positioniert werden sollen.
+Wenn Sie beispielsweise URLs mit https://www.n2sm.net/ höher anzeigen möchten, schreiben Sie url.matches("https://www.n2sm.net/.*").
+Bedingungen können in Groovy geschrieben werden.
+
+Boost-Wert-Ausdruck
+:::::::::::::::::::
+
+Geben Sie den Gewichtungswert für das Dokument an.
+Ausdrücke können in Groovy geschrieben werden.
+
+Sortierreihenfolge
+::::::::::::::::::
+
+Legen Sie die Sortierreihenfolge für das Dokument-Boosting fest.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt. Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/boostdoc-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/boostdoc-2.png

--- a/de/15.3/admin/crawlinginfo-guide.rst
+++ b/de/15.3/admin/crawlinginfo-guide.rst
@@ -1,0 +1,93 @@
+==================
+Crawl-Informationen
+==================
+
+Übersicht
+=========
+
+Die Crawl-Ausführungsergebnisse werden aufgezeichnet, und Crawl-Informationen können auf diesem Verwaltungsbildschirm überprüft werden.
+
+Verwaltung
+==========
+
+Übersicht
+=========
+
+Jedes Mal, wenn ein Crawl ausgeführt wird, wird er als Crawl-Information aufgezeichnet.
+In der Übersicht können Sie den Sitzungsnamen und die Ausführungszeit des durchgeführten Crawls überprüfen.
+Um Details der Crawl-Informationen anzuzeigen, klicken Sie auf die entsprechende Crawl-Information.
+
+|image0|
+
+Details
+=======
+
+Durch Klicken auf die Sitzungs-ID der Crawl-Informationen in der Übersicht werden die Details der entsprechenden Crawl-Informationen angezeigt.
+
+|image1|
+
+Parameterliste
+--------------
+
+Sitzungs-ID
+:::::::::::
+
+Die Sitzungs-ID bei der Crawl-Ausführung.
+
+Crawler-Startzeit
+:::::::::::::::::
+
+Die Uhrzeit, zu der der gesamte Crawl gestartet wurde.
+
+Crawl-Startzeit (Web/Datei)
+:::::::::::::::::::::::::::
+
+Die Uhrzeit, zu der das Web- und Dateisystem-Crawling gestartet wurde.
+
+Crawl-Startzeit (Datenspeicher)
+::::::::::::::::::::::::::::::::
+
+Die Uhrzeit, zu der das Datenspeicher-Crawling gestartet wurde.
+
+Crawl-Endzeit (Web/Datei)
+:::::::::::::::::::::::::
+
+Die Uhrzeit, zu der das Web- und Dateisystem-Crawling beendet wurde.
+
+Crawl-Ausführungszeit (Datenspeicher)
+::::::::::::::::::::::::::::::::::::::
+
+Die Ausführungszeit des Datenspeicher-Crawlings (in Millisekunden).
+
+Indizierungs-Ausführungszeit (Datenspeicher)
+:::::::::::::::::::::::::::::::::::::::::::::
+
+Die Zeit, die für die Indizierung der Web- und Dateisystem-Crawl-Ergebnisse benötigt wurde (in Millisekunden).
+
+Indexgröße (Datenspeicher)
+::::::::::::::::::::::::::
+
+Die Anzahl der indizierten Dokumente.
+
+Crawl-Endzeit (Datenspeicher)
+::::::::::::::::::::::::::::::
+
+Die Uhrzeit, zu der das Datenspeicher-Crawling beendet wurde.
+
+Crawler-Status
+::::::::::::::
+
+Ob der Crawl erfolgreich war oder nicht.
+
+Crawler-Endzeit
+:::::::::::::::
+
+Die Uhrzeit, zu der der gesamte Crawl beendet wurde.
+
+Crawler-Ausführungszeit
+:::::::::::::::::::::::
+
+Die Ausführungszeit des gesamten Crawls (in Millisekunden).
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/crawlinginfo-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/crawlinginfo-2.png

--- a/de/15.3/admin/dashboard-guide.rst
+++ b/de/15.3/admin/dashboard-guide.rst
@@ -1,0 +1,57 @@
+===========
+Dashboard
+===========
+
+Übersicht
+=========
+
+Das Dashboard bietet ein Web-Verwaltungstool zur Verwaltung der OpenSearch-Cluster und -Indizes, auf die |Fess| zugreift.
+
+|image0|
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table:: Von |Fess| verwaltete Indizes
+   :header-rows: 1
+
+   * - Indexname
+     - Beschreibung
+   * - fess.YYYYMMDD
+     - Indizierte Dokumente
+   * - fess_log
+     - Zugriffsprotokolle
+   * - fess.suggest.YYYYMMDD
+     - Vorschlagswörter
+   * - fess_config
+     - |Fess| Konfiguration
+   * - fess_user
+     - Benutzer-/Rollen-/Gruppendaten
+   * - configsync
+     - Wörterbuchkonfiguration
+   * - fess_suggest
+     - Vorschlags-Metadaten
+   * - fess_suggest_array
+     - Vorschlags-Metadaten
+   * - fess_suggest_badword
+     - Liste unerwünschter Vorschlagswörter
+   * - fess_suggest_analyzer
+     - Vorschlags-Metadaten
+   * - fess_crawler
+     - Crawl-Informationen
+
+
+Indexnamen, die mit einem Punkt (.) beginnen, sind Systemindizes und werden daher nicht angezeigt.
+Um Systemindizes anzuzeigen, aktivieren Sie das Kontrollkästchen „special".
+
+Anzahl indizierter Dokumente überprüfen
+========================================
+
+Die Anzahl der indizierten Dokumente wird wie in der Abbildung unten im Fess-Index angezeigt.
+
+|image1|
+
+Wenn Sie auf das Symbol oben rechts in jedem Index klicken, wird ein Operationsmenü für den Index angezeigt.
+Um indizierte Dokumente zu löschen, löschen Sie sie über den Verwaltungssuchbildschirm. Achten Sie darauf, NICHT „delete index" zu verwenden.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/dashboard-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/dashboard-2.png
+.. pdf            :width: 400 px

--- a/de/15.3/admin/dataconfig-guide.rst
+++ b/de/15.3/admin/dataconfig-guide.rst
@@ -1,0 +1,430 @@
+====================
+Datenspeicher-Crawl
+====================
+
+Übersicht
+=========
+
+Mit |Fess| können Sie Datenquellen wie Datenbanken oder CSV als Crawl-Ziele festlegen.
+Hier wird die erforderliche Datenspeicherkonfiguration dafür erläutert.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Übersichtsseite für die Datenspeicherkonfiguration zu öffnen, klicken Sie im linken Menü auf [Crawler > Datenspeicher].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Datenspeicherkonfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Name
+::::
+
+Geben Sie den Namen der Crawl-Konfiguration an.
+
+Handler-Name
+::::::::::::
+
+Der Handler-Name zur Verarbeitung des Datenspeichers.
+
+* DatabaseDataStore: Crawlt eine Datenbank
+* CsvDataStore: Crawlt CSV/TSV-Dateien
+* CsvListDataStore: Crawlt eine CSV-Datei, die Dateipfade zu indizierenden Dateien beschreibt
+
+Parameter
+:::::::::
+
+Geben Sie Parameter für den Datenspeicher an.
+
+Skript
+::::::
+
+Geben Sie an, in welchen Feldern die vom Datenspeicher abgerufenen Werte festgelegt werden sollen.
+Ausdrücke können in Groovy geschrieben werden.
+
+Boost-Wert
+::::::::::
+
+Geben Sie den Boost-Wert für Dokumente an, die mit dieser Konfiguration gecrawlt werden.
+
+Berechtigung
+::::::::::::
+
+Geben Sie die Berechtigung für diese Konfiguration an.
+Um beispielsweise Suchergebnisse für Benutzer anzuzeigen, die zur Gruppe „developer" gehören, geben Sie {group}developer an.
+Für Benutzerebene geben Sie {user}Benutzername an, für Rollenebene {role}Rollenname und für Gruppenebene {group}Gruppenname.
+
+Virtueller Host
+:::::::::::::::
+
+Geben Sie den Hostnamen des virtuellen Hosts an.
+Weitere Details finden Sie unter :doc:`Virtueller Host im Konfigurationshandbuch <../config/virtual-host>`.
+
+Status
+::::::
+
+Geben Sie an, ob diese Crawl-Konfiguration verwendet werden soll.
+
+Beschreibung
+::::::::::::
+
+Sie können eine Beschreibung eingeben.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+Beispiele
+=========
+
+DatabaseDataStore
+-----------------
+
+Datenbank-Crawling wird erklärt.
+
+Als Beispiel wird eine Tabelle in der MySQL-Datenbank testdb wie folgt angenommen, auf die mit Benutzername hoge und Passwort fuga zugegriffen werden kann.
+
+::
+
+    CREATE TABLE doc (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        title VARCHAR(100) NOT NULL,
+        content VARCHAR(255) NOT NULL,
+        latitude VARCHAR(20),
+        longitude VARCHAR(20),
+        versionNo INTEGER NOT NULL,
+        PRIMARY KEY (id)
+    );
+
+Hier fügen wir folgende Daten ein:
+
+::
+
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 1', 'コンテンツ 1 です．', '37.77493', ' -122.419416', 1);
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 2', 'コンテンツ 2 です．', '34.701909', '135.494977', 1);
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 3', 'コンテンツ 3 です．', '-33.868901', '151.207091', 1);
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 4', 'コンテンツ 4 です．', '51.500152', '-0.113736', 1);
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 5', 'コンテンツ 5 です．', '35.681137', '139.766084', 1);
+
+Parameter
+:::::::::
+
+Ein Beispiel für die Parameterkonfiguration ist wie folgt:
+
+::
+
+    driver=com.mysql.jdbc.Driver
+    url=jdbc:mysql://localhost:3306/testdb?useUnicode=true&characterEncoding=UTF-8
+    username=hoge
+    password=fuga
+    sql=select * from doc
+
+Parameter haben das Format „Schlüssel=Wert". Die Schlüsselerklärungen sind wie folgt:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - driver
+     - Treiberklassenname
+   * - url
+     - URL
+   * - username
+     - Benutzername für die Datenbankverbindung
+   * - password
+     - Passwort für die Datenbankverbindung
+   * - sql
+     - SQL-Anweisung zum Abrufen von Crawl-Zielen
+
+Tabelle: Beispiel für DB-Konfigurationsparameter
+
+
+Skript
+::::::
+
+Ein Beispiel für die Skriptkonfiguration ist wie folgt:
+
+::
+
+    url="http://SERVERNAME/" + id
+    host="SERVERNAME"
+    site="SERVERNAME"
+    title=title
+    content=content
+    cache=content
+    digest=content
+    anchor=
+    content_length=content.length()
+    last_modified=new java.util.Date()
+    location=latitude + "," + longitude
+    latitude=latitude
+    longitude=longitude
+
+Parameter haben das Format „Schlüssel=Wert". Die Schlüsselerklärungen sind wie folgt:
+
+Die Werte werden in Groovy geschrieben.
+Schließen Sie Zeichenketten in doppelte Anführungszeichen ein. Durch Zugriff auf den Datenbank-Spaltennamen wird der entsprechende Wert abgerufen.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - url
+     - URL (Passen Sie sie an Ihre Umgebung an, um eine URL zu konfigurieren, über die auf die Daten zugegriffen werden kann)
+   * - host
+     - Hostname
+   * - site
+     - Site-Pfad
+   * - title
+     - Titel
+   * - content
+     - Dokumentinhalt (zu indizierender Text)
+   * - cache
+     - Dokument-Cache (nicht zu indizieren)
+   * - digest
+     - In Suchergebnissen angezeigter Digest-Teil
+   * - anchor
+     - Im Dokument enthaltene Links (normalerweise nicht erforderlich)
+   * - content_length
+     - Dokumentlänge
+   * - last_modified
+     - Letztes Änderungsdatum des Dokuments
+
+Tabelle: Skriptkonfigurationsinhalt
+
+
+Treiber
+:::::::
+
+Zum Verbinden mit der Datenbank ist ein Treiber erforderlich. Platzieren Sie die JAR-Datei in app/WEB-INF/lib.
+
+CsvDataStore
+------------
+
+CSV-Datei-Crawling wird erklärt.
+
+Erstellen Sie beispielsweise eine test.csv-Datei im Verzeichnis /home/taro/csv mit folgendem Inhalt.
+Die Dateikodierung sollte Shift_JIS sein.
+
+::
+
+    1,タイトル 1,テスト1です。
+    2,タイトル 2,テスト2です。
+    3,タイトル 3,テスト3です。
+    4,タイトル 4,テスト4です。
+    5,タイトル 5,テスト5です。
+    6,タイトル 6,テスト6です。
+    7,タイトル 7,テスト7です。
+    8,タイトル 8,テスト8です。
+    9,タイトル 9,テスト9です。
+
+
+Parameter
+:::::::::
+
+Ein Beispiel für die Parameterkonfiguration ist wie folgt:
+
+::
+
+    directories=/home/taro/csv
+    fileEncoding=Shift_JIS
+
+Parameter haben das Format „Schlüssel=Wert". Die Schlüsselerklärungen sind wie folgt:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - directories
+     - Verzeichnis mit CSV-Dateien (.csv oder .tsv)
+   * - files
+     - CSV-Dateien (bei direkter Angabe)
+   * - fileEncoding
+     - Kodierung der CSV-Datei
+   * - separatorCharacter
+     - Trennzeichen
+
+
+Tabelle: Beispiel für CSV-Datei-Konfigurationsparameter
+
+
+Skript
+::::::
+
+Ein Beispiel für die Skriptkonfiguration ist wie folgt:
+
+::
+
+    url="http://SERVERNAME/" + cell1
+    host="SERVERNAME"
+    site="SERVERNAME"
+    title=cell2
+    content=cell3
+    cache=cell3
+    digest=cell3
+    anchor=
+    content_length=cell3.length()
+    last_modified=new java.util.Date()
+
+Parameter haben das Format „Schlüssel=Wert".
+Die Schlüssel sind dieselben wie beim Datenbank-Crawling.
+Daten in CSV-Dateien werden in cell[Nummer] gespeichert (Nummern beginnen bei 1).
+Wenn keine Daten in einer CSV-Zelle vorhanden sind, kann der Wert null sein.
+
+EsDataStore
+-----------
+
+Die Datenquelle ist Elasticsearch, aber die grundlegende Verwendung ist dieselbe wie bei CsvDataStore.
+
+Parameter
+:::::::::
+
+Ein Beispiel für die Parameterkonfiguration ist wie folgt:
+
+::
+
+    settings.cluster.name=elasticsearch
+    hosts=SERVERNAME:9300
+    index=logindex
+    type=data
+
+Parameter haben das Format „Schlüssel=Wert". Die Schlüsselerklärungen sind wie folgt:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - settings.*
+     - Elasticsearch-Einstellungsinformationen
+   * - hosts
+     - Elasticsearch-Verbindungsziel
+   * - index
+     - Indexname
+   * - type
+     - Typname
+   * - query
+     - Abfrage für Abrufbedingungen
+
+Tabelle: Beispiel für Elasticsearch-Konfigurationsparameter
+
+
+Skript
+::::::
+
+Ein Beispiel für die Skriptkonfiguration ist wie folgt:
+
+::
+
+    url=source.url
+    host="SERVERNAME"
+    site="SERVERNAME"
+    title=source.title
+    content=source.content
+    digest=
+    anchor=
+    content_length=source.size
+    last_modified=new java.util.Date()
+
+Parameter haben das Format „Schlüssel=Wert".
+Die Schlüssel sind dieselben wie beim Datenbank-Crawling.
+Sie können Werte mit source.* abrufen und festlegen.
+
+CsvListDataStore
+----------------
+
+Wird zum Crawlen großer Dateimengen verwendet.
+Durch Platzieren einer CSV-Datei mit Pfaden zu aktualisierten Dateien und Crawlen nur der angegebenen Pfade kann die Crawl-Ausführungszeit verkürzt werden.
+
+Das Format zum Beschreiben von Pfaden ist wie folgt:
+
+::
+
+    [Aktion]<Trennzeichen>[Pfad]
+
+Geben Sie eine der folgenden Aktionen an:
+
+* create: Datei wurde erstellt
+* modify: Datei wurde aktualisiert
+* delete: Datei wurde gelöscht
+
+Erstellen Sie beispielsweise eine test.csv-Datei im Verzeichnis /home/taro/csv mit folgendem Inhalt.
+Die Dateikodierung sollte Shift_JIS sein.
+
+Pfade werden in derselben Notation wie bei der Angabe von Crawl-Zielpfaden beim Datei-Crawling beschrieben.
+Geben Sie wie folgt „file:/[Pfad]" oder „smb://[Pfad]" an:
+
+::
+
+    modify,smb://servername/data/testfile1.txt
+    modify,smb://servername/data/testfile2.txt
+    modify,smb://servername/data/testfile3.txt
+    modify,smb://servername/data/testfile4.txt
+    modify,smb://servername/data/testfile5.txt
+    modify,smb://servername/data/testfile6.txt
+    modify,smb://servername/data/testfile7.txt
+    modify,smb://servername/data/testfile8.txt
+    modify,smb://servername/data/testfile9.txt
+    modify,smb://servername/data/testfile10.txt
+
+
+Parameter
+:::::::::
+
+Ein Beispiel für die Parameterkonfiguration ist wie folgt:
+
+::
+
+    directories=/home/taro/csv
+    fileEncoding=Shift_JIS
+
+Parameter haben das Format „Schlüssel=Wert". Die Schlüsselerklärungen sind wie folgt:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - directories
+     - Verzeichnis mit CSV-Dateien (.csv oder .tsv)
+   * - fileEncoding
+     - Kodierung der CSV-Datei
+   * - separatorCharacter
+     - Trennzeichen
+
+
+Tabelle: Beispiel für CSV-Datei-Konfigurationsparameter
+
+
+Skript
+::::::
+
+Ein Beispiel für die Skriptkonfiguration ist wie folgt:
+
+::
+
+    event_type=cell1
+    url=cell2
+
+Parameter haben das Format „Schlüssel=Wert".
+Die Schlüssel sind dieselben wie beim Datenbank-Crawling.
+
+Wenn für das Crawl-Ziel eine Authentifizierung erforderlich ist, müssen auch folgende Einstellungen konfiguriert werden:
+
+::
+
+    crawler.file.auth=example
+    crawler.file.auth.example.scheme=SAMBA
+    crawler.file.auth.example.username=username
+    crawler.file.auth.example.password=password
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/dataconfig-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/dataconfig-2.png

--- a/de/15.3/admin/design-guide.rst
+++ b/de/15.3/admin/design-guide.rst
@@ -1,0 +1,101 @@
+===============
+Seitendesign
+===============
+
+Übersicht
+=========
+
+Hier wird die Konfiguration des Designs des Suchbildschirms erläutert.
+
+Konfiguration
+=============
+
+Anzeige
+-------
+
+Um die Übersichtsseite für die Seitendesignkonfiguration zu öffnen, klicken Sie im linken Menü auf [System > Seitendesign].
+
+|image0|
+
+
+Dateimanager
+------------
+
+Sie können für den Suchbildschirm verfügbare Dateien herunterladen oder löschen.
+
+Seitendateien anzeigen
+----------------------
+
+Sie können JSP-Dateien des Suchbildschirms bearbeiten.
+Durch Klicken auf die Schaltfläche „Bearbeiten" für die Ziel-JSP-Datei können Sie diese JSP-Datei bearbeiten.
+Durch Klicken auf die Schaltfläche „Standard verwenden" können Sie zur JSP-Datei der Installation zurückkehren.
+Speichern Sie im Bearbeitungsbildschirm mit der Schaltfläche „Aktualisieren", um die Änderungen zu übernehmen.
+
+Im Folgenden werden die bearbeitbaren Seiten zusammengefasst:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - /index.jsp
+     - JSP-Datei der Such-Startseite. Diese JSP-Datei bindet alle Teilbereiche der JSP-Dateien ein.
+   * - /header.jsp
+     - JSP-Datei für den Header.
+   * - /footer.jsp
+     - JSP-Datei für den Footer.
+   * - /search.jsp
+     - JSP-Datei der Suchergebnisliste. Diese JSP-Datei bindet alle Teilbereiche der JSP-Dateien ein.
+   * - /searchResults.jsp
+     - JSP-Datei zur Darstellung des Suchergebnisteils der Suchergebnisliste. Diese JSP-Datei wird verwendet, wenn Suchergebnisse vorhanden sind. Ändern Sie diese, wenn Sie die Darstellung der Suchergebnisse anpassen möchten.
+   * - /searchNoResult.jsp
+     - JSP-Datei zur Darstellung des Suchergebnisteils der Suchergebnisliste. Diese JSP-Datei wird verwendet, wenn keine Suchergebnisse vorhanden sind.
+   * - /searchOptions.jsp
+     - JSP-Datei für den Suchoptionsbildschirm.
+   * - /advance.jsp
+     - JSP-Datei für den erweiterten Suchbildschirm.
+   * - /help.jsp
+     - JSP-Datei für die Hilfeseite.
+   * - /error/error.jsp
+     - JSP-Datei für die Suchfehlerseite. Ändern Sie diese, wenn Sie die Darstellung von Suchfehlern anpassen möchten.
+   * - /error/notFound.jsp
+     - JSP-Datei für die Fehlerseite, die angezeigt wird, wenn eine Seite nicht gefunden wird.
+   * - /error/system.jsp
+     - JSP-Datei für die Fehlerseite, die bei Systemfehlern angezeigt wird.
+   * - /error/redirect.jsp
+     - JSP-Datei für die Fehlerseite, die bei HTTP-Weiterleitungen angezeigt wird.
+   * - /error/badRequest.jsp
+     - JSP-Datei für die Fehlerseite, die bei ungültigen Anforderungen angezeigt wird.
+   * - /cache.hbs
+     - Datei zur Anzeige des Caches von Suchergebnissen.
+   * - /login/index.jsp
+     - JSP-Datei für den Anmeldebildschirm.
+   * - /profile/index.jsp
+     - JSP für den Passwortänderungsbildschirm für Benutzer.
+   * - /profile/newpassword.jsp
+     - JSP für den Passwortaktualisierungsbildschirm für Administratoren. Fordert eine Passwortänderung an, wenn Benutzername und Passwort bei der Anmeldung identisch sind.
+
+
+Tabelle: Bearbeitbare JSP-Dateien
+
+|image1|
+
+Hochzuladende Dateien
+---------------------
+
+Sie können Dateien hochladen, die auf dem Suchbildschirm verwendet werden.
+Unterstützte Bilddateinamen sind jpg, gif, png, css, js.
+
+Datei-Upload
+::::::::::::
+
+Geben Sie die hochzuladende Datei an.
+
+Dateiname (optional)
+::::::::::::::::::::
+
+Verwenden Sie dies, wenn Sie der hochzuladenden Datei einen Dateinamen geben möchten.
+Wenn weggelassen, wird der Name der hochgeladenen Datei verwendet.
+Wenn Sie beispielsweise logo.png angeben, wird das Bild auf der Such-Startseite geändert.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/design-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/design-2.png

--- a/de/15.3/admin/dict-guide.rst
+++ b/de/15.3/admin/dict-guide.rst
@@ -1,0 +1,60 @@
+===========
+Wörterbuch
+===========
+
+Übersicht
+=========
+
+Hier wird die Konfiguration von Wörterbüchern erläutert.
+
+Nehmen Sie Wörterbuchänderungen nur vor, wenn Sie die Spezifikationen der jeweiligen Wörterbücher verstehen.
+Fehlerhafte Wörterbuchänderungen können dazu führen, dass auf den Index nicht mehr zugegriffen werden kann.
+
+Übersicht
+=========
+
+Um die Übersichtsseite der verwaltbaren Wörterbücher zu öffnen, klicken Sie im linken Menü auf [System > Wörterbuch].
+
+
+|image0|
+
+
+Kuromoji
+========
+
+Verwaltet das Wörterbuch für die japanische morphologische Analyse.
+ja/kuromoji.txt ist das Wörterbuch für die japanische morphologische Analyse.
+
+Synonyme
+========
+
+Verwaltet das Synonym-Wörterbuch.
+synonym.txt ist die sprachübergreifend verwendete Synonym-Wörterbuchdatei.
+
+Mapping
+=======
+
+Verwaltet das Zeichenersetzungs-Wörterbuch.
+mapping.txt ist die sprachübergreifende oder sprachspezifische Wortersetzungs-Wörterbuchdatei.
+
+Protwords
+=========
+
+Verwaltet das Schutzwort-Wörterbuch.
+protwords.txt wird für jede Sprache platziert und ist eine Wortliste für Wörter, die vom Stemming ausgeschlossen werden sollen.
+
+Stoppwörter
+===========
+
+Verwaltet das Stoppwort-Wörterbuch.
+stopwords.txt wird für jede Sprache platziert und ist eine Wortliste für Wörter, die bei der Indexerstellung ausgeschlossen werden sollen.
+
+Stemmer-Überschreibung
+======================
+
+Verwaltet das Stemmer-Überschreibungs-Wörterbuch.
+stemmer_override.txt wird für jede Sprache platziert und ist eine Wortersetzungs-Wörterbuchdatei zum Überschreiben der Stemming-Verarbeitung.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/dict-1.png
+            :height: 940px

--- a/de/15.3/admin/duplicatehost-guide.rst
+++ b/de/15.3/admin/duplicatehost-guide.rst
@@ -1,0 +1,51 @@
+================
+Duplikat-Hosts
+================
+
+Übersicht
+=========
+
+Hier wird die Konfiguration von Duplikat-Hosts erläutert.
+Duplikat-Hosts werden verwendet, wenn Sie verschiedene Hostnamen beim Crawlen als identisch behandeln möchten.
+Zum Beispiel können Sie dies verwenden, wenn Sie www.example.com und example.com als dieselbe Site behandeln möchten.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Übersichtsseite für die Duplikat-Host-Konfiguration zu öffnen, klicken Sie im linken Menü auf [Crawler > Duplikat-Hosts].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Duplikat-Host-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Kanonischer Name
+::::::::::::::::
+
+Geben Sie den kanonischen Hostnamen an. Duplikat-Hostnamen werden durch den kanonischen Hostnamen ersetzt.
+
+Duplikat-Name
+:::::::::::::
+
+Geben Sie den duplizierenden Hostnamen an. Geben Sie den Hostnamen an, der ersetzt werden soll.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/duplicatehost-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/duplicatehost-2.png

--- a/de/15.3/admin/elevateword-guide.rst
+++ b/de/15.3/admin/elevateword-guide.rst
@@ -1,0 +1,106 @@
+===============
+Zusätzliche Wörter
+===============
+
+Übersicht
+=========
+
+Hier wird die Konfiguration zusätzlicher Wörter für Vorschläge erläutert. Vorschläge werden entsprechend den Suchbegriffen angezeigt, aber Sie können zusätzliche Wörter hinzufügen.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Übersichtsseite für die Konfiguration zusätzlicher Wörter zu öffnen, klicken Sie im linken Menü auf [Vorschläge > Zusätzliche Wörter].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Konfigurationsseite für zusätzliche Wörter zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Wort
+::::
+
+Geben Sie das Wort an, das als Vorschlagskandidat angezeigt werden soll.
+
+Lesung
+::::::
+
+Geben Sie die Lesung des Vorschlagskandidatenworts an.
+
+Berechtigung
+::::::::::::
+
+Legen Sie Rolleninformationen für das Wort fest.
+Nur Benutzer mit der festgelegten Rolle können das Wort in den Vorschlägen sehen.
+
+Label
+:::::
+
+Legen Sie ein Label für das Wort fest.
+Wenn ein anderes als das festgelegte Label ausgewählt ist, wird das Wort nicht in den Vorschlägen angezeigt.
+
+Boost-Wert
+::::::::::
+
+Legen Sie einen Boost-Wert für das Wort fest.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+
+Download
+========
+
+Laden Sie registrierte Wörter im CSV-Format herunter.
+
+|image2|
+
+CSV-Inhalt
+----------
+
+Zeile 1 ist die Kopfzeile.
+Ab Zeile 2 werden die zusätzlichen Wörter aufgeführt.
+
+::
+
+"SuggestWord","Reading","Role","Label","Boost"
+"fess","ふぇす","role1","label1","100"
+
+Upload
+======
+
+Registrieren Sie Wörter im CSV-Format.
+
+|image3|
+
+CSV-Inhalt
+----------
+
+Zeile 1 ist die Kopfzeile.
+Ab Zeile 2 beschreiben Sie die zusätzlichen Wörter.
+
+::
+
+"SuggestWord","Reading","Role","Label","Boost"
+"fess","ふぇす","role1","label1","100"
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/elevateword-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/elevateword-2.png
+.. |image2| image:: ../../../resources/images/ja/15.3/admin/elevateword-3.png
+.. |image3| image:: ../../../resources/images/ja/15.3/admin/elevateword-4.png

--- a/de/15.3/admin/esreq-guide.rst
+++ b/de/15.3/admin/esreq-guide.rst
@@ -1,0 +1,40 @@
+==================
+Abfrageanforderung
+==================
+
+Übersicht
+=========
+
+Auf dieser Seite können Sie JSON-Datei-Abfrageanforderungen an OpenSearch senden.
+
+|image0|
+
+Bedienung
+=========
+
+Anforderung senden
+------------------
+
+Nach der Anmeldung als Administrator geben Sie /admin/esreq/ als URL-Pfad ein.
+Erstellen Sie die Abfrageanforderung, die Sie an OpenSearch senden möchten, als JSON-Datei, wählen Sie diese JSON-Datei als „Anforderungsdatei" aus und klicken Sie auf die Schaltfläche „Senden", um die Anforderung an OpenSearch zu senden.
+Die Antwort wird als Datei heruntergeladen.
+
+Konfigurationsparameter
+-----------------------
+
+Anforderungsdatei
+:::::::::::::::::
+
+Geben Sie eine JSON-Datei an, die die Abfrage-DSL beschreibt.
+Zum Beispiel könnte der Inhalt der JSON-Datei wie folgt aussehen:
+
+::
+
+    POST /_search
+    {
+      "query": {
+        "match_all": {}
+      }
+    }
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/esreq-1.png

--- a/de/15.3/admin/failureurl-guide.rst
+++ b/de/15.3/admin/failureurl-guide.rst
@@ -1,0 +1,66 @@
+=========
+Fehler-URLs
+=========
+
+Übersicht
+=========
+
+Hier werden Fehler-URLs erläutert.
+URLs, die beim Crawlen nicht abgerufen werden konnten, werden aufgezeichnet und können als Fehler-URLs überprüft werden.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Übersichtsseite zur Überprüfung von Fehler-URLs zu öffnen, klicken Sie im linken Menü auf [Systeminformationen > Fehler-URLs].
+
+|image0|
+
+Klicken Sie auf den Bestätigungslink der Fehler-URL, um Details anzuzeigen.
+
+Fehler-URL-Details
+==================
+
+In den Fehler-URL-Details werden beim Crawlen aufgetretene Ausnahmen aufgezeichnet.
+
+|image1|
+
+Detailinhalt
+------------
+
+URL
+:::
+
+Die URL, bei der die Ausnahme aufgetreten ist.
+
+Thread-Name
+:::::::::::
+
+Der Name des Threads, der den Crawl ausgeführt hat.
+Kann beim Überprüfen von Protokolldateien verwendet werden.
+
+Typ
+:::
+
+Der Typ der Ausnahme.
+
+Protokoll
+:::::::::
+
+Der Inhalt der Ausnahme.
+
+Fehleranzahl
+::::::::::::
+
+Die Anzahl, wie oft diese Ausnahme aufgetreten ist.
+
+Letztes Zugriffsdatum
+:::::::::::::::::::::
+
+Die Uhrzeit, zu der diese Ausnahme aufgetreten ist.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/failureurl-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/failureurl-2.png

--- a/de/15.3/admin/fileauth-guide.rst
+++ b/de/15.3/admin/fileauth-guide.rst
@@ -1,0 +1,80 @@
+==================
+Dateiauthentifizierung
+==================
+
+Übersicht
+=========
+
+Hier wird die Konfigurationsmethode erläutert, wenn Dateiauthentifizierung für das Crawlen von Dateien erforderlich ist.
+|Fess| unterstützt die Authentifizierung für FTP oder Windows-Freigabeordner.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Übersichtsseite für die Dateiauthentifizierungskonfiguration zu öffnen, klicken Sie im linken Menü auf [Crawler > Dateiauthentifizierung].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Dateiauthentifizierungskonfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Hostname
+::::::::
+
+Geben Sie den Hostnamen der Site an, die Authentifizierung erfordert.
+
+Port
+::::
+
+Geben Sie den Port der Site an, die Authentifizierung erfordert.
+
+Schema
+::::::
+
+Wählen Sie die Authentifizierungsmethode aus.
+Sie können FTP oder SAMBA (Windows-Freigabeordnerauthentifizierung) verwenden.
+
+Benutzername
+::::::::::::
+
+Geben Sie den Benutzernamen für die Anmeldung bei der Authentifizierungssite an.
+
+Passwort
+::::::::
+
+Geben Sie das Passwort für die Anmeldung bei der Authentifizierungssite an.
+
+Parameter
+:::::::::
+
+Konfigurieren Sie dies, wenn Konfigurationswerte für die Anmeldung bei der Authentifizierungssite erforderlich sind. Für SAMBA können Sie den Domänenwert konfigurieren. Geben Sie ihn wie folgt an:
+
+::
+
+    domain=FUGA
+
+Datei-Crawl-Konfiguration
+:::::::::::::::::::::::::
+
+Geben Sie die Crawl-Konfiguration an, die diese Authentifizierungskonfiguration verwenden soll.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/fileauth-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/fileauth-2.png

--- a/de/15.3/admin/fileconfig-guide.rst
+++ b/de/15.3/admin/fileconfig-guide.rst
@@ -1,0 +1,180 @@
+===========
+Datei-Crawl
+===========
+
+Übersicht
+=========
+
+Auf der Datei-Crawl-Konfigurationsseite können Sie Konfigurationen zum Crawlen von Dateien im Dateisystem oder in freigegebenen Netzwerkordnern verwalten.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Übersichtsseite für die Datei-Crawl-Konfiguration zu öffnen, klicken Sie im linken Menü auf [Crawler > Dateisystem].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Datei-Crawl-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Name
+::::
+
+Der Name der Konfiguration.
+
+Pfad
+::::
+
+In diesem Pfad geben Sie an, wo das Crawlen beginnen soll (z. B. file:/ oder smb://).
+
+Zu crawlender Pfad
+::::::::::::::::::
+
+Pfade, die mit dem regulären Ausdruck (Java-Format) übereinstimmen, der in diesem Element angegeben ist, werden vom |Fess| Crawler gecrawlt.
+
+Vom Crawlen ausgeschlossener Pfad
+::::::::::::::::::::::::::::::::::
+
+Pfade, die mit dem regulären Ausdruck (Java-Format) übereinstimmen, der in diesem Element angegeben ist, werden vom |Fess| Crawler nicht gecrawlt.
+
+Zu durchsuchender Pfad
+:::::::::::::::::::::::
+
+Pfade, die mit dem regulären Ausdruck (Java-Format) übereinstimmen, der in diesem Element angegeben ist, werden in die Suche einbezogen.
+
+Von der Suche ausgeschlossener Pfad
+::::::::::::::::::::::::::::::::::::
+
+Pfade, die mit dem regulären Ausdruck (Java-Format) übereinstimmen, der in diesem Element angegeben ist, werden von der Suche ausgeschlossen.
+
+Konfigurationsparameter
+:::::::::::::::::::::::
+
+Sie können Crawl-Konfigurationsinformationen angeben.
+
+Tiefe
+:::::
+
+Geben Sie die Tiefe der zu crawlenden Dateisystemstruktur an.
+
+Maximale Zugriffszahl
+:::::::::::::::::::::
+
+Geben Sie die Anzahl der zu indizierenden Pfade an.
+
+Thread-Anzahl
+:::::::::::::
+
+Geben Sie die Anzahl der für diese Konfiguration zu verwendenden Threads an.
+
+Intervall
+:::::::::
+
+Geben Sie die Wartezeit an, die jeder Thread nach dem Crawlen eines Pfads wartet.
+
+Boost-Wert
+::::::::::
+
+Der Boost-Wert ist die Priorität von Dokumenten, die durch diese Konfiguration indiziert werden.
+
+Berechtigung
+::::::::::::
+
+Geben Sie die Berechtigung für diese Konfiguration an.
+Um beispielsweise Suchergebnisse für Benutzer anzuzeigen, die zur Gruppe „developer" gehören, geben Sie {group}developer an.
+Für Benutzerebene geben Sie {user}Benutzername an, für Rollenebene {role}Rollenname und für Gruppenebene {group}Gruppenname.
+
+Virtueller Host
+:::::::::::::::
+
+Geben Sie den Hostnamen des virtuellen Hosts an.
+Weitere Details finden Sie unter :doc:`Virtueller Host im Konfigurationshandbuch <../config/virtual-host>`.
+
+Status
+::::::
+
+Wenn diese Konfiguration aktiviert ist, enthält der Standard-Crawler-Job diese Konfiguration beim Crawlen.
+
+Beschreibung
+::::::::::::
+
+Sie können eine Beschreibung eingeben.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt. Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+Beispiele
+=========
+
+Lokale Dateien crawlen
+----------------------
+
+Um Dateien unter /home/share zu crawlen, würde die Konfiguration wie folgt aussehen:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Wert
+   * - Name
+     - Freigabeverzeichnis
+   * - Pfad
+     - file:/home/share
+
+Andere Parameter können mit Standardeinstellungen belassen werden.
+
+Windows-Freigabeordner crawlen
+-------------------------------
+
+Um Dateien unter \\SERVER\SharedFolder zu crawlen, würde die Konfiguration wie folgt aussehen:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Wert
+   * - Name
+     - Freigabeordner
+   * - Pfad
+     - smb://SERVER/SharedFolder/
+
+Wenn für den Zugriff auf den Freigabeordner ein Benutzername/Passwort erforderlich ist, müssen Sie eine Dateiauthentifizierungskonfiguration über [Crawler > Dateiauthentifizierung] im linken Menü erstellen.
+Die Konfiguration dafür würde wie folgt aussehen:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - Wert
+   * - Hostname
+     - SERVER
+   * - Schema
+     - SAMBA
+   * - Benutzername
+     - (Bitte eingeben)
+   * - Passwort
+     - (Bitte eingeben)
+
+
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/fileconfig-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/fileconfig-2.png
+.. pdf            :height: 940 px

--- a/de/15.3/admin/general-guide.rst
+++ b/de/15.3/admin/general-guide.rst
@@ -1,0 +1,294 @@
+=========
+Allgemein
+=========
+
+Übersicht
+=========
+
+Auf dieser Verwaltungsseite können Sie die Konfiguration von |Fess| verwalten.
+Sie können verschiedene Konfigurationen von |Fess| ändern, ohne |Fess| neu zu starten.
+
+|image0|
+
+Konfigurationsinhalt
+====================
+
+System
+------
+
+JSON-Antwort
+::::::::::::
+
+Gibt an, ob die JSON-API aktiviert werden soll.
+
+Anmeldung erforderlich
+::::::::::::::::::::::
+
+Gibt an, ob eine Anmeldung für die Suchfunktion erforderlich ist.
+
+Anmeldelink anzeigen
+::::::::::::::::::::
+
+Konfiguriert, ob auf dem Suchbildschirm ein Link zur Anmeldeseite angezeigt werden soll.
+
+Doppelte Ergebnisse zusammenklappen
+::::::::::::::::::::::::::::::::::::
+
+Konfiguriert, ob das Zusammenklappen doppelter Ergebnisse aktiviert werden soll.
+
+Thumbnail-Anzeige
+:::::::::::::::::
+
+Konfiguriert, ob die Thumbnail-Anzeige aktiviert werden soll.
+
+Standard-Label-Wert
+:::::::::::::::::::
+
+Beschreiben Sie den Label-Wert, der standardmäßig zur Suchbedingung hinzugefügt werden soll.
+Um ihn für Rollen oder Gruppen anzugeben, fügen Sie „role:" oder „group:" hinzu, wie z. B. „role:admin=label1".
+
+Standard-Sortierwert
+::::::::::::::::::::
+
+Beschreiben Sie den Sortierwert, der standardmäßig zur Suchbedingung hinzugefügt werden soll.
+Um ihn für Rollen oder Gruppen anzugeben, fügen Sie „role:" oder „group:" hinzu, wie z. B. „role:admin=content_length.desc".
+
+Virtueller Host
+:::::::::::::::
+
+Konfigurieren Sie den virtuellen Host.
+Weitere Details finden Sie unter :doc:`Virtueller Host im Konfigurationshandbuch <../config/virtual-host>`.
+
+Beliebte Wörter-Antwort
+:::::::::::::::::::::::
+
+Gibt an, ob die API für beliebte Wörter aktiviert werden soll.
+
+CSV-Datei-Kodierung
+:::::::::::::::::::
+
+Geben Sie die Kodierung für heruntergeladene CSV-Dateien an.
+
+Suchparameter hinzufügen
+::::::::::::::::::::::::
+
+Aktivieren Sie dies, wenn Sie Parameter an die Suchergebnisanzeige übergeben möchten.
+
+Benachrichtigungs-E-Mail
+::::::::::::::::::::::::
+
+Geben Sie die E-Mail-Adresse an, die bei Abschluss des Crawls benachrichtigt werden soll.
+Mehrere Adressen können durch Kommas getrennt angegeben werden. Ein E-Mail-Server ist erforderlich.
+
+Crawler
+-------
+
+Letztes Änderungsdatum überprüfen
+::::::::::::::::::::::::::::::::::
+
+Aktivieren Sie dies für differenzielles Crawling.
+
+Gleichzeitige Crawler-Konfigurationen
+::::::::::::::::::::::::::::::::::::::
+
+Geben Sie die Anzahl der gleichzeitig auszuführenden Crawl-Konfigurationen an.
+
+Vorherige Dokumente löschen
+::::::::::::::::::::::::::::
+
+Geben Sie die Anzahl der Tage für die Gültigkeitsdauer nach der Indizierung an.
+
+Auszuschließende Fehlertypen
+::::::::::::::::::::::::::::
+
+Fehler-URLs, die den Schwellenwert überschreiten, werden vom Crawlen ausgeschlossen, aber hier angegebene Ausnahmenamen werden auch dann gecrawlt, wenn sie den Schwellenwert überschreiten.
+
+Fehlerzahl-Schwellenwert
+::::::::::::::::::::::::
+
+Wenn ein zu crawlendes Dokument mehr als die hier angegebene Anzahl in Fehler-URLs aufgezeichnet wurde, wird es beim nächsten Crawl ausgeschlossen.
+
+Protokollierung
+---------------
+
+Suchprotokoll
+:::::::::::::
+
+Gibt an, ob die Suchprotokollierung aktiviert werden soll.
+
+Benutzerprotokoll
+:::::::::::::::::
+
+Gibt an, ob die Benutzerprotokollierung aktiviert werden soll.
+
+Favoritenprotokoll
+::::::::::::::::::
+
+Gibt an, ob die Favoritenprotokollierung aktiviert werden soll.
+
+Vorherige Suchprotokolle löschen
+:::::::::::::::::::::::::::::::::
+
+Löscht Suchprotokolle, die älter als die angegebene Anzahl von Tagen sind.
+
+Vorherige Jobprotokolle löschen
+::::::::::::::::::::::::::::::::
+
+Löscht Jobprotokolle, die älter als die angegebene Anzahl von Tagen sind.
+
+Vorherige Benutzerprotokolle löschen
+:::::::::::::::::::::::::::::::::::::
+
+Löscht Benutzerprotokolle, die älter als die angegebene Anzahl von Tagen sind.
+
+Bot-Namen zum Löschen von Protokollen
+::::::::::::::::::::::::::::::::::::::
+
+Geben Sie Bot-Namen an, die aus Suchprotokollen ausgeschlossen werden sollen.
+
+Protokollebene
+::::::::::::::
+
+Geben Sie die Protokollebene für fess.log an.
+
+Vorschlag
+---------
+
+Vorschlag aus Suchbegriffen
+:::::::::::::::::::::::::::
+
+Gibt an, ob Vorschlagskandidaten aus Suchprotokollen generiert werden sollen.
+
+Vorschlag aus Dokumenten
+::::::::::::::::::::::::
+
+Gibt an, ob Vorschlagskandidaten aus indizierten Dokumenten generiert werden sollen.
+
+Vorherige Vorschlagsinformationen löschen
+::::::::::::::::::::::::::::::::::::::::::
+
+Löscht Vorschlagsdaten, die älter als die angegebene Anzahl von Tagen sind.
+
+LDAP
+----
+
+LDAP-URL
+::::::::
+
+Geben Sie die URL des LDAP-Servers an.
+
+Basis-DN
+::::::::
+
+Geben Sie den Basis-Distinguished-Name für die Anmeldung am Suchbildschirm an.
+
+Bind-DN
+:::::::
+
+Geben Sie den Bind-DN des Administrators an.
+
+Passwort
+::::::::
+
+Geben Sie das Passwort für den Bind-DN an.
+
+Benutzer-DN
+:::::::::::
+
+Geben Sie den Distinguished-Name des Benutzers an.
+
+Kontofilter
+:::::::::::
+
+Geben Sie den Common Name oder die UID des Benutzers an.
+
+Gruppenfilter
+:::::::::::::
+
+Geben Sie die Filterbedingung für abzurufende Gruppen an.
+
+memberOf-Attribut
+:::::::::::::::::
+
+Geben Sie den memberOf-Attributnamen an, der auf dem LDAP-Server verfügbar ist.
+Für Active Directory ist es memberOf.
+Für andere LDAP-Server kann es isMemberOf sein.
+
+
+Benachrichtigungsanzeige
+------------------------
+
+Anmeldeseite
+::::::::::::
+
+Beschreiben Sie die Nachricht, die auf dem Anmeldebildschirm angezeigt werden soll.
+
+Such-Startseite
+:::::::::::::::
+
+Beschreiben Sie die Nachricht, die auf dem Such-Startbildschirm angezeigt werden soll.
+
+Speicher
+--------
+
+Nach der Konfiguration dieser Elemente wird das Menü [System > Speicher] im linken Menü angezeigt.
+Informationen zur Dateiverwaltung finden Sie unter :doc:`Speicher <../admin/storage-guide>`.
+
+Endpunkt
+::::::::
+
+Geben Sie die Endpunkt-URL des MinIO-Servers an.
+
+Zugriffsschlüssel
+:::::::::::::::::
+
+Geben Sie den Zugriffsschlüssel des MinIO-Servers an.
+
+Geheimer Schlüssel
+::::::::::::::::::
+
+Geben Sie den geheimen Schlüssel des MinIO-Servers an.
+
+Bucket
+::::::
+
+Geben Sie den zu verwaltenden Bucket-Namen an.
+
+Beispiele
+=========
+
+LDAP-Konfigurationsbeispiele
+-----------------------------
+
+.. tabularcolumns:: |p{4cm}|p{4cm}|p{4cm}|
+.. list-table:: LDAP/Active Directory-Konfiguration
+   :header-rows: 1
+
+   * - Name
+     - Wert (LDAP)
+     - Wert (Active Directory)
+   * - LDAP-URL
+     - ldap://SERVERNAME:389
+     - ldap://SERVERNAME:389
+   * - Basis-DN
+     - cn=Directory Manager
+     - dc=fess,dc=codelibs,dc=org
+   * - Bind-DN
+     - uid=%s,ou=People,dc=fess,dc=codelibs,dc=org
+     - manager@fess.codelibs.org
+   * - Benutzer-DN
+     - uid=%s,ou=People,dc=fess,dc=codelibs,dc=org
+     - %s@fess.codelibs.org
+   * - Kontofilter
+     - cn=%s oder uid=%s
+     - (&(objectClass=user)(sAMAccountName=%s))
+   * - Gruppenfilter
+     -
+     - (member:1.2.840.113556.1.4.1941:=%s)
+   * - memberOf
+     - isMemberOf
+     - memberOf
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/general-1.png
+.. pdf            :height: 940 px

--- a/de/15.3/admin/group-guide.rst
+++ b/de/15.3/admin/group-guide.rst
@@ -1,0 +1,45 @@
+======
+Gruppe
+======
+
+Übersicht
+=========
+
+Sie können Gruppen verwalten, zu denen Benutzer gehören.
+Dies kann beispielsweise bei der LDAP-Integration verwendet werden.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Übersichtsseite für die Gruppenkonfiguration zu öffnen, klicken Sie im linken Menü auf [Benutzer > Gruppe].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Gruppenkonfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Name
+::::
+
+Gruppenname.
+
+Löschmethode
+------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/group-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/group-2.png

--- a/de/15.3/admin/index.rst
+++ b/de/15.3/admin/index.rst
@@ -1,0 +1,52 @@
+|Fess| Administratorhandbuch
+============================
+
+.. toctree::
+   :maxdepth: 3
+
+   intro
+   dashboard-guide
+   wizard-guide
+   general-guide
+   scheduler-guide
+   design-guide
+   dict-guide
+   kuromoji-guide
+   synonym-guide
+   mapping-guide
+   protwords-guide
+   stopwords-guide
+   stemmeroverride-guide
+   accesstoken-guide
+   plugin-guide
+   storage-guide
+   webconfig-guide
+   fileconfig-guide
+   dataconfig-guide
+   labeltype-guide
+   keymatch-guide
+   boostdoc-guide
+   relatedcontent-guide
+   relatedquery-guide
+   pathmap-guide
+   webauth-guide
+   fileauth-guide
+   reqheader-guide
+   duplicatehost-guide
+   user-guide
+   role-guide
+   group-guide
+   suggest-guide
+   elevateword-guide
+   badword-guide
+   systeminfo-guide
+   searchlog-guide
+   joblog-guide
+   crawlinginfo-guide
+   log-guide
+   failureurl-guide
+   searchlist-guide
+   backup-guide
+   maintenance-guide
+   esreq-guide
+

--- a/de/15.3/admin/intro.rst
+++ b/de/15.3/admin/intro.rst
@@ -1,0 +1,34 @@
+=========
+Einführung
+=========
+
+Zielgruppe
+==========
+
+Dieses Dokument richtet sich an Benutzer, die für die Verwaltung von |Fess| verantwortlich sind.
+
+Bevor Sie beginnen
+==================
+
+Dieses Dokument beschreibt die Konfigurationsverwaltung von |Fess|. Grundlegende Kenntnisse im Umgang mit Computern werden vorausgesetzt.
+
+Online-Zugang
+=============
+
+Für Downloads, professionelle Dienstleistungen, Support und weitere Entwicklerinformationen besuchen Sie bitte:
+
+-  Projektseite:
+   `https://fess.codelibs.org/ <https://fess.codelibs.org/>`__
+
+Kontakt für technischen Support
+================================
+
+Wenn Sie technische Fragen zu diesem Produkt haben, die nicht durch die Dokumentation beantwortet werden können, besuchen Sie bitte:
+
+-  Issues:
+   `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
+
+Kommerzieller Support
+---------------------
+
+Wenn Sie kommerziellen Support wie technische Unterstützung oder Wartung für dieses Produkt benötigen, wenden Sie sich bitte an `N2SM, Inc. <https://www.n2sm.net/>`__.

--- a/de/15.3/admin/joblog-guide.rst
+++ b/de/15.3/admin/joblog-guide.rst
@@ -1,0 +1,68 @@
+=========
+Jobprotokoll
+=========
+
+Übersicht
+=========
+
+Zeigt die Ergebnisse ausgeführter Jobs als Liste an.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Jobprotokoll-Überprüfungsseite zu öffnen, klicken Sie im linken Menü auf [Systeminformationen > Jobprotokoll].
+
+|image0|
+
+Jobprotokoll-Details
+--------------------
+
+Sie können den Protokollinhalt des Jobs überprüfen. Es werden Jobname, Status, Start-/Abschlusszeit, Ergebnis usw. angezeigt.
+
+|image1|
+
+Name
+::::
+
+Der Name des ausgeführten Jobs.
+
+Status
+::::::
+
+Das Ausführungsergebnis des Jobs.
+
+Ziel
+::::
+
+Das Ziel, für das der Job ausgeführt wird.
+
+Startzeit
+:::::::::
+
+Die UNIX-Zeit, zu der der Job gestartet wurde.
+
+Endzeit
+:::::::
+
+Die UNIX-Zeit, zu der der Job beendet wurde.
+
+Ausführungsmethode
+::::::::::::::::::
+
+Die Ausführungsumgebung, in der der Job ausgeführt wurde.
+
+Skript
+::::::
+
+Der Ausführungsinhalt des Jobs.
+
+Ergebnis
+::::::::
+
+Das Ausführungsergebnis des Jobs.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/joblog-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/joblog-2.png

--- a/de/15.3/admin/keymatch-guide.rst
+++ b/de/15.3/admin/keymatch-guide.rst
@@ -1,0 +1,66 @@
+===========
+Schlüsselübereinstimmung
+===========
+
+Übersicht
+=========
+
+Hier wird die Konfiguration der Schlüsselübereinstimmung erläutert.
+Durch die Konfiguration der Schlüsselübereinstimmung können Sie Dokumente in den Suchergebnissen höher positionieren, wenn nach registrierten Suchbegriffen gesucht wird.
+Eine häufige Verwendung ist Werbung.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+Um die Konfigurationsübersichtsseite für Schlüsselübereinstimmungen zu öffnen, klicken Sie im linken Menü auf [Crawler > Schlüsselübereinstimmung].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Konfigurationsseite für Schlüsselübereinstimmungen zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Suchbegriff
+:::::::::::
+
+Die Gewichtung wird nur in Suchergebnissen angewendet, wenn nach diesem Suchbegriff gesucht wird.
+
+Abfrage
+:::::::
+
+Zieldokumente, die höher positioniert werden sollen, werden durch die Suchabfrage bestimmt.
+
+Größe
+:::::
+
+Geben Sie die maximale Anzahl von Dokumenten an, die mit der Abfrage übereinstimmen.
+
+Boost-Wert
+::::::::::
+
+Geben Sie den Gewichtungswert für Dokumente an.
+
+Virtueller Host
+:::::::::::::::
+
+Geben Sie den Hostnamen des virtuellen Hosts an.
+Weitere Details finden Sie unter :doc:`Virtueller Host im Konfigurationshandbuch <../config/virtual-host>`.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/keymatch-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/keymatch-2.png

--- a/de/15.3/admin/kuromoji-guide.rst
+++ b/de/15.3/admin/kuromoji-guide.rst
@@ -1,0 +1,76 @@
+================
+Kuromoji-Wörterbuch
+================
+
+Übersicht
+=========
+
+Personennamen, Eigennamen, Fachbegriffe usw. können für die morphologische Analyse registriert werden.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Kuromoji-Konfigurationsübersichtsseite zu öffnen, wählen Sie im linken Menü [System > Wörterbuch] aus und klicken Sie dann auf kuromoji.
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfigurationsmethode
+---------------------
+
+Um die Kuromoji-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Token
+:::::
+
+Geben Sie das Wort ein, das in der morphologischen Analyse verarbeitet werden soll.
+
+Segmentierung
+:::::::::::::
+
+Wenn das Wort aus zusammengesetzten Wörtern besteht, kann es so konfiguriert werden, dass es auch bei der Suche nach segmentierten Wörtern gefunden wird.
+Zum Beispiel können Sie „全文検索エンジン" als „全文 検索 エンジン" eingeben, damit auch nach segmentierten Wörtern gesucht werden kann.
+
+Lesung
+::::::
+
+Geben Sie die Lesung des als Token eingegebenen Worts in Katakana ein.
+Wenn Sie segmentiert haben, geben Sie die Lesung segmentiert ein.
+Zum Beispiel geben Sie „ゼンブン ケンサク エンジン" ein.
+
+Wortart
+:::::::
+
+Geben Sie die Wortart des eingegebenen Worts ein.
+
+Download
+========
+
+Sie können im Kuromoji-Wörterbuchformat herunterladen.
+
+Upload
+======
+
+Sie können im Kuromoji-Wörterbuchformat hochladen.
+Das Kuromoji-Wörterbuchformat ist durch Kommas (,) getrennt: „Token,Segmentiertes Token,Lesung des segmentierten Tokens,Wortart".
+Segmentierte Token werden durch Leerzeichen getrennt.
+Wenn keine Segmentierung erforderlich ist, sind Token und segmentiertes Token gleich.
+Zum Beispiel:
+
+::
+
+    朝青龍,朝青龍,アサショウリュウ,カスタム名詞
+    関西国際空港,関西 国際 空港,カンサイ コクサイ クウコウ,カスタム名詞
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/kuromoji-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/kuromoji-2.png

--- a/de/15.3/admin/labeltype-guide.rst
+++ b/de/15.3/admin/labeltype-guide.rst
@@ -1,0 +1,87 @@
+=====
+Label
+=====
+
+Übersicht
+=========
+
+
+Hier wird die Konfiguration von Labels erläutert.
+Labels können Dokumente klassifizieren, die in Suchergebnissen angezeigt werden.
+Die Label-Konfiguration gibt Pfade an, auf die Labels angewendet werden sollen, mithilfe regulärer Ausdrücke.
+Wenn Labels registriert sind, wird ein Label-Dropdown-Feld in den Suchoptionen angezeigt.
+
+Die hier vorgenommene Label-Konfiguration gilt für Web- oder Dateisystem-Crawl-Konfigurationen.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Label-Konfigurationsübersichtsseite zu öffnen, klicken Sie im linken Menü auf [Crawler > Label].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Label-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Name
+::::
+
+Geben Sie den Namen an, der im Label-Auswahl-Dropdown-Feld bei der Suche angezeigt werden soll.
+
+Wert
+::::
+
+Geben Sie die Kennung zur Klassifizierung von Dokumenten an.
+Geben Sie alphanumerische Zeichen an.
+
+Zielpfad
+::::::::
+
+Konfigurieren Sie Pfade, auf die Labels angewendet werden sollen, mithilfe regulärer Ausdrücke.
+Sie können mehrere Pfade angeben, indem Sie mehrere Zeilen schreiben.
+Dokumente, die mit den hier angegebenen Pfaden übereinstimmen, erhalten das Label.
+
+Ausgeschlossener Pfad
+:::::::::::::::::::::
+
+Konfigurieren Sie Pfade, die vom Crawl-Ziel ausgeschlossen werden sollen, mithilfe regulärer Ausdrücke.
+Sie können mehrere Pfade angeben, indem Sie mehrere Zeilen schreiben.
+
+Berechtigung
+::::::::::::
+
+Geben Sie die Berechtigung für diese Konfiguration an.
+Um beispielsweise Suchergebnisse für Benutzer anzuzeigen, die zur Gruppe „developer" gehören, geben Sie {group}developer an.
+Für Benutzerebene geben Sie {user}Benutzername an, für Rollenebene {role}Rollenname und für Gruppenebene {group}Gruppenname.
+
+Virtueller Host
+:::::::::::::::
+
+Geben Sie den Hostnamen des virtuellen Hosts an.
+Weitere Details finden Sie unter :doc:`Virtueller Host im Konfigurationshandbuch <../config/virtual-host>`.
+
+Anzeigereihenfolge
+::::::::::::::::::
+
+Geben Sie die Anzeigereihenfolge der Labels an.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/labeltype-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/labeltype-2.png

--- a/de/15.3/admin/log-guide.rst
+++ b/de/15.3/admin/log-guide.rst
@@ -1,0 +1,70 @@
+============
+Protokolldatei
+============
+
+Übersicht
+=========
+
+Hier wird der Download von Protokolldateien erläutert, die von |Fess| ausgegeben werden.
+
+Konfiguration
+=============
+
+Anzeige
+-------
+
+Um die Protokolldateiseite zu öffnen, klicken Sie im linken Menü auf [Systeminformationen > Protokolldatei].
+
+|image0|
+
+Download
+--------
+
+Sie können Protokolldateien herunterladen, indem Sie auf den angezeigten Protokolldateinamen klicken.
+
+``server_*.log``
+::::::::::::::::
+
+Protokolliert werden die Protokolle von |Fess| als Anwendungsserver.
+
+fess.log
+::::::::
+
+Protokolliert werden die Protokolle von |Fess| als Anwendung.
+
+fess-crawler.log
+::::::::::::::::
+
+Protokolliert werden die Crawler-Protokolle.
+
+audit.log
+:::::::::
+
+Protokolliert werden Anmeldeinformationen und Zugriffsprotokolle des Verwaltungsbildschirms.
+
+fess-thumbnail.log
+::::::::::::::::::
+
+Protokolliert werden die Protokolle der Thumbnail-Funktion.
+
+fess-suggest.log
+::::::::::::::::
+
+Protokolliert werden die Protokolle der Vorschlagsfunktion.
+
+fess-urls.log
+:::::::::::::
+
+Protokolliert wird die Zeit, die für einen einzelnen Crawl benötigt wurde.
+
+search.log
+::::::::::
+
+Protokolliert werden die Suchprotokolle.
+
+gc-crawler.log
+::::::::::::::
+
+Protokolliert werden die GC-Protokolle von Fess.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/log-1.png

--- a/de/15.3/admin/maintenance-guide.rst
+++ b/de/15.3/admin/maintenance-guide.rst
@@ -1,0 +1,67 @@
+=========
+Wartung
+=========
+
+Übersicht
+=========
+
+Die Wartungsseite wird verwendet, wenn Systemdatenoperationen ausgeführt werden.
+
+|image0|
+
+Bedienung
+=========
+
+Neuindizierung
+--------------
+
+Sie können einen neuen Index aus dem vorhandenen Fess-Index neu erstellen.
+Führen Sie dies aus, wenn Sie das Index-Mapping ändern möchten.
+
+
+Konfigurationsparameter
+-----------------------
+
+Alias aktualisieren
+:::::::::::::::::::
+
+Durch Aktivierung können Sie nach Abschluss der Neuindizierung die Aliasse fess.search und fess.update, die dem vorhandenen Index zugewiesen sind, auf den neuen Index umstellen.
+
+
+Wörterbuch initialisieren
+:::::::::::::::::::::::::
+
+Durch Aktivierung können Sie die Wörterbuchkonfiguration initialisieren.
+
+
+Shard-Anzahl
+::::::::::::
+
+Sie können die OpenSearch-Shard-Anzahl (index.number_of_shards) angeben.
+
+
+Maximale Replikatanzahl
+:::::::::::::::::::::::
+
+Sie können die maximale OpenSearch-Replikatanzahl (index.auto_expand_replicas) angeben.
+
+
+Dokumentindex neu laden
+-----------------------
+
+Sie können den Dokumentindex neu laden, um die Indexkonfiguration zu übernehmen.
+
+
+Crawler-Index
+-------------
+
+Sie können den fess_crawler-Index (Crawl-Informationen) löschen.
+Führen Sie dies nicht während der Crawler-Ausführung aus.
+
+
+Diagnose
+--------
+
+Sie können Protokolldateien im ZIP-Format herunterladen.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/maintenance-1.png

--- a/de/15.3/admin/mapping-guide.rst
+++ b/de/15.3/admin/mapping-guide.rst
@@ -1,0 +1,55 @@
+==================
+Mapping-Wörterbuch
+==================
+
+Übersicht
+=========
+
+Bestimmte Zeichen (Symbole, Zeichencodes, Vollbreite/Halbbreite) können auf andere Zeichen gemappt werden.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Mapping-Konfigurationsübersichtsseite zu öffnen, wählen Sie im linken Menü [System > Wörterbuch] aus und klicken Sie dann auf mapping.
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfigurationsmethode
+---------------------
+
+Um die Mapping-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Quelle
+::::::
+
+Geben Sie die Zeichen (Symbole, Zeichencodes, Vollbreite/Halbbreite) ein, die gemappt werden sollen.
+
+Ziel
+::::
+
+Erweitern Sie die in der Quelle eingegebenen Zeichen mit den Zielzeichen.
+
+Download
+========
+
+Sie können im Mapping-Wörterbuchformat herunterladen.
+
+Upload
+======
+
+Sie können im Mapping-Wörterbuchformat hochladen.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/mapping-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/mapping-2.png
+

--- a/de/15.3/admin/pathmap-guide.rst
+++ b/de/15.3/admin/pathmap-guide.rst
@@ -1,0 +1,67 @@
+============
+Pfad-Mapping
+============
+
+Übersicht
+=========
+
+Hier wird die Konfiguration des Pfad-Mappings erläutert.
+Pfad-Mapping kann verwendet werden, wenn Sie Links ersetzen möchten, die in Suchergebnissen angezeigt werden.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Pfad-Mapping-Konfigurationsübersichtsseite zu öffnen, klicken Sie im linken Menü auf [Crawler > Pfad-Mapping].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Pfad-Mapping-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Regulärer Ausdruck
+::::::::::::::::::
+
+Geben Sie die zu ersetzende Zeichenkette an.
+Die Beschreibungsmethode folgt regulären Java-Ausdrücken.
+
+Ersetzung
+:::::::::
+
+Geben Sie die Zeichenkette an, durch die der übereinstimmende reguläre Ausdruck ersetzt werden soll.
+
+Verarbeitungstyp
+::::::::::::::::
+
+Geben Sie den Zeitpunkt der Ersetzung an.
+
+* Crawl: Ersetzt die URL nach dem Abrufen des Dokuments beim Crawlen und vor der Indizierung.
+* Anzeige: Ersetzt die URL bei der Suche vor der Anzeige.
+* Crawl/Anzeige: Ersetzt die URL sowohl beim Crawlen als auch bei der Anzeige.
+* Gespeicherte URL: Ersetzt die URL beim Crawlen vor dem Abrufen des Dokuments.
+
+Anzeigereihenfolge
+::::::::::::::::::
+
+Sie können die Verarbeitungsreihenfolge des Pfad-Mappings angeben.
+Wird in aufsteigender Reihenfolge verarbeitet.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/pathmap-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/pathmap-2.png

--- a/de/15.3/admin/plugin-guide.rst
+++ b/de/15.3/admin/plugin-guide.rst
@@ -1,0 +1,32 @@
+=========
+Plug-ins
+=========
+
+Übersicht
+=========
+
+Die Plug-in-Konfigurationsseite verwaltet Plug-ins.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Übersichtsseite der installierten Plug-ins zu öffnen, klicken Sie im linken Menü auf [System > Plug-ins].
+
+|image0|
+
+Klicken Sie zum Deinstallieren auf die Schaltfläche „Löschen".
+
+Installation
+------------
+
+Um ein neues Plug-in zu installieren, klicken Sie auf die Schaltfläche „Installieren".
+
+|image1|
+
+Wählen Sie im Dropdown-Menü das zu installierende Plug-in aus und klicken Sie auf die Schaltfläche „Installieren", um die Installation zu starten.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/plugin-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/plugin-2.png

--- a/de/15.3/admin/protwords-guide.rst
+++ b/de/15.3/admin/protwords-guide.rst
@@ -1,0 +1,52 @@
+==================
+Protwords-Wörterbuch
+==================
+
+Übersicht
+=========
+
+Sie können Wörter verwalten, die von der Stemming-Verarbeitung ausgeschlossen werden sollen.
+Da die Stemming-Verarbeitung grundsätzlich regelbasiert ist, kann eine unbeabsichtigte Normalisierung auftreten.
+Beispielsweise wird das Wort Maine (Name eines US-Bundesstaates) zu main normalisiert.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Protwords-Konfigurationsübersichtsseite zu öffnen, wählen Sie im linken Menü [System > Wörterbuch] aus und klicken Sie dann auf protwords.
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfigurationsmethode
+---------------------
+
+Um die Protwords-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Wortinformation
+:::::::::::::::
+
+Geben Sie Wörter ein, die von der Stemming-Verarbeitung ausgeschlossen werden sollen.
+
+
+Download
+========
+
+Sie können im Protwords-Wörterbuchformat herunterladen.
+
+Upload
+======
+
+Sie können im Protwords-Wörterbuchformat hochladen.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/protwords-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/protwords-2.png

--- a/de/15.3/admin/relatedcontent-guide.rst
+++ b/de/15.3/admin/relatedcontent-guide.rst
@@ -1,0 +1,57 @@
+==================
+Verwandte Inhalte
+==================
+
+Übersicht
+=========
+
+
+Hier wird die Konfiguration verwandter Inhalte erläutert.
+Wenn die Suchabfrage mit dem angegebenen Suchbegriff übereinstimmt, können verwandte Inhalte oben in den Suchergebnissen angezeigt werden.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Übersichtsseite für die Konfiguration verwandter Inhalte zu öffnen, klicken Sie im linken Menü auf [Crawler > Verwandte Inhalte].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Konfigurationsseite für verwandte Inhalte zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Suchbegriff
+:::::::::::
+
+Geben Sie den Suchbegriff an, mit dem die Suchabfrage übereinstimmen soll.
+
+Inhalt
+::::::
+
+Geben Sie den Inhalt an, der in den Suchergebnissen angezeigt werden soll.
+
+Virtueller Host
+:::::::::::::::
+
+Geben Sie den Hostnamen des virtuellen Hosts an.
+Weitere Details finden Sie unter :doc:`Virtueller Host im Konfigurationshandbuch <../config/virtual-host>`.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/relatedcontent-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/relatedcontent-2.png

--- a/de/15.3/admin/relatedquery-guide.rst
+++ b/de/15.3/admin/relatedquery-guide.rst
@@ -1,0 +1,59 @@
+==================
+Verwandte Abfragen
+==================
+
+Übersicht
+=========
+
+Hier wird die Konfiguration verwandter Abfragen erläutert.
+Sie können Suchergebnisse mit registrierten verwandten Abfragen verbessern.
+Verwandte Abfragen können als Alternativbegriffe für Suchbegriffe verwendet werden.
+
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Übersichtsseite für die Konfiguration verwandter Abfragen zu öffnen, klicken Sie im linken Menü auf [Crawler > Verwandte Abfragen].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Konfigurationsseite für verwandte Abfragen zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Suchbegriff
+:::::::::::
+
+Geben Sie den Suchbegriff an, mit dem die Suchabfrage übereinstimmen soll.
+
+Abfrage
+:::::::
+
+Geben Sie die Abfrage an.
+
+Virtueller Host
+:::::::::::::::
+
+Geben Sie den Hostnamen des virtuellen Hosts an.
+Weitere Details finden Sie unter :doc:`Virtueller Host im Konfigurationshandbuch <../config/virtual-host>`.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/relatedquery-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/relatedquery-2.png

--- a/de/15.3/admin/reqheader-guide.rst
+++ b/de/15.3/admin/reqheader-guide.rst
@@ -1,0 +1,57 @@
+==================
+Anforderungsheader
+==================
+
+Übersicht
+=========
+
+Hier wird die Konfiguration von Anforderungsheadern erläutert.
+Die Anforderungsheader-Funktion fügt Anforderungsheaderinformationen zu Anforderungen hinzu, die beim Crawlen von Dokumenten gestellt werden.
+Dies kann beispielsweise verwendet werden, wenn ein Authentifizierungssystem Headerinformationen überprüft und bei bestimmten Werten eine automatische Anmeldung durchführt.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Anforderungsheader-Konfigurationsübersichtsseite zu öffnen, klicken Sie im linken Menü auf [Crawler > Anforderungsheader].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Anforderungsheader-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Name
+::::
+
+Geben Sie den Anforderungsheadernamen an, der der Anforderung hinzugefügt werden soll.
+
+Wert
+::::
+
+Geben Sie den Anforderungsheaderwert an, der der Anforderung hinzugefügt werden soll.
+
+Web-Konfiguration
+:::::::::::::::::
+
+Wählen Sie den Namen der Web-Crawl-Konfiguration aus, zu der der Anforderungsheader hinzugefügt werden soll.
+Der Anforderungsheader wird nur zu den ausgewählten Crawl-Konfigurationen hinzugefügt.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/reqheader-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/reqheader-2.png

--- a/de/15.3/admin/role-guide.rst
+++ b/de/15.3/admin/role-guide.rst
@@ -1,0 +1,46 @@
+======
+Rolle
+======
+
+Übersicht
+=========
+
+Sie können Rollen verwalten, zu denen Benutzer gehören.
+Dies kann beispielsweise bei der LDAP-Integration verwendet werden.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Rollen-Konfigurationsübersichtsseite zu öffnen, klicken Sie im linken Menü auf [Benutzer > Rolle].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Rollen-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Name
+::::
+
+Rollenname.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/role-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/role-2.png

--- a/de/15.3/admin/scheduler-guide.rst
+++ b/de/15.3/admin/scheduler-guide.rst
@@ -1,0 +1,105 @@
+=========
+Scheduler
+=========
+
+Übersicht
+=========
+
+Hier wird die Konfiguration des Job-Schedulers erläutert.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Job-Scheduler-Konfigurationsübersichtsseite zu öffnen, klicken Sie im linken Menü auf [System > Scheduler].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Scheduler-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Name
+::::
+
+Der in der Übersicht angezeigte Name.
+
+Ziel
+::::
+
+Das Ziel kann als Kennung verwendet werden, um zu bestimmen, ob ein Job ausgeführt werden soll, wenn er direkt über einen Batch-Befehl ausgeführt wird.
+Wenn Sie das Crawling nicht per Befehl ausführen, geben Sie „all" an.
+
+Zeitplan
+::::::::
+
+Konfigurieren Sie den Zeitplan.
+Der hier konfigurierte Zeitplan führt den im Skript beschriebenen Job aus.
+
+Das Beschreibungsformat ist das CRON-Format in der Form „Minute Stunde Tag Monat Wochentag".
+Zum Beispiel führt „0 12 \* \* 3" den Job jeden Mittwoch um 12:00 Uhr aus.
+
+Ausführungsmethode
+::::::::::::::::::
+
+Geben Sie die Skriptausführungsumgebung an.
+Derzeit wird nur „groovy" unterstützt.
+
+Skript
+::::::
+
+Beschreiben Sie den Ausführungsinhalt des Jobs in der unter „Ausführungsmethode" angegebenen Sprache.
+
+Um beispielsweise nur drei Crawl-Konfigurationen als Crawl-Job auszuführen, schreiben Sie Folgendes (vorausgesetzt, die Web-Crawl-Konfigurations-IDs sind 1 und 2 und die Dateisystem-Crawl-Konfigurations-ID ist 1):
+
+::
+
+    return container.getComponent("crawlJob").logLevel("info").webConfigIds(["1", "2"] as String[]).fileConfigIds(["1"] as String[]).dataConfigIds([] as String[]).execute(executor);
+
+Protokollierung
+:::::::::::::::
+
+Durch Aktivierung wird der Vorgang im Jobprotokoll aufgezeichnet.
+
+Crawler-Job
+:::::::::::
+
+Durch Aktivierung wird er als Crawler-Job behandelt.
+Durch Konfiguration von job.max.crawler.processes in fess_config.properties können Sie verhindern, dass mehr Crawler als erforderlich gestartet werden.
+Standardmäßig gibt es keine Begrenzung für die Anzahl der Crawler-Starts.
+
+Status
+::::::
+
+Geben Sie den aktiven/inaktiven Status des Jobs an.
+Wenn deaktiviert, wird der Job nicht ausgeführt.
+
+Anzeigereihenfolge
+::::::::::::::::::
+
+Geben Sie die Anzeigereihenfolge in der Job-Übersicht an.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+Manuelles Crawlen
+=================
+
+Klicken Sie unter „Scheduler" auf „Default Crawler" und dann auf die Schaltfläche „Jetzt starten".
+Um den Crawler zu stoppen, klicken Sie auf „Default Crawler" und dann auf die Schaltfläche „Stoppen".
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/scheduler-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/scheduler-2.png

--- a/de/15.3/admin/searchlist-guide.rst
+++ b/de/15.3/admin/searchlist-guide.rst
@@ -1,0 +1,33 @@
+====
+Suche
+====
+
+Übersicht
+=========
+
+Hier wird die Verwaltungssuche erläutert.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Suchseite zu öffnen, klicken Sie im linken Menü auf [Systeminformationen > Suche].
+
+|image0|
+
+Suchliste
+---------
+
+Sie können nach angegebenen Bedingungen suchen.
+Im normalen Suchbildschirm werden Rollen- und Browser-Bedingungen implizit hinzugefügt, aber in dieser Verwaltungssuche werden sie nicht hinzugefügt.
+Sie können auch bestimmte Dokumente aus dem Index aus den angezeigten Suchergebnissen löschen.
+
+Massenlöschung
+--------------
+
+Wenn Sie alle Dokumente aus dem Index löschen möchten, können Sie dies tun, indem Sie „\*:\*" eingeben und auf die Schaltfläche „Alle mit dieser Abfrage löschen" klicken.
+Es ist auch möglich, nur Zieldokumente zu löschen, indem Sie Suchbedingungen angeben.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/searchlist-1.png

--- a/de/15.3/admin/searchlog-guide.rst
+++ b/de/15.3/admin/searchlog-guide.rst
@@ -1,0 +1,30 @@
+===========
+Suchprotokoll
+===========
+
+Übersicht
+=========
+
+Such-, Klick- und Favoriten-Ausführungsergebnisse werden aufgezeichnet, und Suchprotokolle können auf diesem Verwaltungsbildschirm überprüft werden.
+
+Verwaltung
+==========
+
+Übersicht
+=========
+
+In der Übersicht können Sie Such-, Klick- und Favoriten-Suchprotokolle überprüfen.
+Um Details des Suchprotokolls anzuzeigen, klicken Sie auf das entsprechende Suchprotokoll.
+
+|image0|
+
+Details
+=======
+
+Durch Klicken auf ein Suchprotokoll in der Übersicht werden die Details des entsprechenden Suchprotokolls angezeigt.
+
+|image1|
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/searchlog-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/searchlog-2.png

--- a/de/15.3/admin/stemmeroverride-guide.rst
+++ b/de/15.3/admin/stemmeroverride-guide.rst
@@ -1,0 +1,55 @@
+=============================
+Stemmer-Überschreibungs-Wörterbuch
+=============================
+
+Übersicht
+=========
+
+Bestimmte Zeichen (Symbole, Zeichencodes, Vollbreite/Halbbreite) können für die Stemmer-Überschreibung auf andere Zeichen gemappt werden.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Stemmer-Überschreibungs-Konfigurationsübersichtsseite zu öffnen, wählen Sie im linken Menü [System > Wörterbuch] aus und klicken Sie dann auf stemmeroverride.
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfigurationsmethode
+---------------------
+
+Um die Stemmer-Überschreibungs-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Quelle
+::::::
+
+Geben Sie die Zeichen (Symbole, Zeichencodes, Vollbreite/Halbbreite) ein, die für die Stemmer-Überschreibung gemappt werden sollen.
+
+Ziel
+::::
+
+Erweitern Sie die in der Quelle eingegebenen Zeichen mit den Zielzeichen.
+
+Download
+========
+
+Sie können im Stemmer-Überschreibungs-Wörterbuchformat herunterladen.
+
+Upload
+======
+
+Sie können im Stemmer-Überschreibungs-Wörterbuchformat hochladen.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/stemmeroverride-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/stemmeroverride-2.png
+

--- a/de/15.3/admin/stopwords-guide.rst
+++ b/de/15.3/admin/stopwords-guide.rst
@@ -1,0 +1,55 @@
+=====================
+Stoppwort-Wörterbuch
+=====================
+
+Übersicht
+=========
+
+Bestimmte Zeichen (Symbole, Zeichencodes, Vollbreite/Halbbreite) können als Stoppwörter konfiguriert werden.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Stoppwort-Konfigurationsübersichtsseite zu öffnen, wählen Sie im linken Menü [System > Wörterbuch] aus und klicken Sie dann auf stopwords.
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfigurationsmethode
+---------------------
+
+Um die Stoppwort-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Quelle
+::::::
+
+Geben Sie die Zeichen (Symbole, Zeichencodes, Vollbreite/Halbbreite) ein, die als Stoppwörter konfiguriert werden sollen.
+
+Ziel
+::::
+
+Erweitern Sie die in der Quelle eingegebenen Zeichen mit den Zielzeichen.
+
+Download
+========
+
+Sie können im Stoppwort-Wörterbuchformat herunterladen.
+
+Upload
+======
+
+Sie können im Stoppwort-Wörterbuchformat hochladen.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/stopwords-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/stopwords-2.png
+

--- a/de/15.3/admin/storage-guide.rst
+++ b/de/15.3/admin/storage-guide.rst
@@ -1,0 +1,73 @@
+========
+Speicher
+========
+
+Übersicht
+=========
+
+Auf der Speicherseite können Sie Dateien auf MinIO verwalten, einem Amazon S3-kompatiblen Objektspeicher.
+
+Verwaltung
+==========
+
+Konfiguration des Objektspeicher-Servers
+-----------------------------------------
+
+Öffnen Sie die Speicherkonfiguration unter [System > Allgemein] und konfigurieren Sie die folgenden Elemente:
+
+- Endpunkt: Endpunkt-URL des Speicherservers
+- Zugriffsschlüssel: Zugriffsschlüssel des Speicherservers
+- Geheimer Schlüssel: Geheimer Schlüssel des Speicherservers
+- Bucket: Name des zu verwaltenden Buckets
+
+
+Anzeige
+-------
+
+Um die Objektübersichtsseite zu öffnen, klicken Sie im linken Menü auf [System > Speicher].
+
+|image0|
+
+
+Name
+::::
+
+Der Dateiname des Objekts
+
+
+Größe
+:::::
+
+Die Größe des Objekts
+
+
+Letztes Änderungsdatum
+::::::::::::::::::::::
+
+Das letzte Änderungsdatum des Objekts
+
+Download
+--------
+
+Durch Klicken auf die Schaltfläche „Download" können Sie das Objekt herunterladen.
+
+
+Löschen
+-------
+
+Durch Klicken auf die Schaltfläche „Löschen" können Sie das Objekt löschen.
+
+
+Upload
+------
+
+Klicken Sie oben rechts auf die Schaltfläche „Datei hochladen", um das Datei-Upload-Fenster zu öffnen.
+
+
+Ordner erstellen
+----------------
+
+Klicken Sie auf die Schaltfläche „Ordner erstellen" rechts neben der Pfadanzeige, um das Ordnererstellungsfenster zu öffnen. Beachten Sie, dass leere Ordner nicht erstellt werden können.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/storage-1.png

--- a/de/15.3/admin/suggest-guide.rst
+++ b/de/15.3/admin/suggest-guide.rst
@@ -1,0 +1,37 @@
+===============
+Vorschlagswort
+===============
+
+Übersicht
+=========
+
+Die Vorschlagswortseite verwaltet Wörter, die in der Schlüsselwortvorschlagsfunktion angezeigt werden.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Vorschlagswort-Übersichtsseite zu öffnen, klicken Sie im linken Menü auf [Vorschläge > Vorschlagswort].
+
+|image0|
+
+Klicken Sie zum Löschen auf die Schaltfläche „Löschen".
+
+
+Worttyp
+:::::::
+
+- Alle: Alle registrierten Wörter
+- Dokument: Aus indizierten Dokumenten generierte Wörter
+- Suchbegriff: Aus Suchprotokollen generierte Wörter
+
+Wortanzahl
+::::::::::
+
+Anzahl der registrierten Wörter
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/suggest-1.png
+

--- a/de/15.3/admin/synonym-guide.rst
+++ b/de/15.3/admin/synonym-guide.rst
@@ -1,0 +1,81 @@
+==================
+Synonym-Wörterbuch
+==================
+
+Übersicht
+=========
+
+Sie können Synonyme für Wörter mit derselben Bedeutung (z. B. GB, Gigabyte) verwalten.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Synonym-Konfigurationsübersichtsseite zu öffnen, wählen Sie im linken Menü [System > Wörterbuch] aus und klicken Sie dann auf synonym.
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfigurationsmethode
+---------------------
+
+Um die Synonym-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Da die Standardkonfiguration für die Indexerstellung Bi-Gramm ist, müssen Sie darauf achten, dass das konvertierte Wort nicht zu einem einzelnen Zeichen wird.
+Außerdem müssen Sie bei der Registrierung von Synonymen wie folgt vorgehen:
+
+* Hiragana als Katakana registrieren
+* Kleine Katakana als große Katakana registrieren
+* Vollbreiten-Alphanumerika als Halbbreiten-Alphanumerika registrieren
+* Synonyme nicht doppelt registrieren
+
+Quelle
+::::::
+
+Geben Sie das Wort ein, das als Synonym behandelt werden soll.
+
+Ziel
+::::
+
+Erweitern Sie das in der Quelle eingegebene Wort mit dem Zielwort.
+Wenn Sie beispielsweise „TV" sowohl als „TV" als auch als „テレビ" behandeln möchten, geben Sie „TV" in der Quelle ein und „TV" und „テレビ" im Ziel.
+
+Download
+========
+
+Sie können im Synonym-Wörterbuchformat herunterladen, das von Apache Lucene bereitgestellt wird.
+
+Upload
+======
+
+Sie können im Synonym-Wörterbuchformat hochladen, das von Apache Lucene bereitgestellt wird.
+Da Synonyme eine Ersetzung einer Wortgruppe durch eine andere Wortgruppe darstellen, werden in der Wörterbuchbeschreibung Kommas (,) und Konvertierung (=>) verwendet.
+Um beispielsweise „TV" durch „テレビ" zu ersetzen, verwenden Sie => und schreiben wie folgt:
+
+::
+
+    TV=>テレビ
+
+Um „fess" und „フェス" gleich zu behandeln, schreiben Sie wie folgt:
+
+::
+
+    fess,フエス=>fess,フエス
+
+In solchen Fällen kann => weggelassen und wie folgt geschrieben werden:
+
+::
+
+    fess,フエス
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/synonym-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/synonym-2.png

--- a/de/15.3/admin/systeminfo-guide.rst
+++ b/de/15.3/admin/systeminfo-guide.rst
@@ -1,0 +1,44 @@
+================
+Systeminformationen
+================
+
+Übersicht
+=========
+
+Hier können Sie Eigenschaftsinformationen wie Umgebungsvariablen des derzeit laufenden Systems überprüfen.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Systeminformationsseite zu öffnen, klicken Sie im linken Menü auf [Systeminformationen > Konfigurationsinformationen].
+
+|image0|
+
+Anzeigeelemente
+---------------
+
+Umgebungsvariablen-Eigenschaften
+:::::::::::::::::::::::::::::::::
+
+Sie können die Umgebungsvariablen des Servers auflisten.
+
+System-Eigenschaften
+::::::::::::::::::::
+
+Sie können die für |Fess| konfigurierten Systemeigenschaften auflisten.
+
+App-Eigenschaften
+:::::::::::::::::
+
+Sie können die Konfigurationsinformationen von |Fess| überprüfen.
+
+Fehlerberichts-Eigenschaften
+:::::::::::::::::::::::::::::
+
+Dies ist eine Liste von Eigenschaften, die beim Melden von Fehlern angehängt werden sollen.
+Es werden Werte extrahiert, die keine persönlichen Informationen enthalten.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/systeminfo-1.png

--- a/de/15.3/admin/upgrade-guide.rst
+++ b/de/15.3/admin/upgrade-guide.rst
@@ -1,0 +1,8 @@
+=========
+Aktualisierung
+=========
+
+Referenz
+========
+
+Bitte beziehen Sie sich auf den `Installationshandbuch <https://fess.codelibs.org/ja/15.3/install/index.html>`__.

--- a/de/15.3/admin/user-guide.rst
+++ b/de/15.3/admin/user-guide.rst
@@ -1,0 +1,54 @@
+========
+Benutzer
+========
+
+Übersicht
+=========
+
+Sie können Benutzer verwalten, die sich bei |Fess| anmelden.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Benutzer-Konfigurationsübersichtsseite zu öffnen, klicken Sie im linken Menü auf [Benutzer > Benutzer].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Benutzer-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Benutzername
+::::::::::::
+
+Benutzername.
+
+Rolle
+:::::
+
+Geben Sie die Rolle an, zu der der Benutzer gehört.
+
+Gruppe
+::::::
+
+Geben Sie die Gruppe an, zu der der Benutzer gehört.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/user-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/user-2.png

--- a/de/15.3/admin/webauth-guide.rst
+++ b/de/15.3/admin/webauth-guide.rst
@@ -1,0 +1,93 @@
+==================
+Web-Authentifizierung
+==================
+
+Übersicht
+=========
+
+Hier wird die Konfigurationsmethode erläutert, wenn Web-Authentifizierung für das Crawlen von Webs erforderlich ist.
+|Fess| unterstützt das Crawlen mit BASIC-, DIGEST- und NTLM-Authentifizierung.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Web-Authentifizierungs-Konfigurationsübersichtsseite zu öffnen, klicken Sie im linken Menü auf [Crawler > Web-Authentifizierung].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Web-Authentifizierungskonfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Neu erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Hostname
+::::::::
+
+Geben Sie den Hostnamen der Site an, die Authentifizierung erfordert.
+Wenn weggelassen, wird dies auf jeden Hostnamen in der angegebenen Web-Crawl-Konfiguration angewendet.
+
+Port
+::::
+
+Geben Sie den Port der Site an, die Authentifizierung erfordert.
+Um dies auf alle Ports anzuwenden, geben Sie -1 an.
+In diesem Fall wird dies auf jeden Port in der angegebenen Web-Crawl-Konfiguration angewendet.
+
+Realm
+:::::
+
+Geben Sie den Realm-Namen der Site an, die Authentifizierung erfordert.
+Wenn weggelassen, wird dies auf jeden Realm-Namen in der angegebenen Web-Crawl-Konfiguration angewendet.
+
+Schema
+::::::
+
+Wählen Sie die Authentifizierungsmethode aus.
+Sie können BASIC-, DIGEST-, NTLM- oder FORM-Authentifizierung verwenden.
+
+Benutzername
+::::::::::::
+
+Geben Sie den Benutzernamen für die Anmeldung bei der Authentifizierungssite an.
+
+Passwort
+::::::::
+
+Geben Sie das Passwort für die Anmeldung bei der Authentifizierungssite an.
+
+Parameter
+:::::::::
+
+Konfigurieren Sie dies, wenn Konfigurationswerte für die Anmeldung bei der Authentifizierungssite erforderlich sind.
+Für NTLM-Authentifizierung können Sie die Werte für Workstation und Domäne konfigurieren.
+Geben Sie sie wie folgt an:
+
+::
+
+    workstation=HOGE
+    domain=FUGA
+
+Web-Konfiguration
+:::::::::::::::::
+
+Wählen Sie den Web-Konfigurationsnamen aus, auf den die oben genannte Authentifizierungskonfiguration angewendet werden soll.
+Sie müssen die Web-Crawl-Konfiguration im Voraus registrieren.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt.
+Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/webauth-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/webauth-2.png

--- a/de/15.3/admin/webconfig-guide.rst
+++ b/de/15.3/admin/webconfig-guide.rst
@@ -1,0 +1,250 @@
+===========
+Web-Crawl
+===========
+
+Übersicht
+=========
+
+Die Web-Crawl-Konfigurationsseite konfiguriert Web-Crawling.
+
+Verwaltung
+==========
+
+Anzeige
+-------
+
+Um die Web-Crawl-Konfigurationsübersichtsseite zu öffnen, klicken Sie im linken Menü auf [Crawler > Web].
+
+|image0|
+
+Klicken Sie auf den Konfigurationsnamen, um ihn zu bearbeiten.
+
+Konfiguration erstellen
+-----------------------
+
+Um die Web-Crawl-Konfigurationsseite zu öffnen, klicken Sie auf die Schaltfläche „Erstellen".
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Name
+::::
+
+Konfigurationsname.
+
+URL
+:::
+
+Die Start-URL für das Crawling.
+
+Zu crawlende URL
+::::::::::::::::
+
+URLs, die mit dem regulären Ausdruck (Java-Format) übereinstimmen, der in diesem Element angegeben ist, werden vom |Fess| Crawler gecrawlt.
+
+Vom Crawlen ausgeschlossene URL
+::::::::::::::::::::::::::::::::
+
+URLs, die mit dem regulären Ausdruck (Java-Format) übereinstimmen, der in diesem Element angegeben ist, werden vom |Fess| Crawler nicht gecrawlt.
+
+Zu durchsuchende URL
+:::::::::::::::::::::
+
+URLs, die mit dem regulären Ausdruck (Java-Format) übereinstimmen, der in diesem Element angegeben ist, werden in die Suche einbezogen.
+
+Von der Suche ausgeschlossene URL
+::::::::::::::::::::::::::::::::::
+
+URLs, die mit dem regulären Ausdruck (Java-Format) übereinstimmen, der in diesem Element angegeben ist, werden von der Suche ausgeschlossen.
+
+Konfigurationsparameter
+:::::::::::::::::::::::
+
+Sie können Crawl-Konfigurationsinformationen angeben.
+
+Tiefe
+:::::
+
+Sie können die Tiefe beim Verfolgen von Links angeben, die in gecrawlten Dokumenten enthalten sind.
+
+Maximale Zugriffszahl
+:::::::::::::::::::::
+
+Die Anzahl der zu indizierenden URLs.
+
+User-Agent
+::::::::::
+
+Der Name des |Fess| Crawlers.
+
+Thread-Anzahl
+:::::::::::::
+
+Die Anzahl der Crawl-Threads für diese Konfiguration.
+
+Intervall
+:::::::::
+
+Das Zeitintervall für jeden Thread beim Crawlen von URLs.
+
+Boost-Wert
+::::::::::
+
+Die Gewichtung von Dokumenten, die durch diese Konfiguration indiziert werden.
+
+Berechtigung
+::::::::::::
+
+Geben Sie die Berechtigung für diese Konfiguration an.
+Um beispielsweise Suchergebnisse für Benutzer anzuzeigen, die zur Gruppe „developer" gehören, geben Sie {group}developer an.
+Für Benutzerebene geben Sie {user}Benutzername an, für Rollenebene {role}Rollenname und für Gruppenebene {group}Gruppenname.
+
+Virtueller Host
+:::::::::::::::
+
+Geben Sie den Hostnamen des virtuellen Hosts an.
+Weitere Details finden Sie unter :doc:`../config/virtual-host`.
+
+Status
+::::::
+
+Wenn aktiviert, enthält der Standard-Crawler-Zeitplanjob diese Konfiguration.
+
+Beschreibung
+::::::::::::
+
+Sie können eine Beschreibung eingeben.
+
+Konfiguration löschen
+---------------------
+
+Klicken Sie auf den Konfigurationsnamen auf der Übersichtsseite und dann auf die Schaltfläche „Löschen". Es wird ein Bestätigungsbildschirm angezeigt. Klicken Sie auf die Schaltfläche „Löschen", um die Konfiguration zu löschen.
+
+Beispiele
+=========
+
+fess.codelibs.org crawlen
+-------------------------
+
+Um eine Web-Crawl-Konfiguration zu erstellen, die Seiten unter https://fess.codelibs.org/ crawlt, verwenden Sie die folgenden Konfigurationswerte:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Konfigurationselement
+     - Konfigurationswert
+   * - Name
+     - Fess
+   * - URL
+     - https://fess.codelibs.org/
+   * - Zu crawlende URL
+     - https://fess.codelibs.org/.*
+
+Andere Konfigurationswerte verwenden Standardwerte.
+
+Web-Authentifizierungs-Site crawlen
+------------------------------------
+
+Fess unterstützt das Crawlen mit BASIC-, DIGEST- und NTLM-Authentifizierung.
+Weitere Details zur Web-Authentifizierung finden Sie auf der Web-Authentifizierungsseite.
+
+Redmine
+:::::::
+
+Um eine Web-Crawl-Konfiguration zu erstellen, die passwortgeschützte Redmine-Seiten (z. B. https://<server>/) crawlt, verwenden Sie die folgenden Konfigurationswerte:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Konfigurationselement
+     - Konfigurationswert
+   * - Name
+     - Redmine
+   * - URL
+     - https://<server>/my/page
+   * - Zu crawlende URL
+     - https://<server>/.*
+   * - Konfigurationsparameter
+     - client.robotsTxtEnabled=false (Optional)
+
+Erstellen Sie dann eine Web-Authentifizierungskonfiguration mit den folgenden Konfigurationswerten:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Konfigurationselement
+     - Konfigurationswert
+   * - Schema
+     - Form
+   * - Benutzername
+     - (Konto für Crawling)
+   * - Passwort
+     - (Passwort für das Konto)
+   * - Parameter
+     - | encoding=UTF-8
+       | token_method=GET
+       | token_url=https://<server>/login
+       | token_pattern=name="authenticity_token"[^>]+value="([^"]+)"
+       | token_name=authenticity_token
+       | login_method=POST
+       | login_url=https://<server>/login
+       | login_parameters=username=${username}&password=${password}
+   * - Web-Authentifizierung
+     - Redmine
+
+
+XWiki
+:::::
+
+Um eine Web-Crawl-Konfiguration zu erstellen, die XWiki-Seiten (z. B. https://<server>/xwiki/) crawlt, verwenden Sie die folgenden Konfigurationswerte:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Konfigurationselement
+     - Konfigurationswert
+   * - Name
+     - XWiki
+   * - URL
+     - https://<server>/xwiki/bin/view/Main/
+   * - Zu crawlende URL
+     - https://<server>/.*
+   * - Konfigurationsparameter
+     - client.robotsTxtEnabled=false (Optional)
+
+Erstellen Sie dann eine Web-Authentifizierungskonfiguration mit den folgenden Konfigurationswerten:
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Konfigurationselement
+     - Konfigurationswert
+   * - Schema
+     - Form
+   * - Benutzername
+     - (Konto für Crawling)
+   * - Passwort
+     - (Passwort für das Konto)
+   * - Parameter
+     - | encoding=UTF-8
+       | token_method=GET
+       | token_url=http://<server>/xwiki/bin/login/XWiki/XWikiLogin
+       | token_pattern=name="form_token" +value="([^"]+)"
+       | token_name=form_token
+       | login_method=POST
+       | login_url=http://<server>/xwiki/bin/loginsubmit/XWiki/XWikiLogin
+       | login_parameters=j_username=${username}&j_password=${password}
+   * - Web-Authentifizierung
+     - XWiki
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/webconfig-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/webconfig-2.png
+.. pdf            :height: 940 px

--- a/de/15.3/admin/wizard-guide.rst
+++ b/de/15.3/admin/wizard-guide.rst
@@ -1,0 +1,57 @@
+====================
+Konfigurations-Assistent
+====================
+
+Übersicht
+=========
+
+Die Assistentenseite bietet ein einfaches Setup-Tool zum Registrieren von Crawl-Konfigurationen.
+
+Einfaches Setup
+---------------
+
+Diese Seite ist die Startseite zum Registrieren von Crawl-Konfigurationen.
+
+|image0|
+
+Crawl-Konfiguration
+-------------------
+
+Auf dieser Seite können Sie Crawl-Konfigurationen erstellen.
+
+|image1|
+
+Konfigurationsparameter
+-----------------------
+
+Name
+::::
+
+Geben Sie den Konfigurationsnamen an (z. B. Fess-Site).
+
+Crawl-Pfad
+::::::::::
+
+Geben Sie die Start-URL oder den Dateipfad für das Crawling an (z. B. https://fess.codelibs.org/).
+
+Maximale Zugriffszahl
+:::::::::::::::::::::
+
+Legen Sie die Obergrenze der zu crawlenden Seiten fest.
+
+Tiefe
+:::::
+
+Legen Sie die Tiefe beim Verfolgen von Links fest, die in gecrawlten Dokumenten enthalten sind.
+
+Crawler
+-------
+
+Um den |Fess| Crawler zu starten, klicken Sie auf die Schaltfläche „Crawlen starten". Wenn Sie noch nicht crawlen möchten, klicken Sie auf die Schaltfläche „Überspringen".
+
+|image2|
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/wizard-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/wizard-2.png
+.. |image2| image:: ../../../resources/images/ja/15.3/admin/wizard-3.png


### PR DESCRIPTION
Translate all 47 files from ja/15.3/admin to de/15.3/admin with commercial-quality German documentation. This includes:
- Core documentation files (index.rst, intro.rst)
- Configuration guides for all admin features
- System management and monitoring guides
- Crawler and search configuration guides