### PR TITLE
Create Spanish admin guide translation

### DIFF
--- a/es/15.3/admin/accesstoken-guide.rst
+++ b/es/15.3/admin/accesstoken-guide.rst
@@ -1,0 +1,63 @@
+====================
+Token de Acceso
+====================
+
+Descripción general
+===================
+
+La página de configuración de tokens de acceso gestiona los tokens de acceso.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de tokens de acceso que se muestra a continuación, haga clic en [Sistema > Token de acceso] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de token de acceso, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre
+::::::
+
+Especifique un nombre para describir este token de acceso.
+
+Permisos
+::::::::
+
+Configure los permisos del token de acceso.
+Descríbalo en el formato "{user|group|role}nombre".
+Por ejemplo, para que los usuarios que pertenecen al grupo developer vean los resultados de búsqueda, configure el permiso como "{group}developer".
+
+Nombre del parámetro
+::::::::::::::::::::
+
+Especifique el nombre del parámetro de solicitud al especificar permisos como consulta de búsqueda.
+
+Fecha de vencimiento
+::::::::::::::::::::
+
+Especifique la fecha de vencimiento del token de acceso.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/accesstoken-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/accesstoken-2.png

--- a/es/15.3/admin/backup-guide.rst
+++ b/es/15.3/admin/backup-guide.rst
@@ -1,0 +1,74 @@
+==================
+Copia de Seguridad
+==================
+
+Descripción general
+===================
+
+La página de copia de seguridad le permite descargar y cargar la información de configuración de |Fess|.
+
+Descarga
+--------
+
+|Fess| mantiene la información de configuración como índice.
+Para descargar, haga clic en el nombre del índice.
+
+|image0|
+
+fess_config.bulk
+::::::::::::::::
+
+fess_config.bulk contiene la información de configuración de |Fess|.
+
+fess_basic_config.bulk
+::::::::::::::::::::::
+
+fess_basic_config.bulk contiene la información de configuración de |Fess| excluyendo las URL con falla.
+
+fess_user.bulk
+::::::::::::::
+
+fess_user.bulk contiene información de usuarios, roles y grupos.
+
+system.properties
+:::::::::::::::::
+
+system.properties contiene información de configuración general.
+
+fess.json
+:::::::::
+
+fess.json contiene información de configuración del índice fess.
+
+doc.json
+::::::::
+
+doc.json contiene información de mapeo del índice fess.
+
+click_log.ndjson
+::::::::::::::::
+
+click_log.ndjson contiene información de registros de clics.
+
+favorite_log.ndjson
+:::::::::::::::::::
+
+favorite_log.ndjson contiene información de registros de favoritos.
+
+search_log.ndjson
+:::::::::::::::::
+
+search_log.ndjson contiene información de registros de búsqueda.
+
+user_info.ndjson
+::::::::::::::::
+
+user_info.ndjson contiene información de usuarios de búsqueda.
+
+Carga
+-----
+
+Puede cargar e importar información de configuración.
+Los archivos que se pueden restaurar son \*.bulk y system.properties.
+
+  .. |image0| image:: ../../../resources/images/ja/15.3/admin/backup-1.png

--- a/es/15.3/admin/badword-guide.rst
+++ b/es/15.3/admin/badword-guide.rst
@@ -1,0 +1,85 @@
+==================
+Palabra Excluida
+==================
+
+Descripción general
+===================
+
+Aquí se explica la configuración de palabras excluidas de sugerencias.
+Las sugerencias se muestran según el término de búsqueda, pero puede configurar para que esas palabras no se muestren en las sugerencias.
+
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de palabras excluidas de sugerencias que se muestra a continuación, haga clic en [Sugerencia > Palabra excluida] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de creación de palabra excluida de sugerencia, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Candidato de sugerencia
+:::::::::::::::::::::::
+
+Registre palabras prohibidas.
+Las palabras registradas aquí no se mostrarán en las sugerencias.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+Descarga
+========
+
+Descarga las palabras registradas en formato CSV.
+
+|image2|
+
+Contenido del CSV
+-----------------
+
+La primera línea es el encabezado.
+Desde la segunda línea en adelante se describen las palabras excluidas.
+
+::
+
+"BadWord"
+"検索エンジン"
+
+Carga
+=====
+
+Registra palabras en formato CSV.
+
+|image3|
+
+Contenido del CSV
+-----------------
+
+La primera línea es el encabezado.
+Desde la segunda línea en adelante se describen las palabras excluidas.
+
+::
+
+"BadWord"
+"検索エンジン"
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/badword-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/badword-2.png
+.. |image2| image:: ../../../resources/images/ja/15.3/admin/badword-3.png
+.. |image3| image:: ../../../resources/images/ja/15.3/admin/badword-4.png

--- a/es/15.3/admin/boostdoc-guide.rst
+++ b/es/15.3/admin/boostdoc-guide.rst
@@ -1,0 +1,58 @@
+=======================
+Impulso de Documento
+=======================
+
+Descripción general
+===================
+
+Aquí se explica la configuración relacionada con el impulso de documento.
+Al configurar el impulso de documento, puede posicionar documentos en la parte superior de los resultados de búsqueda independientemente del término de búsqueda.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de impulso de documento que se muestra a continuación, haga clic en [Rastreador > Impulso de documento] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de impulso de documento, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Condición
+:::::::::
+
+Especifique la condición de los documentos que desea posicionar en la parte superior.
+Por ejemplo, si desea mostrar en la parte superior las URL que contienen https://www.n2sm.net/, describa url.matches("https://www.n2sm.net/.*").
+Las condiciones se pueden describir en Groovy.
+
+Expresión de valor de impulso
+::::::::::::::::::::::::::::::
+
+Especifique el valor de ponderación del documento.
+Las expresiones se pueden describir en Groovy.
+
+Orden de clasificación
+:::::::::::::::::::::::
+
+Configure el orden de clasificación del impulso de documento.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación. Al presionar el botón de eliminar, se eliminará la configuración.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/boostdoc-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/boostdoc-2.png

--- a/es/15.3/admin/crawlinginfo-guide.rst
+++ b/es/15.3/admin/crawlinginfo-guide.rst
@@ -1,0 +1,93 @@
+=======================
+Información de Rastreo
+=======================
+
+Descripción general
+===================
+
+Los resultados de ejecución del rastreo se registran y la información de rastreo se puede verificar en esta pantalla de administración.
+
+Método de gestión
+==================
+
+Lista
+=====
+
+Cada vez que se ejecuta un rastreo, se registra como información de rastreo.
+En la lista puede verificar el nombre de sesión del rastreo ejecutado y la hora de ejecución.
+Si desea verificar los detalles de la información de rastreo, haga clic en la información de rastreo objetivo.
+
+|image0|
+
+Detalles
+========
+
+Al hacer clic en el ID de sesión de la información de rastreo en la lista, se muestran los detalles de la información de rastreo objetivo.
+
+|image1|
+
+Lista de elementos
+------------------
+
+ID de sesión
+::::::::::::
+
+ID de sesión en el momento de la ejecución del rastreo.
+
+Hora de inicio del rastreador
+::::::::::::::::::::::::::::::
+
+Hora en la que comenzó todo el rastreo.
+
+Hora de inicio del rastreo (Web/Archivo)
+:::::::::::::::::::::::::::::::::::::::::
+
+Hora en la que comenzó el rastreo web y del sistema de archivos.
+
+Hora de inicio del rastreo (Almacén de datos)
+::::::::::::::::::::::::::::::::::::::::::::::
+
+Hora en la que comenzó el rastreo del almacén de datos.
+
+Hora de finalización del rastreo (Web/Archivo)
+:::::::::::::::::::::::::::::::::::::::::::::::
+
+Hora en la que finalizó el rastreo web y del sistema de archivos.
+
+Tiempo de ejecución del rastreo (Almacén de datos)
+:::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Tiempo de ejecución del rastreo del almacén de datos (milisegundos).
+
+Tiempo de ejecución de indexación (Almacén de datos)
+:::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Tiempo que se tardó en indexar los resultados del rastreo web y del sistema de archivos (milisegundos).
+
+Tamaño del índice (Almacén de datos)
+:::::::::::::::::::::::::::::::::::::
+
+Número de documentos indexados.
+
+Hora de finalización del rastreo (Almacén de datos)
+::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Hora en la que finalizó el rastreo del almacén de datos.
+
+Estado del rastreador
+:::::::::::::::::::::
+
+Si el rastreo tuvo éxito o no.
+
+Hora de finalización del rastreador
+::::::::::::::::::::::::::::::::::::
+
+Hora en la que finalizó todo el rastreo.
+
+Tiempo de ejecución del rastreador
+:::::::::::::::::::::::::::::::::::
+
+Tiempo de ejecución de todo el rastreo (milisegundos).
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/crawlinginfo-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/crawlinginfo-2.png

--- a/es/15.3/admin/dashboard-guide.rst
+++ b/es/15.3/admin/dashboard-guide.rst
@@ -1,0 +1,57 @@
+==================
+Panel de Control
+==================
+
+Descripción general
+===================
+
+El panel de control proporciona una herramienta de administración web para gestionar el clúster e índices de OpenSearch a los que accede |Fess|.
+
+|image0|
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table:: Índices gestionados por |Fess|
+   :header-rows: 1
+
+   * - Nombre del índice
+     - Descripción
+   * - fess.AAAAMMDD
+     - Documentos indexados
+   * - fess_log
+     - Registro de accesos
+   * - fess.suggest.AAAAMMDD
+     - Palabras de sugerencia
+   * - fess_config
+     - Configuración de |Fess|
+   * - fess_user
+     - Datos de usuarios/roles/grupos
+   * - configsync
+     - Configuración de diccionarios
+   * - fess_suggest
+     - Metadatos de sugerencias
+   * - fess_suggest_array
+     - Metadatos de sugerencias
+   * - fess_suggest_badword
+     - Lista de palabras prohibidas en sugerencias
+   * - fess_suggest_analyzer
+     - Metadatos de sugerencias
+   * - fess_crawler
+     - Información de rastreo
+
+
+Los nombres de índices que comienzan con un punto (.) son índices del sistema y no se muestran.
+Para mostrar también los índices del sistema, active la casilla de verificación "special".
+
+Verificar el número de documentos indexados
+============================================
+
+El número de documentos indexados se muestra en el índice fess, como se muestra en la figura siguiente.
+
+|image1|
+
+Al hacer clic en el icono de la esquina superior derecha de cada índice, se muestra un menú de operaciones para el índice.
+Si desea eliminar documentos indexados, elimínelos desde la pantalla de búsqueda administrativa. Tenga cuidado de no eliminarlos con "delete index".
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/dashboard-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/dashboard-2.png
+.. pdf            :width: 400 px

--- a/es/15.3/admin/dataconfig-guide.rst
+++ b/es/15.3/admin/dataconfig-guide.rst
@@ -1,0 +1,430 @@
+=======================
+Rastreo de Almacén de Datos
+=======================
+
+Descripción general
+===================
+
+|Fess| puede rastrear fuentes de datos como bases de datos y CSV.
+Aquí se explica la configuración del almacén de datos necesaria para ello.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista para configurar el almacén de datos que se muestra a continuación, haga clic en [Rastreador > Almacén de datos] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración del almacén de datos, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre
+::::::
+
+Especifique el nombre de la configuración de rastreo.
+
+Nombre del controlador
+::::::::::::::::::::::
+
+Es el nombre del controlador que procesa el almacén de datos.
+
+* DatabaseDataStore: Rastrea bases de datos
+* CsvDataStore: Rastrea archivos CSV/TSV
+* CsvListDataStore: Rastrea archivos CSV que describen rutas de archivos a indexar
+
+Parámetros
+::::::::::
+
+Especifique los parámetros relacionados con el almacén de datos.
+
+Script
+::::::
+
+Especifique en qué campos configurar los valores obtenidos del almacén de datos, etc.
+Las expresiones se pueden describir en Groovy.
+
+Valor de impulso
+::::::::::::::::
+
+Especifique el valor de impulso de los documentos al rastrear con esta configuración.
+
+Permisos
+::::::::
+
+Especifique el permiso para esta configuración.
+La forma de especificar permisos es, por ejemplo, para mostrar resultados de búsqueda a usuarios que pertenecen al grupo developer, especifique {group}developer.
+La especificación por usuario es {user}nombre_usuario, la especificación por rol es {role}nombre_rol, y la especificación por grupo es {group}nombre_grupo.
+
+Host virtual
+::::::::::::
+
+Especifique el nombre de host del host virtual.
+Para más detalles, consulte :doc:`Host virtual en la guía de configuración <../config/virtual-host>`.
+
+Estado
+::::::
+
+Especifique si desea utilizar esta configuración de rastreo.
+
+Descripción
+:::::::::::
+
+Puede ingresar una descripción.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+Ejemplo
+=======
+
+DatabaseDataStore
+-----------------
+
+Se explicará el rastreo de bases de datos.
+
+Como ejemplo, se explicará asumiendo que existe la siguiente tabla en una base de datos llamada testdb en MySQL, y que se puede conectar con el nombre de usuario hoge y la contraseña fuga.
+
+::
+
+    CREATE TABLE doc (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        title VARCHAR(100) NOT NULL,
+        content VARCHAR(255) NOT NULL,
+        latitude VARCHAR(20),
+        longitude VARCHAR(20),
+        versionNo INTEGER NOT NULL,
+        PRIMARY KEY (id)
+    );
+
+Aquí, se insertarán los siguientes datos.
+
+::
+
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 1', 'コンテンツ 1 です．', '37.77493', ' -122.419416', 1);
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 2', 'コンテンツ 2 です．', '34.701909', '135.494977', 1);
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 3', 'コンテンツ 3 です．', '-33.868901', '151.207091', 1);
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 4', 'コンテンツ 4 です．', '51.500152', '-0.113736', 1);
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 5', 'コンテンツ 5 です．', '35.681137', '139.766084', 1);
+
+Parámetros
+::::::::::
+
+Un ejemplo de configuración de parámetros sería el siguiente.
+
+::
+
+    driver=com.mysql.jdbc.Driver
+    url=jdbc:mysql://localhost:3306/testdb?useUnicode=true&characterEncoding=UTF-8
+    username=hoge
+    password=fuga
+    sql=select * from doc
+
+Los parámetros están en formato "clave=valor". La descripción de las claves es la siguiente.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - driver
+     - Nombre de la clase del controlador
+   * - url
+     - URL
+   * - username
+     - Nombre de usuario para conectarse a la BD
+   * - password
+     - Contraseña para conectarse a la BD
+   * - sql
+     - Sentencia SQL para obtener el objeto del rastreo
+
+Tabla: Ejemplo de parámetros de configuración de BD
+
+
+Script
+::::::
+
+Un ejemplo de configuración de script sería el siguiente.
+
+::
+
+    url="http://SERVERNAME/" + id
+    host="SERVERNAME"
+    site="SERVERNAME"
+    title=title
+    content=content
+    cache=content
+    digest=content
+    anchor=
+    content_length=content.length()
+    last_modified=new java.util.Date()
+    location=latitude + "," + longitude
+    latitude=latitude
+    longitude=longitude
+
+Los parámetros están en formato "clave=valor". La descripción de las claves es la siguiente.
+
+En el lado del valor, se describe en Groovy.
+Las cadenas deben encerrarse entre comillas dobles. Si accede por nombre de columna de la base de datos, será ese valor.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - url
+     - URL (Configure una URL que pueda acceder a los datos según su entorno)
+   * - host
+     - Nombre de host
+   * - site
+     - Ruta del sitio
+   * - title
+     - Título
+   * - content
+     - Contenido del documento (cadena objeto de indexación)
+   * - cache
+     - Caché del documento (no es objeto de indexación)
+   * - digest
+     - Parte del resumen que se muestra en los resultados de búsqueda
+   * - anchor
+     - Enlaces contenidos en el documento (normalmente no es necesario especificarlo)
+   * - content_length
+     - Longitud del documento
+   * - last_modified
+     - Fecha de última actualización del documento
+
+Tabla: Contenido de configuración del script
+
+
+Controlador
+:::::::::::
+
+Se necesita un controlador para conectarse a la base de datos. Coloque el archivo jar en app/WEB-INF/lib.
+
+CsvDataStore
+------------
+
+Se explicará el rastreo de archivos CSV.
+
+Por ejemplo, genere el archivo test.csv en el directorio /home/taro/csv con el siguiente contenido.
+La codificación del archivo debe ser Shift_JIS.
+
+::
+
+    1,タイトル 1,テスト1です。
+    2,タイトル 2,テスト2です。
+    3,タイトル 3,テスト3です。
+    4,タイトル 4,テスト4です。
+    5,タイトル 5,テスト5です。
+    6,タイトル 6,テスト6です。
+    7,タイトル 7,テスト7です。
+    8,タイトル 8,テスト8です。
+    9,タイトル 9,テスト9です。
+
+
+Parámetros
+::::::::::
+
+Un ejemplo de configuración de parámetros sería el siguiente.
+
+::
+
+    directories=/home/taro/csv
+    fileEncoding=Shift_JIS
+
+Los parámetros están en formato "clave=valor". La descripción de las claves es la siguiente.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - directories
+     - Directorio que contiene archivos CSV (.csv o .tsv)
+   * - files
+     - Archivo CSV (si se especifica directamente)
+   * - fileEncoding
+     - Codificación del archivo CSV
+   * - separatorCharacter
+     - Carácter separador
+
+
+Tabla: Ejemplo de parámetros de configuración de archivo CSV
+
+
+Script
+::::::
+
+Un ejemplo de configuración de script sería el siguiente.
+
+::
+
+    url="http://SERVERNAME/" + cell1
+    host="SERVERNAME"
+    site="SERVERNAME"
+    title=cell2
+    content=cell3
+    cache=cell3
+    digest=cell3
+    anchor=
+    content_length=cell3.length()
+    last_modified=new java.util.Date()
+
+Los parámetros están en formato "clave=valor".
+Las claves son las mismas que en el caso del rastreo de bases de datos.
+Los datos dentro del archivo CSV se mantienen en cell[número] (el número comienza desde 1).
+Si no hay datos en una celda del archivo CSV, puede ser nulo.
+
+EsDataStore
+-----------
+
+La fuente de obtención de datos es elasticsearch, pero el uso básico es el mismo que CsvDataStore.
+
+Parámetros
+::::::::::
+
+Un ejemplo de configuración de parámetros sería el siguiente.
+
+::
+
+    settings.cluster.name=elasticsearch
+    hosts=SERVERNAME:9300
+    index=logindex
+    type=data
+
+Los parámetros están en formato "clave=valor". La descripción de las claves es la siguiente.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - settings.*
+     - Información de configuración de elasticsearch
+   * - hosts
+     - elasticsearch de destino de conexión
+   * - index
+     - Nombre del índice
+   * - type
+     - Nombre del tipo
+   * - query
+     - Consulta de condiciones para obtener
+
+Tabla: Ejemplo de parámetros de configuración de elasticsearch
+
+
+Script
+::::::
+
+Un ejemplo de configuración de script sería el siguiente.
+
+::
+
+    url=source.url
+    host="SERVERNAME"
+    site="SERVERNAME"
+    title=source.title
+    content=source.content
+    digest=
+    anchor=
+    content_length=source.size
+    last_modified=new java.util.Date()
+
+Los parámetros están en formato "clave=valor".
+Las claves son las mismas que en el caso del rastreo de bases de datos.
+Puede obtener y configurar valores mediante source.*.
+
+CsvListDataStore
+----------------
+
+Se utiliza al rastrear una gran cantidad de archivos.
+Al colocar un archivo CSV que describe las rutas de los archivos actualizados y rastrear solo las rutas especificadas, puede acortar el tiempo de ejecución del rastreo.
+
+El formato para describir las rutas es el siguiente.
+
+::
+
+    [acción]<carácter separador>[ruta]
+
+Especifique una de las siguientes acciones:
+
+* create: Se creó el archivo
+* modify: Se actualizó el archivo
+* delete: Se eliminó el archivo
+
+Por ejemplo, genere el archivo test.csv en el directorio /home/taro/csv con el siguiente contenido.
+La codificación del archivo debe ser Shift_JIS.
+
+Describa las rutas con la misma notación que cuando especifica rutas objetivo de rastreo en el rastreo de archivos.
+Especifique como "file:/[ruta]" o "smb://[ruta]" de la siguiente manera.
+
+::
+
+    modify,smb://servername/data/testfile1.txt
+    modify,smb://servername/data/testfile2.txt
+    modify,smb://servername/data/testfile3.txt
+    modify,smb://servername/data/testfile4.txt
+    modify,smb://servername/data/testfile5.txt
+    modify,smb://servername/data/testfile6.txt
+    modify,smb://servername/data/testfile7.txt
+    modify,smb://servername/data/testfile8.txt
+    modify,smb://servername/data/testfile9.txt
+    modify,smb://servername/data/testfile10.txt
+
+
+Parámetros
+::::::::::
+
+Un ejemplo de configuración de parámetros sería el siguiente.
+
+::
+
+    directories=/home/taro/csv
+    fileEncoding=Shift_JIS
+
+Los parámetros están en formato "clave=valor". La descripción de las claves es la siguiente.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - directories
+     - Directorio que contiene archivos CSV (.csv o .tsv)
+   * - fileEncoding
+     - Codificación del archivo CSV
+   * - separatorCharacter
+     - Carácter separador
+
+
+Tabla: Ejemplo de parámetros de configuración de archivo CSV
+
+
+Script
+::::::
+
+Un ejemplo de configuración de script sería el siguiente.
+
+::
+
+    event_type=cell1
+    url=cell2
+
+Los parámetros están en formato "clave=valor".
+Las claves son las mismas que en el caso del rastreo de bases de datos.
+
+Si se requiere autenticación en el destino del rastreo, también es necesario configurar lo siguiente.
+
+::
+
+    crawler.file.auth=example
+    crawler.file.auth.example.scheme=SAMBA
+    crawler.file.auth.example.username=username
+    crawler.file.auth.example.password=password
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/dataconfig-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/dataconfig-2.png

--- a/es/15.3/admin/design-guide.rst
+++ b/es/15.3/admin/design-guide.rst
@@ -1,0 +1,101 @@
+==================
+Diseño de Página
+==================
+
+Descripción general
+===================
+
+Aquí se explica la configuración relacionada con el diseño de la pantalla de búsqueda.
+
+Método de configuración
+========================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista para configurar el diseño de página que se muestra a continuación, haga clic en [Sistema > Diseño de página] en el menú izquierdo.
+
+|image0|
+
+
+Administrador de archivos
+--------------------------
+
+Puede descargar o eliminar archivos disponibles en la pantalla de búsqueda.
+
+Visualización de archivos de página
+------------------------------------
+
+Puede editar los archivos JSP de la pantalla de búsqueda.
+Puede editar un archivo JSP haciendo clic en el botón de edición del archivo JSP objetivo.
+Además, al presionar el botón "Usar predeterminado", puede editarlo como el archivo JSP en el momento de la instalación.
+Los cambios se reflejan guardando con el botón de actualización en la pantalla de edición.
+
+A continuación se resume la descripción de las páginas editables.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - /index.jsp
+     - Es el archivo JSP de la página principal de búsqueda. Este archivo JSP incluye los archivos JSP de cada parte.
+   * - /header.jsp
+     - Es el archivo JSP del encabezado.
+   * - /footer.jsp
+     - Es el archivo JSP del pie de página.
+   * - /search.jsp
+     - Es el archivo JSP de la página de lista de resultados de búsqueda. Este archivo JSP incluye los archivos JSP de cada parte.
+   * - /searchResults.jsp
+     - Es el archivo JSP que representa la parte de resultados de búsqueda de la página de lista de resultados de búsqueda. Es el archivo JSP utilizado cuando hay resultados de búsqueda. Cámbielo si desea personalizar la presentación de los resultados de búsqueda.
+   * - /searchNoResult.jsp
+     - Es el archivo JSP que representa la parte de resultados de búsqueda de la página de lista de resultados de búsqueda. Es el archivo JSP utilizado cuando no hay resultados de búsqueda.
+   * - /searchOptions.jsp
+     - Es el archivo JSP de la pantalla de opciones de búsqueda.
+   * - /advance.jsp
+     - Es el archivo JSP de la pantalla de búsqueda avanzada.
+   * - /help.jsp
+     - Es el archivo JSP de la página de ayuda.
+   * - /error/error.jsp
+     - Es el archivo JSP de la página de error de búsqueda. Cámbielo si desea personalizar la presentación de errores de búsqueda.
+   * - /error/notFound.jsp
+     - Es el archivo JSP de la página de error que se muestra cuando no se encuentra una página.
+   * - /error/system.jsp
+     - Es el archivo JSP de la página de error que se muestra en caso de error del sistema.
+   * - /error/redirect.jsp
+     - Es el archivo JSP de la página de error que se muestra cuando ocurre una redirección HTTP.
+   * - /error/badRequest.jsp
+     - Es el archivo JSP de la página de error que se muestra cuando ocurre una solicitud inválida.
+   * - /cache.hbs
+     - Es el archivo que muestra la caché de los resultados de búsqueda.
+   * - /login/index.jsp
+     - Es el archivo JSP de la pantalla de inicio de sesión.
+   * - /profile/index.jsp
+     - Es el JSP de la pantalla de cambio de contraseña para usuarios.
+   * - /profile/newpassword.jsp
+     - Es el JSP de la pantalla de actualización de contraseña para administradores. Si el nombre de usuario y la contraseña son la misma cadena al iniciar sesión, solicita un cambio de contraseña.
+
+
+Tabla: Archivos JSP editables
+
+|image1|
+
+Archivos a cargar
+-----------------
+
+Puede cargar archivos para usar en la pantalla de búsqueda.
+Los nombres de archivo de imagen admitidos son jpg, gif, png, css, js.
+
+Carga de archivo
+::::::::::::::::
+
+Especifique el archivo a cargar.
+
+Nombre de archivo (opcional)
+:::::::::::::::::::::::::::::
+
+Se utiliza si desea especificar un nombre de archivo para el archivo a cargar.
+Si se omite, se utilizará el nombre del archivo cargado.
+Por ejemplo, si especifica logo.png, se cambiará la imagen de la página principal de búsqueda.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/design-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/design-2.png

--- a/es/15.3/admin/dict-guide.rst
+++ b/es/15.3/admin/dict-guide.rst
@@ -1,0 +1,60 @@
+============
+Diccionario
+============
+
+Descripción general
+===================
+
+Aquí se explica la configuración relacionada con los diccionarios.
+
+Realice cambios en los diccionarios después de comprender las especificaciones de cada diccionario.
+Si la modificación del diccionario falla, es posible que no se pueda acceder al índice.
+
+Lista
+=====
+
+Para abrir la página de lista de diccionarios administrables que se muestra a continuación, haga clic en [Sistema > Diccionario] en el menú izquierdo.
+
+
+|image0|
+
+
+Kuromoji
+========
+
+Administra el diccionario para el análisis morfológico del japonés.
+ja/kuromoji.txt es el archivo de diccionario para el análisis morfológico del japonés.
+
+Sinónimos
+=========
+
+Administra el diccionario de sinónimos.
+synonym.txt es el archivo de diccionario de sinónimos utilizado comúnmente en todos los idiomas.
+
+Mapeo
+=====
+
+Administra el diccionario de sustitución de caracteres.
+mapping.txt es el archivo de diccionario de sustitución de palabras común a todos los idiomas o para cada idioma.
+
+Protwords
+=========
+
+Administra el diccionario de palabras protegidas.
+protwords.txt se coloca para cada idioma y es un archivo de lista de palabras que se excluirán del stemming, etc.
+
+Palabras vacías
+===============
+
+Administra el diccionario de palabras vacías.
+stopwords.txt se coloca para cada idioma y es un archivo de lista de palabras que se excluirán al crear el índice.
+
+Anulación de Stemmer
+====================
+
+Administra el diccionario de anulación de Stemmer.
+stemmer_override.txt se coloca para cada idioma y es un archivo de diccionario de sustitución de palabras para anular el procesamiento de stemming.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/dict-1.png
+            :height: 940px

--- a/es/15.3/admin/duplicatehost-guide.rst
+++ b/es/15.3/admin/duplicatehost-guide.rst
@@ -1,0 +1,51 @@
+==================
+Host Duplicado
+==================
+
+Descripción general
+===================
+
+Aquí se explica la configuración relacionada con los hosts duplicados.
+Los hosts duplicados se utilizan cuando desea tratar diferentes nombres de host como iguales durante el rastreo.
+Por ejemplo, se puede utilizar cuando desea tratar www.example.com y example.com como el mismo sitio.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista para configurar hosts duplicados que se muestra a continuación, haga clic en [Rastreador > Host duplicado] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de host duplicado, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre canónico
+:::::::::::::::
+
+Especifique el nombre de host canónico. Los nombres de host duplicados se reemplazan con el nombre de host canónico.
+
+Nombre duplicado
+::::::::::::::::
+
+Especifique el nombre de host duplicado. Especifique el nombre de host que desea reemplazar.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/duplicatehost-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/duplicatehost-2.png

--- a/es/15.3/admin/elevateword-guide.rst
+++ b/es/15.3/admin/elevateword-guide.rst
@@ -1,0 +1,106 @@
+==================
+Palabra Adicional
+==================
+
+Descripción general
+===================
+
+Aquí se explica la configuración de candidatos de palabras adicionales para sugerencias. Las sugerencias se muestran según el término de búsqueda, pero puede agregar esas palabras.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista para configurar palabras adicionales que se muestra a continuación, haga clic en [Sugerencia > Palabra adicional] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de palabra adicional, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Palabra
+:::::::
+
+Especifique la palabra que se mostrará como candidata de sugerencia.
+
+Lectura
+:::::::
+
+Especifique la lectura de la palabra candidata de sugerencia.
+
+Permisos
+::::::::
+
+Configure la información de rol para la palabra.
+La sugerencia solo se mostrará a los usuarios que tengan el rol configurado.
+
+Etiqueta
+::::::::
+
+Configure la etiqueta para la palabra.
+Si se selecciona una etiqueta diferente a la configurada, no se mostrará en la sugerencia.
+
+Valor de impulso
+::::::::::::::::
+
+Configure el valor de impulso para la palabra.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+
+Descarga
+========
+
+Descarga las palabras registradas en formato CSV.
+
+|image2|
+
+Contenido del CSV
+-----------------
+
+La primera línea es el encabezado.
+Desde la segunda línea en adelante se describen las palabras adicionales.
+
+::
+
+"SuggestWord","Reading","Role","Label","Boost"
+"fess","ふぇす","role1","label1","100"
+
+Carga
+=====
+
+Registra palabras en formato CSV.
+
+|image3|
+
+Contenido del CSV
+-----------------
+
+La primera línea es el encabezado.
+Desde la segunda línea en adelante se describen las palabras adicionales.
+
+::
+
+"SuggestWord","Reading","Role","Label","Boost"
+"fess","ふぇす","role1","label1","100"
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/elevateword-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/elevateword-2.png
+.. |image2| image:: ../../../resources/images/ja/15.3/admin/elevateword-3.png
+.. |image3| image:: ../../../resources/images/ja/15.3/admin/elevateword-4.png

--- a/es/15.3/admin/esreq-guide.rst
+++ b/es/15.3/admin/esreq-guide.rst
@@ -1,0 +1,40 @@
+=======================
+Solicitud de Consulta
+=======================
+
+Descripción general
+===================
+
+Esta página envía solicitudes de consulta de archivos JSON a OpenSearch.
+
+|image0|
+
+Método de operación
+===================
+
+Envío de solicitud
+------------------
+
+Después de iniciar sesión como administrador, ingrese /admin/esreq/ como la ruta de la URL.
+Cree la solicitud de consulta que desea enviar a OpenSearch como un archivo JSON, seleccione ese archivo JSON como "Archivo de solicitud" y haga clic en el botón "Enviar" para enviar la solicitud a OpenSearch.
+La respuesta se descarga como un archivo.
+
+Parámetros de configuración
+----------------------------
+
+Archivo de solicitud
+::::::::::::::::::::
+
+Especifique un archivo JSON que describa el DSL de consulta.
+Por ejemplo, el contenido del archivo JSON sería el siguiente.
+
+::
+
+    POST /_search
+    {
+      "query": {
+        "match_all": {}
+      }
+    }
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/esreq-1.png

--- a/es/15.3/admin/failureurl-guide.rst
+++ b/es/15.3/admin/failureurl-guide.rst
@@ -1,0 +1,66 @@
+================
+URL con Falla
+================
+
+Descripción general
+===================
+
+Aquí se explica sobre las URL con falla.
+Las URL que no se pudieron obtener durante el rastreo se registran y se pueden verificar como URL con falla.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista para verificar las URL con falla, haga clic en [Información del sistema > URL con falla] en el menú izquierdo.
+
+|image0|
+
+Al hacer clic en el enlace de verificación de URL con falla, se muestran los detalles.
+
+Detalles de URL con falla
+==========================
+
+Los detalles de URL con falla registran las excepciones que ocurrieron durante el rastreo.
+
+|image1|
+
+Contenido de los detalles
+--------------------------
+
+URL
+:::
+
+URL en la que ocurrió la excepción.
+
+Nombre del hilo
+:::::::::::::::
+
+Nombre del hilo que estaba ejecutando el rastreo.
+Se puede utilizar al verificar archivos de registro.
+
+Tipo
+::::
+
+Tipo de excepción.
+
+Registro
+::::::::
+
+Contenido de la excepción.
+
+Número de errores
+:::::::::::::::::
+
+Número de veces que ocurrió esta excepción.
+
+Fecha del último acceso
+:::::::::::::::::::::::
+
+Hora en la que ocurrió esta excepción.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/failureurl-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/failureurl-2.png

--- a/es/15.3/admin/fileauth-guide.rst
+++ b/es/15.3/admin/fileauth-guide.rst
@@ -1,0 +1,80 @@
+==========================
+Autenticación de Archivos
+==========================
+
+Descripción general
+===================
+
+Aquí se explica el método de configuración cuando se requiere autenticación de archivos para el rastreo dirigido a archivos.
+|Fess| admite la autenticación para FTP o carpetas compartidas de Windows.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista para configurar la autenticación de archivos que se muestra a continuación, haga clic en [Rastreador > Autenticación de archivos] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de autenticación de archivos, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre de host
+::::::::::::::
+
+Especifique el nombre de host del sitio que requiere autenticación.
+
+Puerto
+::::::
+
+Especifique el puerto del sitio que requiere autenticación.
+
+Esquema
+:::::::
+
+Seleccione el método de autenticación.
+Puede utilizar FTP o SAMBA (autenticación de carpeta compartida de Windows).
+
+Nombre de usuario
+:::::::::::::::::
+
+Especifique el nombre de usuario para iniciar sesión en el sitio de autenticación.
+
+Contraseña
+::::::::::
+
+Especifique la contraseña para iniciar sesión en el sitio de autenticación.
+
+Parámetros
+::::::::::
+
+Configure si hay valores de configuración necesarios para iniciar sesión en el sitio de autenticación. Para SAMBA, puede configurar el valor de domain. Si desea configurarlo, descríbalo de la siguiente manera:
+
+::
+
+    domain=FUGA
+
+Configuración de rastreo de archivos
+:::::::::::::::::::::::::::::::::::::
+
+Especifique la configuración de rastreo que utilizará esta configuración de autenticación.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/fileauth-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/fileauth-2.png

--- a/es/15.3/admin/fileconfig-guide.rst
+++ b/es/15.3/admin/fileconfig-guide.rst
@@ -1,0 +1,180 @@
+=======================
+Rastreo de Sistema de Archivos
+=======================
+
+Descripción general
+===================
+
+La página de configuración de rastreo de archivos le permite administrar la configuración para rastrear archivos en el sistema de archivos o en carpetas compartidas en la red.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista para configurar el rastreo de archivos que se muestra a continuación, haga clic en [Rastreador > Sistema de archivos] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de rastreo de archivos, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre
+::::::
+
+Es el nombre de la configuración.
+
+Ruta
+::::
+
+En esta ruta, especifique dónde comenzar el rastreo (ejemplo: file:/ o smb://).
+
+Rutas a rastrear
+::::::::::::::::
+
+Las rutas que coincidan con la expresión regular (formato Java) especificada en este elemento serán objeto del rastreador de |Fess|.
+
+Rutas excluidas del rastreo
+::::::::::::::::::::::::::::
+
+Las rutas que coincidan con la expresión regular (formato Java) especificada en este elemento no serán objeto del rastreador de |Fess|.
+
+Rutas a buscar
+::::::::::::::
+
+Las rutas que coincidan con la expresión regular (formato Java) especificada en este elemento serán objeto de búsqueda.
+
+Rutas excluidas de la búsqueda
+:::::::::::::::::::::::::::::::
+
+Las rutas que coincidan con la expresión regular (formato Java) especificada en este elemento no serán objeto de búsqueda.
+
+Parámetros de configuración
+::::::::::::::::::::::::::::
+
+Puede especificar información de configuración de rastreo.
+
+Profundidad
+:::::::::::
+
+Especifique la profundidad de la estructura del sistema de archivos a rastrear.
+
+Número máximo de accesos
+:::::::::::::::::::::::::
+
+Especifique el número de rutas a indexar.
+
+Número de hilos
+:::::::::::::::
+
+Especifique el número de hilos a utilizar para esta configuración.
+
+Intervalo
+:::::::::
+
+Especifique el tiempo de espera cada vez que un hilo rastrea una ruta.
+
+Valor de impulso
+::::::::::::::::
+
+El valor de impulso es la prioridad de los documentos indexados por esta configuración.
+
+Permisos
+::::::::
+
+Especifique el permiso para esta configuración.
+La forma de especificar permisos es, por ejemplo, para mostrar resultados de búsqueda a usuarios que pertenecen al grupo developer, especifique {group}developer.
+La especificación por usuario es {user}nombre_usuario, la especificación por rol es {role}nombre_rol, y la especificación por grupo es {group}nombre_grupo.
+
+Host virtual
+::::::::::::
+
+Especifique el nombre de host del host virtual.
+Para más detalles, consulte :doc:`Host virtual en la guía de configuración <../config/virtual-host>`.
+
+Estado
+::::::
+
+Cuando esta configuración está habilitada, el trabajo del rastreador predeterminado realizará el rastreo incluyendo esta configuración.
+
+Descripción
+:::::::::::
+
+Puede ingresar una descripción.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación. Al presionar el botón de eliminar, se eliminará la configuración.
+
+Ejemplo
+=======
+
+Rastrear archivos locales
+--------------------------
+
+Para rastrear archivos bajo /home/share, la configuración sería la siguiente.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Nombre
+     - Valor
+   * - Nombre
+     - Directorio compartido
+   * - Ruta
+     - file:/home/share
+
+Los otros parámetros pueden usar la configuración predeterminada.
+
+Rastrear carpeta compartida de Windows
+---------------------------------------
+
+Para rastrear archivos bajo \\SERVER\SharedFolder, la configuración sería la siguiente.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Nombre
+     - Valor
+   * - Nombre
+     - Carpeta compartida
+   * - Ruta
+     - smb://SERVER/SharedFolder/
+
+Si se requiere nombre de usuario/contraseña para acceder a la carpeta compartida, es necesario crear una configuración de autenticación de archivos desde [Rastreador > Autenticación de archivos] en el menú izquierdo.
+En ese caso, la configuración sería la siguiente.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Nombre
+     - Valor
+   * - Nombre de host
+     - SERVER
+   * - Esquema
+     - SAMBA
+   * - Nombre de usuario
+     - (Ingrese)
+   * - Contraseña
+     - (Ingrese)
+
+
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/fileconfig-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/fileconfig-2.png
+.. pdf            :height: 940 px

--- a/es/15.3/admin/general-guide.rst
+++ b/es/15.3/admin/general-guide.rst
@@ -1,0 +1,294 @@
+=======
+General
+=======
+
+Descripción general
+===================
+
+En esta página de administración, puede gestionar la configuración de |Fess|.
+Puede cambiar varias configuraciones de |Fess| sin necesidad de reiniciarlo.
+
+|image0|
+
+Contenido de la configuración
+==============================
+
+Sistema
+-------
+
+Respuesta JSON
+::::::::::::::
+
+Especifique si desea habilitar la API JSON.
+
+Se requiere inicio de sesión
+:::::::::::::::::::::::::::::
+
+Especifique si desea hacer que el inicio de sesión sea obligatorio para la función de búsqueda.
+
+Mostrar enlace de inicio de sesión
+:::::::::::::::::::::::::::::::::::
+
+Configure si desea mostrar el enlace a la página de inicio de sesión en la pantalla de búsqueda.
+
+Contraer resultados duplicados
+:::::::::::::::::::::::::::::::
+
+Configure si desea habilitar la contracción de resultados duplicados.
+
+Mostrar miniaturas
+::::::::::::::::::
+
+Configure si desea habilitar la visualización de miniaturas.
+
+Valor de etiqueta predeterminado
+:::::::::::::::::::::::::::::::::
+
+Describa el valor de etiqueta que se agregará a las condiciones de búsqueda de forma predeterminada.
+Si especifica por rol o grupo, añada "role:" o "group:" como en "role:admin=label1".
+
+Valor de ordenamiento predeterminado
+:::::::::::::::::::::::::::::::::::::
+
+Describa el valor de ordenamiento que se agregará a las condiciones de búsqueda de forma predeterminada.
+Si especifica por rol o grupo, añada "role:" o "group:" como en "role:admin=content_length.desc".
+
+Host virtual
+::::::::::::
+
+Configure el host virtual.
+Para más detalles, consulte :doc:`Host virtual en la guía de configuración <../config/virtual-host>`.
+
+Respuesta de palabras populares
+::::::::::::::::::::::::::::::::
+
+Especifique si desea habilitar la API de palabras populares.
+
+Codificación de archivos CSV
+:::::::::::::::::::::::::::::
+
+Especifique la codificación de los archivos CSV que se descargarán.
+
+Agregar parámetros de búsqueda
+:::::::::::::::::::::::::::::::
+
+Habilite esto si desea pasar parámetros a la visualización de resultados de búsqueda.
+
+Correo de notificación
+::::::::::::::::::::::
+
+Especifique las direcciones de correo electrónico que recibirán notificaciones al completarse el rastreo.
+Se pueden especificar varias direcciones separadas por comas. Se requiere un servidor de correo para su uso.
+
+Rastreador
+----------
+
+Verificar fecha de última actualización
+::::::::::::::::::::::::::::::::::::::::
+
+Habilite esto para realizar rastreo diferencial.
+
+Configuración simultánea del rastreador
+::::::::::::::::::::::::::::::::::::::::
+
+Especifique el número de configuraciones de rastreo que se ejecutarán simultáneamente.
+
+Eliminar documentos anteriores
+:::::::::::::::::::::::::::::::
+
+Especifique el número de días del período de validez después de la indexación.
+
+Tipos de error excluidos
+:::::::::::::::::::::::::
+
+Las URL con fallas que excedan el umbral se excluyen del rastreo, pero los nombres de excepción especificados aquí seguirán siendo objeto de rastreo incluso si exceden el umbral de URL con fallas.
+
+Umbral de número de fallas
+:::::::::::::::::::::::::::
+
+Si un documento objeto de rastreo se registra en las URL con fallas más veces que el número especificado aquí, se excluirá del próximo rastreo.
+
+Registro
+--------
+
+Registro de búsqueda
+::::::::::::::::::::
+
+Especifique si desea habilitar el registro de búsquedas.
+
+Registro de usuario
+:::::::::::::::::::
+
+Especifique si desea habilitar el registro de usuarios.
+
+Registro de favoritos
+:::::::::::::::::::::
+
+Especifique si desea habilitar el registro de favoritos.
+
+Eliminar registros de búsqueda anteriores
+::::::::::::::::::::::::::::::::::::::::::
+
+Elimina los registros de búsqueda anteriores al número de días especificado.
+
+Eliminar registros de trabajo anteriores
+:::::::::::::::::::::::::::::::::::::::::
+
+Elimina los registros de trabajo anteriores al número de días especificado.
+
+Eliminar registros de usuario anteriores
+:::::::::::::::::::::::::::::::::::::::::
+
+Elimina los registros de usuario anteriores al número de días especificado.
+
+Nombres de bots para eliminar del registro
+:::::::::::::::::::::::::::::::::::::::::::
+
+Especifique los nombres de bots que se excluirán de los registros de búsqueda.
+
+Nivel de registro
+:::::::::::::::::
+
+Especifique el nivel de registro para fess.log.
+
+Sugerencias
+-----------
+
+Sugerir con términos de búsqueda
+:::::::::::::::::::::::::::::::::
+
+Especifique si desea generar candidatos de sugerencia a partir de los registros de búsqueda.
+
+Sugerir con documentos
+:::::::::::::::::::::::
+
+Especifique si desea generar candidatos de sugerencia a partir de los documentos indexados.
+
+Eliminar información de sugerencias anterior
+:::::::::::::::::::::::::::::::::::::::::::::
+
+Elimina los datos de sugerencias anteriores al número de días especificado.
+
+LDAP
+----
+
+URL de LDAP
+:::::::::::
+
+Especifique la URL del servidor LDAP.
+
+Base DN
+:::::::
+
+Especifique el nombre distinguido base para iniciar sesión en la pantalla de búsqueda.
+
+Bind DN
+:::::::
+
+Especifique el Bind DN del administrador.
+
+Contraseña
+::::::::::
+
+Especifique la contraseña del Bind DN.
+
+User DN
+:::::::
+
+Especifique el nombre distinguido del usuario.
+
+Filtro de cuenta
+::::::::::::::::
+
+Especifique el Common Name o uid del usuario.
+
+Filtro de grupo
+:::::::::::::::
+
+Especifique las condiciones de filtro para los grupos que desea obtener.
+
+Atributo memberOf
+:::::::::::::::::
+
+Especifique el nombre del atributo memberOf disponible en el servidor LDAP.
+Para Active Directory, es memberOf.
+Para otros servidores LDAP, puede ser isMemberOf.
+
+
+Visualización de notificaciones
+--------------------------------
+
+Página de inicio de sesión
+:::::::::::::::::::::::::::
+
+Describa el mensaje que se mostrará en la pantalla de inicio de sesión.
+
+Página principal de búsqueda
+:::::::::::::::::::::::::::::
+
+Describa el mensaje que se mostrará en la pantalla principal de búsqueda.
+
+Almacenamiento
+--------------
+
+Después de configurar cada elemento, aparecerá un menú [Sistema > Almacenamiento] en el menú izquierdo.
+Para la gestión de archivos, consulte :doc:`Almacenamiento <../admin/storage-guide>`.
+
+Punto de acceso
+:::::::::::::::
+
+Especifique la URL del punto de acceso del servidor MinIO.
+
+Clave de acceso
+:::::::::::::::
+
+Especifique la clave de acceso del servidor MinIO.
+
+Clave secreta
+:::::::::::::
+
+Especifique la clave secreta del servidor MinIO.
+
+Bucket
+::::::
+
+Especifique el nombre del bucket a gestionar.
+
+Ejemplo
+=======
+
+Ejemplo de configuración LDAP
+------------------------------
+
+.. tabularcolumns:: |p{4cm}|p{4cm}|p{4cm}|
+.. list-table:: Configuración de LDAP/Active Directory
+   :header-rows: 1
+
+   * - Nombre
+     - Valor (LDAP)
+     - Valor (Active Directory)
+   * - URL de LDAP
+     - ldap://SERVERNAME:389
+     - ldap://SERVERNAME:389
+   * - Base DN
+     - cn=Directory Manager
+     - dc=fess,dc=codelibs,dc=org
+   * - Bind DN
+     - uid=%s,ou=People,dc=fess,dc=codelibs,dc=org
+     - manager@fess.codelibs.org
+   * - User DN
+     - uid=%s,ou=People,dc=fess,dc=codelibs,dc=org
+     - %s@fess.codelibs.org
+   * - Filtro de cuenta
+     - cn=%s o uid=%s
+     - (&(objectClass=user)(sAMAccountName=%s))
+   * - Filtro de grupo
+     -
+     - (member:1.2.840.113556.1.4.1941:=%s)
+   * - memberOf
+     - isMemberOf
+     - memberOf
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/general-1.png
+.. pdf            :height: 940 px

--- a/es/15.3/admin/group-guide.rst
+++ b/es/15.3/admin/group-guide.rst
@@ -1,0 +1,45 @@
+========
+Grupo
+========
+
+Descripción general
+===================
+
+Puede administrar los grupos a los que pertenecen los usuarios.
+Se puede utilizar en casos como la integración con LDAP.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista para configurar grupos que se muestra a continuación, haga clic en [Usuario > Grupo] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de grupo, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre
+::::::
+
+Nombre del grupo.
+
+Método de eliminación
+---------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/group-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/group-2.png

--- a/es/15.3/admin/index.rst
+++ b/es/15.3/admin/index.rst
@@ -1,0 +1,52 @@
+Guía del Administrador de |Fess|
+===================================
+
+.. toctree::
+   :maxdepth: 3
+
+   intro
+   dashboard-guide
+   wizard-guide
+   general-guide
+   scheduler-guide
+   design-guide
+   dict-guide
+   kuromoji-guide
+   synonym-guide
+   mapping-guide
+   protwords-guide
+   stopwords-guide
+   stemmeroverride-guide
+   accesstoken-guide
+   plugin-guide
+   storage-guide
+   webconfig-guide
+   fileconfig-guide
+   dataconfig-guide
+   labeltype-guide
+   keymatch-guide
+   boostdoc-guide
+   relatedcontent-guide
+   relatedquery-guide
+   pathmap-guide
+   webauth-guide
+   fileauth-guide
+   reqheader-guide
+   duplicatehost-guide
+   user-guide
+   role-guide
+   group-guide
+   suggest-guide
+   elevateword-guide
+   badword-guide
+   systeminfo-guide
+   searchlog-guide
+   joblog-guide
+   crawlinginfo-guide
+   log-guide
+   failureurl-guide
+   searchlist-guide
+   backup-guide
+   maintenance-guide
+   esreq-guide
+

--- a/es/15.3/admin/intro.rst
+++ b/es/15.3/admin/intro.rst
@@ -1,0 +1,34 @@
+============
+Introducción
+============
+
+Público objetivo
+================
+
+Este documento está destinado a usuarios responsables de las tareas administrativas de |Fess|.
+
+Antes de leer
+=============
+
+Este documento describe cómo gestionar la configuración de |Fess|. Se requieren conocimientos básicos de operación de computadoras.
+
+Acceso en línea
+===============
+
+Para descargas, servicios profesionales, soporte y otra información para desarrolladores, visite:
+
+-  Sitio del proyecto:
+   `https://fess.codelibs.org/ <https://fess.codelibs.org/>`__
+
+Contacto para soporte técnico
+==============================
+
+Si tiene preguntas técnicas sobre este producto y no encuentra una solución en la documentación, visite:
+
+-  Incidencias:
+   `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
+
+Soporte comercial
+-----------------
+
+Si necesita soporte comercial, como asistencia técnica o mantenimiento de este producto, póngase en contacto con `N2SM, Inc. <https://www.n2sm.net/>`__.

--- a/es/15.3/admin/joblog-guide.rst
+++ b/es/15.3/admin/joblog-guide.rst
@@ -1,0 +1,68 @@
+==================
+Registro de Trabajos
+==================
+
+Descripción general
+===================
+
+Muestra como lista los resultados de los trabajos ejecutados.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de verificación de registro de trabajos que se muestra a continuación, haga clic en [Información del sistema > Registro de trabajos] en el menú izquierdo.
+
+|image0|
+
+Detalles del registro de trabajos
+----------------------------------
+
+Puede verificar el contenido del registro del trabajo. Muestra el nombre del trabajo, estado, hora de inicio/finalización, resultados, etc.
+
+|image1|
+
+Nombre
+::::::
+
+Nombre del trabajo ejecutado.
+
+Estado
+::::::
+
+Resultado de la ejecución del trabajo.
+
+Destino
+:::::::
+
+Destino en el que se ejecuta el trabajo.
+
+Hora de inicio
+::::::::::::::
+
+Hora UNIX en la que comenzó el trabajo.
+
+Hora de finalización
+::::::::::::::::::::
+
+Hora UNIX en la que finalizó el trabajo.
+
+Método de ejecución
+:::::::::::::::::::
+
+Entorno de ejecución en el que se ejecutó el trabajo.
+
+Script
+::::::
+
+Contenido de ejecución del trabajo.
+
+Resultado
+:::::::::
+
+Resultado de la ejecución del trabajo.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/joblog-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/joblog-2.png

--- a/es/15.3/admin/keymatch-guide.rst
+++ b/es/15.3/admin/keymatch-guide.rst
@@ -1,0 +1,66 @@
+====================
+Coincidencia de Clave
+====================
+
+Descripción general
+===================
+
+Aquí se explica la configuración relacionada con la coincidencia de clave.
+Al configurar la coincidencia de clave, puede posicionar documentos en la parte superior de los resultados de búsqueda cuando se busca con el término de búsqueda registrado.
+Un uso común es para publicidad.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+Para abrir la página de lista de configuración de coincidencia de clave que se muestra a continuación, haga clic en [Rastreador > Coincidencia de clave] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de coincidencia de clave, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Término de búsqueda
+:::::::::::::::::::
+
+La ponderación se aplicará solo en los resultados de búsqueda al buscar con este término de búsqueda.
+
+Consulta
+::::::::
+
+Los documentos objetivo que desea posicionar en la parte superior se determinan mediante la consulta de búsqueda.
+
+Tamaño
+::::::
+
+Especifique el número máximo de documentos que coinciden con la consulta.
+
+Valor de impulso
+::::::::::::::::
+
+Especifique el valor de ponderación del documento.
+
+Host virtual
+::::::::::::
+
+Especifique el nombre de host del host virtual.
+Para más detalles, consulte :doc:`Host virtual en la guía de configuración <../config/virtual-host>`.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/keymatch-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/keymatch-2.png

--- a/es/15.3/admin/kuromoji-guide.rst
+++ b/es/15.3/admin/kuromoji-guide.rst
@@ -1,0 +1,76 @@
+=====================
+Diccionario Kuromoji
+=====================
+
+Descripción general
+===================
+
+Puede registrar nombres de personas, nombres propios, términos especializados, etc. para el análisis morfológico.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de Kuromoji que se muestra a continuación, seleccione [Sistema > Diccionario] en el menú izquierdo y luego haga clic en kuromoji.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Método de configuración
+-----------------------
+
+Para abrir la página de configuración de Kuromoji, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Token
+:::::
+
+Ingrese la palabra a procesar en el análisis morfológico.
+
+Segmentación
+::::::::::::
+
+Si una palabra está compuesta de una palabra compuesta, puede hacer que se encuentre incluso cuando se busca con la palabra segmentada.
+Por ejemplo, al ingresar "全文検索エンジン" como "全文 検索 エンジン", puede permitir que se busque también con palabras segmentadas.
+
+Lectura
+:::::::
+
+Ingrese la lectura de la palabra ingresada como token en katakana.
+Si se realizó segmentación, ingrésela segmentada.
+Por ejemplo, ingrese "ゼンブン ケンサク エンジン".
+
+Parte del discurso
+::::::::::::::::::
+
+Ingrese la parte del discurso de la palabra ingresada.
+
+Descarga
+========
+
+Puede descargar en el formato de diccionario de Kuromoji.
+
+Carga
+=====
+
+Puede cargar en el formato de diccionario de Kuromoji.
+El formato de diccionario de Kuromoji está separado por comas (,) como "token,token segmentado,lectura del token segmentado,parte del discurso".
+Los tokens segmentados se separan con espacios.
+Si no es necesario segmentar, el token y el token segmentado serán iguales.
+Por ejemplo, sería como sigue:
+
+::
+
+    朝青龍,朝青龍,アサショウリュウ,カスタム名詞
+    関西国際空港,関西 国際 空港,カンサイ コクサイ クウコウ,カスタム名詞
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/kuromoji-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/kuromoji-2.png

--- a/es/15.3/admin/labeltype-guide.rst
+++ b/es/15.3/admin/labeltype-guide.rst
@@ -1,0 +1,87 @@
+==========
+Etiquetas
+==========
+
+Descripción general
+===================
+
+
+Aquí se explica la configuración relacionada con las etiquetas.
+Las etiquetas pueden clasificar los documentos que se muestran en los resultados de búsqueda.
+La configuración de etiquetas especifica con expresiones regulares las rutas a las que se agregarán etiquetas.
+Si registra etiquetas, se mostrará un cuadro desplegable de etiquetas en las opciones de búsqueda.
+
+Esta configuración de etiquetas se aplica a la configuración de rastreo web o del sistema de archivos.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de etiquetas que se muestra a continuación, haga clic en [Rastreador > Etiquetas] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de etiquetas, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre
+::::::
+
+Especifique el nombre que se mostrará en el cuadro desplegable de selección de etiquetas durante la búsqueda.
+
+Valor
+:::::
+
+Especifique el identificador al clasificar documentos.
+Especifíquelo en caracteres alfanuméricos.
+
+Rutas objetivo
+::::::::::::::
+
+Configure con expresiones regulares las rutas a las que se agregarán etiquetas.
+Puede especificar múltiples rutas describiéndolas en múltiples líneas.
+Se configurará la etiqueta en los documentos que coincidan con las rutas especificadas aquí.
+
+Rutas excluidas
+:::::::::::::::
+
+Configure con expresiones regulares las rutas que desea excluir del objetivo entre las rutas objetivo de rastreo.
+Puede especificar múltiples rutas describiéndolas en múltiples líneas.
+
+Permisos
+::::::::
+
+Especifique el permiso para esta configuración.
+La forma de especificar permisos es, por ejemplo, para mostrar resultados de búsqueda a usuarios que pertenecen al grupo developer, especifique {group}developer.
+La especificación por usuario es {user}nombre_usuario, la especificación por rol es {role}nombre_rol, y la especificación por grupo es {group}nombre_grupo.
+
+Host virtual
+::::::::::::
+
+Especifique el nombre de host del host virtual.
+Para más detalles, consulte :doc:`Host virtual en la guía de configuración <../config/virtual-host>`.
+
+Orden de visualización
+:::::::::::::::::::::::
+
+Especifique el orden de visualización de las etiquetas.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/labeltype-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/labeltype-2.png

--- a/es/15.3/admin/log-guide.rst
+++ b/es/15.3/admin/log-guide.rst
@@ -1,0 +1,70 @@
+==================
+Archivo de Registro
+==================
+
+Descripción general
+===================
+
+Aquí se explica la descarga de archivos de registro generados por |Fess|.
+
+Método de configuración
+========================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de archivos de registro que se muestra a continuación, haga clic en [Información del sistema > Archivo de registro] en el menú izquierdo.
+
+|image0|
+
+Descarga
+--------
+
+Puede descargar el archivo de registro haciendo clic en el nombre del archivo de registro que se muestra.
+
+``server_*.log``
+::::::::::::::::
+
+Se registran los registros de |Fess| como servidor de aplicaciones.
+
+fess.log
+::::::::
+
+Se registran los registros de |Fess| como aplicación.
+
+fess-crawler.log
+::::::::::::::::
+
+Se registran los registros del rastreador.
+
+audit.log
+:::::::::
+
+Se registran la información de inicio de sesión y los registros de acceso a la pantalla de administración.
+
+fess-thumbnail.log
+::::::::::::::::::
+
+Se registran los registros de la función de miniaturas.
+
+fess-suggest.log
+::::::::::::::::
+
+Se registran los registros de la función de sugerencias.
+
+fess-urls.log
+:::::::::::::
+
+Se registra el tiempo que tardó un rastreo.
+
+search.log
+::::::::::
+
+Se registran los registros de búsqueda.
+
+gc-crawler.log
+::::::::::::::
+
+Se registran los registros de GC de fess.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/log-1.png

--- a/es/15.3/admin/maintenance-guide.rst
+++ b/es/15.3/admin/maintenance-guide.rst
@@ -1,0 +1,67 @@
+===============
+Mantenimiento
+===============
+
+Descripción general
+===================
+
+La página de mantenimiento se utiliza al ejecutar operaciones de datos del sistema.
+
+|image0|
+
+Método de operación
+===================
+
+Reindexación
+------------
+
+Puede recrear un nuevo índice a partir del índice fess existente.
+Se ejecuta cuando desea cambiar el mapeo del índice, etc.
+
+
+Parámetros de configuración
+----------------------------
+
+Actualizar alias
+::::::::::::::::
+
+Al habilitarlo, después de que se complete la reindexación, puede reasignar los alias fess.search y fess.update asignados al índice existente al nuevo índice.
+
+
+Inicializar diccionarios
+:::::::::::::::::::::::::
+
+Al habilitarlo, puede inicializar la configuración de los diccionarios.
+
+
+Número de fragmentos
+:::::::::::::::::::::
+
+Puede especificar el número de fragmentos de OpenSearch (index.number_of_shards).
+
+
+Número máximo de réplicas
+::::::::::::::::::::::::::
+
+Puede especificar el número máximo de réplicas de OpenSearch (index.auto_expand_replicas).
+
+
+Recargar índice de documentos
+------------------------------
+
+Puede recargar el índice de documentos para reflejar la configuración del índice.
+
+
+Índice de Rastreador
+--------------------
+
+Puede eliminar el índice fess_crawler (información de rastreo).
+No lo ejecute mientras el rastreador esté en ejecución.
+
+
+Diagnóstico
+-----------
+
+Puede descargar archivos de registro en formato zip.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/maintenance-1.png

--- a/es/15.3/admin/mapping-guide.rst
+++ b/es/15.3/admin/mapping-guide.rst
@@ -1,0 +1,55 @@
+==================
+Diccionario de Mapeo
+==================
+
+Descripción general
+===================
+
+Puede mapear caracteres específicos (símbolos, códigos de caracteres, ancho completo/medio) a otros caracteres.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de mapeo que se muestra a continuación, seleccione [Sistema > Diccionario] en el menú izquierdo y luego haga clic en mapping.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Método de configuración
+-----------------------
+
+Para abrir la página de configuración de mapeo, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Origen de la conversión
+:::::::::::::::::::::::
+
+Ingrese los caracteres (símbolos, códigos de caracteres, ancho completo/medio) que serán objeto del mapeo.
+
+Después de la conversión
+:::::::::::::::::::::::::
+
+Expanda los caracteres ingresados en el origen de la conversión con los caracteres después de la conversión.
+
+Descarga
+========
+
+Puede descargar en el formato de diccionario de mapeo.
+
+Carga
+=====
+
+Puede cargar en el formato de diccionario de mapeo.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/mapping-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/mapping-2.png
+

--- a/es/15.3/admin/pathmap-guide.rst
+++ b/es/15.3/admin/pathmap-guide.rst
@@ -1,0 +1,67 @@
+================
+Mapeo de Rutas
+================
+
+Descripción general
+===================
+
+Aquí se explica la configuración relacionada con el mapeo de rutas.
+El mapeo de rutas se puede utilizar cuando desea reemplazar los enlaces que se muestran en los resultados de búsqueda, etc.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de mapeo de rutas que se muestra a continuación, haga clic en [Rastreador > Mapeo de rutas] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de mapeo de rutas, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Expresión regular
+:::::::::::::::::
+
+Especifique la cadena que desea reemplazar.
+El método de descripción sigue las expresiones regulares de Java.
+
+Reemplazo
+:::::::::
+
+Especifique la cadena que reemplazará la expresión regular coincidente.
+
+Tipo de procesamiento
+:::::::::::::::::::::
+
+Especifique el momento del reemplazo.
+
+* Rastreo: Reemplaza la URL después de obtener el documento durante el rastreo, antes de indexar.
+* Visualización: Reemplaza la URL antes de mostrar durante la búsqueda.
+* Rastreo/Visualización: Reemplaza la URL tanto en rastreo como en visualización.
+* URL guardada: Reemplaza la URL antes de obtener el documento durante el rastreo.
+
+Orden de visualización
+:::::::::::::::::::::::
+
+Puede especificar el orden de procesamiento del mapeo de rutas.
+Se procesa en orden ascendente.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/pathmap-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/pathmap-2.png

--- a/es/15.3/admin/plugin-guide.rst
+++ b/es/15.3/admin/plugin-guide.rst
@@ -1,0 +1,32 @@
+==========
+Complemento
+==========
+
+Descripción general
+===================
+
+La página de configuración de complementos gestiona los complementos.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de complementos instalados que se muestra a continuación, haga clic en [Sistema > Complemento] en el menú izquierdo.
+
+|image0|
+
+Para desinstalar, haga clic en el botón de eliminar.
+
+Instalación
+-----------
+
+Para instalar un nuevo complemento, haga clic en el botón de instalación.
+
+|image1|
+
+Seleccione el complemento que desea instalar en el menú desplegable y haga clic en el botón de instalación para comenzar la instalación.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/plugin-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/plugin-2.png

--- a/es/15.3/admin/protwords-guide.rst
+++ b/es/15.3/admin/protwords-guide.rst
@@ -1,0 +1,52 @@
+========================
+Diccionario de Protwords
+========================
+
+Descripción general
+===================
+
+Puede administrar palabras que se excluirán del procesamiento de stemming.
+El procesamiento de stemming es básicamente un procesamiento basado en reglas, por lo que puede ocurrir una normalización no deseada.
+Por ejemplo, la palabra Maine (nombre de un estado de EE. UU.) se normaliza a main.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de Protwords que se muestra a continuación, seleccione [Sistema > Diccionario] en el menú izquierdo y luego haga clic en protwords.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Método de configuración
+-----------------------
+
+Para abrir la página de configuración de Protwords, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Información de la palabra
+::::::::::::::::::::::::::
+
+Ingrese las palabras que se excluirán del procesamiento de stemming.
+
+
+Descarga
+========
+
+Puede descargar en el formato de diccionario de Protwords.
+
+Carga
+=====
+
+Puede cargar en el formato de diccionario de Protwords.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/protwords-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/protwords-2.png

--- a/es/15.3/admin/relatedcontent-guide.rst
+++ b/es/15.3/admin/relatedcontent-guide.rst
@@ -1,0 +1,57 @@
+=======================
+Contenido Relacionado
+=======================
+
+Descripción general
+===================
+
+
+Aquí se explica la configuración de contenido relacionado.
+Si la consulta de búsqueda coincide con el término de búsqueda especificado, puede mostrar contenido relacionado en la parte superior de los resultados de búsqueda.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista para configurar el contenido relacionado que se muestra a continuación, haga clic en [Rastreador > Contenido relacionado] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de contenido relacionado, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Término de búsqueda
+:::::::::::::::::::
+
+Especifique el término de búsqueda que desea coincidir con la consulta de búsqueda.
+
+Contenido
+:::::::::
+
+Especifique el contenido que desea mostrar en los resultados de búsqueda.
+
+Host virtual
+::::::::::::
+
+Especifique el nombre de host del host virtual.
+Para más detalles, consulte :doc:`Host virtual en la guía de configuración <../config/virtual-host>`.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/relatedcontent-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/relatedcontent-2.png

--- a/es/15.3/admin/relatedquery-guide.rst
+++ b/es/15.3/admin/relatedquery-guide.rst
@@ -1,0 +1,59 @@
+====================
+Consulta Relacionada
+====================
+
+Descripción general
+===================
+
+Aquí se explica la configuración de consulta relacionada.
+Puede mejorar los resultados de búsqueda con las consultas relacionadas registradas.
+Las consultas relacionadas se pueden utilizar como términos alternativos para los términos de búsqueda.
+
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista para configurar consultas relacionadas que se muestra a continuación, haga clic en [Rastreador > Consulta relacionada] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de consulta relacionada, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Término de búsqueda
+:::::::::::::::::::
+
+Especifique el término de búsqueda que desea coincidir con la consulta de búsqueda.
+
+Consulta
+::::::::
+
+Especifique la consulta.
+
+Host virtual
+::::::::::::
+
+Especifique el nombre de host del host virtual.
+Para más detalles, consulte :doc:`Host virtual en la guía de configuración <../config/virtual-host>`.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/relatedquery-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/relatedquery-2.png

--- a/es/15.3/admin/reqheader-guide.rst
+++ b/es/15.3/admin/reqheader-guide.rst
@@ -1,0 +1,57 @@
+===========================
+Encabezado de Solicitud
+===========================
+
+Descripción general
+===================
+
+Aquí se explica la configuración relacionada con los encabezados de solicitud.
+La función de encabezado de solicitud es información de encabezado de solicitud que se agrega a la solicitud al rastrear y obtener documentos.
+Por ejemplo, se puede utilizar en casos donde el sistema de autenticación ve la información del encabezado y, si hay un valor específico, inicia sesión automáticamente.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de encabezados de solicitud que se muestra a continuación, haga clic en [Rastreador > Encabezado de solicitud] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de encabezado de solicitud, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre
+::::::
+
+Especifique el nombre del encabezado de solicitud al agregarlo a la solicitud.
+
+Valor
+:::::
+
+Especifique el valor del encabezado de solicitud al agregarlo a la solicitud.
+
+Configuración web
+:::::::::::::::::
+
+Seleccione el nombre de configuración de rastreo web al que se agregará el encabezado de solicitud.
+El encabezado de solicitud se agregará solo en la configuración de rastreo seleccionada.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/reqheader-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/reqheader-2.png

--- a/es/15.3/admin/role-guide.rst
+++ b/es/15.3/admin/role-guide.rst
@@ -1,0 +1,46 @@
+======
+Rol
+======
+
+Descripción general
+===================
+
+Puede administrar los roles a los que pertenecen los usuarios.
+Se puede utilizar en casos como la integración con LDAP.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de roles que se muestra a continuación, haga clic en [Usuario > Rol] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de rol, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre
+::::::
+
+Nombre del rol.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/role-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/role-2.png

--- a/es/15.3/admin/scheduler-guide.rst
+++ b/es/15.3/admin/scheduler-guide.rst
@@ -1,0 +1,105 @@
+=================
+Programador de Tareas
+=================
+
+Descripción general
+===================
+
+Aquí se explica la configuración relacionada con el programador de tareas.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración del programador de tareas que se muestra a continuación, haga clic en [Sistema > Programador] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración del programador, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre
+::::::
+
+Es el nombre que se muestra en la lista.
+
+Destino
+:::::::
+
+El destino se puede utilizar como identificador para determinar si ejecutar o no el trabajo al ejecutarlo directamente con un comando en un lote, etc.
+Si no ejecuta el rastreo mediante comandos, especifique "all".
+
+Programación
+::::::::::::
+
+Configure la programación.
+El trabajo descrito en el script se ejecutará según la programación configurada aquí.
+
+El formato de descripción es formato CRON con el formato "minuto hora día mes día_de_la_semana".
+Por ejemplo, "0 12 \* \* 3" ejecutará el trabajo todos los miércoles a las 12:00 PM.
+
+Método de ejecución
+:::::::::::::::::::
+
+Especifique el entorno de ejecución del script.
+Actualmente solo se admite "groovy".
+
+Script
+::::::
+
+Describa el contenido de ejecución del trabajo en el lenguaje especificado en el método de ejecución.
+
+Por ejemplo, si desea ejecutar solo tres configuraciones de rastreo como trabajo de rastreo, descríbalo de la siguiente manera (asumiendo que los ID de configuración de rastreo web son 1 y 2, y el ID de configuración de rastreo del sistema de archivos es 1).
+
+::
+
+    return container.getComponent("crawlJob").logLevel("info").webConfigIds(["1", "2"] as String[]).fileConfigIds(["1"] as String[]).dataConfigIds([] as String[]).execute(executor);
+
+Registro
+::::::::
+
+Al habilitarlo, se registrará en el registro de trabajos.
+
+Trabajo del rastreador
+::::::::::::::::::::::
+
+Al habilitarlo, se tratará como un trabajo del rastreador.
+Al configurar job.max.crawler.processes en fess_config.properties, puede evitar que se inicien más rastreadores de lo necesario.
+De forma predeterminada, no hay límite en el número de rastreadores que se pueden iniciar.
+
+Estado
+::::::
+
+Especifique el estado habilitado/deshabilitado del trabajo.
+Si se deshabilita, el trabajo no se ejecutará.
+
+Orden de visualización
+:::::::::::::::::::::::
+
+Especifique el orden de visualización en la lista de trabajos.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+Método de rastreo manual
+=========================
+
+Haga clic en "Default Crawler" en "Programador" y luego haga clic en el botón "Iniciar ahora".
+Para detener el rastreador, haga clic en "Default Crawler" y luego haga clic en el botón "Detener".
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/scheduler-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/scheduler-2.png

--- a/es/15.3/admin/searchlist-guide.rst
+++ b/es/15.3/admin/searchlist-guide.rst
@@ -1,0 +1,33 @@
+=========
+Búsqueda
+=========
+
+Descripción general
+===================
+
+Aquí se explica la búsqueda administrativa.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de búsqueda que se muestra a continuación, haga clic en [Información del sistema > Búsqueda] en el menú izquierdo.
+
+|image0|
+
+Lista de búsqueda
+-----------------
+
+Puede buscar con las condiciones especificadas.
+En la pantalla de búsqueda normal, las condiciones de roles y navegador se agregan implícitamente, pero en esta búsqueda administrativa no se agregan.
+También puede eliminar documentos específicos del índice de los resultados de búsqueda mostrados.
+
+Eliminación masiva
+------------------
+
+Si desea eliminar todos los documentos del índice, haga clic en el botón "Eliminar todo con esta consulta" con "\*:\*" para eliminarlos.
+También es posible especificar condiciones de búsqueda y eliminar solo los documentos objetivo.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/searchlist-1.png

--- a/es/15.3/admin/searchlog-guide.rst
+++ b/es/15.3/admin/searchlog-guide.rst
@@ -1,0 +1,30 @@
+====================
+Registro de Búsqueda
+====================
+
+Descripción general
+===================
+
+Los resultados de ejecución de búsqueda, clics y favoritos se registran, y los registros de búsqueda se pueden verificar en esta pantalla de administración.
+
+Método de gestión
+==================
+
+Lista
+=====
+
+En la lista puede verificar los registros de búsqueda de búsquedas, clics y favoritos.
+Si desea verificar los detalles del registro de búsqueda, haga clic en el registro de búsqueda objetivo.
+
+|image0|
+
+Detalles
+========
+
+Al hacer clic en un registro de búsqueda desde la lista, se muestran los detalles del registro de búsqueda objetivo.
+
+|image1|
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/searchlog-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/searchlog-2.png

--- a/es/15.3/admin/stemmeroverride-guide.rst
+++ b/es/15.3/admin/stemmeroverride-guide.rst
@@ -1,0 +1,55 @@
+====================================
+Diccionario de Anulación de Stemmer
+====================================
+
+Descripción general
+===================
+
+Puede anular el procesamiento de stemmer para caracteres específicos (símbolos, códigos de caracteres, ancho completo/medio) con otros caracteres.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de anulación de Stemmer que se muestra a continuación, seleccione [Sistema > Diccionario] en el menú izquierdo y luego haga clic en stemmeroverride.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Método de configuración
+-----------------------
+
+Para abrir la página de configuración de anulación de Stemmer, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Origen de la conversión
+:::::::::::::::::::::::
+
+Ingrese los caracteres (símbolos, códigos de caracteres, ancho completo/medio) que serán objeto de la anulación de Stemmer.
+
+Después de la conversión
+:::::::::::::::::::::::::
+
+Expanda los caracteres ingresados en el origen de la conversión con los caracteres después de la conversión.
+
+Descarga
+========
+
+Puede descargar en el formato de diccionario de anulación de Stemmer.
+
+Carga
+=====
+
+Puede cargar en el formato de diccionario de anulación de Stemmer.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/stemmeroverride-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/stemmeroverride-2.png
+

--- a/es/15.3/admin/stopwords-guide.rst
+++ b/es/15.3/admin/stopwords-guide.rst
@@ -1,0 +1,55 @@
+============================
+Diccionario de Palabras Vacías
+============================
+
+Descripción general
+===================
+
+Puede convertir caracteres específicos (símbolos, códigos de caracteres, ancho completo/medio) en palabras vacías.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de palabras vacías que se muestra a continuación, seleccione [Sistema > Diccionario] en el menú izquierdo y luego haga clic en stopwords.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Método de configuración
+-----------------------
+
+Para abrir la página de configuración de palabras vacías, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Origen de la conversión
+:::::::::::::::::::::::
+
+Ingrese los caracteres (símbolos, códigos de caracteres, ancho completo/medio) que serán objeto de palabras vacías.
+
+Después de la conversión
+:::::::::::::::::::::::::
+
+Expanda los caracteres ingresados en el origen de la conversión con los caracteres después de la conversión.
+
+Descarga
+========
+
+Puede descargar en el formato de diccionario de palabras vacías.
+
+Carga
+=====
+
+Puede cargar en el formato de diccionario de palabras vacías.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/stopwords-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/stopwords-2.png
+

--- a/es/15.3/admin/storage-guide.rst
+++ b/es/15.3/admin/storage-guide.rst
@@ -1,0 +1,73 @@
+==============
+Almacenamiento
+==============
+
+Descripción general
+===================
+
+La página de almacenamiento le permite administrar archivos en MinIO, un almacenamiento de objetos compatible con Amazon S3.
+
+Método de gestión
+==================
+
+Configuración del servidor de almacenamiento de objetos
+--------------------------------------------------------
+
+Abra la configuración de almacenamiento desde [Sistema > General] y configure los siguientes elementos:
+
+- Punto de acceso: URL del punto de acceso del servidor de almacenamiento
+- Clave de acceso: Clave de acceso del servidor de almacenamiento
+- Clave secreta: Clave secreta del servidor de almacenamiento
+- Bucket: Nombre del bucket a administrar
+
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de objetos que se muestra a continuación, haga clic en [Sistema > Almacenamiento] en el menú izquierdo.
+
+|image0|
+
+
+Nombre
+::::::
+
+Nombre del archivo del objeto
+
+
+Tamaño
+::::::
+
+Tamaño del objeto
+
+
+Fecha de última actualización
+::::::::::::::::::::::::::::::
+
+Fecha de última actualización del objeto
+
+Descarga
+--------
+
+Puede descargar el objeto haciendo clic en el botón de descarga.
+
+
+Eliminar
+--------
+
+Puede eliminar el objeto haciendo clic en el botón de eliminar.
+
+
+Carga
+-----
+
+Puede abrir la ventana de carga de archivos haciendo clic en el botón de carga de archivos en la esquina superior derecha.
+
+
+Crear carpeta
+-------------
+
+Puede abrir la ventana de creación de carpeta haciendo clic en el botón de crear carpeta a la derecha de la visualización de ruta. Tenga en cuenta que no se pueden crear carpetas vacías.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/storage-1.png

--- a/es/15.3/admin/suggest-guide.rst
+++ b/es/15.3/admin/suggest-guide.rst
@@ -1,0 +1,37 @@
+=======================
+Palabra de Sugerencia
+=======================
+
+Descripción general
+===================
+
+La página de palabras de sugerencia administra las palabras que se muestran en las sugerencias de palabras clave.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de palabras de sugerencia que se muestra a continuación, haga clic en [Sugerencia > Palabra de sugerencia] en el menú izquierdo.
+
+|image0|
+
+Si desea eliminar, haga clic en el botón de eliminar.
+
+
+Tipo de palabra
+:::::::::::::::
+
+- Todas: Todas las palabras registradas
+- Documento: Palabras generadas a partir de documentos indexados
+- Término de búsqueda: Palabras generadas a partir de registros de búsqueda
+
+Número de palabras
+::::::::::::::::::
+
+Número de palabras registradas
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/suggest-1.png
+

--- a/es/15.3/admin/synonym-guide.rst
+++ b/es/15.3/admin/synonym-guide.rst
@@ -1,0 +1,81 @@
+=====================
+Diccionario de Sinónimos
+=====================
+
+Descripción general
+===================
+
+Puede administrar sinónimos de palabras con el mismo significado (GB, gigabyte, etc.).
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de sinónimos que se muestra a continuación, seleccione [Sistema > Diccionario] en el menú izquierdo y luego haga clic en synonym.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Método de configuración
+-----------------------
+
+Para abrir la página de configuración de sinónimos, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Dado que la configuración estándar para la creación de índices es bi-gram, es necesario registrar de manera que la palabra después de la conversión no sea de un solo carácter.
+Además, al registrar sinónimos, es necesario registrar de la siguiente manera:
+
+* Registrar hiragana en katakana
+* Registrar katakana minúscula en katakana mayúscula
+* Registrar caracteres alfanuméricos de ancho completo en caracteres alfanuméricos de ancho medio
+* No registrar sinónimos duplicados
+
+Origen de la conversión
+:::::::::::::::::::::::
+
+Ingrese la palabra que será objeto de tratamiento como sinónimo.
+
+Después de la conversión
+:::::::::::::::::::::::::
+
+Expanda la palabra ingresada en el origen de la conversión con la palabra después de la conversión.
+Por ejemplo, si desea tratar "TV" como "TV" y "テレビ", ingrese "TV" en el origen de la conversión e ingrese "TV" y "テレビ" en después de la conversión.
+
+Descarga
+========
+
+Puede descargar en el formato de diccionario de sinónimos proporcionado por Apache Lucene.
+
+Carga
+=====
+
+Puede cargar en el formato de diccionario de sinónimos proporcionado por Apache Lucene.
+Dado que los sinónimos son el reemplazo de un grupo de palabras por otro grupo de palabras, en la descripción del diccionario se utilizan comas (,) y conversión (=>).
+Por ejemplo, si desea reemplazar "TV" con "テレビ", use => y descríbalo de la siguiente manera:
+
+::
+
+    TV=>テレビ
+
+Si desea tratar "fess" y "フェス" como lo mismo, descríbalo de la siguiente manera:
+
+::
+
+    fess,フエス=>fess,フエス
+
+En casos como el anterior, también puede omitir => y describirlo de la siguiente manera:
+
+::
+
+    fess,フエス
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/synonym-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/synonym-2.png

--- a/es/15.3/admin/systeminfo-guide.rst
+++ b/es/15.3/admin/systeminfo-guide.rst
@@ -1,0 +1,44 @@
+=====================
+Información del Sistema
+=====================
+
+Descripción general
+===================
+
+Aquí puede verificar la información de propiedades, como las variables de entorno del sistema actualmente en funcionamiento.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de información del sistema que se muestra a continuación, haga clic en [Información del sistema > Información de configuración] en el menú izquierdo.
+
+|image0|
+
+Elementos mostrados
+-------------------
+
+Propiedades de variables de entorno
+::::::::::::::::::::::::::::::::::::
+
+Puede listar las variables de entorno del servidor.
+
+Propiedades del sistema
+:::::::::::::::::::::::
+
+Puede listar las propiedades del sistema configuradas en |Fess|.
+
+Propiedades de la aplicación
+:::::::::::::::::::::::::::::
+
+Puede verificar la información de configuración de |Fess|.
+
+Propiedades del informe de errores
+:::::::::::::::::::::::::::::::::::
+
+Es una lista de propiedades para adjuntar al informar un error.
+Extrae valores que no contienen información personal.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/systeminfo-1.png

--- a/es/15.3/admin/upgrade-guide.rst
+++ b/es/15.3/admin/upgrade-guide.rst
@@ -1,0 +1,8 @@
+==============
+Actualización
+==============
+
+Referencia
+==========
+
+Consulte la `Guía de instalación <https://fess.codelibs.org/ja/15.3/install/index.html>`__.

--- a/es/15.3/admin/user-guide.rst
+++ b/es/15.3/admin/user-guide.rst
@@ -1,0 +1,54 @@
+==========
+Usuario
+==========
+
+Descripción general
+===================
+
+Puede administrar los usuarios que inician sesión en |Fess|.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de usuarios que se muestra a continuación, haga clic en [Usuario > Usuario] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de usuario, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre de usuario
+:::::::::::::::::
+
+Nombre de usuario.
+
+Rol
+:::
+
+Especifique los roles a los que pertenece el usuario.
+
+Grupo
+:::::
+
+Especifique los grupos a los que pertenece el usuario.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/user-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/user-2.png

--- a/es/15.3/admin/webauth-guide.rst
+++ b/es/15.3/admin/webauth-guide.rst
@@ -1,0 +1,93 @@
+==================
+Autenticación Web
+==================
+
+Descripción general
+===================
+
+Aquí se explica el método de configuración cuando se requiere autenticación web para el rastreo dirigido a la web.
+|Fess| admite el rastreo de autenticación BASIC, autenticación DIGEST y autenticación NTLM.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de autenticación web que se muestra a continuación, haga clic en [Rastreador > Autenticación web] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de autenticación web, haga clic en el botón de nueva creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre de host
+::::::::::::::
+
+Especifique el nombre de host del sitio que requiere autenticación.
+Si se omite, se aplicará con cualquier nombre de host en la configuración de rastreo web especificada.
+
+Puerto
+::::::
+
+Especifique el puerto del sitio que requiere autenticación.
+Si desea aplicarlo a todos los puertos, especifique -1.
+En ese caso, se aplicará con cualquier puerto en la configuración de rastreo web especificada.
+
+Dominio
+:::::::
+
+Especifique el nombre de dominio del sitio que requiere autenticación.
+Si se omite, se aplicará con cualquier nombre de dominio en la configuración de rastreo web especificada.
+
+Esquema
+:::::::
+
+Seleccione el método de autenticación.
+Puede utilizar autenticación BASIC, autenticación DIGEST, autenticación NTLM o autenticación FORM.
+
+Nombre de usuario
+:::::::::::::::::
+
+Especifique el nombre de usuario para iniciar sesión en el sitio de autenticación.
+
+Contraseña
+::::::::::
+
+Especifique la contraseña para iniciar sesión en el sitio de autenticación.
+
+Parámetros
+::::::::::
+
+Configure si hay valores de configuración necesarios para iniciar sesión en el sitio de autenticación.
+Para la autenticación NTLM, puede configurar los valores de workstation y domain.
+Si desea configurarlos, descríbalos de la siguiente manera:
+
+::
+
+    workstation=HOGE
+    domain=FUGA
+
+Configuración web
+:::::::::::::::::
+
+Seleccione el nombre de configuración web al que se aplicará la configuración de autenticación anterior.
+Es necesario registrar la configuración de rastreo web de antemano.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
+Al presionar el botón de eliminar, se eliminará la configuración.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/webauth-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/webauth-2.png

--- a/es/15.3/admin/webconfig-guide.rst
+++ b/es/15.3/admin/webconfig-guide.rst
@@ -1,0 +1,250 @@
+================
+Rastreo Web
+================
+
+Descripción general
+===================
+
+La página de configuración de rastreo web configura el rastreo web.
+
+Método de gestión
+==================
+
+Método de visualización
+-----------------------
+
+Para abrir la página de lista de configuración de rastreo web que se muestra a continuación, haga clic en [Rastreador > Web] en el menú izquierdo.
+
+|image0|
+
+Para editar, haga clic en el nombre de la configuración.
+
+Crear configuración
+-------------------
+
+Para abrir la página de configuración de rastreo web, haga clic en el botón de creación.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre
+::::::
+
+Nombre de la configuración.
+
+URL
+:::
+
+URL que será el punto de inicio del rastreo.
+
+URL a rastrear
+::::::::::::::
+
+Las URL que coincidan con la expresión regular (formato Java) especificada en este elemento serán objeto del rastreador de |Fess|.
+
+URL excluidas del rastreo
+::::::::::::::::::::::::::
+
+Las URL que coincidan con la expresión regular (formato Java) especificada en este elemento no serán objeto del rastreador de |Fess|.
+
+URL a buscar
+::::::::::::
+
+Las URL que coincidan con la expresión regular (formato Java) especificada en este elemento serán objeto de búsqueda.
+
+URL excluidas de la búsqueda
+:::::::::::::::::::::::::::::
+
+Las URL que coincidan con la expresión regular (formato Java) especificada en este elemento no serán objeto de búsqueda.
+
+Parámetros de configuración
+::::::::::::::::::::::::::::
+
+Puede especificar información de configuración de rastreo.
+
+Profundidad
+:::::::::::
+
+Puede especificar la profundidad al seguir enlaces contenidos en documentos rastreados.
+
+Número máximo de accesos
+:::::::::::::::::::::::::
+
+Número de URLs que se indexarán.
+
+Agente de usuario
+:::::::::::::::::
+
+Nombre del rastreador de |Fess|.
+
+Número de hilos
+:::::::::::::::
+
+Número de hilos de rastreo en esta configuración.
+
+Intervalo
+:::::::::
+
+Intervalo de tiempo en cada hilo al rastrear URLs.
+
+Valor de impulso
+::::::::::::::::
+
+Peso de los documentos indexados en esta configuración.
+
+Permisos
+::::::::
+
+Especifique el permiso para esta configuración.
+La forma de especificar permisos es, por ejemplo, para mostrar resultados de búsqueda a usuarios que pertenecen al grupo developer, especifique {group}developer.
+La especificación por usuario es {user}nombre_usuario, la especificación por rol es {role}nombre_rol, y la especificación por grupo es {group}nombre_grupo.
+
+Host virtual
+::::::::::::
+
+Especifique el nombre de host del host virtual.
+Para más detalles, consulte :doc:`../config/virtual-host`.
+
+Estado
+::::::
+
+Si está habilitado, el trabajo programado del rastreador predeterminado incluirá esta configuración.
+
+Descripción
+:::::::::::
+
+Puede ingresar una descripción.
+
+Eliminar configuración
+----------------------
+
+Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación. Al presionar el botón de eliminar, se eliminará la configuración.
+
+Ejemplo
+=======
+
+Rastrear fess.codelibs.org
+--------------------------
+
+Para crear una configuración de rastreo web que rastree páginas debajo de https://fess.codelibs.org/, use los siguientes valores de configuración.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Elemento de configuración
+     - Valor de configuración
+   * - Nombre
+     - Fess
+   * - URL
+     - https://fess.codelibs.org/
+   * - URL a rastrear
+     - https://fess.codelibs.org/.*
+
+Use los valores predeterminados para los otros valores de configuración.
+
+Rastreo web de sitios con autenticación web
+--------------------------------------------
+
+Fess admite el rastreo de autenticación BASIC, autenticación DIGEST y autenticación NTLM.
+Para obtener más detalles sobre la autenticación web, consulte la página de autenticación web.
+
+Redmine
+:::::::
+
+Para crear una configuración de rastreo web que rastree páginas de Redmine protegidas con contraseña (ej. https://<server>/), use los siguientes valores de configuración.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Elemento de configuración
+     - Valor de configuración
+   * - Nombre
+     - Redmine
+   * - URL
+     - https://<server>/my/page
+   * - URL a rastrear
+     - https://<server>/.*
+   * - Parámetros de configuración
+     - client.robotsTxtEnabled=false (Opcional)
+
+Después de eso, cree la configuración de autenticación web con los siguientes valores de configuración.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Elemento de configuración
+     - Valor de configuración
+   * - Esquema
+     - Form
+   * - Nombre de usuario
+     - (Cuenta para rastreo)
+   * - Contraseña
+     - (Contraseña para la cuenta)
+   * - Parámetros
+     - | encoding=UTF-8
+       | token_method=GET
+       | token_url=https://<server>/login
+       | token_pattern=name="authenticity_token"[^>]+value="([^"]+)"
+       | token_name=authenticity_token
+       | login_method=POST
+       | login_url=https://<server>/login
+       | login_parameters=username=${username}&password=${password}
+   * - Autenticación web
+     - Redmine
+
+
+XWiki
+:::::
+
+Para crear una configuración de rastreo web que rastree páginas de XWiki (ej. https://<server>/xwiki/), use los siguientes valores de configuración.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Elemento de configuración
+     - Valor de configuración
+   * - Nombre
+     - XWiki
+   * - URL
+     - https://<server>/xwiki/bin/view/Main/
+   * - URL a rastrear
+     - https://<server>/.*
+   * - Parámetros de configuración
+     - client.robotsTxtEnabled=false (Opcional)
+
+Después de eso, cree la configuración de autenticación web con los siguientes valores de configuración.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Elemento de configuración
+     - Valor de configuración
+   * - Esquema
+     - Form
+   * - Nombre de usuario
+     - (Cuenta para rastreo)
+   * - Contraseña
+     - (Contraseña para la cuenta)
+   * - Parámetros
+     - | encoding=UTF-8
+       | token_method=GET
+       | token_url=http://<server>/xwiki/bin/login/XWiki/XWikiLogin
+       | token_pattern=name="form_token" +value="([^"]+)"
+       | token_name=form_token
+       | login_method=POST
+       | login_url=http://<server>/xwiki/bin/loginsubmit/XWiki/XWikiLogin
+       | login_parameters=j_username=${username}&j_password=${password}
+   * - Autenticación web
+     - XWiki
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/webconfig-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/webconfig-2.png
+.. pdf            :height: 940 px

--- a/es/15.3/admin/wizard-guide.rst
+++ b/es/15.3/admin/wizard-guide.rst
@@ -1,0 +1,57 @@
+=======================
+Asistente de Configuración
+=======================
+
+Descripción general
+===================
+
+La página del asistente proporciona una herramienta de configuración simplificada para registrar configuraciones de rastreo.
+
+Configuración simplificada
+---------------------------
+
+Esta es una página de inicio para registrar configuraciones de rastreo.
+
+|image0|
+
+Configuración del rastreo
+--------------------------
+
+En esta página puede crear configuraciones de rastreo.
+
+|image1|
+
+Parámetros de configuración
+----------------------------
+
+Nombre
+::::::
+
+Especifique el nombre de la configuración (ejemplo: Sitio de Fess).
+
+Ruta de rastreo
+:::::::::::::::
+
+Especifique la URL o ruta del archivo del punto de inicio del rastreo (ejemplo: https://fess.codelibs.org/).
+
+Número máximo de accesos
+:::::::::::::::::::::::::
+
+Establezca el límite superior de páginas que se rastrearán.
+
+Profundidad
+:::::::::::
+
+Establezca la profundidad al seguir enlaces contenidos en documentos rastreados.
+
+Rastreador
+----------
+
+Para iniciar el rastreador de |Fess|, haga clic en el botón "Iniciar rastreo". Si aún no desea rastrear, haga clic en el botón "Omitir".
+
+|image2|
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/wizard-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/wizard-2.png
+.. |image2| image:: ../../../resources/images/ja/15.3/admin/wizard-3.png


### PR DESCRIPTION
Translate 47 administrator guide documents from Japanese to Spanish with commercial product documentation quality. This includes:

- Main index and introduction
- Dashboard, wizard, and general configuration
- Scheduler and design settings
- Dictionary management (Kuromoji, synonym, mapping, etc.)
- Access tokens and plugins
- Crawl configurations (web, file, data store)
- Labels and search optimization settings
- Path mapping and authentication
- User, role, and group management
- Suggest word management
- System information and logs
- Backup, maintenance, and upgrade guides

All translations maintain technical accuracy and professional tone suitable for enterprise software documentation in Spanish.