### PR TITLE
Create Spanish API guide documentation

### DIFF
--- a/es/15.3/api/api-gsa.rst
+++ b/es/15.3/api/api-gsa.rst
@@ -1,0 +1,19 @@
+========================================
+API compatible con Google Search Appliance
+========================================
+
+|Fess| también proporciona una API que devuelve los resultados de búsqueda en formato XML compatible con Google Search Appliance (GSA).
+Para obtener información sobre el formato XML, consulte la \ `documentación oficial de GSA <https://www.google.com/support/enterprise/static/gsa/docs/admin/74/gsa_doc_set/xml_reference/results_format.html>`__\ .
+
+Configuración
+=============
+
+Agregue ``web.api.gsa=true`` a system.properties para habilitar la API compatible con Google Search Appliance.
+
+Solicitud
+=========
+
+Al enviar una solicitud como
+``http://localhost:8080/gsa/?q=término de búsqueda``
+a |Fess|, puede recibir los resultados de búsqueda en formato XML compatible con GSA.
+Los valores que se pueden especificar como parámetros de solicitud son los mismos que en la \ `API de búsqueda de respuesta JSON <api-search.html>`__\ .

--- a/es/15.3/api/api-health.rst
+++ b/es/15.3/api/api-health.rst
@@ -1,0 +1,60 @@
+===========
+API de salud
+===========
+
+Obtención del estado
+=====================
+
+Solicitud
+---------
+
+==================  ====================================================
+Método HTTP         GET
+Endpoint            ``/api/v1/health``
+==================  ====================================================
+
+Al enviar una solicitud como ``http://<Server Name>/api/v1/health`` a |Fess|, puede recibir el estado del servidor de |Fess| en formato JSON.
+
+Parámetros de solicitud
+-----------------------
+
+No se pueden especificar parámetros de solicitud.
+
+Respuesta
+---------
+
+Se devuelve una respuesta como la siguiente:
+
+::
+
+    {
+      "data": {
+        "status": "green",
+        "timed_out": false
+      }
+    }
+
+Los elementos son los siguientes:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Información de respuesta
+
+   * - data
+     - Elemento principal de resultados de búsqueda.
+   * - status
+     - Estado del sistema. Se devuelve ``green`` si es normal, ``yellow`` si hay advertencias, ``red`` si hay errores.
+   * - timed_out
+     - Presencia de tiempo de espera. Se devuelve ``false`` si la respuesta se devolvió dentro del tiempo especificado, ``true`` si se agotó el tiempo de espera.
+
+Respuesta de error
+==================
+
+Si la API de salud falla, se devuelve una respuesta de error como la siguiente:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Respuesta de error
+
+   * - Código de estado
+     - Descripción
+   * - 500 Internal Server Error
+     - Cuando se produce un error interno del servidor

--- a/es/15.3/api/api-label.rst
+++ b/es/15.3/api/api-label.rst
@@ -1,0 +1,92 @@
+================
+API de etiquetas
+================
+
+Obtención de etiquetas
+======================
+
+Solicitud
+---------
+
+==================  ====================================================
+Método HTTP         GET
+Endpoint            ``/api/v1/labels``
+==================  ====================================================
+
+Al enviar una solicitud como ``http://<Server Name>/api/v1/labels`` a |Fess|, puede recibir una lista de las etiquetas registradas en |Fess| en formato JSON.
+
+Parámetros de solicitud
+-----------------------
+
+No hay parámetros de solicitud disponibles.
+
+
+Respuesta
+---------
+
+Se devuelve una respuesta como la siguiente:
+
+::
+
+    {
+      "record_count": 9,
+      "data": [
+        {
+          "label": "AWS",
+          "value": "aws"
+        },
+        {
+          "label": "Azure",
+          "value": "azure"
+        }
+      ]
+    }
+
+Los elementos son los siguientes:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+
+.. list-table::
+
+   * - record_count
+     - Número de etiquetas registradas.
+   * - data
+     - Elemento principal de resultados de búsqueda.
+   * - label
+     - Nombre de la etiqueta.
+   * - value
+     - Valor de la etiqueta.
+
+Tabla: Información de respuesta
+
+Ejemplos de uso
+===============
+
+Ejemplo de solicitud usando el comando curl:
+
+::
+
+    curl "http://localhost:8080/api/v1/labels"
+
+Ejemplo de solicitud usando JavaScript:
+
+::
+
+    fetch('http://localhost:8080/api/v1/labels')
+      .then(response => response.json())
+      .then(data => {
+        console.log('Lista de etiquetas:', data.data);
+      });
+
+Respuesta de error
+==================
+
+Si la API de etiquetas falla, se devuelve una respuesta de error como la siguiente:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Respuesta de error
+
+   * - Código de estado
+     - Descripción
+   * - 500 Internal Server Error
+     - Cuando se produce un error interno del servidor

--- a/es/15.3/api/api-overview.rst
+++ b/es/15.3/api/api-overview.rst
@@ -1,0 +1,82 @@
+================
+Descripción de la API
+================
+
+
+API proporcionadas por |Fess|
+==============================
+
+Este documento describe las API proporcionadas por |Fess|.
+Utilizando las API, puede usar |Fess| como servidor de búsqueda en sistemas web existentes y otros.
+
+URL base
+========
+
+Los endpoints de la API de |Fess| se proporcionan con la siguiente URL base:
+
+::
+
+    http://<Server Name>/api/v1/
+
+Por ejemplo, si se ejecuta en un entorno local, sería:
+
+::
+
+    http://localhost:8080/api/v1/
+
+Autenticación
+=============
+
+En la versión actual, no se requiere autenticación para usar la API.
+Sin embargo, es necesario habilitar la API en las diversas configuraciones de la consola de administración.
+
+Método HTTP
+===========
+
+Todos los endpoints de la API se acceden mediante el método **GET**.
+
+Formato de respuesta
+====================
+
+Todas las respuestas de la API se devuelven en **formato JSON** (excepto la API compatible con GSA).
+El ``Content-Type`` de la respuesta es ``application/json``.
+
+Manejo de errores
+=================
+
+Si una solicitud de API falla, se devuelve información de error junto con el código de estado HTTP apropiado.
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Códigos de estado HTTP
+
+   * - 200
+     - La solicitud se procesó correctamente.
+   * - 400
+     - Los parámetros de la solicitud son incorrectos.
+   * - 404
+     - No se encontró el recurso solicitado.
+   * - 500
+     - Se produjo un error interno del servidor.
+
+Tabla: Códigos de estado HTTP
+
+Tipos de API
+============
+
+|Fess| proporciona las siguientes API:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table::
+
+   * - search
+     - API para obtener resultados de búsqueda.
+   * - popularword
+     - API para obtener palabras populares.
+   * - label
+     - API para obtener la lista de etiquetas creadas.
+   * - health
+     - API para obtener el estado del servidor.
+   * - suggest
+     - API para obtener palabras sugeridas.
+
+Tabla: Tipos de API

--- a/es/15.3/api/api-popularword.rst
+++ b/es/15.3/api/api-popularword.rst
@@ -1,0 +1,74 @@
+========================
+API de palabras populares
+========================
+
+Obtención de lista de palabras populares
+=========================================
+
+Solicitud
+---------
+
+==================  ====================================================
+Método HTTP         GET
+Endpoint            ``/api/v1/popular-words``
+==================  ====================================================
+
+Al enviar una solicitud como ``http://<Server Name>/api/v1/popular-words?seed=123`` a |Fess|, puede recibir una lista de las palabras populares registradas en |Fess| en formato JSON.
+Para usar la API de palabras populares, debe habilitar la respuesta de palabras populares en Sistema > Configuración general de la consola de administración.
+
+Parámetros de solicitud
+-----------------------
+
+Los parámetros de solicitud disponibles son los siguientes:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Parámetros de solicitud
+
+   * - seed
+     - Semilla para obtener palabras populares (este valor permite obtener diferentes patrones de palabras)
+   * - label
+     - Nombre de etiqueta filtrada
+   * - field
+     - Nombre de campo para generar palabras populares
+
+
+Respuesta
+---------
+
+Se devuelve una respuesta como la siguiente:
+
+::
+
+    {
+      "record_count": 3,
+      "data": [
+        "python",
+        "java",
+        "javascript"
+      ]
+    }
+
+Los elementos son los siguientes:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Información de respuesta
+
+   * - record_count
+     - Número de palabras populares registradas
+   * - data
+     - Array de palabras populares
+
+Respuesta de error
+==================
+
+Si la API de palabras populares falla, se devuelve una respuesta de error como la siguiente:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Respuesta de error
+
+   * - Código de estado
+     - Descripción
+   * - 400 Bad Request
+     - Cuando los parámetros de solicitud son incorrectos
+   * - 500 Internal Server Error
+     - Cuando se produce un error interno del servidor

--- a/es/15.3/api/api-search.rst
+++ b/es/15.3/api/api-search.rst
@@ -1,0 +1,249 @@
+==============
+API de búsqueda
+==============
+
+Obtención de resultados de búsqueda
+====================================
+
+Solicitud
+---------
+
+==================  ====================================================
+Método HTTP         GET
+Endpoint            ``/api/v1/documents``
+==================  ====================================================
+
+Al enviar una solicitud como
+``http://<Server Name>/api/v1/documents?q=término de búsqueda``
+a |Fess|, puede recibir los resultados de búsqueda de |Fess| en formato JSON.
+Para usar la API de búsqueda, debe habilitar la respuesta JSON en Sistema > Configuración general de la consola de administración.
+
+Parámetros de solicitud
+-----------------------
+
+Al especificar parámetros de solicitud como
+``http://<Server Name>/api/v1/documents?q=término de búsqueda&num=50&fields.label=fess``,
+puede realizar búsquedas más avanzadas.
+Los parámetros de solicitud disponibles son los siguientes:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table::
+
+   * - q
+     - Término de búsqueda. Se pasa con codificación URL.
+   * - start
+     - Posición inicial del número de resultados. Comienza desde 0.
+   * - num
+     - Número de resultados a mostrar. El valor predeterminado es 20. Se pueden mostrar hasta 100 resultados.
+   * - sort
+     - Ordenar. Se utiliza para ordenar los resultados de búsqueda.
+   * - fields.label
+     - Valor de etiqueta. Se utiliza para especificar una etiqueta.
+   * - facet.field
+     - Especificación de campo de faceta. (Ejemplo) ``facet.field=label``
+   * - facet.query
+     - Especificación de consulta de faceta. (Ejemplo) ``facet.query=timestamp:[now/d-1d TO *]``
+   * - facet.size
+     - Especificación del número máximo de facetas a obtener. Es válido cuando se especifica facet.field.
+   * - facet.minDocCount
+     - Obtiene facetas con un recuento mayor o igual a este valor. Es válido cuando se especifica facet.field.
+   * - geo.location.point
+     - Especificación de latitud y longitud. (Ejemplo) ``geo.location.point=35.0,139.0``
+   * - geo.location.distance
+     - Especificación de la distancia desde el punto central. (Ejemplo) ``geo.location.distance=10km``
+   * - lang
+     - Especificación del idioma de búsqueda. (Ejemplo) ``lang=en``
+   * - preference
+     - Cadena que especifica el shard al realizar la búsqueda. (Ejemplo) ``preference=abc``
+   * - callback
+     - Nombre del callback cuando se utiliza JSONP. No es necesario especificarlo si no se utiliza JSONP.
+
+Tabla: Parámetros de solicitud
+
+
+Respuesta
+---------
+
+| Se devuelve una respuesta como la siguiente:
+| (Formato embellecido)
+
+::
+
+    {
+      "q": "Fess",
+      "query_id": "bd60f9579a494dfd8c03db7c8aa905b0",
+      "exec_time": 0.21,
+      "query_time": 0,
+      "page_size": 20,
+      "page_number": 1,
+      "record_count": 31625,
+      "page_count": 1,
+      "highlight_params": "&hq=n2sm&hq=Fess",
+      "next_page": true,
+      "prev_page": false,
+      "start_record_number": 1,
+      "end_record_number": 20,
+      "page_numbers": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5"
+      ],
+      "partial": false,
+      "search_query": "(Fess OR n2sm)",
+      "requested_time": 1507822131845,
+      "related_query": [
+        "aaa"
+      ],
+      "related_contents": [],
+      "data": [
+        {
+          "filetype": "html",
+          "title": "Open Source Enterprise Search Server: Fess — Fess 11.0 documentation",
+          "content_title": "Open Source Enterprise Search Server: Fess — Fe...",
+          "digest": "Docs » Open Source Enterprise Search Server: Fess Commercial Support Open Source Enterprise Search Server: Fess What is Fess ? Fess is very powerful and easily deployable Enterprise Search Server. ...",
+          "host": "fess.codelibs.org",
+          "last_modified": "2017-10-09T22:28:56.000Z",
+          "content_length": "29624",
+          "timestamp": "2017-10-09T22:28:56.000Z",
+          "url_link": "https://fess.codelibs.org/",
+          "created": "2017-10-10T15.30:48.609Z",
+          "site_path": "fess.codelibs.org/",
+          "doc_id": "e79fbfdfb09d4bffb58ec230c68f6f7e",
+          "url": "https://fess.codelibs.org/",
+          "content_description": "Enterprise Search Server: <strong>Fess</strong> Commercial Support Open...Search Server: <strong>Fess</strong> What is <strong>Fess</strong> ? <strong>Fess</strong> is very powerful...You can install and run <strong>Fess</strong> quickly on any platforms...Java runtime environment. <strong>Fess</strong> is provided under Apache...Apache license. Demo <strong>Fess</strong> is OpenSearch-based search",
+          "site": "fess.codelibs.org/",
+          "boost": "10.0",
+          "mimetype": "text/html"
+        }
+      ]
+    }
+
+Los elementos son los siguientes:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Información de respuesta
+
+   * - q
+     - Término de búsqueda
+   * - exec_time
+     - Tiempo de respuesta (en segundos)
+   * - query_time
+     - Tiempo de procesamiento de consulta (en milisegundos)
+   * - page_size
+     - Número de resultados mostrados
+   * - page_number
+     - Número de página
+   * - record_count
+     - Número de resultados encontrados para el término de búsqueda
+   * - page_count
+     - Número de páginas de resultados encontrados para el término de búsqueda
+   * - highlight_params
+     - Parámetros de resaltado
+   * - next_page
+     - true: existe la página siguiente. false: no existe la página siguiente.
+   * - prev_page
+     - true: existe la página anterior. false: no existe la página anterior.
+   * - start_record_number
+     - Posición inicial del número de registro
+   * - end_record_number
+     - Posición final del número de registro
+   * - page_numbers
+     - Array de números de página
+   * - partial
+     - Se establece en true cuando los resultados de búsqueda se truncan debido a un tiempo de espera de búsqueda u otros motivos.
+   * - search_query
+     - Consulta de búsqueda
+   * - requested_time
+     - Hora de la solicitud (en milisegundos epoch)
+   * - related_query
+     - Consulta relacionada
+   * - related_contents
+     - Consulta de contenido relacionado
+   * - facet_field
+     - Información de documentos que coinciden con el campo de faceta dado (solo cuando se proporciona ``facet.field`` en los parámetros de solicitud)
+   * - facet_query
+     - Número de documentos que coinciden con la consulta de faceta dada (solo cuando se proporciona ``facet.query`` en los parámetros de solicitud)
+   * - result
+     - Elemento principal de resultados de búsqueda
+   * - filetype
+     - Tipo de archivo
+   * - created
+     - Fecha y hora de creación del documento
+   * - title
+     - Título del documento
+   * - doc_id
+     - ID del documento
+   * - url
+     - URL del documento
+   * - site
+     - Nombre del sitio
+   * - content_description
+     - Descripción del contenido
+   * - host
+     - Nombre del host
+   * - digest
+     - Cadena de resumen del documento
+   * - boost
+     - Valor de impulso del documento
+   * - mimetype
+     - Tipo MIME
+   * - last_modified
+     - Fecha y hora de última modificación
+   * - content_length
+     - Tamaño del documento
+   * - url_link
+     - URL como resultado de búsqueda
+   * - timestamp
+     - Fecha y hora de actualización del documento
+
+
+Búsqueda de todos los documentos
+=================================
+
+Para buscar todos los documentos objetivo, envíe la siguiente solicitud:
+``http://<Server Name>/api/v1/documents/all?q=término de búsqueda``
+
+Para usar esta funcionalidad, debe establecer api.search.scroll en true en fess_config.properties.
+
+Parámetros de solicitud
+-----------------------
+
+Los parámetros de solicitud disponibles son los siguientes:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table::
+
+   * - q
+     - Término de búsqueda. Se pasa con codificación URL.
+   * - num
+     - Número de resultados a mostrar. El valor predeterminado es 20. Se pueden mostrar hasta 100 resultados.
+   * - sort
+     - Ordenar. Se utiliza para ordenar los resultados de búsqueda.
+
+Tabla: Parámetros de solicitud
+
+Respuesta de error
+==================
+
+Si la API de búsqueda falla, se devuelve una respuesta de error como la siguiente:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Respuesta de error
+
+   * - Código de estado
+     - Descripción
+   * - 400 Bad Request
+     - Cuando los parámetros de solicitud son incorrectos
+   * - 500 Internal Server Error
+     - Cuando se produce un error interno del servidor
+
+Ejemplo de respuesta de error:
+
+::
+
+    {
+      "message": "Invalid request parameter",
+      "status": 400
+    }

--- a/es/15.3/api/api-suggest.rst
+++ b/es/15.3/api/api-suggest.rst
@@ -1,0 +1,92 @@
+==================
+API de sugerencias
+==================
+
+Obtención de lista de palabras sugeridas
+=========================================
+
+Solicitud
+---------
+
+==================  ====================================================
+Método HTTP         GET
+Endpoint            ``/api/v1/suggest-words``
+==================  ====================================================
+
+Al enviar una solicitud como ``http://<Server Name>/api/v1/suggest-words?q=palabra sugerida`` a |Fess|, puede recibir una lista de las palabras sugeridas registradas en |Fess| en formato JSON.
+Para usar la API de palabras sugeridas, debe habilitar "Sugerir desde documentos" o "Sugerir desde palabras de búsqueda" en Sistema > Configuración general de la consola de administración.
+
+Parámetros de solicitud
+-----------------------
+
+Los parámetros de solicitud disponibles son los siguientes:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Parámetros de solicitud
+
+   * - q
+     - Palabra clave para realizar sugerencias. (Ejemplo) ``q=fess``
+   * - num
+     - Número de palabras sugeridas. Predeterminado 10. (Ejemplo) ``num=20``
+   * - label
+     - Nombre de etiqueta filtrada. (Ejemplo) ``label=java``
+   * - fields
+     - Nombre de campo para filtrar el objetivo de sugerencia. Sin filtro predeterminado. (Ejemplo) ``fields=content,title``
+   * - lang
+     - Especificación del idioma de búsqueda. (Ejemplo) ``lang=en``
+
+
+Respuesta
+---------
+
+Se devuelve una respuesta como la siguiente:
+
+::
+
+    {
+      "query_time": 18,
+      "record_count": 355,
+      "page_size": 10,
+      "data": [
+        {
+          "text": "fess",
+          "labels": [
+            "java",
+            "python"
+          ]
+        }
+      ]
+    }
+
+Los elementos son los siguientes:
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Información de respuesta
+
+   * - query_time
+     - Tiempo de procesamiento de consulta (en milisegundos).
+   * - record_count
+     - Número de palabras sugeridas registradas.
+   * - page_size
+     - Tamaño de página.
+   * - data
+     - Elemento principal de resultados de búsqueda.
+   * - text
+     - Palabra sugerida.
+   * - labels
+     - Array de valores de etiquetas.
+
+Respuesta de error
+==================
+
+Si la API de sugerencias falla, se devuelve una respuesta de error como la siguiente:
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Respuesta de error
+
+   * - Código de estado
+     - Descripción
+   * - 400 Bad Request
+     - Cuando los parámetros de solicitud son incorrectos
+   * - 500 Internal Server Error
+     - Cuando se produce un error interno del servidor

--- a/es/15.3/api/index.rst
+++ b/es/15.3/api/index.rst
@@ -1,0 +1,13 @@
+Guía de API de |Fess|
+=====================
+
+.. toctree::
+   :maxdepth: 2
+
+   intro
+   api-overview
+   api-search
+   api-label
+   api-popularword
+   api-suggest
+   api-health

--- a/es/15.3/api/intro.rst
+++ b/es/15.3/api/intro.rst
@@ -1,0 +1,62 @@
+============
+Introducción
+============
+
+Público objetivo
+================
+
+Este documento está destinado a desarrolladores que utilizan las funcionalidades de API de |Fess|.
+Se presupone el conocimiento de los siguientes temas:
+
+- Conceptos básicos de API REST
+- Formato de datos JSON
+- Conocimientos fundamentales del protocolo HTTP
+
+Antes de comenzar
+==================
+
+Este documento describe cómo usar las API en |Fess| 15.3.
+
+Requisitos previos para el uso de la API
+=========================================
+
+Antes de utilizar las API de |Fess|, es necesario realizar las siguientes configuraciones:
+
+- |Fess| 15.3 o posterior debe estar instalado y en funcionamiento normal
+- Habilitar la configuración necesaria para cada API desde la consola de administración (consulte la documentación de cada API)
+- El acceso a los endpoints de la API debe ser posible a través de la red
+
+Acceso en línea
+===============
+
+Para descargas, servicios profesionales, soporte y otra información para desarrolladores, visite:
+
+-  Sitio del proyecto: https://fess.codelibs.org/
+
+Contacto para soporte técnico
+==============================
+
+Si tiene preguntas técnicas sobre este producto y no puede encontrar una solución en la documentación, visite:
+
+-  Issues:
+   `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
+
+Soporte comercial
+-----------------
+
+Si necesita soporte comercial como asistencia técnica o mantenimiento para este producto, consulte con \ `N2SM,
+Inc. <https://www.n2sm.net/>`__\ .
+
+Referencia a sitios web de terceros relacionados
+=================================================
+
+El proyecto |Fess| no se responsabiliza de la validez de los sitios web de terceros mencionados en este documento. El proyecto |Fess| no garantiza, ni asume responsabilidades u obligaciones sobre el contenido, publicidad, productos, servicios u otros materiales disponibles a través de dichos sitios o recursos.
+El proyecto |Fess| no asume responsabilidad u obligación por ningún daño o perjuicio causado o alegado en relación con el uso o la confianza en el contenido, publicidad, productos, servicios u otros materiales disponibles a través de dichos sitios o recursos.
+
+Cómo enviar comentarios y sugerencias
+======================================
+
+El proyecto |Fess| se esfuerza por mejorar esta documentación y agradece los comentarios y sugerencias de los lectores.
+
+-  Issues:
+   `https://github.com/codelibs/fess-docs/issues <https://github.com/codelibs/fess-docs/issues>`__


### PR DESCRIPTION
Translate the complete API guide from Japanese to Spanish for commercial product documentation quality. Includes all API endpoints: search, label, popular words, suggest, health, and GSA compatibility.