### PR TITLE
Create French translation of Fess configuration guide

### DIFF
--- a/fr/15.3/config/admin-analyzer.rst
+++ b/fr/15.3/config/admin-analyzer.rst
@@ -1,0 +1,22 @@
+=========================
+Configuration de l'Analyzer
+=========================
+
+À propos de l'Analyzer
+==============
+
+Lors de la création d'un index pour la recherche, il est nécessaire de segmenter les documents pour les enregistrer en tant qu'index.
+|Fess| enregistre la fonctionnalité de décomposition des documents en mots en tant qu'Analyzer.
+L'Analyzer est composé de CharFilter, Tokenizer et TokenFilter.
+
+Fondamentalement, les éléments plus petits que l'unité segmentée par l'Analyzer ne seront pas trouvés lors d'une recherche.
+Par exemple, considérons la phrase « habiter à Tokyo ».
+Supposons que cette phrase ait été divisée par l'Analyzer en « Tokyo », « à » et « habiter ».
+Dans ce cas, une recherche du terme « Tokyo » donnera des résultats.
+Cependant, une recherche du terme « Kyo » ne donnera pas de résultats.
+
+La configuration de l'Analyzer est enregistrée en créant l'index fess avec app/WEB-INF/classes/fess_indices/fess.json lorsque l'index fess n'existe pas au démarrage de |Fess|.
+Pour savoir comment configurer l'Analyzer, consultez la documentation de l'Analyzer d'OpenSearch.
+
+La configuration de l'Analyzer a un impact important sur la recherche.
+Si vous souhaitez modifier l'Analyzer, faites-le en comprenant le fonctionnement de l'Analyzer de Lucene ou consultez le support commercial.

--- a/fr/15.3/config/admin-index-backup.rst
+++ b/fr/15.3/config/admin-index-backup.rst
@@ -1,0 +1,322 @@
+========================
+Gestion des index
+========================
+
+Aperçu
+====
+
+Les données gérées par |Fess| sont stockées sous forme d'index OpenSearch.
+La sauvegarde et la restauration des index de recherche sont essentielles pour une exploitation stable du système.
+Cette section explique les procédures de sauvegarde, de restauration et de migration des index.
+
+Structure des index
+==================
+
+|Fess| utilise les index suivants.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Nom de l'index
+     - Description
+   * - ``fess.{date}``
+     - Index des documents à rechercher (créé quotidiennement)
+   * - ``fess_log``
+     - Journaux de recherche et de clics
+   * - ``fess_user``
+     - Informations utilisateur
+   * - ``fess_config``
+     - Informations de configuration système
+   * - ``configsync``
+     - Informations de synchronisation de configuration
+
+Sauvegarde et restauration des index
+====================================
+
+Vous pouvez effectuer des sauvegardes et des restaurations d'index en utilisant la fonctionnalité de snapshot d'OpenSearch.
+
+Configuration du référentiel de snapshots
+--------------------------------
+
+Tout d'abord, configurez un référentiel pour stocker les données de sauvegarde.
+
+**Pour un référentiel de système de fichiers :**
+
+1. Ajoutez le chemin du référentiel au fichier de configuration d'OpenSearch (``config/opensearch.yml``).
+
+::
+
+    path.repo: ["/var/opensearch/backup"]
+
+2. Redémarrez OpenSearch.
+
+3. Enregistrez le référentiel.
+
+::
+
+    curl -X PUT "localhost:9201/_snapshot/fess_backup" -H 'Content-Type: application/json' -d'
+    {
+      "type": "fs",
+      "settings": {
+        "location": "/var/opensearch/backup",
+        "compress": true
+      }
+    }'
+
+.. note::
+   Dans la configuration par défaut de |Fess|, OpenSearch démarre sur le port 9201.
+
+**Pour un référentiel AWS S3 :**
+
+Pour utiliser S3 comme destination de sauvegarde, installez et configurez le plugin ``repository-s3``.
+
+::
+
+    curl -X PUT "localhost:9201/_snapshot/fess_s3_backup" -H 'Content-Type: application/json' -d'
+    {
+      "type": "s3",
+      "settings": {
+        "bucket": "my-fess-backup-bucket",
+        "region": "ap-northeast-1",
+        "base_path": "fess-snapshots"
+      }
+    }'
+
+Création de snapshots (sauvegarde)
+------------------------------------
+
+Sauvegarde de tous les index
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sauvegarder tous les index.
+
+::
+
+    curl -X PUT "localhost:9201/_snapshot/fess_backup/snapshot_1?wait_for_completion=true" -H 'Content-Type: application/json' -d'
+    {
+      "indices": "*",
+      "ignore_unavailable": true,
+      "include_global_state": false
+    }'
+
+Sauvegarde d'index spécifiques
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sauvegarder uniquement des index spécifiques.
+
+::
+
+    curl -X PUT "localhost:9201/_snapshot/fess_backup/snapshot_fess_only?wait_for_completion=true" -H 'Content-Type: application/json' -d'
+    {
+      "indices": "fess.*,fess_config",
+      "ignore_unavailable": true,
+      "include_global_state": false
+    }'
+
+Sauvegarde automatique régulière
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Vous pouvez exécuter des sauvegardes régulières en utilisant cron ou similaire.
+
+::
+
+    #!/bin/bash
+    DATE=$(date +%Y%m%d_%H%M%S)
+    curl -X PUT "localhost:9201/_snapshot/fess_backup/snapshot_${DATE}?wait_for_completion=true" -H 'Content-Type: application/json' -d'
+    {
+      "indices": "*",
+      "ignore_unavailable": true,
+      "include_global_state": false
+    }'
+
+Vérification des snapshots
+----------------------
+
+Vérifier la liste des snapshots créés.
+
+::
+
+    curl -X GET "localhost:9201/_snapshot/fess_backup/_all?pretty"
+
+Vérifier les détails d'un snapshot spécifique.
+
+::
+
+    curl -X GET "localhost:9201/_snapshot/fess_backup/snapshot_1?pretty"
+
+Restauration à partir de snapshots
+------------------------------
+
+Restauration de tous les index
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    curl -X POST "localhost:9201/_snapshot/fess_backup/snapshot_1/_restore?wait_for_completion=true" -H 'Content-Type: application/json' -d'
+    {
+      "indices": "*",
+      "ignore_unavailable": true,
+      "include_global_state": false
+    }'
+
+Restauration d'index spécifiques
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    curl -X POST "localhost:9201/_snapshot/fess_backup/snapshot_1/_restore?wait_for_completion=true" -H 'Content-Type: application/json' -d'
+    {
+      "indices": "fess.20250101",
+      "ignore_unavailable": true,
+      "include_global_state": false
+    }'
+
+Restauration avec renommage de l'index
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Vous pouvez également modifier le nom de l'index lors de la restauration.
+
+::
+
+    curl -X POST "localhost:9201/_snapshot/fess_backup/snapshot_1/_restore?wait_for_completion=true" -H 'Content-Type: application/json' -d'
+    {
+      "indices": "fess.20250101",
+      "rename_pattern": "fess.(.+)",
+      "rename_replacement": "restored_fess.$1",
+      "ignore_unavailable": true,
+      "include_global_state": false
+    }'
+
+Suppression de snapshots
+----------------------
+
+Vous pouvez supprimer d'anciens snapshots pour économiser de l'espace de stockage.
+
+::
+
+    curl -X DELETE "localhost:9201/_snapshot/fess_backup/snapshot_1"
+
+Sauvegarde des fichiers de configuration
+==========================
+
+Outre les index OpenSearch, sauvegardez également les fichiers de configuration suivants.
+
+Fichiers à sauvegarder
+--------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Fichier/Répertoire
+     - Description
+   * - ``app/WEB-INF/conf/system.properties``
+     - Configuration système (installation zip)
+   * - ``/etc/fess/system.properties``
+     - Configuration système (paquets RPM/DEB)
+   * - ``app/WEB-INF/classes/fess_config.properties``
+     - Configuration détaillée de Fess
+   * - ``/etc/fess/fess_config.properties``
+     - Configuration détaillée de Fess (paquets RPM/DEB)
+   * - ``app/WEB-INF/classes/log4j2.xml``
+     - Configuration des journaux
+   * - ``/etc/fess/log4j2.xml``
+     - Configuration des journaux (paquets RPM/DEB)
+   * - ``app/WEB-INF/classes/fess_indices/``
+     - Fichiers de définition d'index
+   * - ``thumbnail/``
+     - Images miniatures (si nécessaire)
+
+Exemple de sauvegarde des fichiers de configuration
+----------------------------
+
+::
+
+    #!/bin/bash
+    BACKUP_DIR="/backup/fess/$(date +%Y%m%d_%H%M%S)"
+    mkdir -p ${BACKUP_DIR}
+
+    # Copie des fichiers de configuration
+    cp -r /etc/fess/ ${BACKUP_DIR}/
+    cp -r /var/lib/fess/app/WEB-INF/conf/ ${BACKUP_DIR}/
+    cp -r /var/lib/fess/app/WEB-INF/classes/fess_indices/ ${BACKUP_DIR}/
+
+    # Option : Images miniatures
+    # cp -r /var/lib/fess/thumbnail/ ${BACKUP_DIR}/
+
+    echo "Backup completed: ${BACKUP_DIR}"
+
+Migration de données
+==========
+
+Procédure de migration vers un autre environnement
+------------------
+
+1. **Créer une sauvegarde sur l'environnement source**
+
+   - Créez un snapshot OpenSearch.
+   - Sauvegardez les fichiers de configuration.
+
+2. **Préparer l'environnement de destination**
+
+   - Installez |Fess| dans le nouvel environnement.
+   - Démarrez OpenSearch.
+
+3. **Restaurer les fichiers de configuration**
+
+   - Copiez les fichiers de configuration sauvegardés dans le nouvel environnement.
+   - Modifiez les chemins, noms d'hôte, etc. si nécessaire.
+
+4. **Restaurer les index**
+
+   - Configurez le référentiel de snapshots.
+   - Restaurez les index à partir du snapshot.
+
+5. **Vérifier le fonctionnement**
+
+   - Démarrez |Fess|.
+   - Accédez à l'interface d'administration et vérifiez la configuration.
+   - Vérifiez que la fonction de recherche fonctionne correctement.
+
+Précautions lors de la mise à niveau de version
+----------------------------
+
+Lors de la migration de données entre différentes versions de |Fess|, prenez en compte les points suivants.
+
+- Si la version majeure d'OpenSearch est différente, des problèmes de compatibilité peuvent survenir.
+- Si la structure de l'index a été modifiée, une réindexation peut être nécessaire.
+- Pour plus de détails, consultez le guide de mise à niveau de chaque version.
+
+Dépannage
+======================
+
+Échec de la création de snapshot
+--------------------------------
+
+1. Vérifiez les permissions pour le chemin du référentiel.
+2. Vérifiez qu'il y a suffisamment d'espace disque.
+3. Vérifiez les messages d'erreur dans les fichiers journaux d'OpenSearch.
+
+Échec de la restauration
+------------------
+
+1. Vérifiez qu'un index du même nom n'existe pas déjà.
+2. Vérifiez que la version d'OpenSearch est compatible.
+3. Vérifiez que le snapshot n'est pas corrompu.
+
+Impossible de rechercher après la restauration
+------------------------
+
+1. Vérifiez que l'index a été restauré correctement : ``curl -X GET "localhost:9201/_cat/indices?v"``
+2. Vérifiez qu'il n'y a pas d'erreurs dans les fichiers journaux de |Fess|.
+3. Vérifiez que les fichiers de configuration sont correctement restaurés.
+
+Informations de référence
+========
+
+Pour des informations détaillées, consultez la documentation officielle d'OpenSearch.
+
+- `Fonctionnalité de snapshot <https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/snapshots/index/>`_
+- `Configuration de référentiel <https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/>`_
+- `Référentiel S3 <https://opensearch.org/docs/latest/install-and-configure/install-opensearch/plugins/#s3-repository>`_

--- a/fr/15.3/config/admin-logging.rst
+++ b/fr/15.3/config/admin-logging.rst
@@ -1,0 +1,659 @@
+==================
+Configuration des journaux
+==================
+
+Aperçu
+====
+
+|Fess| génère plusieurs fichiers journaux pour enregistrer l'état de fonctionnement du système et les informations d'erreur.
+Une configuration appropriée des journaux facilite le dépannage et la surveillance du système.
+
+Types de fichiers journaux
+==================
+
+Fichiers journaux principaux
+------------------
+
+Les principaux fichiers journaux générés par |Fess| sont les suivants.
+
+.. list-table:: Liste des fichiers journaux
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Nom du fichier
+     - Contenu
+   * - ``fess.log``
+     - Journaux d'opérations dans l'interface d'administration et de recherche, erreurs d'application, événements système
+   * - ``fess_crawler.log``
+     - Journaux lors de l'exécution de l'exploration, URL explorées, informations sur les documents récupérés, erreurs
+   * - ``fess_suggest.log``
+     - Journaux lors de la génération de suggestions (candidats de recherche), informations de mise à jour d'index
+   * - ``server_?.log``
+     - Journaux système du serveur d'applications comme Tomcat
+   * - ``audit.log``
+     - Journaux d'audit pour l'authentification des utilisateurs, connexion/déconnexion, opérations importantes
+
+Emplacement des fichiers journaux
+------------------
+
+**Pour l'installation Zip :**
+
+::
+
+    {FESS_HOME}/logs/
+
+**Pour les paquets RPM/DEB :**
+
+::
+
+    /var/log/fess/
+
+Vérification des journaux lors du dépannage
+----------------------------------
+
+En cas de problème, vérifiez les journaux en suivant ces étapes.
+
+1. **Identifier le type d'erreur**
+
+   - Erreur d'application → ``fess.log``
+   - Erreur d'exploration → ``fess_crawler.log``
+   - Erreur d'authentification → ``audit.log``
+   - Erreur de serveur → ``server_?.log``
+
+2. **Vérifier les erreurs les plus récentes**
+
+   ::
+
+       tail -f /var/log/fess/fess.log
+
+3. **Rechercher des erreurs spécifiques**
+
+   ::
+
+       grep -i "error" /var/log/fess/fess.log
+       grep -i "exception" /var/log/fess/fess.log
+
+4. **Vérifier le contexte de l'erreur**
+
+   En vérifiant les journaux avant et après l'erreur, vous pouvez identifier la cause.
+
+   ::
+
+       grep -B 10 -A 10 "OutOfMemoryError" /var/log/fess/fess.log
+
+Configuration du niveau de journalisation
+================
+
+À propos des niveaux de journalisation
+--------------
+
+Les niveaux de journalisation contrôlent le niveau de détail des journaux générés.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Niveau
+     - Description
+   * - ``FATAL``
+     - Erreur fatale (l'application ne peut pas continuer)
+   * - ``ERROR``
+     - Erreur (une partie des fonctionnalités ne fonctionne pas)
+   * - ``WARN``
+     - Avertissement (problème potentiel)
+   * - ``INFO``
+     - Information (événement important)
+   * - ``DEBUG``
+     - Informations de débogage (journaux de fonctionnement détaillés)
+   * - ``TRACE``
+     - Informations de trace (le plus détaillé)
+
+Niveaux de journalisation recommandés
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Environnement
+     - Niveau recommandé
+     - Raison
+   * - Environnement de production
+     - ``WARN``
+     - Priorité aux performances et à l'espace disque
+   * - Environnement de staging
+     - ``INFO``
+     - Enregistrer les événements importants
+   * - Environnement de développement
+     - ``DEBUG``
+     - Informations de débogage détaillées nécessaires
+   * - Lors de l'investigation de problèmes
+     - ``DEBUG`` ou ``TRACE``
+     - Activer temporairement les journaux détaillés
+
+Modification via l'interface d'administration
+------------------
+
+La méthode la plus simple consiste à modifier via l'interface d'administration.
+
+1. Connectez-vous à l'interface d'administration.
+2. Sélectionnez « Général » dans le menu « Système ».
+3. Sélectionnez le niveau souhaité dans « Niveau de journalisation ».
+4. Cliquez sur le bouton « Mettre à jour ».
+
+.. note::
+   Les modifications dans l'interface d'administration sont conservées même après le redémarrage de |Fess|.
+
+Modification via le fichier de configuration
+----------------------
+
+Pour une configuration plus détaillée des journaux, modifiez le fichier de configuration Log4j2.
+
+Emplacement du fichier de configuration
+~~~~~~~~~~~~~~~~~~
+
+- **Installation Zip** : ``app/WEB-INF/classes/log4j2.xml``
+- **Paquets RPM/DEB** : ``/etc/fess/log4j2.xml``
+
+Exemples de configuration de base
+~~~~~~~~~~~~~~
+
+**Niveau de journalisation par défaut :**
+
+::
+
+    <Logger name="org.codelibs.fess" level="warn"/>
+
+**Exemple : Changement au niveau DEBUG**
+
+::
+
+    <Logger name="org.codelibs.fess" level="debug"/>
+
+**Exemple : Modification du niveau de journalisation pour un paquet spécifique**
+
+::
+
+    <Logger name="org.codelibs.fess.crawler" level="info"/>
+    <Logger name="org.codelibs.fess.ds" level="debug"/>
+    <Logger name="org.codelibs.fess.app.web" level="warn"/>
+
+.. warning::
+   Les niveaux ``DEBUG`` et ``TRACE`` génèrent une grande quantité de journaux,
+   ne les utilisez pas en environnement de production. Cela affecte l'espace disque et les performances.
+
+Configuration via les variables d'environnement
+~~~~~~~~~~~~~~~~~~
+
+Vous pouvez également spécifier le niveau de journalisation lors du démarrage du système.
+
+::
+
+    FESS_JAVA_OPTS="$FESS_JAVA_OPTS -Dlog.level=debug"
+
+Configuration des journaux d'exploration
+====================
+
+Les journaux d'exploration sont générés au niveau ``INFO`` par défaut.
+
+Configuration dans l'interface d'administration
+----------------
+
+1. Ouvrez la configuration d'exploration cible depuis le menu « Explorateur » de l'interface d'administration.
+2. Sélectionnez « Script » dans l'onglet « Configuration ».
+3. Ajoutez ce qui suit dans le champ script.
+
+::
+
+    logLevel("DEBUG")
+
+Valeurs configurables :
+
+- ``FATAL``
+- ``ERROR``
+- ``WARN``
+- ``INFO``
+- ``DEBUG``
+- ``TRACE``
+
+Modification du niveau de journalisation uniquement pour des modèles d'URL spécifiques
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    if (url.contains("example.com")) {
+        logLevel("DEBUG")
+    }
+
+Modification du niveau de journalisation pour l'ensemble du processus d'exploration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Configuration dans ``fess_config.properties`` :
+
+::
+
+    logging.level.org.codelibs.fess.crawler=DEBUG
+
+Rotation des journaux
+==================
+
+Aperçu
+----
+
+Les fichiers journaux grossissent avec le temps, une rotation régulière (gestion des générations) est donc nécessaire.
+
+Rotation automatique avec Log4j2
+-------------------------------
+
+|Fess| utilise le RollingFileAppender de Log4j2 pour effectuer automatiquement la rotation des journaux.
+
+Configuration par défaut
+~~~~~~~~~~~~~~~~
+
+- **Taille du fichier** : Rotation lorsque 10 Mo sont dépassés
+- **Nombre de générations conservées** : Maximum 10 fichiers
+
+Exemple de fichier de configuration (``log4j2.xml``) :
+
+::
+
+    <RollingFile name="FessFile"
+                 fileName="${log.dir}/fess.log"
+                 filePattern="${log.dir}/fess.log.%i">
+        <PatternLayout pattern="%d{ISO8601} [%t] %-5p %c - %m%n"/>
+        <Policies>
+            <SizeBasedTriggeringPolicy size="10MB"/>
+        </Policies>
+        <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
+Configuration de rotation quotidienne
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pour une rotation quotidienne plutôt que par taille :
+
+::
+
+    <RollingFile name="FessFile"
+                 fileName="${log.dir}/fess.log"
+                 filePattern="${log.dir}/fess.log.%d{yyyy-MM-dd}">
+        <PatternLayout pattern="%d{ISO8601} [%t] %-5p %c - %m%n"/>
+        <Policies>
+            <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+        </Policies>
+        <DefaultRolloverStrategy max="30"/>
+    </RollingFile>
+
+Configuration de compression
+~~~~~~~~
+
+Pour compresser automatiquement lors de la rotation :
+
+::
+
+    <RollingFile name="FessFile"
+                 fileName="${log.dir}/fess.log"
+                 filePattern="${log.dir}/fess.log.%d{yyyy-MM-dd}.gz">
+        <PatternLayout pattern="%d{ISO8601} [%t] %-5p %c - %m%n"/>
+        <Policies>
+            <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+        </Policies>
+        <DefaultRolloverStrategy max="30"/>
+    </RollingFile>
+
+Rotation avec logrotate
+------------------------------
+
+Dans un environnement Linux, vous pouvez également gérer la rotation des journaux avec logrotate.
+
+Exemple de ``/etc/logrotate.d/fess`` :
+
+::
+
+    /var/log/fess/*.log {
+        daily
+        rotate 14
+        compress
+        delaycompress
+        missingok
+        notifempty
+        create 0644 fess fess
+        sharedscripts
+        postrotate
+            systemctl reload fess > /dev/null 2>&1 || true
+        endscript
+    }
+
+Explication de la configuration :
+
+- ``daily`` : Rotation quotidienne
+- ``rotate 14`` : Conserver 14 générations
+- ``compress`` : Compresser les anciens journaux
+- ``delaycompress`` : Ne pas compresser la génération précédente (l'application peut être en cours d'écriture)
+- ``missingok`` : Pas d'erreur si le fichier journal n'existe pas
+- ``notifempty`` : Ne pas effectuer de rotation pour les fichiers journaux vides
+- ``create 0644 fess fess`` : Permissions et propriétaire du nouveau fichier journal
+
+Surveillance des journaux
+========
+
+En environnement de production, il est recommandé de surveiller les fichiers journaux pour détecter rapidement les erreurs.
+
+Modèles de journaux à surveiller
+----------------------
+
+Modèles d'erreurs importants
+~~~~~~~~~~~~~~~~~~~~
+
+- Journaux de niveau ``ERROR`` et ``FATAL``
+- ``OutOfMemoryError``
+- ``Connection refused``
+- ``Timeout``
+- ``Exception``
+- ``circuit_breaker_exception``
+- ``Too many open files``
+
+Modèles d'alerte
+~~~~~~~~~~~~~~~~~~
+
+- Journaux de niveau ``WARN`` fréquents
+- ``Retrying``
+- ``Slow query``
+- ``Queue full``
+
+Surveillance en temps réel
+----------------
+
+Surveillance en temps réel avec la commande tail :
+
+::
+
+    tail -f /var/log/fess/fess.log | grep -i "error\|exception"
+
+Surveillance simultanée de plusieurs fichiers journaux :
+
+::
+
+    tail -f /var/log/fess/*.log
+
+Exemples d'outils de surveillance
+--------------
+
+**Logwatch**
+
+Analyse et rapport périodiques des fichiers journaux.
+
+::
+
+    # Installation (CentOS/RHEL)
+    yum install logwatch
+
+    # Envoi de rapport quotidien
+    logwatch --service fess --mailto admin@example.com
+
+**Logstash + OpenSearch + OpenSearch Dashboards**
+
+Analyse de journaux en temps réel et visualisation.
+
+**Fluentd**
+
+Collecte et transfert de journaux.
+
+::
+
+    <source>
+      @type tail
+      path /var/log/fess/fess.log
+      pos_file /var/log/fluentd/fess.log.pos
+      tag fess.app
+      <parse>
+        @type multiline
+        format_firstline /^\d{4}-\d{2}-\d{2}/
+        format1 /^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) \[(?<thread>.*?)\] (?<level>\w+)\s+(?<logger>.*?) - (?<message>.*)/
+      </parse>
+    </source>
+
+**Prometheus + Grafana**
+
+Surveillance des métriques et alertes.
+
+Configuration des alertes
+------------
+
+Exemple de notification lors de la détection d'erreur :
+
+::
+
+    # Script simple de notification par e-mail
+    tail -n 0 -f /var/log/fess/fess.log | while read line; do
+        echo "$line" | grep -i "error\|fatal" && \
+        echo "$line" | mail -s "Fess Error Alert" admin@example.com
+    done
+
+Format des journaux
+================
+
+Format par défaut
+----------------------
+
+Format de journal par défaut de |Fess| :
+
+::
+
+    %d{ISO8601} [%t] %-5p %c - %m%n
+
+Explication de chaque élément :
+
+- ``%d{ISO8601}`` : Horodatage (format ISO8601)
+- ``[%t]`` : Nom du thread
+- ``%-5p`` : Niveau de journalisation (largeur de 5 caractères, aligné à gauche)
+- ``%c`` : Nom du logger (nom du paquet)
+- ``%m`` : Message
+- ``%n`` : Saut de ligne
+
+Exemples de formats personnalisés
+----------------------
+
+Sortie des journaux au format JSON
+~~~~~~~~~~~~~~~~~~
+
+::
+
+    <PatternLayout>
+        <pattern>{"timestamp":"%d{ISO8601}","thread":"%t","level":"%-5p","logger":"%c","message":"%m"}%n</pattern>
+    </PatternLayout>
+
+Inclure des informations plus détaillées
+~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    <PatternLayout pattern="%d{ISO8601} [%t] %-5p %c{1.} [%F:%L] - %m%n"/>
+
+Informations supplémentaires :
+
+- ``%c{1.}`` : Nom de paquet abrégé
+- ``%F`` : Nom du fichier
+- ``%L`` : Numéro de ligne
+
+Impact sur les performances
+======================
+
+La sortie des journaux affecte les E/S disque et les performances.
+
+Bonnes pratiques
+------------------
+
+1. **Utiliser le niveau WARN ou supérieur en production**
+
+   Éviter de générer des journaux détaillés inutiles.
+
+2. **Nettoyage régulier des fichiers journaux**
+
+   Supprimer ou compresser les anciens fichiers journaux.
+
+3. **Utilisation de la sortie de journaux asynchrone**
+
+   Utiliser l'appender asynchrone de Log4j2 pour réduire la surcharge de sortie des journaux.
+
+   ::
+
+       <Async name="AsyncFile">
+           <AppenderRef ref="FessFile"/>
+       </Async>
+
+4. **Assurer un espace disque suffisant**
+
+   Assurer un espace disque suffisant pour les fichiers journaux.
+
+5. **Sélection appropriée du niveau de journalisation**
+
+   Configurer le niveau de journalisation en fonction de l'environnement.
+
+Mesure des performances
+------------------
+
+Mesurer l'impact de la sortie des journaux :
+
+::
+
+    # Vérifier la quantité de journaux générés
+    du -sh /var/log/fess/
+
+    # Augmentation des journaux par heure
+    watch -n 3600 'du -sh /var/log/fess/'
+
+Dépannage
+======================
+
+Les journaux ne sont pas générés
+------------------
+
+**Causes et solutions :**
+
+1. **Permissions du répertoire des journaux**
+
+   ::
+
+       ls -ld /var/log/fess/
+       # Modifier les permissions si nécessaire
+       sudo chown -R fess:fess /var/log/fess/
+       sudo chmod 755 /var/log/fess/
+
+2. **Espace disque**
+
+   ::
+
+       df -h /var/log
+       # En cas d'espace insuffisant, supprimer les anciens journaux
+       find /var/log/fess/ -name "*.log.*" -mtime +30 -delete
+
+3. **Fichier de configuration Log4j2**
+
+   ::
+
+       # Vérifier la syntaxe du fichier de configuration
+       xmllint --noout /etc/fess/log4j2.xml
+
+4. **Vérifier SELinux**
+
+   ::
+
+       # Si SELinux est activé
+       getenforce
+       # Définir le contexte si nécessaire
+       restorecon -R /var/log/fess/
+
+Le fichier journal devient trop volumineux
+------------------------------
+
+1. **Ajuster le niveau de journalisation**
+
+   Définir au niveau ``WARN`` ou supérieur.
+
+2. **Vérifier la configuration de rotation des journaux**
+
+   ::
+
+       # Vérifier la configuration de log4j2.xml
+       grep -A 5 "RollingFile" /etc/fess/log4j2.xml
+
+3. **Désactiver les sorties de journaux inutiles**
+
+   ::
+
+       # Supprimer les journaux pour un paquet spécifique
+       <Logger name="org.apache.http" level="error"/>
+
+4. **Solution temporaire**
+
+   ::
+
+       # Compresser les anciens fichiers journaux
+       gzip /var/log/fess/fess.log.[1-9]
+
+       # Supprimer les anciens fichiers journaux
+       find /var/log/fess/ -name "*.log.*" -mtime +7 -delete
+
+Impossible de trouver un journal spécifique
+------------------------
+
+1. **Vérifier le niveau de journalisation**
+
+   Si le niveau de journalisation est trop bas, il ne sera pas généré.
+
+   ::
+
+       grep "org.codelibs.fess" /etc/fess/log4j2.xml
+
+2. **Vérifier le chemin du fichier journal**
+
+   ::
+
+       # Vérifier la destination réelle de sortie des journaux
+       ps aux | grep fess
+       lsof -p <PID> | grep log
+
+3. **Vérifier l'horodatage**
+
+   Vérifiez que l'heure système est correcte.
+
+   ::
+
+       date
+       timedatectl status
+
+4. **Mise en mémoire tampon des journaux**
+
+   Les journaux peuvent ne pas être écrits immédiatement.
+
+   ::
+
+       # Forcer le vidage des journaux
+       systemctl reload fess
+
+Caractères corrompus dans les journaux
+------------------------
+
+1. **Configuration de l'encodage**
+
+   Spécifier l'encodage des caractères dans ``log4j2.xml`` :
+
+   ::
+
+       <PatternLayout pattern="%d{ISO8601} [%t] %-5p %c - %m%n" charset="UTF-8"/>
+
+2. **Configuration des variables d'environnement**
+
+   ::
+
+       export LANG=ja_JP.UTF-8
+       export LC_ALL=ja_JP.UTF-8
+
+Informations de référence
+========
+
+- :doc:`setup-memory` - Configuration de la mémoire
+- :doc:`crawler-advanced` - Configuration avancée de l'explorateur
+- :doc:`admin-index-backup` - Sauvegarde de l'index
+- `Documentation Log4j2 <https://logging.apache.org/log4j/2.x/>`_

--- a/fr/15.3/config/admin-opensearch-dashboards.rst
+++ b/fr/15.3/config/admin-opensearch-dashboards.rst
@@ -1,0 +1,167 @@
+===================================
+Configuration de la visualisation des journaux de recherche
+===================================
+
+À propos de la visualisation des journaux de recherche
+========================
+
+|Fess| collecte les journaux de recherche et de clics des utilisateurs.
+Les journaux de recherche collectés peuvent être analysés et visualisés à l'aide d'`OpenSearch Dashboards <https://opensearch.org/docs/latest/dashboards/index/>`__.
+
+Informations pouvant être visualisées
+----------------
+
+Avec la configuration par défaut, les informations suivantes peuvent être visualisées.
+
+-  Temps moyen pour afficher les résultats de recherche
+-  Nombre de recherches par seconde
+-  Classement des User Agent des utilisateurs accédant
+-  Classement des mots-clés de recherche
+-  Classement des mots-clés de recherche avec 0 résultat
+-  Nombre total de résultats de recherche
+-  Tendances de recherche dans le temps
+
+En utilisant la fonction Visualize pour créer de nouveaux graphiques et les ajouter au Dashboard, vous pouvez construire votre propre tableau de bord de surveillance.
+
+Configuration de la visualisation des données avec OpenSearch Dashboards
+==============================================
+
+Installation d'OpenSearch Dashboards
+------------------------------------
+
+OpenSearch Dashboards est un outil de visualisation des données d'OpenSearch utilisé par |Fess|.
+Installez OpenSearch Dashboards en suivant la `documentation officielle d'OpenSearch <https://opensearch.org/docs/latest/install-and-configure/install-dashboards/index/>`__.
+
+Modification du fichier de configuration
+------------------
+
+Pour permettre à OpenSearch Dashboards de reconnaître OpenSearch utilisé par |Fess|, modifiez le fichier de configuration ``config/opensearch_dashboards.yml``.
+
+::
+
+    opensearch.hosts: ["http://localhost:9201"]
+
+Remplacez ``localhost`` par le nom d'hôte ou l'adresse IP appropriée selon votre environnement.
+Dans la configuration par défaut de |Fess|, OpenSearch démarre sur le port 9201.
+
+.. note::
+   Si le numéro de port d'OpenSearch est différent, modifiez-le avec le numéro de port approprié.
+
+Démarrage d'OpenSearch Dashboards
+-----------------------------
+
+Après avoir modifié le fichier de configuration, démarrez OpenSearch Dashboards.
+
+::
+
+    $ cd /path/to/opensearch-dashboards
+    $ ./bin/opensearch-dashboards
+
+Après le démarrage, accédez à ``http://localhost:5601`` dans votre navigateur.
+
+Configuration du modèle d'index
+--------------------------
+
+1. Sélectionnez le menu « Management » depuis l'écran d'accueil d'OpenSearch Dashboards.
+2. Sélectionnez « Index Patterns ».
+3. Cliquez sur le bouton « Create index pattern ».
+4. Entrez ``fess_log*`` dans Index pattern name.
+5. Cliquez sur le bouton « Next step ».
+6. Sélectionnez ``requestedAt`` dans Time field.
+7. Cliquez sur le bouton « Create index pattern ».
+
+Vous êtes maintenant prêt à visualiser les journaux de recherche de |Fess|.
+
+Création de visualisations et de tableaux de bord
+----------------------------
+
+Création de visualisations de base
+~~~~~~~~~~~~~~~~~~~~
+
+1. Sélectionnez « Visualize » dans le menu de gauche.
+2. Cliquez sur le bouton « Create visualization ».
+3. Sélectionnez le type de visualisation (graphique linéaire, graphique circulaire, graphique à barres, etc.).
+4. Sélectionnez le modèle d'index ``fess_log*`` que vous avez créé.
+5. Configurez les métriques et les buckets (unités d'agrégation) nécessaires.
+6. Cliquez sur le bouton « Save » pour enregistrer la visualisation.
+
+Création de tableaux de bord
+~~~~~~~~~~~~~~~~~~~~
+
+1. Sélectionnez « Dashboard » dans le menu de gauche.
+2. Cliquez sur le bouton « Create dashboard ».
+3. Cliquez sur le bouton « Add » pour ajouter les visualisations que vous avez créées.
+4. Ajustez la mise en page et cliquez sur le bouton « Save » pour enregistrer.
+
+Configuration du fuseau horaire
+------------------
+
+Si l'affichage de l'heure n'est pas correct, configurez le fuseau horaire.
+
+1. Sélectionnez « Management » dans le menu de gauche.
+2. Sélectionnez « Advanced Settings ».
+3. Recherchez ``dateFormat:tz``.
+4. Définissez le fuseau horaire sur une valeur appropriée (par exemple : ``Asia/Tokyo`` ou ``UTC``).
+5. Cliquez sur le bouton « Save ».
+
+Vérification des données de journal
+----------------
+
+1. Sélectionnez « Discover » dans le menu de gauche.
+2. Sélectionnez le modèle d'index ``fess_log*``.
+3. Les données du journal de recherche s'affichent.
+4. Vous pouvez spécifier la période à afficher avec la sélection de plage de temps en haut à droite.
+
+Principaux champs de journal de recherche
+----------------------
+
+Les journaux de recherche de |Fess| contiennent les informations suivantes.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Nom du champ
+     - Description
+   * - ``queryId``
+     - Identifiant unique de la requête de recherche
+   * - ``searchWord``
+     - Mot-clé de recherche
+   * - ``requestedAt``
+     - Date et heure d'exécution de la recherche
+   * - ``responseTime``
+     - Temps de réponse des résultats de recherche (millisecondes)
+   * - ``queryTime``
+     - Temps d'exécution de la requête (millisecondes)
+   * - ``hitCount``
+     - Nombre de résultats trouvés
+   * - ``userAgent``
+     - Informations du navigateur de l'utilisateur
+   * - ``clientIp``
+     - Adresse IP du client
+   * - ``languages``
+     - Langue utilisée
+   * - ``roles``
+     - Informations de rôle de l'utilisateur
+   * - ``user``
+     - Nom d'utilisateur (lors de la connexion)
+
+En utilisant ces champs, vous pouvez analyser les journaux de recherche sous différents angles.
+
+Dépannage
+----------------------
+
+Si les données ne s'affichent pas
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Vérifiez qu'OpenSearch fonctionne correctement.
+- Vérifiez que la configuration ``opensearch.hosts`` dans ``opensearch_dashboards.yml`` est correcte.
+- Vérifiez que des recherches ont été effectuées dans |Fess| et que les journaux sont enregistrés.
+- Vérifiez que la plage de temps du modèle d'index est configurée de manière appropriée.
+
+En cas d'erreur de connexion
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Vérifiez que le numéro de port d'OpenSearch est correct.
+- Vérifiez la configuration du pare-feu ou des groupes de sécurité.
+- Vérifiez qu'il n'y a pas d'erreurs dans les fichiers journaux d'OpenSearch.

--- a/fr/15.3/config/crawler-advanced.rst
+++ b/fr/15.3/config/crawler-advanced.rst
@@ -1,0 +1,957 @@
+========================
+Configuration avancée du robot d'indexation
+========================
+
+Présentation
+====
+
+Ce guide explique les paramètres avancés du robot d'indexation de |Fess|.
+Pour la configuration de base du robot d'indexation, consultez :doc:`crawler-basic`.
+
+.. warning::
+   Les paramètres de cette page peuvent affecter l'ensemble du système.
+   Lors de la modification des paramètres, testez-les suffisamment avant de les appliquer à l'environnement de production.
+
+Configuration générale
+========
+
+Emplacement des fichiers de configuration
+------------------
+
+La configuration détaillée du robot d'indexation s'effectue dans les fichiers suivants.
+
+- **Configuration principale** : ``/etc/fess/fess_config.properties`` (ou ``app/WEB-INF/classes/fess_config.properties``)
+- **Configuration de la longueur du contenu** : ``app/WEB-INF/classes/crawler/contentlength.xml``
+- **Configuration des composants** : ``app/WEB-INF/classes/crawler/container.xml``
+
+Script par défaut
+--------------------
+
+Configure le langage de script par défaut du robot d'indexation.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.default.script``
+     - Langage de script du robot d'indexation
+     - ``groovy``
+
+::
+
+    crawler.default.script=groovy
+
+Pool de threads HTTP
+------------------
+
+Configuration du pool de threads du robot d'indexation HTTP.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.http.thread_pool.size``
+     - Taille du pool de threads HTTP
+     - ``0``
+
+::
+
+    # Si 0, configuration automatique
+    crawler.http.thread_pool.size=0
+
+Configuration du traitement des documents
+====================
+
+Configuration de base
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.document.max.site.length``
+     - Nombre maximum de lignes du site du document
+     - ``100``
+   * - ``crawler.document.site.encoding``
+     - Encodage du site du document
+     - ``UTF-8``
+   * - ``crawler.document.unknown.hostname``
+     - Valeur de remplacement pour un nom d'hôte inconnu
+     - ``unknown``
+   * - ``crawler.document.use.site.encoding.on.english``
+     - Utiliser l'encodage du site pour les documents en anglais
+     - ``false``
+   * - ``crawler.document.append.data``
+     - Ajouter des données au document
+     - ``true``
+   * - ``crawler.document.append.filename``
+     - Ajouter le nom de fichier au document
+     - ``false``
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    crawler.document.max.site.length=100
+    crawler.document.site.encoding=UTF-8
+    crawler.document.unknown.hostname=unknown
+    crawler.document.use.site.encoding.on.english=false
+    crawler.document.append.data=true
+    crawler.document.append.filename=false
+
+Configuration du traitement des mots
+------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.document.max.alphanum.term.size``
+     - Longueur maximale des mots alphanumériques
+     - ``20``
+   * - ``crawler.document.max.symbol.term.size``
+     - Longueur maximale des mots symboles
+     - ``10``
+   * - ``crawler.document.duplicate.term.removed``
+     - Suppression des mots en double
+     - ``false``
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    # Modifier la longueur maximale des alphanumériques à 50 caractères
+    crawler.document.max.alphanum.term.size=50
+
+    # Modifier la longueur maximale des symboles à 20 caractères
+    crawler.document.max.symbol.term.size=20
+
+    # Supprimer les mots en double
+    crawler.document.duplicate.term.removed=true
+
+.. note::
+   L'augmentation de ``max.alphanum.term.size`` permet d'indexer complètement les longs ID, tokens, URLs, etc.,
+   mais la taille de l'index augmentera.
+
+Configuration du traitement des caractères
+------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.document.space.chars``
+     - Définition des caractères d'espacement
+     - ``\u0009\u000A...``
+   * - ``crawler.document.fullstop.chars``
+     - Définition des caractères de ponctuation
+     - ``\u002e\u06d4...``
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    # Valeur par défaut (incluant les caractères Unicode)
+    crawler.document.space.chars=\u0009\u000A\u000B\u000C\u000D\u001C\u001D\u001E\u001F\u0020\u00A0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u200B\u200C\u202F\u205F\u3000\uFEFF\uFFFD\u00B6
+
+    crawler.document.fullstop.chars=\u002e\u06d4\u2e3c\u3002
+
+Configuration des protocoles
+==============
+
+Protocoles supportés
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.web.protocols``
+     - Protocoles d'indexation Web
+     - ``http,https``
+   * - ``crawler.file.protocols``
+     - Protocoles d'indexation de fichiers
+     - ``file,smb,smb1,ftp,storage``
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    crawler.web.protocols=http,https
+    crawler.file.protocols=file,smb,smb1,ftp,storage
+
+Paramètres de variables d'environnement
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.data.env.param.key.pattern``
+     - Motif de clé de paramètre de variable d'environnement
+     - ``^FESS_ENV_.*``
+
+::
+
+    # Les variables d'environnement commençant par FESS_ENV_ peuvent être utilisées dans la configuration d'indexation
+    crawler.data.env.param.key.pattern=^FESS_ENV_.*
+
+Configuration de robots.txt
+===============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.ignore.robots.txt``
+     - Ignorer robots.txt
+     - ``false``
+   * - ``crawler.ignore.robots.tags``
+     - Balises robots à ignorer
+     - (vide)
+   * - ``crawler.ignore.content.exception``
+     - Ignorer les exceptions de contenu
+     - ``true``
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    # Ignorer robots.txt (non recommandé)
+    crawler.ignore.robots.txt=false
+
+    # Ignorer des balises robots spécifiques
+    crawler.ignore.robots.tags=
+
+    # Ignorer les exceptions de contenu
+    crawler.ignore.content.exception=true
+
+.. warning::
+   Définir ``crawler.ignore.robots.txt=true`` peut violer
+   les conditions d'utilisation du site. Soyez prudent lors de l'indexation de sites externes.
+
+Configuration de la gestion des erreurs
+==============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.failure.url.status.codes``
+     - Codes d'état HTTP considérés comme des échecs
+     - ``404``
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    # Traiter également 403 comme une erreur en plus de 404
+    crawler.failure.url.status.codes=404,403
+
+Configuration de la surveillance système
+================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.system.monitor.interval``
+     - Intervalle de surveillance système (secondes)
+     - ``60``
+
+::
+
+    # Surveillance du système toutes les 30 secondes
+    crawler.system.monitor.interval=30
+
+Configuration des threads actifs
+------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.hotthread.ignore_idle_threads``
+     - Ignorer les threads inactifs
+     - ``true``
+   * - ``crawler.hotthread.interval``
+     - Intervalle d'instantané
+     - ``500ms``
+   * - ``crawler.hotthread.snapshots``
+     - Nombre d'instantanés
+     - ``10``
+   * - ``crawler.hotthread.threads``
+     - Nombre de threads surveillés
+     - ``3``
+   * - ``crawler.hotthread.timeout``
+     - Timeout
+     - ``30s``
+   * - ``crawler.hotthread.type``
+     - Type de surveillance
+     - ``cpu``
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    crawler.hotthread.ignore_idle_threads=true
+    crawler.hotthread.interval=500ms
+    crawler.hotthread.snapshots=10
+    crawler.hotthread.threads=3
+    crawler.hotthread.timeout=30s
+    crawler.hotthread.type=cpu
+
+Configuration des métadonnées
+==============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.metadata.content.excludes``
+     - Métadonnées à exclure
+     - ``resourceName,X-Parsed-By...``
+   * - ``crawler.metadata.name.mapping``
+     - Mappage des noms de métadonnées
+     - ``title=title:string...``
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    # Métadonnées à exclure
+    crawler.metadata.content.excludes=resourceName,X-Parsed-By,Content-Encoding.*,Content-Type.*,X-TIKA.*,X-FESS.*
+
+    # Mappage des noms de métadonnées
+    crawler.metadata.name.mapping=\
+        title=title:string\n\
+        Title=title:string\n\
+        dc:title=title:string
+
+Configuration du robot d'indexation HTML
+===================
+
+Configuration XPath
+----------
+
+Configuration XPath pour extraire les éléments HTML.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.document.html.content.xpath``
+     - XPath du contenu
+     - ``//BODY``
+   * - ``crawler.document.html.lang.xpath``
+     - XPath de la langue
+     - ``//HTML/@lang``
+   * - ``crawler.document.html.digest.xpath``
+     - XPath du résumé
+     - ``//META[@name='description']/@content``
+   * - ``crawler.document.html.canonical.xpath``
+     - XPath de l'URL canonique
+     - ``//LINK[@rel='canonical'][1]/@href``
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    # Configuration par défaut
+    crawler.document.html.content.xpath=//BODY
+    crawler.document.html.lang.xpath=//HTML/@lang
+    crawler.document.html.digest.xpath=//META[@name='description']/@content
+    crawler.document.html.canonical.xpath=//LINK[@rel='canonical'][1]/@href
+
+Exemples de XPath personnalisés
+~~~~~~~~~~~~~~~~~~~
+
+::
+
+    # Extraire uniquement un élément div spécifique comme contenu
+    crawler.document.html.content.xpath=//DIV[@id='main-content']
+
+    # Inclure également les mots-clés meta dans le résumé
+    crawler.document.html.digest.xpath=//META[@name='description']/@content|//META[@name='keywords']/@content
+
+Traitement des balises HTML
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.document.html.pruned.tags``
+     - Balises HTML à supprimer
+     - ``noscript,script,style,header,footer,aside,nav,a[rel=nofollow]``
+   * - ``crawler.document.html.max.digest.length``
+     - Longueur maximale du résumé
+     - ``120``
+   * - ``crawler.document.html.default.lang``
+     - Langue par défaut
+     - (vide)
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    # Ajouter des balises à supprimer
+    crawler.document.html.pruned.tags=noscript,script,style,header,footer,aside,nav,a[rel=nofollow],form
+
+    # Résumé de 200 caractères
+    crawler.document.html.max.digest.length=200
+
+    # Langue par défaut en japonais
+    crawler.document.html.default.lang=ja
+
+Filtre de motifs d'URL
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.document.html.default.include.index.patterns``
+     - Motifs d'URL à inclure dans l'index
+     - (vide)
+   * - ``crawler.document.html.default.exclude.index.patterns``
+     - Motifs d'URL à exclure de l'index
+     - ``(?i).*(css|js|jpeg...)``
+   * - ``crawler.document.html.default.include.search.patterns``
+     - Motifs d'URL à inclure dans les résultats de recherche
+     - (vide)
+   * - ``crawler.document.html.default.exclude.search.patterns``
+     - Motifs d'URL à exclure des résultats de recherche
+     - (vide)
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    # Motif d'exclusion par défaut
+    crawler.document.html.default.exclude.index.patterns=(?i).*(css|js|jpeg|jpg|gif|png|bmp|wmv|xml|ico|exe)
+
+    # Indexer uniquement des chemins spécifiques
+    crawler.document.html.default.include.index.patterns=https://example\\.com/docs/.*
+
+Configuration du robot d'indexation de fichiers
+======================
+
+Configuration de base
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.document.file.name.encoding``
+     - Encodage des noms de fichiers
+     - (vide)
+   * - ``crawler.document.file.no.title.label``
+     - Étiquette pour les fichiers sans titre
+     - ``No title.``
+   * - ``crawler.document.file.ignore.empty.content``
+     - Ignorer le contenu vide
+     - ``false``
+   * - ``crawler.document.file.max.title.length``
+     - Longueur maximale du titre
+     - ``100``
+   * - ``crawler.document.file.max.digest.length``
+     - Longueur maximale du résumé
+     - ``200``
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    # Traiter les noms de fichiers en Windows-31J
+    crawler.document.file.name.encoding=Windows-31J
+
+    # Étiquette pour les fichiers sans titre
+    crawler.document.file.no.title.label=Sans titre
+
+    # Ignorer les fichiers vides
+    crawler.document.file.ignore.empty.content=true
+
+    # Longueur du titre et du résumé
+    crawler.document.file.max.title.length=200
+    crawler.document.file.max.digest.length=500
+
+Traitement du contenu
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.document.file.append.meta.content``
+     - Ajouter les métadonnées au contenu
+     - ``true``
+   * - ``crawler.document.file.append.body.content``
+     - Ajouter le corps au contenu
+     - ``true``
+   * - ``crawler.document.file.default.lang``
+     - Langue par défaut
+     - (vide)
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    crawler.document.file.append.meta.content=true
+    crawler.document.file.append.body.content=true
+    crawler.document.file.default.lang=ja
+
+Filtre de motifs d'URL de fichiers
+------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.document.file.default.include.index.patterns``
+     - Motifs à inclure dans l'index
+     - (vide)
+   * - ``crawler.document.file.default.exclude.index.patterns``
+     - Motifs à exclure de l'index
+     - (vide)
+   * - ``crawler.document.file.default.include.search.patterns``
+     - Motifs à inclure dans les résultats de recherche
+     - (vide)
+   * - ``crawler.document.file.default.exclude.search.patterns``
+     - Motifs à exclure des résultats de recherche
+     - (vide)
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    # Indexer uniquement des extensions spécifiques
+    crawler.document.file.default.include.index.patterns=.*\\.(pdf|docx|xlsx|pptx)$
+
+    # Exclure le dossier temp
+    crawler.document.file.default.exclude.index.patterns=.*/temp/.*
+
+Configuration du cache
+==============
+
+Cache de documents
+----------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.document.cache.enabled``
+     - Activer le cache de documents
+     - ``true``
+   * - ``crawler.document.cache.max.size``
+     - Taille maximale du cache (octets)
+     - ``2621440`` (2,5 Mo)
+   * - ``crawler.document.cache.supported.mimetypes``
+     - Types MIME à mettre en cache
+     - ``text/html``
+   * - ``crawler.document.cache.html.mimetypes``
+     - Types MIME traités comme HTML
+     - ``text/html``
+
+Exemple de configuration
+~~~~~~
+
+::
+
+    # Activer le cache de documents
+    crawler.document.cache.enabled=true
+
+    # Taille du cache à 5 Mo
+    crawler.document.cache.max.size=5242880
+
+    # Types MIME à mettre en cache
+    crawler.document.cache.supported.mimetypes=text/html,application/xhtml+xml
+
+    # Types MIME traités comme HTML
+    crawler.document.cache.html.mimetypes=text/html,application/xhtml+xml
+
+.. note::
+   L'activation du cache affiche un lien de cache dans les résultats de recherche,
+   permettant aux utilisateurs de consulter le contenu au moment de l'indexation.
+
+Options JVM
+==============
+
+Vous pouvez configurer les options JVM du processus du robot d'indexation.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``jvm.crawler.options``
+     - Options JVM du robot d'indexation
+     - ``-Xms128m -Xmx512m...``
+
+Configuration par défaut
+--------------
+
+::
+
+    jvm.crawler.options=-Xms128m -Xmx512m \
+        -XX:MaxMetaspaceSize=128m \
+        -XX:+UseG1GC \
+        -XX:MaxGCPauseMillis=60000 \
+        -XX:-HeapDumpOnOutOfMemoryError
+
+Description des principales options
+----------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Option
+     - Description
+   * - ``-Xms128m``
+     - Taille initiale du tas (128 Mo)
+   * - ``-Xmx512m``
+     - Taille maximale du tas (512 Mo)
+   * - ``-XX:MaxMetaspaceSize=128m``
+     - Taille maximale du Metaspace (128 Mo)
+   * - ``-XX:+UseG1GC``
+     - Utiliser le collecteur de déchets G1
+   * - ``-XX:MaxGCPauseMillis=60000``
+     - Objectif de temps de pause GC (60 secondes)
+   * - ``-XX:-HeapDumpOnOutOfMemoryError``
+     - Désactiver le vidage du tas en cas d'OutOfMemory
+
+Exemples de configuration personnalisée
+--------------
+
+**Pour indexer des fichiers volumineux :**
+
+::
+
+    jvm.crawler.options=-Xms256m -Xmx2g \
+        -XX:MaxMetaspaceSize=256m \
+        -XX:+UseG1GC \
+        -XX:MaxGCPauseMillis=60000
+
+**Lors du débogage :**
+
+::
+
+    jvm.crawler.options=-Xms128m -Xmx512m \
+        -XX:MaxMetaspaceSize=128m \
+        -XX:+UseG1GC \
+        -XX:+HeapDumpOnOutOfMemoryError \
+        -XX:HeapDumpPath=/tmp/crawler_dump.hprof
+
+Consultez :doc:`setup-memory` pour plus de détails.
+
+Optimisation des performances
+==========================
+
+Optimisation de la vitesse d'indexation
+--------------------
+
+**1. Ajustement du nombre de threads**
+
+Vous pouvez améliorer la vitesse d'indexation en augmentant le nombre d'indexations parallèles.
+
+::
+
+    # Ajuster le nombre de threads dans la configuration d'indexation de l'interface d'administration
+    Nombre de threads : 10
+
+Cependant, faites attention à la charge sur le serveur cible.
+
+**2. Ajustement des timeouts**
+
+Pour les sites à réponse lente, ajustez les timeouts.
+
+::
+
+    # Ajouter aux « Paramètres de configuration » de la configuration d'indexation
+    client.connectionTimeout=10000
+    client.socketTimeout=30000
+
+**3. Exclusion du contenu inutile**
+
+La vitesse d'indexation s'améliore en excluant les images, CSS, fichiers JavaScript, etc.
+
+::
+
+    # Motif d'URL d'exclusion
+    .*\.(jpg|jpeg|png|gif|css|js|ico)$
+
+**4. Configuration de nouvelle tentative**
+
+Ajustez le nombre de nouvelles tentatives et l'intervalle en cas d'erreur.
+
+::
+
+    # Ajouter aux « Paramètres de configuration » de la configuration d'indexation
+    client.maxRetry=3
+    client.retryInterval=1000
+
+Optimisation de l'utilisation de la mémoire
+--------------------
+
+**1. Ajustement de la taille du tas**
+
+::
+
+    jvm.crawler.options=-Xms256m -Xmx1g
+
+**2. Ajustement de la taille du cache**
+
+::
+
+    crawler.document.cache.max.size=1048576  # 1 Mo
+
+**3. Exclusion des fichiers volumineux**
+
+::
+
+    # Ajouter aux « Paramètres de configuration » de la configuration d'indexation
+    client.maxContentLength=10485760  # 10 Mo
+
+Consultez :doc:`setup-memory` pour plus de détails.
+
+Amélioration de la qualité de l'index
+----------------------
+
+**1. Optimisation du XPath**
+
+Excluez les éléments inutiles (navigation, publicités, etc.).
+
+::
+
+    crawler.document.html.content.xpath=//DIV[@id='main-content']
+    crawler.document.html.pruned.tags=noscript,script,style,header,footer,aside,nav,form,iframe
+
+**2. Optimisation du résumé**
+
+::
+
+    crawler.document.html.max.digest.length=200
+
+**3. Mappage des métadonnées**
+
+::
+
+    crawler.metadata.name.mapping=\
+        title=title:string\n\
+        description=digest:string\n\
+        keywords=label:string
+
+Dépannage
+======================
+
+Mémoire insuffisante
+----------
+
+**Symptômes :**
+
+- ``OutOfMemoryError`` est enregistré dans ``fess_crawler.log``
+- L'indexation s'arrête en cours de route
+
+**Solutions :**
+
+1. Augmenter la taille du tas du robot d'indexation
+
+   ::
+
+       jvm.crawler.options=-Xms256m -Xmx2g
+
+2. Réduire le nombre de threads parallèles
+
+3. Exclure les fichiers volumineux
+
+Consultez :doc:`setup-memory` pour plus de détails.
+
+L'indexation est lente
+--------------
+
+**Symptômes :**
+
+- L'indexation prend trop de temps
+- Les timeouts se produisent fréquemment
+
+**Solutions :**
+
+1. Augmenter le nombre de threads (attention à la charge sur le serveur cible)
+
+2. Ajuster les timeouts
+
+   ::
+
+       client.connectionTimeout=5000
+       client.socketTimeout=10000
+
+3. Exclure les URLs inutiles
+
+Impossible d'extraire un contenu spécifique
+------------------------------
+
+**Symptômes :**
+
+- Le texte de la page n'est pas extrait correctement
+- Les informations importantes ne sont pas incluses dans les résultats de recherche
+
+**Solutions :**
+
+1. Vérifier et ajuster le XPath
+
+   ::
+
+       crawler.document.html.content.xpath=//DIV[@class='content']
+
+2. Vérifier les balises supprimées
+
+   ::
+
+       crawler.document.html.pruned.tags=script,style
+
+3. Pour le contenu généré dynamiquement par JavaScript, envisagez une autre méthode (indexation API, etc.)
+
+Des caractères corrompus apparaissent
+------------------
+
+**Symptômes :**
+
+- Des caractères corrompus apparaissent dans les résultats de recherche
+- Certaines langues ne s'affichent pas correctement
+
+**Solutions :**
+
+1. Vérifier les paramètres d'encodage
+
+   ::
+
+       crawler.document.site.encoding=UTF-8
+       crawler.crawling.data.encoding=UTF-8
+
+2. Configurer l'encodage des noms de fichiers
+
+   ::
+
+       crawler.document.file.name.encoding=Windows-31J
+
+3. Vérifier les erreurs d'encodage dans les journaux
+
+   ::
+
+       grep -i "encoding" /var/log/fess/fess_crawler.log
+
+Bonnes pratiques
+==================
+
+1. **Valider dans un environnement de test**
+
+   Avant d'appliquer en production, validez suffisamment dans un environnement de test.
+
+2. **Ajustement progressif**
+
+   Ne modifiez pas les paramètres de manière importante en une seule fois, ajustez progressivement et vérifiez les effets.
+
+3. **Surveillance des journaux**
+
+   Après avoir modifié les paramètres, surveillez les journaux pour vérifier qu'il n'y a pas d'erreurs ou de problèmes de performance.
+
+   ::
+
+       tail -f /var/log/fess/fess_crawler.log
+
+4. **Sauvegarde**
+
+   Avant de modifier les fichiers de configuration, effectuez toujours une sauvegarde.
+
+   ::
+
+       cp /etc/fess/fess_config.properties /etc/fess/fess_config.properties.bak
+
+5. **Documentation**
+
+   Documentez les paramètres modifiés et leur raison.
+
+Informations de référence
+========
+
+- :doc:`crawler-basic` - Configuration de base du robot d'indexation
+- :doc:`crawler-thumbnail` - Configuration des vignettes
+- :doc:`setup-memory` - Configuration de la mémoire
+- :doc:`admin-logging` - Configuration des journaux
+- :doc:`search-advanced` - Configuration de recherche avancée

--- a/fr/15.3/config/crawler-basic.rst
+++ b/fr/15.3/config/crawler-basic.rst
@@ -1,0 +1,635 @@
+====================
+Configuration de base du robot d'indexation
+====================
+
+Présentation
+====
+
+Le robot d'indexation (crawler) de |Fess| est une fonctionnalité qui collecte automatiquement du contenu à partir de sites Web et de systèmes de fichiers, et l'enregistre dans l'index de recherche.
+Ce guide explique les concepts de base et les méthodes de configuration du robot d'indexation.
+
+Concepts de base du robot d'indexation
+====================
+
+Qu'est-ce qu'un robot d'indexation
+--------------
+
+Un robot d'indexation (Crawler) est un programme qui collecte automatiquement du contenu en suivant des liens à partir d'une URL ou d'un chemin de fichier spécifié.
+
+Le robot d'indexation de |Fess| présente les caractéristiques suivantes :
+
+- **Support multi-protocole** : HTTP/HTTPS, système de fichiers, SMB, FTP, etc.
+- **Exécution planifiée** : Indexation périodique automatique
+- **Indexation incrémentale** : Mise à jour uniquement du contenu modifié
+- **Traitement parallèle** : Indexation simultanée de plusieurs URLs
+- **Conformité aux règles des robots** : Respect du fichier robots.txt
+
+Types de robots d'indexation
+----------------
+
+|Fess| propose les types de robots d'indexation suivants selon la cible.
+
+.. list-table:: Types de robots d'indexation
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * - Type
+     - Cible
+     - Usage
+   * - **Robot Web**
+     - Sites Web (HTTP/HTTPS)
+     - Sites Web publics, sites Web intranet
+   * - **Robot de fichiers**
+     - Système de fichiers, SMB, FTP
+     - Serveurs de fichiers, dossiers partagés
+   * - **Robot de base de données**
+     - Bases de données
+     - Sources de données RDB, CSV, JSON, etc.
+
+Création de la configuration d'indexation
+==================
+
+Ajout d'une configuration d'indexation de base
+--------------------------
+
+1. **Accéder à l'interface d'administration**
+
+   Accédez à ``http://localhost:8080/admin`` dans votre navigateur et connectez-vous en tant qu'administrateur.
+
+2. **Ouvrir l'écran de configuration du robot d'indexation**
+
+   Dans le menu de gauche, sélectionnez « Crawler » → « Web » ou « File System ».
+
+3. **Créer une nouvelle configuration**
+
+   Cliquez sur le bouton « Nouveau ».
+
+4. **Saisir les informations de base**
+
+   - **Nom** : Nom d'identification de la configuration d'indexation (ex : Wiki d'entreprise)
+   - **URL** : URL de départ de l'indexation (ex : ``https://wiki.example.com/``)
+   - **Intervalle d'indexation** : Fréquence d'exécution de l'indexation (ex : toutes les heures)
+   - **Nombre de threads** : Nombre d'indexations parallèles (ex : 5)
+   - **Profondeur** : Profondeur des niveaux de liens à suivre (ex : 3)
+
+5. **Enregistrer**
+
+   Cliquez sur le bouton « Créer » pour enregistrer la configuration.
+
+Exemples de configuration du robot Web
+---------------------
+
+Indexation d'un site intranet d'entreprise
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    Nom : Portail d'entreprise
+    URL : http://intranet.example.com/
+    Intervalle d'indexation : 1 fois par jour
+    Nombre de threads : 10
+    Profondeur : Illimitée (-1)
+    Nombre maximum d'accès : 10000
+
+Indexation d'un site Web public
+~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    Nom : Site produit
+    URL : https://www.example.com/products/
+    Intervalle d'indexation : 1 fois par semaine
+    Nombre de threads : 5
+    Profondeur : 5
+    Nombre maximum d'accès : 1000
+
+Exemples de configuration du robot de fichiers
+--------------------------
+
+Système de fichiers local
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    Nom : Dossier Documents
+    URL : file:///home/share/documents/
+    Intervalle d'indexation : 1 fois par jour
+    Nombre de threads : 3
+    Profondeur : Illimitée (-1)
+
+SMB/CIFS (Partage de fichiers Windows)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    Nom : Serveur de fichiers
+    URL : smb://fileserver.example.com/share/
+    Intervalle d'indexation : 1 fois par jour
+    Nombre de threads : 5
+    Profondeur : Illimitée (-1)
+
+Configuration des informations d'authentification
+--------------
+
+Pour accéder à des sites ou des serveurs de fichiers nécessitant une authentification, configurez les informations d'authentification.
+
+1. Dans l'interface d'administration, sélectionnez « Crawler » → « Authentication »
+2. Cliquez sur « Nouveau »
+3. Saisissez les informations d'authentification :
+
+   ::
+
+       Nom d'hôte : wiki.example.com
+       Port : 443
+       Méthode d'authentification : Basic Authentication
+       Nom d'utilisateur : crawler_user
+       Mot de passe : ********
+
+4. Cliquez sur « Créer »
+
+Exécution de l'indexation
+==============
+
+Exécution manuelle
+--------
+
+Pour exécuter immédiatement une indexation configurée :
+
+1. Dans la liste des configurations d'indexation, sélectionnez la configuration cible
+2. Cliquez sur le bouton « Démarrer »
+3. Vérifiez l'état d'exécution du travail dans le menu « Scheduler »
+
+Exécution planifiée
+----------------
+
+Pour exécuter l'indexation périodiquement :
+
+1. Ouvrez le menu « Scheduler »
+2. Sélectionnez le travail « Default Crawler »
+3. Configurez l'expression de planification (format Cron)
+
+   ::
+
+       # Exécution quotidienne à 2h du matin
+       0 0 2 * * ?
+
+       # Exécution chaque heure à 0 minute
+       0 0 * * * ?
+
+       # Exécution du lundi au vendredi à 18h
+       0 0 18 ? * MON-FRI
+
+4. Cliquez sur « Mettre à jour »
+
+Vérification de l'état de l'indexation
+------------------
+
+Pour vérifier l'état de l'indexation en cours :
+
+1. Ouvrez le menu « Scheduler »
+2. Vérifiez les travaux en cours d'exécution
+3. Consultez les détails dans les journaux :
+
+   ::
+
+       tail -f /var/log/fess/fess_crawler.log
+
+Paramètres de configuration de base
+================
+
+Limitation des cibles d'indexation
+------------------
+
+Limitation par motif d'URL
+~~~~~~~~~~~~~~~~~~~~~
+
+Vous pouvez cibler ou exclure des motifs d'URL spécifiques pour l'indexation.
+
+**Motifs d'URL à inclure (expression régulière) :**
+
+::
+
+    # Indexer uniquement sous /docs/
+    https://example\.com/docs/.*
+
+**Motifs d'URL à exclure (expression régulière) :**
+
+::
+
+    # Exclure des répertoires spécifiques
+    .*/admin/.*
+    .*/private/.*
+
+    # Exclure des extensions de fichiers spécifiques
+    .*\.(jpg|png|gif|css|js)$
+
+Limitation de profondeur
+~~~~~~~~~~
+
+Limiter la profondeur des niveaux de liens à suivre :
+
+- **0** : URL de départ uniquement
+- **1** : URL de départ et pages liées à partir de celle-ci
+- **-1** : Illimitée (suivre tous les liens)
+
+Nombre maximum d'accès
+~~~~~~~~~~~~~~
+
+Limite supérieure du nombre de pages à indexer :
+
+::
+
+    Nombre maximum d'accès : 1000
+
+L'indexation s'arrête après 1000 pages.
+
+Nombre d'indexations parallèles (nombre de threads)
+--------------------------
+
+Spécifie le nombre d'URLs à indexer simultanément.
+
+.. list-table:: Nombre de threads recommandé
+   :header-rows: 1
+   :widths: 40 30 30
+
+   * - Environnement
+     - Valeur recommandée
+     - Description
+   * - Petits sites (jusqu'à 10 000 pages)
+     - 3 à 5
+     - Réduire la charge sur le serveur cible
+   * - Sites moyens (10 000 à 100 000 pages)
+     - 5 à 10
+     - Configuration équilibrée
+   * - Grands sites (plus de 100 000 pages)
+     - 10 à 20
+     - Indexation rapide nécessaire
+   * - Serveurs de fichiers
+     - 3 à 5
+     - Tenir compte de la charge d'E/S des fichiers
+
+.. warning::
+   L'augmentation excessive du nombre de threads impose une charge excessive sur le serveur cible.
+   Veuillez définir une valeur appropriée.
+
+Intervalle d'indexation
+------------
+
+Spécifie la fréquence d'exécution de l'indexation.
+
+::
+
+    # Spécification horaire
+    Intervalle d'indexation : 3600000  # millisecondes (1 heure)
+
+    # Ou configuré dans le planificateur
+    0 0 2 * * ?  # Tous les jours à 2h du matin
+
+Configuration de la taille des fichiers
+====================
+
+Vous pouvez définir la limite supérieure de la taille des fichiers à indexer.
+
+Limite supérieure de la taille des fichiers à récupérer
+----------------------------
+
+Ajoutez ce qui suit aux « Paramètres de configuration » de la configuration du robot d'indexation :
+
+::
+
+    client.maxContentLength=10485760
+
+Récupère les fichiers jusqu'à 10 Mo. Par défaut, il n'y a pas de limite.
+
+.. note::
+   Lors de l'indexation de fichiers volumineux, ajustez également les paramètres de mémoire.
+   Consultez :doc:`setup-memory` pour plus de détails.
+
+Limite supérieure de la taille des fichiers à indexer
+------------------------------------
+
+Vous pouvez définir la limite supérieure de la taille à indexer pour chaque type de fichier.
+
+**Valeurs par défaut :**
+
+- Fichiers HTML : 2,5 Mo
+- Autres fichiers : 10 Mo
+
+**Fichier de configuration :** ``app/WEB-INF/classes/crawler/contentlength.xml``
+
+::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+            "http://dbflute.org/meta/lastadi10.dtd">
+    <components namespace="fessCrawler">
+            <include path="crawler/container.xml" />
+
+            <component name="contentLengthHelper"
+                    class="org.codelibs.fess.crawler.helper.ContentLengthHelper" instance="singleton">
+                    <property name="defaultMaxLength">10485760</property><!-- 10M -->
+                    <postConstruct name="addMaxLength">
+                            <arg>"text/html"</arg>
+                            <arg>2621440</arg><!-- 2.5M -->
+                    </postConstruct>
+                    <postConstruct name="addMaxLength">
+                            <arg>"application/pdf"</arg>
+                            <arg>5242880</arg><!-- 5M -->
+                    </postConstruct>
+            </component>
+    </components>
+
+Cela ajoute une configuration pour traiter les fichiers PDF jusqu'à 5 Mo.
+
+.. warning::
+   Lors de l'augmentation de la taille des fichiers traités, augmentez également les paramètres de mémoire du robot d'indexation.
+
+Limitation de la longueur des mots
+==============
+
+Présentation
+----
+
+Les longues chaînes de caractères alphanumériques uniquement ou les symboles consécutifs entraînent une augmentation de la taille de l'index et une dégradation des performances.
+Par conséquent, |Fess| impose par défaut les limites suivantes :
+
+- **Caractères alphanumériques consécutifs** : jusqu'à 20 caractères
+- **Symboles consécutifs** : jusqu'à 10 caractères
+
+Méthode de configuration
+--------
+
+Modifiez ``fess_config.properties``.
+
+**Configuration par défaut :**
+
+::
+
+    crawler.document.max.alphanum.term.size=20
+    crawler.document.max.symbol.term.size=10
+
+**Exemple : pour assouplir les limites**
+
+::
+
+    crawler.document.max.alphanum.term.size=50
+    crawler.document.max.symbol.term.size=20
+
+.. note::
+   Si vous devez rechercher de longues chaînes alphanumériques (ex : numéros de série, tokens, etc.),
+   augmentez cette valeur. Cependant, la taille de l'index augmentera.
+
+Configuration du proxy
+==============
+
+Présentation
+----
+
+Lors de l'indexation de sites externes depuis un intranet, ils peuvent être bloqués par un pare-feu.
+Dans ce cas, effectuez l'indexation via un serveur proxy.
+
+Méthode de configuration
+--------
+
+Dans la configuration d'indexation de l'interface d'administration, ajoutez ce qui suit aux « Paramètres de configuration ».
+
+**Configuration proxy de base :**
+
+::
+
+    client.proxyHost=proxy.example.com
+    client.proxyPort=8080
+
+**Proxy nécessitant une authentification :**
+
+::
+
+    client.proxyHost=proxy.example.com
+    client.proxyPort=8080
+    client.proxyUsername=proxyuser
+    client.proxyPassword=proxypass
+
+**Exclure des hôtes spécifiques du proxy :**
+
+::
+
+    client.nonProxyHosts=localhost|127.0.0.1|*.example.com
+
+Configuration proxy à l'échelle du système
+--------------------------
+
+Si vous utilisez le même proxy pour toutes les configurations d'indexation, vous pouvez le configurer avec des variables d'environnement.
+
+::
+
+    export http_proxy=http://proxy.example.com:8080
+    export https_proxy=http://proxy.example.com:8080
+    export no_proxy=localhost,127.0.0.1,.example.com
+
+Configuration de robots.txt
+=================
+
+Présentation
+----
+
+robots.txt est un fichier qui indique aux robots d'indexation s'ils peuvent ou non indexer.
+|Fess| respecte robots.txt par défaut.
+
+Méthode de configuration
+--------
+
+Pour ignorer robots.txt, modifiez ``fess_config.properties``.
+
+::
+
+    crawler.ignore.robots.txt=true
+
+.. warning::
+   Lors de l'indexation de sites externes, respectez robots.txt.
+   L'ignorer peut imposer une charge excessive sur le serveur ou violer les conditions d'utilisation.
+
+Configuration du User-Agent
+=================
+
+Vous pouvez modifier le User-Agent du robot d'indexation.
+
+Configuration dans l'interface d'administration
+----------------
+
+Ajoutez aux « Paramètres de configuration » de la configuration d'indexation :
+
+::
+
+    client.userAgent=MyCompanyCrawler/1.0
+
+Configuration à l'échelle du système
+------------------
+
+Configurez dans ``fess_config.properties`` :
+
+::
+
+    crawler.user.agent=MyCompanyCrawler/1.0
+
+Configuration de l'encodage
+====================
+
+Encodage des données d'indexation
+--------------------------------
+
+Configurez dans ``fess_config.properties`` :
+
+::
+
+    crawler.crawling.data.encoding=UTF-8
+
+Encodage des noms de fichiers
+----------------------------
+
+Encodage des noms de fichiers du système de fichiers :
+
+::
+
+    crawler.document.file.name.encoding=UTF-8
+
+Dépannage de l'indexation
+================================
+
+L'indexation ne démarre pas
+----------------------
+
+**Points à vérifier :**
+
+1. Vérifier si le planificateur est activé
+
+   - Dans le menu « Scheduler », vérifiez si le travail « Default Crawler » est activé
+
+2. Vérifier si la configuration d'indexation est activée
+
+   - Dans la liste des configurations d'indexation, vérifiez si la configuration cible est activée
+
+3. Vérifier les journaux
+
+   ::
+
+       tail -f /var/log/fess/fess.log
+       tail -f /var/log/fess/fess_crawler.log
+
+L'indexation s'arrête en cours de route
+------------------------
+
+**Causes possibles :**
+
+1. **Mémoire insuffisante**
+
+   - Vérifiez s'il y a des ``OutOfMemoryError`` dans ``fess_crawler.log``
+   - Augmenter la mémoire du robot d'indexation (voir :doc:`setup-memory`)
+
+2. **Erreur réseau**
+
+   - Ajuster les paramètres de timeout
+   - Vérifier les paramètres de nouvelle tentative
+
+3. **Erreur de la cible d'indexation**
+
+   - Vérifier s'il y a de nombreuses erreurs 404
+   - Vérifier les détails des erreurs dans les journaux
+
+Une page spécifique n'est pas indexée
+------------------------------
+
+**Points à vérifier :**
+
+1. **Vérifier les motifs d'URL**
+
+   - Vérifier si elle ne correspond pas aux motifs d'URL exclus
+
+2. **Vérifier robots.txt**
+
+   - Vérifier ``/robots.txt`` du site cible
+
+3. **Vérifier l'authentification**
+
+   - Pour les pages nécessitant une authentification, vérifier les paramètres d'authentification
+
+4. **Limitation de profondeur**
+
+   - Vérifier si la hiérarchie des liens dépasse la limite de profondeur
+
+5. **Nombre maximum d'accès**
+
+   - Vérifier si le nombre maximum d'accès a été atteint
+
+L'indexation est lente
+--------------
+
+**Solutions :**
+
+1. **Augmenter le nombre de threads**
+
+   - Augmenter le nombre d'indexations parallèles (mais attention à la charge sur le serveur cible)
+
+2. **Exclure les URLs inutiles**
+
+   - Ajouter les images et les fichiers CSS aux motifs d'URL exclus
+
+3. **Ajuster les paramètres de timeout**
+
+   - Pour les sites à réponse lente, réduire le timeout
+
+4. **Augmenter la mémoire du robot d'indexation**
+
+   - Voir :doc:`setup-memory`
+
+Bonnes pratiques
+==================
+
+Recommandations pour la configuration d'indexation
+----------------------
+
+1. **Définir un nombre de threads approprié**
+
+   Définissez un nombre de threads approprié pour ne pas imposer une charge excessive sur le serveur cible.
+
+2. **Optimisation des motifs d'URL**
+
+   En excluant les fichiers inutiles (images, CSS, JavaScript, etc.),
+   vous réduisez le temps d'indexation et améliorez la qualité de l'index.
+
+3. **Configuration de la limitation de profondeur**
+
+   Définissez une profondeur appropriée en fonction de la structure du site.
+   Utilisez illimitée (-1) uniquement pour indexer l'ensemble du site.
+
+4. **Configuration du nombre maximum d'accès**
+
+   Définissez une limite supérieure pour éviter d'indexer un nombre inattendu de pages.
+
+5. **Ajustement de l'intervalle d'indexation**
+
+   Définissez un intervalle approprié en fonction de la fréquence de mise à jour.
+   - Sites fréquemment mis à jour : toutes les 1 heure à quelques heures
+   - Sites rarement mis à jour : tous les 1 jour à 1 semaine
+
+Recommandations pour la configuration de la planification
+--------------------------
+
+1. **Exécution nocturne**
+
+   Exécutez pendant les périodes de faible charge du serveur (ex : 2h du matin).
+
+2. **Éviter les exécutions en double**
+
+   Configurez pour démarrer l'indexation suivante après la fin de l'indexation précédente.
+
+3. **Notification en cas d'erreur**
+
+   Configurez une notification par e-mail en cas d'échec de l'indexation.
+
+Informations de référence
+========
+
+- :doc:`crawler-advanced` - Configuration avancée du robot d'indexation
+- :doc:`crawler-thumbnail` - Configuration des vignettes
+- :doc:`setup-memory` - Configuration de la mémoire
+- :doc:`admin-logging` - Configuration des journaux

--- a/fr/15.3/config/crawler-thumbnail.rst
+++ b/fr/15.3/config/crawler-thumbnail.rst
@@ -1,0 +1,64 @@
+===============
+Configuration des vignettes
+===============
+
+Affichage des vignettes
+===============
+
+|Fess| peut afficher des vignettes dans les résultats de recherche.
+Les vignettes sont générées en fonction du type MIME des résultats de recherche.
+Pour les types MIME pris en charge, les vignettes sont générées lors de l'affichage des résultats de recherche.
+Le traitement de génération de vignettes peut être configuré et ajouté pour chaque type MIME.
+
+Pour afficher les vignettes, connectez-vous en tant qu'administrateur et activez l'affichage des vignettes dans les paramètres généraux, puis enregistrez.
+
+Vignettes des fichiers HTML
+======================
+
+Les vignettes HTML utilisent les images spécifiées ou contenues dans le HTML.
+Les vignettes sont recherchées dans l'ordre suivant et affichées si elles sont spécifiées.
+
+- Valeur de l'attribut content d'une balise meta avec l'attribut name défini sur thumbnail
+- Valeur de l'attribut content d'une balise meta avec l'attribut property défini sur og:image
+- Image de taille appropriée pour une vignette dans une balise img
+
+
+Vignettes des fichiers MS Office
+===========================
+
+Les vignettes des fichiers MS Office sont générées à l'aide de LibreOffice et ImageMagick.
+Si les commandes unoconv et convert sont installées, les vignettes sont générées.
+
+Installation des paquets
+------------------
+
+Pour les systèmes d'exploitation de type Redhat, installez les paquets suivants pour créer des images.
+
+::
+
+    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick
+
+Script de génération
+-----------
+
+Lors de l'installation via le paquet RPM/Deb, le script de génération de vignettes pour MS Office est installé dans /usr/share/fess/bin/generate-thumbnail.
+
+Vignettes des fichiers PDF
+=====================
+
+Les vignettes PDF sont générées à l'aide d'ImageMagick.
+Si la commande convert est installée, les vignettes sont générées.
+
+Désactivation du travail de vignettes
+==================
+
+Pour désactiver le travail de vignettes, configurez ce qui suit.
+
+1. Dans l'interface d'administration, allez dans Système > Général, décochez « Affichage des vignettes », et cliquez sur le bouton « Mettre à jour ».
+2. Définissez ``thumbnail.crawler.enabled`` sur ``false`` dans ``app/WEB-INF/classes/fess_config.properties`` ou ``/etc/fess/fess_config.properties``.
+
+::
+
+    thumbnail.crawler.enabled=false
+
+3. Redémarrez le service Fess.

--- a/fr/15.3/config/index.rst
+++ b/fr/15.3/config/index.rst
@@ -1,0 +1,52 @@
+Guide de configuration |Fess|
+=============================
+
+Ce guide complet couvre la configuration de |Fess|. Chaque section est organisée par thématique.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Introduction
+
+   intro
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Configuration de base
+
+   setup-port-network
+   setup-memory
+   setup-windows-service
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Configuration du crawler
+
+   crawler-basic
+   crawler-advanced
+   crawler-thumbnail
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Configuration des fonctions de recherche
+
+   search-basic
+   search-advanced
+   search-geosearch
+   search-scroll
+   search-form-integration
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Configuration de sécurité
+
+   security-role
+   security-virtual-host
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Administration système
+
+   admin-logging
+   admin-index-backup
+   admin-analyzer
+   admin-opensearch-dashboards

--- a/fr/15.3/config/intro.rst
+++ b/fr/15.3/config/intro.rst
@@ -1,0 +1,48 @@
+============
+Introduction
+============
+
+Public visé
+===========
+
+Ce document est destiné aux utilisateurs chargés de la configuration de |Fess|.
+
+Avant de commencer
+==================
+
+Ce document présente les méthodes de configuration de |Fess|.
+Des connaissances de base en informatique sont requises.
+
+Accès en ligne
+==============
+
+Pour les téléchargements, les services professionnels, le support et autres informations destinées aux développeurs, veuillez consulter :
+
+-  Site du projet : https://fess.codelibs.org/
+
+Contact pour le support technique
+==================================
+
+Si vous avez des questions techniques concernant ce produit et que vous ne trouvez pas de solution dans la documentation, veuillez consulter :
+
+-  Issues :
+   `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
+
+Support commercial
+------------------
+
+Si vous avez besoin d'un support commercial tel que l'assistance technique ou la maintenance de ce produit, veuillez contacter `N2SM, Inc. <https://www.n2sm.net/>`__
+
+Référence aux sites Web tiers
+==============================
+
+Le projet |Fess| n'est pas responsable de la validité des sites Web tiers mentionnés dans ce document.
+Le projet |Fess| n'offre aucune garantie, responsabilité ou obligation concernant le contenu, les publicités, les produits, les services ou autres documents disponibles via ces sites ou ressources.
+Le projet |Fess| n'est pas responsable des dommages ou préjudices causés par ou liés à l'utilisation ou à la confiance accordée au contenu, aux publicités, aux produits, aux services ou autres documents disponibles via ces sites ou ressources.
+
+Comment envoyer vos commentaires et suggestions
+================================================
+
+Le projet |Fess| s'efforce d'améliorer continuellement cette documentation et accueille favorablement les commentaires et suggestions des lecteurs.
+
+-  Liste de diffusion : `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__

--- a/fr/15.3/config/search-advanced.rst
+++ b/fr/15.3/config/search-advanced.rst
@@ -1,0 +1,169 @@
+===========
+Paramètres liés à la recherche
+===========
+
+Les paramètres décrits ci-dessous sont spécifiés dans fess_config.properties.
+Un redémarrage de |Fess| est nécessaire après modification.
+
+Recherche floue
+=========
+
+Une recherche floue est appliquée aux mots-clés de 4 caractères ou plus, ce qui permet de trouver des correspondances avec une différence d'un caractère.
+Pour désactiver ce paramètre, spécifiez `-1`.
+::
+
+    query.boost.fuzzy.min.length=-1
+
+Valeur du délai d'expiration lors de la recherche
+=================
+
+Vous pouvez spécifier la valeur du délai d'expiration lors de la recherche.
+La valeur initiale est de 10 secondes.
+::
+
+    query.timeout=10000
+
+Nombre maximum de caractères lors de la recherche
+==============
+
+Vous pouvez spécifier le nombre maximum de caractères lors de la recherche.
+La valeur initiale est de 1000 caractères.
+::
+
+    query.max.length=1000
+
+Sortie des journaux lors d'un délai d'expiration de recherche
+=======================
+
+Paramètre de sortie des journaux en cas de délai d'expiration lors de la recherche.
+La valeur initiale est `true (activé)`.
+::
+
+    query.timeout.logging=true
+
+Affichage du nombre de correspondances
+===========
+
+À spécifier lorsqu'un affichage du nombre de correspondances supérieur à 10 000 est nécessaire.
+Par défaut, lorsque plus de 10 000 résultats sont trouvés, l'affichage est le suivant :
+
+`Résultats de recherche pour xxxxx environ 10 000 ou plus 1 - 10 sur (4.94 secondes)`
+
+::
+
+    query.track.total.hits=10000
+
+Nom de l'index lors de la recherche par géolocalisation
+=======================
+
+Spécifie le nom de l'index lors de la recherche par géolocalisation.
+La valeur initiale est `location`.
+::
+
+    query.geo.fields=location
+
+Spécification de langue dans les paramètres de requête
+=======================
+
+Spécifie le nom du paramètre pour spécifier la langue dans les paramètres de requête.
+Par exemple, en passant `browser_lang=en` dans l'URL comme paramètre de requête, la langue d'affichage de l'écran passe à l'anglais.
+::
+
+    query.browser.lang.parameter.name=browser_lang
+
+Spécification de la recherche par préfixe
+==============
+
+Lors d'une recherche de correspondance exacte, si spécifiée avec `〜\*`, effectue une recherche par préfixe.
+La valeur initiale est `true (activé)`.
+::
+
+    query.replace.term.with.prefix.query=true
+
+Chaînes de mise en surbrillance
+==============
+
+Les phrases sont délimitées par les chaînes spécifiées ici pour obtenir un affichage de surbrillance naturel.
+Les chaînes spécifiées sont des caractères Unicode avec u comme délimiteur de début.
+::
+
+    query.highlight.terminal.chars=u0021u002Cu002Eu003Fu0589u061Fu06D4u0700u0701u0702u0964u104Au104Bu1362u1367u1368u166Eu1803u1809u203Cu203Du2047u2048u2049u3002uFE52uFE57uFF01uFF0EuFF1FuFF61
+
+La valeur initiale est définie comme suit (après décodage) :
+
+``! , . ? ։ ؟ ۔ ܀ ܁ ܂ । ၊ ။ ። ፧ ፨ ᙮ ᠃ ᠉ ‼ ‽ ⁇ ⁈ ⁉ 。 ﹒ ﹗ ！ ． ？ ｡``
+
+Fragments de mise en surbrillance
+==================
+
+Spécifie le nombre de caractères des fragments de mise en surbrillance récupérés d'OpenSearch et le nombre de fragments.
+::
+
+    query.highlight.fragment.size=60
+    query.highlight.number.of.fragments=2
+
+Méthode de génération de la mise en surbrillance
+==============
+
+Spécifie la méthode de génération de la mise en surbrillance dans OpenSearch.
+::
+
+    query.highlight.type=fvh
+
+Balises cibles de mise en surbrillance
+===============
+
+Spécifie les balises de début et de fin des cibles de mise en surbrillance.
+::
+
+    query.highlight.tag.pre=<strong>
+    query.highlight.tag.post=</strong>
+
+Valeurs transmises au surligneur d'OpenSearch
+===========================
+
+Spécifie les valeurs transmises au surligneur d'OpenSearch.
+::
+
+    query.highlight.boundary.chars=u0009u000Au0013u0020
+    query.highlight.boundary.max.scan=20
+    query.highlight.boundary.scanner=chars
+    query.highlight.encoder=default
+
+Noms de champs à ajouter à la réponse
+========================
+
+Spécifie les noms de champs à ajouter à la réponse lors d'une recherche normale ou d'une recherche API.
+::
+
+    query.additional.response.fields=
+    query.additional.api.response.fields=
+
+Ajout de noms de champs
+==============
+
+À spécifier lors de l'ajout de noms de champs de recherche ou de noms de champs de facettes.
+::
+
+    query.additional.search.fields=
+    query.additional.facet.fields=
+
+Paramètres pour obtenir les résultats de recherche au format XML compatible GSA
+===================================
+
+Utilisé lors de l'obtention des résultats de recherche au format XML compatible GSA.
+
+Spécifie les noms de champs à ajouter à la réponse lors de l'utilisation du format XML compatible GSA.
+    ::
+
+        query.gsa.response.fields=UE,U,T,RK,S,LANG
+
+Spécifie la langue lors de l'utilisation du format XML compatible GSA.
+    ::
+
+        query.gsa.default.lang=en
+
+Spécifie le tri par défaut lors de l'utilisation du format XML compatible GSA.
+    ::
+
+        query.gsa.default.sort=

--- a/fr/15.3/config/search-basic.rst
+++ b/fr/15.3/config/search-basic.rst
@@ -1,0 +1,234 @@
+========
+Fonction de recherche
+========
+
+Aperçu
+====
+
+|Fess| offre une puissante fonction de recherche en texte intégral.
+Cette section décrit les paramètres détaillés et les méthodes d'utilisation de la fonction de recherche.
+
+Affichage du nombre de résultats de recherche
+==================
+
+Comportement par défaut
+----------------
+
+Lorsque les résultats de recherche dépassent 10 000 éléments, le nombre affiché sur l'écran des résultats est "environ 10 000 ou plus".
+Il s'agit du paramètre par défaut qui prend en compte les performances d'OpenSearch.
+
+Exemple de recherche
+
+|image0|
+
+.. |image0| image:: ../../../resources/images/ja/15.3/config/search-result.png
+
+Affichage du nombre exact de correspondances
+----------------------
+
+Pour afficher le nombre exact de correspondances au-delà de 10 000 éléments, modifiez le paramètre suivant dans ``fess_config.properties``.
+
+::
+
+    query.track.total.hits=100000
+
+Ce paramètre permet d'obtenir le nombre exact de correspondances jusqu'à 100 000 éléments.
+Cependant, une valeur élevée peut affecter les performances.
+
+.. warning::
+   Une valeur trop élevée peut dégrader les performances de recherche.
+   Veuillez définir une valeur appropriée en fonction de votre situation d'utilisation réelle.
+
+Options de recherche
+==============
+
+Recherche de base
+------------
+
+Dans |Fess|, une recherche en texte intégral est exécutée simplement en saisissant des mots-clés dans la zone de recherche.
+La saisie de plusieurs mots-clés effectue une recherche ET (AND).
+
+::
+
+    recherche moteur
+
+Dans l'exemple ci-dessus, les documents contenant à la fois "recherche" et "moteur" sont recherchés.
+
+Recherche OU (OR)
+------
+
+Pour effectuer une recherche OU, insérez ``OR`` entre les mots-clés.
+
+::
+
+    recherche OR moteur
+
+Recherche NON (NOT)
+-------
+
+Pour exclure un mot-clé spécifique, ajoutez ``-`` (signe moins) devant le mot-clé.
+
+::
+
+    recherche -moteur
+
+Recherche de phrase
+------------
+
+Pour rechercher une phrase exacte, entourez-la de guillemets doubles.
+
+::
+
+    "moteur de recherche"
+
+Recherche par champ spécifique
+------------------
+
+Vous pouvez effectuer une recherche en spécifiant des champs particuliers.
+
+::
+
+    title:moteur de recherche
+    url:https://fess.codelibs.org/
+
+Principaux champs :
+
+- ``title`` : Titre du document
+- ``content`` : Corps du document
+- ``url`` : URL du document
+- ``filetype`` : Type de fichier (par exemple : pdf, html, doc)
+- ``label`` : Étiquette (classification)
+
+Recherche avec caractères génériques
+------------------
+
+Les recherches utilisant des caractères génériques sont possibles.
+
+- ``*`` : Zéro ou plusieurs caractères arbitraires
+- ``?`` : Un caractère arbitraire
+
+::
+
+    recherche*
+    recherche?oteur
+
+Recherche floue
+------------
+
+Une recherche floue qui gère les fautes de frappe et les variations d'orthographe est disponible.
+Par défaut, une recherche floue est automatiquement appliquée aux mots-clés de 4 caractères ou plus.
+
+::
+
+    moteur de recherche~
+
+En spécifiant une valeur numérique après ``~``, vous pouvez spécifier la distance d'édition.
+
+Tri des résultats de recherche
+================
+
+Par défaut, les résultats de recherche sont triés par ordre de pertinence.
+Vous pouvez spécifier différents ordres de tri via les paramètres de l'interface d'administration ou les paramètres de l'API.
+
+- Ordre de pertinence (par défaut)
+- Ordre chronologique des mises à jour
+- Ordre chronologique de création
+- Ordre de taille de fichier
+
+Recherche à facettes
+==============
+
+La recherche à facettes vous permet d'affiner les résultats de recherche par catégorie.
+Par défaut, le champ étiquette (label) est défini comme facette.
+
+Vous pouvez affiner les résultats de recherche en cliquant sur les facettes affichées sur le côté gauche de l'écran de recherche.
+
+Mise en surbrillance des résultats de recherche
+====================
+
+Les mots-clés de recherche sont mis en surbrillance dans le titre et le résumé des résultats de recherche.
+Les paramètres de mise en surbrillance peuvent être personnalisés dans ``fess_config.properties``.
+
+::
+
+    query.highlight.tag.pre=<strong>
+    query.highlight.tag.post=</strong>
+    query.highlight.fragment.size=60
+    query.highlight.number.of.fragments=2
+
+Fonction de suggestion
+==============
+
+Lorsque vous saisissez des caractères dans la zone de recherche, des suggestions (auto-complétion) s'affichent.
+Les suggestions sont générées en fonction des mots-clés de recherche précédents et des mots-clés de recherche populaires.
+
+La fonction de suggestion peut être activée/désactivée dans les paramètres "Général" de l'interface d'administration.
+
+Journaux de recherche
+========
+
+|Fess| enregistre toutes les requêtes de recherche et les journaux de clics.
+Ces journaux peuvent être utilisés aux fins suivantes :
+
+- Analyse et amélioration de la qualité de recherche
+- Analyse du comportement des utilisateurs
+- Identification des mots-clés de recherche populaires
+- Identification des mots-clés sans résultats de recherche
+
+Les journaux de recherche sont stockés dans l'index ``fess_log`` d'OpenSearch,
+et peuvent être visualisés et analysés dans OpenSearch Dashboards.
+Pour plus de détails, consultez :doc:`kibana`.
+
+Optimisation des performances
+==========================
+
+Configuration du délai d'expiration de recherche
+----------------------
+
+Vous pouvez configurer le délai d'expiration de recherche. La valeur par défaut est de 10 secondes.
+
+::
+
+    query.timeout=10000
+
+Nombre maximum de caractères de requête de recherche
+----------------------
+
+Pour des raisons de sécurité et de performance, vous pouvez limiter le nombre maximum de caractères d'une requête de recherche.
+
+::
+
+    query.max.length=1000
+
+Utilisation du cache
+----------------
+
+En activant le cache des résultats de recherche, vous pouvez réduire le temps de réponse pour les mêmes requêtes de recherche.
+Les paramètres de cache doivent être ajustés en fonction des exigences du système.
+
+Dépannage
+======================
+
+Les résultats de recherche ne s'affichent pas
+----------------------
+
+1. Vérifiez que l'index a été créé correctement.
+2. Vérifiez que l'exploration s'est terminée normalement.
+3. Vérifiez qu'aucune permission d'accès n'est définie sur les documents de recherche.
+4. Vérifiez qu'OpenSearch fonctionne normalement.
+
+La recherche est lente
+--------------
+
+1. Vérifiez la taille de la mémoire heap d'OpenSearch.
+2. Optimisez le nombre de partitions et de répliques de l'index.
+3. Vérifiez la complexité de la requête de recherche.
+4. Vérifiez les ressources matérielles (CPU, mémoire, E/S disque).
+
+Des résultats peu pertinents s'affichent
+----------------------------
+
+1. Ajustez les paramètres de boost (``query.boost.title``, ``query.boost.content``, etc.).
+2. Revoyez les paramètres de recherche floue.
+3. Vérifiez la configuration de l'analyseur.
+4. Si nécessaire, consultez le support commercial.

--- a/fr/15.3/config/search-form-integration.rst
+++ b/fr/15.3/config/search-form-integration.rst
@@ -1,0 +1,65 @@
+==============
+Placement du formulaire de recherche
+==============
+
+Méthode de placement du formulaire de recherche
+=================
+
+En plaçant un formulaire de recherche sur un site existant, vous pouvez rediriger vers les résultats de recherche de |Fess|.
+Ici, nous expliquons avec un exemple où |Fess| est configuré sur https://search.n2sm.co.jp/ et où un formulaire de recherche est placé sur chaque page d'un site existant.
+
+Formulaire de recherche
+---------
+
+Placez le code suivant à l'endroit où vous souhaitez afficher le formulaire de recherche sur la page.
+
+::
+
+    <form id="searchForm" method="get" action="https://search.n2sm.co.jp/search/">
+    <input id="query" type="text" name="q" maxlength="1000" autocomplete="off">
+    <input type="submit" name="search" value="Rechercher">
+    </form>
+
+Ajustez selon les besoins avec CSS en ajoutant un nom de classe avec l'attribut class pour correspondre au design de votre site.
+Modifiez l'URL https://search.n2sm.co.jp/ avec l'URL de votre serveur |Fess| configuré.
+
+
+Suggestions
+--------
+
+Vous pouvez également configurer la fonction de suggestion dans le formulaire de recherche placé.
+Pour configurer cela, ajoutez le code suivant avant </body>.
+
+::
+
+    <script type="text/javascript" src="https://search.n2sm.co.jp/js/jquery-3.6.3.min.js"></script>
+    <script type="text/javascript" src="https://search.n2sm.co.jp/js/suggestor.js"></script>
+    <script>
+    $(function() {
+      $('#query').suggestor({
+        ajaxinfo : {
+          url : 'https://search.n2sm.co.jp/api/v1/suggest-words',
+          fn :  ["_default", "content", "title"],
+          num : 10
+        },
+        boxCssInfo: {
+          border: "1px solid rgba(82, 168, 236, 0.5)",
+          "-webkit-box-shadow":
+            "0 1px 1px 0px rgba(0, 0, 0, 0.1), 0 3px 2px 0px rgba(82, 168, 236, 0.2)",
+          "-moz-box-shadow":
+            "0 1px 1px 0px rgba(0, 0, 0, 0.1), 0 3px 2px 0px rgba(82, 168, 236, 0.2)",
+          "box-shadow":
+            "0 1px 1px 0px rgba(0, 0, 0, 0.1), 0 3px 2px 0px rgba(82, 168, 236, 0.2)",
+          "background-color": "#fff",
+          "z-index": "10000"
+        },
+        minterm: 2,
+        adjustWidthVal : 11,
+        searchForm : $('#searchForm')
+      });
+    });
+    </script>
+
+Si vous utilisez déjà jQuery sur votre site, il n'est pas nécessaire d'ajouter l'élément script jQuery.
+
+Pour la valeur spécifiée dans "z-index", veuillez spécifier une valeur qui ne chevauche pas avec d'autres éléments.

--- a/fr/15.3/config/search-geosearch.rst
+++ b/fr/15.3/config/search-geosearch.rst
@@ -1,0 +1,281 @@
+============
+Recherche par géolocalisation
+============
+
+Aperçu
+====
+
+|Fess| peut effectuer des recherches avec une zone géographique spécifiée sur des documents contenant des informations de géolocalisation (latitude et longitude).
+En utilisant cette fonction, vous pouvez rechercher des documents situés dans une certaine distance d'un point spécifique,
+ou créer un système de recherche intégré avec des services de cartographie comme Google Maps.
+
+Cas d'utilisation
+============
+
+La recherche par géolocalisation peut être utilisée pour les applications suivantes :
+
+- Recherche de magasins : Rechercher les magasins proches de la position actuelle de l'utilisateur
+- Recherche immobilière : Rechercher des propriétés dans une certaine distance d'une gare ou d'une installation spécifique
+- Recherche d'événements : Rechercher des informations sur des événements autour d'un lieu spécifié
+- Recherche d'installations : Recherche à proximité de sites touristiques ou d'installations publiques
+
+Méthode de configuration
+========
+
+Configuration lors de la génération de l'index
+------------------------
+
+Définition du champ de géolocalisation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Dans |Fess|, le champ ``location`` est défini par défaut pour stocker les informations de géolocalisation.
+Ce champ est configuré comme un type ``geo_point`` d'OpenSearch.
+
+Format d'enregistrement des informations de géolocalisation
+~~~~~~~~~~~~~~~~~~
+
+Lors de la génération de l'index, définissez la latitude et la longitude séparées par une virgule dans le champ ``location``.
+
+**Format :**
+
+::
+
+    latitude,longitude
+
+**Exemple :**
+
+::
+
+    45.17614,-93.87341
+
+.. note::
+   La latitude doit être spécifiée dans la plage de -90 à 90, et la longitude dans la plage de -180 à 180.
+
+Exemple de configuration pour l'exploration de base de données
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Lors de l'utilisation de l'exploration de base de données, définissez la latitude et la longitude dans le champ ``location``
+à partir d'une source de données contenant des informations de géolocalisation.
+
+**Exemple : Récupération depuis une base de données**
+
+::
+
+    SELECT
+        id,
+        name,
+        address,
+        CONCAT(latitude, ',', longitude) as location
+    FROM stores
+
+Ajout d'informations de géolocalisation via script
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Vous pouvez également ajouter dynamiquement des informations de géolocalisation à un document en utilisant la fonction de script de configuration d'exploration.
+
+::
+
+    // Définir la latitude et la longitude dans le champ location
+    doc.location = "35.681236,139.767125";
+
+Configuration lors de la recherche
+------------
+
+Pour effectuer une recherche par géolocalisation, spécifiez le point central et la plage de recherche dans les paramètres de requête.
+
+Paramètres de requête
+~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Nom du paramètre
+     - Description
+   * - ``geo.location.point``
+     - Latitude et longitude du point central de recherche (séparées par une virgule)
+   * - ``geo.location.distance``
+     - Rayon de recherche à partir du point central (avec unité)
+
+Unités de distance
+~~~~~~~~~~
+
+Les unités suivantes peuvent être utilisées pour la distance :
+
+- ``km`` : Kilomètres
+- ``m`` : Mètres
+- ``mi`` : Miles
+- ``yd`` : Yards
+
+Exemples de recherche
+======
+
+Recherche de base
+------------
+
+Pour rechercher des documents dans un rayon de 10 km autour de la gare de Tokyo (35.681236, 139.767125) :
+
+::
+
+    http://localhost:8080/search?q=mot-clé&geo.location.point=35.681236,139.767125&geo.location.distance=10km
+
+Recherche autour de la position actuelle
+----------------
+
+Pour rechercher dans un rayon de 1 km autour de la position actuelle de l'utilisateur :
+
+::
+
+    http://localhost:8080/search?q=ramen&geo.location.point=35.681236,139.767125&geo.location.distance=1km
+
+Tri par distance
+----------------
+
+Pour trier les résultats de recherche par ordre de distance, utilisez le paramètre ``sort``.
+
+::
+
+    http://localhost:8080/search?q=magasin&geo.location.point=35.681236,139.767125&geo.location.distance=5km&sort=location.distance
+
+Utilisation avec l'API
+-----------
+
+La recherche par géolocalisation peut également être utilisée avec l'API JSON.
+
+::
+
+    curl -X POST "http://localhost:8080/json/?q=hôtel" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "geo.location.point": "35.681236,139.767125",
+        "geo.location.distance": "5km"
+      }'
+
+Personnalisation du nom de champ
+==========================
+
+Modification du nom de champ par défaut
+----------------------------
+
+Pour modifier le nom de champ utilisé pour la recherche par géolocalisation,
+modifiez le paramètre suivant dans ``fess_config.properties``.
+
+::
+
+    query.geo.fields=location
+
+Pour spécifier plusieurs noms de champs, séparez-les par des virgules.
+
+::
+
+    query.geo.fields=location,geo_point,coordinates
+
+Exemples d'implémentation
+======
+
+Implémentation dans une application web
+---------------------------
+
+Exemple d'obtention de la position actuelle avec JavaScript pour effectuer une recherche :
+
+.. code-block:: javascript
+
+    // Obtenir la position actuelle avec l'API Geolocation du navigateur
+    navigator.geolocation.getCurrentPosition(function(position) {
+        const latitude = position.coords.latitude;
+        const longitude = position.coords.longitude;
+        const distance = "5km";
+
+        // Construction de l'URL de recherche
+        const searchUrl = `/search?q=&geo.location.point=${latitude},${longitude}&geo.location.distance=${distance}`;
+
+        // Exécution de la recherche
+        window.location.href = searchUrl;
+    });
+
+Intégration avec Google Maps
+--------------------
+
+Exemple d'affichage des résultats de recherche sous forme de marqueurs sur Google Maps :
+
+.. code-block:: javascript
+
+    // Initialisation de la carte
+    const map = new google.maps.Map(document.getElementById('map'), {
+        center: {lat: 35.681236, lng: 139.767125},
+        zoom: 13
+    });
+
+    // Exécution de la recherche par géolocalisation avec l'API Fess
+    fetch('/json/?q=magasin&geo.location.point=35.681236,139.767125&geo.location.distance=5km')
+        .then(response => response.json())
+        .then(data => {
+            // Affichage des résultats de recherche sous forme de marqueurs
+            data.response.result.forEach(doc => {
+                if (doc.location) {
+                    const [lat, lng] = doc.location.split(',').map(Number);
+                    new google.maps.Marker({
+                        position: {lat: lat, lng: lng},
+                        map: map,
+                        title: doc.title
+                    });
+                }
+            });
+        });
+
+Optimisation des performances
+====================
+
+Optimisation de la configuration de l'index
+------------------------
+
+Lors du traitement de grandes quantités de données de géolocalisation, optimisez la configuration de l'index.
+
+Vérifiez la configuration du champ de géolocalisation dans ``app/WEB-INF/classes/fess_indices/fess.json``.
+
+::
+
+    "location": {
+        "type": "geo_point"
+    }
+
+Limitation de la zone de recherche
+--------------
+
+En tenant compte des performances, il est recommandé de définir la zone de recherche au minimum nécessaire.
+
+- Les recherches sur une large zone (plus de 50 km) peuvent prendre du temps
+- Définissez une zone appropriée en fonction de votre utilisation
+
+Dépannage
+======================
+
+La recherche par géolocalisation ne fonctionne pas
+------------------------
+
+1. Vérifiez que les données sont correctement stockées dans le champ ``location``.
+2. Vérifiez que le format de latitude et longitude est correct (séparé par une virgule).
+3. Vérifiez que ``location`` est défini comme type ``geo_point`` dans le mappage de l'index OpenSearch.
+
+Aucun résultat de recherche n'est renvoyé
+----------------------
+
+1. Vérifiez s'il existe des documents dans la plage de distance spécifiée.
+2. Vérifiez que les valeurs de latitude et longitude sont dans les plages correctes (latitude : -90 à 90, longitude : -180 à 180).
+3. Vérifiez que l'unité de distance est correctement spécifiée.
+
+Les informations de géolocalisation ne s'affichent pas correctement
+----------------------------
+
+1. Vérifiez que le champ ``location`` est correctement défini lors de l'exploration.
+2. Vérifiez que le type de données de latitude et longitude dans la source de données est numérique.
+3. Si vous définissez des informations de géolocalisation via un script, vérifiez que le format de concaténation de chaînes est correct.
+
+Informations de référence
+========
+
+Pour plus de détails sur la recherche par géolocalisation, consultez les ressources suivantes :
+
+- `OpenSearch Geo Queries <https://opensearch.org/docs/latest/query-dsl/geo-and-xy/index/>`_
+- `OpenSearch Geo Point <https://opensearch.org/docs/latest/field-types/supported-field-types/geo-point/>`_
+- `API de géolocalisation (MDN) <https://developer.mozilla.org/ja/docs/Web/API/Geolocation_API>`_

--- a/fr/15.3/config/search-scroll.rst
+++ b/fr/15.3/config/search-scroll.rst
@@ -1,0 +1,386 @@
+==================
+Récupération en masse des résultats de recherche
+==================
+
+Aperçu
+====
+
+La recherche normale de |Fess| affiche uniquement un nombre limité de résultats de recherche grâce à la fonction de pagination.
+Si vous souhaitez récupérer tous les résultats de recherche en une seule fois, utilisez la fonction de recherche par défilement (Scroll Search).
+
+Cette fonction est utile lorsque vous devez traiter tous les résultats de recherche,
+comme pour l'export de données en masse, les sauvegardes ou l'analyse de grandes quantités de données.
+
+Cas d'utilisation
+============
+
+La recherche par défilement est adaptée aux utilisations suivantes :
+
+- Export de tous les résultats de recherche
+- Récupération de grandes quantités de données pour l'analyse de données
+- Récupération de données dans des traitements par lots
+- Synchronisation de données vers des systèmes externes
+- Collecte de données pour la génération de rapports
+
+.. warning::
+   La recherche par défilement renvoie de grandes quantités de données et consomme donc
+   plus de ressources serveur que la recherche normale. Activez-la uniquement si nécessaire.
+
+Méthode de configuration
+========
+
+Activation de la recherche par défilement
+----------------------
+
+Par défaut, la recherche par défilement est désactivée pour des raisons de sécurité et de performances.
+Pour l'activer, modifiez le paramètre suivant dans ``fess_config.properties`` ou ``/etc/fess/fess_config.properties``.
+
+::
+
+    api.search.scroll=true
+
+.. note::
+   Après avoir modifié les paramètres, vous devez redémarrer |Fess|.
+
+Configuration des champs de réponse
+--------------------------
+
+Vous pouvez personnaliser les champs inclus dans la réponse des résultats de recherche.
+Par défaut, seuls les champs de base sont renvoyés, mais vous pouvez spécifier des champs supplémentaires.
+
+::
+
+    query.additional.scroll.response.fields=content,mimetype,filename,created,last_modified
+
+Pour spécifier plusieurs champs, énumérez-les séparés par des virgules.
+
+Configuration du délai d'expiration du défilement
+----------------------------
+
+Vous pouvez configurer la durée de validité du contexte de défilement.
+La valeur par défaut est de 1 minute.
+
+::
+
+    api.search.scroll.timeout=1m
+
+Unités :
+- ``s`` : secondes
+- ``m`` : minutes
+- ``h`` : heures
+
+Méthode d'utilisation
+========
+
+Utilisation de base
+----------------
+
+L'accès à la recherche par défilement s'effectue via l'URL suivante.
+
+::
+
+    http://localhost:8080/json/scroll?q=mot-clé
+
+Les résultats de recherche sont renvoyés au format NDJSON (Newline Delimited JSON).
+Chaque ligne contient un document au format JSON.
+
+**Exemple :**
+
+::
+
+    curl "http://localhost:8080/json/scroll?q=Fess"
+
+Paramètres de requête
+--------------------
+
+Les paramètres suivants peuvent être utilisés pour la recherche par défilement.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Nom du paramètre
+     - Description
+   * - ``q``
+     - Requête de recherche (obligatoire)
+   * - ``size``
+     - Nombre d'éléments à récupérer par défilement (par défaut : 100)
+   * - ``scroll``
+     - Durée de validité du contexte de défilement (par défaut : 1m)
+   * - ``fields.label``
+     - Filtrage par étiquette
+
+Spécification de la requête de recherche
+----------------
+
+Vous pouvez spécifier une requête de recherche comme dans une recherche normale.
+
+**Exemple : Recherche par mot-clé**
+
+::
+
+    curl "http://localhost:8080/json/scroll?q=moteur de recherche"
+
+**Exemple : Recherche par champ spécifique**
+
+::
+
+    curl "http://localhost:8080/json/scroll?q=title:Fess"
+
+**Exemple : Récupération de tous les éléments (sans condition de recherche)**
+
+::
+
+    curl "http://localhost:8080/json/scroll?q=*:*"
+
+Spécification du nombre d'éléments à récupérer
+--------------
+
+Vous pouvez modifier le nombre d'éléments récupérés par défilement.
+
+::
+
+    curl "http://localhost:8080/json/scroll?q=Fess&size=500"
+
+.. note::
+   Si le paramètre ``size`` est trop élevé, l'utilisation de la mémoire augmente.
+   Il est généralement recommandé de le définir dans la plage de 100 à 1000.
+
+Filtrage par étiquette
+--------------------------
+
+Vous pouvez récupérer uniquement les documents appartenant à une étiquette spécifique.
+
+::
+
+    curl "http://localhost:8080/json/scroll?q=*:*&fields.label=public"
+
+En cas d'authentification requise
+----------------
+
+Si vous utilisez la recherche basée sur les rôles, vous devez inclure des informations d'authentification.
+
+::
+
+    curl -u username:password "http://localhost:8080/json/scroll?q=Fess"
+
+Ou en utilisant un jeton API :
+
+::
+
+    curl -H "Authorization: Bearer YOUR_API_TOKEN" \
+         "http://localhost:8080/json/scroll?q=Fess"
+
+Format de réponse
+==============
+
+Format NDJSON
+----------
+
+La réponse de la recherche par défilement est renvoyée au format NDJSON (Newline Delimited JSON).
+Chaque ligne représente un document.
+
+**Exemple :**
+
+::
+
+    {"url":"http://example.com/page1","title":"Page 1","content":"..."}
+    {"url":"http://example.com/page2","title":"Page 2","content":"..."}
+    {"url":"http://example.com/page3","title":"Page 3","content":"..."}
+
+Champs de réponse
+--------------------
+
+Principaux champs inclus par défaut :
+
+- ``url`` : URL du document
+- ``title`` : Titre
+- ``content`` : Corps du texte (extrait)
+- ``score`` : Score de recherche
+- ``boost`` : Valeur de boost
+- ``created`` : Date de création
+- ``last_modified`` : Date de dernière modification
+
+Exemples de traitement de données
+============
+
+Exemple de traitement en Python
+----------------
+
+.. code-block:: python
+
+    import requests
+    import json
+
+    # Exécution de la recherche par défilement
+    url = "http://localhost:8080/json/scroll"
+    params = {
+        "q": "Fess",
+        "size": 100
+    }
+
+    response = requests.get(url, params=params, stream=True)
+
+    # Traitement de la réponse NDJSON ligne par ligne
+    for line in response.iter_lines():
+        if line:
+            doc = json.loads(line)
+            print(f"Title: {doc.get('title')}")
+            print(f"URL: {doc.get('url')}")
+            print("---")
+
+Enregistrement dans un fichier
+----------------
+
+Exemple d'enregistrement des résultats de recherche dans un fichier :
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/json/scroll?q=*:*" > all_documents.ndjson
+
+Conversion en CSV
+-----------
+
+Exemple de conversion en CSV à l'aide de la commande jq :
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/json/scroll?q=Fess" | \
+        jq -r '[.url, .title, .score] | @csv' > results.csv
+
+Analyse de données
+----------
+
+Exemple d'analyse des données récupérées :
+
+.. code-block:: python
+
+    import json
+    import pandas as pd
+    from collections import Counter
+
+    # Lecture du fichier NDJSON
+    documents = []
+    with open('all_documents.ndjson', 'r') as f:
+        for line in f:
+            documents.append(json.loads(line))
+
+    # Conversion en DataFrame
+    df = pd.DataFrame(documents)
+
+    # Statistiques de base
+    print(f"Total documents: {len(df)}")
+    print(f"Average score: {df['score'].mean()}")
+
+    # Analyse des domaines des URL
+    df['domain'] = df['url'].apply(lambda x: x.split('/')[2])
+    print(df['domain'].value_counts())
+
+Performances et meilleures pratiques
+==================================
+
+Méthodes d'utilisation efficaces
+----------------
+
+1. **Configuration appropriée du paramètre size**
+
+   - Une valeur trop petite augmente la surcharge de communication
+   - Une valeur trop grande augmente l'utilisation de la mémoire
+   - Recommandé : 100 à 1000
+
+2. **Optimisation des conditions de recherche**
+
+   - Spécifiez des conditions de recherche pour ne récupérer que les documents nécessaires
+   - N'effectuez la récupération complète que si vraiment nécessaire
+
+3. **Utilisation en heures creuses**
+
+   - Exécutez la récupération de grandes quantités de données pendant les périodes de faible charge système
+
+4. **Utilisation dans des traitements par lots**
+
+   - Exécutez la synchronisation régulière de données en tant que tâches par lots
+
+Optimisation de l'utilisation de la mémoire
+--------------------
+
+Lors du traitement de grandes quantités de données, utilisez le traitement en streaming pour réduire l'utilisation de la mémoire.
+
+.. code-block:: python
+
+    import requests
+    import json
+
+    url = "http://localhost:8080/json/scroll"
+    params = {"q": "*:*", "size": 100}
+
+    # Traitement en streaming
+    with requests.get(url, params=params, stream=True) as response:
+        for line in response.iter_lines(decode_unicode=True):
+            if line:
+                doc = json.loads(line)
+                # Traitement du document
+                process_document(doc)
+
+Considérations de sécurité
+====================
+
+Restrictions d'accès
+------------
+
+Étant donné que la recherche par défilement renvoie de grandes quantités de données, veuillez configurer des restrictions d'accès appropriées.
+
+1. **Restriction par adresse IP**
+
+   Autoriser l'accès uniquement à partir d'adresses IP spécifiques
+
+2. **Authentification API**
+
+   Utiliser des jetons API ou l'authentification Basic
+
+3. **Restriction basée sur les rôles**
+
+   Autoriser l'accès uniquement aux utilisateurs ayant des rôles spécifiques
+
+Limitation de débit
+----------
+
+Pour éviter les accès excessifs, il est recommandé de configurer une limitation de débit sur le proxy inverse.
+
+Dépannage
+======================
+
+La recherche par défilement n'est pas disponible
+----------------------------
+
+1. Vérifiez que ``api.search.scroll`` est défini sur ``true``.
+2. Vérifiez que vous avez redémarré |Fess|.
+3. Consultez les journaux d'erreurs.
+
+Une erreur de délai d'expiration se produit
+----------------------------
+
+1. Augmentez la valeur de ``api.search.scroll.timeout``.
+2. Réduisez le paramètre ``size`` pour répartir le traitement.
+3. Affinez les conditions de recherche pour réduire la quantité de données récupérées.
+
+Erreur de mémoire insuffisante
+----------------
+
+1. Réduisez le paramètre ``size``.
+2. Augmentez la taille de la mémoire heap de |Fess|.
+3. Vérifiez la taille de la mémoire heap d'OpenSearch.
+
+La réponse est vide
+--------------------
+
+1. Vérifiez que la requête de recherche est correcte.
+2. Vérifiez que l'étiquette ou les conditions de filtre spécifiées sont correctes.
+3. Vérifiez les paramètres de permission de recherche basée sur les rôles.
+
+Informations de référence
+========
+
+- :doc:`search` - Détails de la fonction de recherche
+- :doc:`search-config` - Paramètres liés à la recherche
+- `API Scroll d'OpenSearch <https://opensearch.org/docs/latest/api-reference/scroll/>`_

--- a/fr/15.3/config/security-role.rst
+++ b/fr/15.3/config/security-role.rst
@@ -1,0 +1,54 @@
+=================================
+Configuration de la recherche basée sur les rôles
+=================================
+
+À propos de la recherche basée sur les rôles
+==================
+
+|Fess| permet de différencier les résultats de recherche en fonction des informations d'authentification des utilisateurs authentifiés par un système d'authentification arbitraire.
+Par exemple, l'utilisateur A avec le rôle a verra les informations du rôle a dans les résultats de recherche, mais l'utilisateur B sans le rôle a ne les verra pas même en effectuant une recherche.
+En utilisant cette fonctionnalité, il est possible de réaliser des recherches par département ou par poste pour les utilisateurs connectés dans un portail ou un environnement d'authentification unique.
+
+La recherche basée sur les rôles de |Fess| peut obtenir les informations de rôle à partir de :
+
+-  Paramètres de requête
+
+-  En-têtes de requête
+
+-  Cookies
+
+-  Informations d'authentification de |Fess|
+
+Dans les portails et les systèmes d'authentification unique de type agent, les informations de rôle peuvent être obtenues en stockant les informations d'authentification dans les cookies pour le domaine et le chemin où |Fess| fonctionne lors de l'authentification.
+De plus, dans les systèmes d'authentification unique de type proxy inverse, les informations de rôle peuvent être obtenues en ajoutant les informations d'authentification aux paramètres de requête ou aux en-têtes de requête lors de l'accès à |Fess|.
+
+Configuration de la recherche basée sur les rôles
+=================
+
+Cette section explique comment configurer la recherche basée sur les rôles en utilisant les informations d'authentification de |Fess|.
+
+Configuration dans l'interface d'administration de |Fess|
+---------------------
+
+Démarrez |Fess| et connectez-vous en tant qu'administrateur.
+Créez des rôles et des utilisateurs.
+Par exemple, créez Role1 dans l'écran de gestion des rôles et créez un utilisateur appartenant à Role1 dans l'écran de gestion des utilisateurs.
+Ensuite, dans la configuration de l'exploration, saisissez {role}Role1 dans le champ de permission et enregistrez.
+Pour spécifier par utilisateur, vous pouvez écrire {user}nom_utilisateur, et pour spécifier par groupe, vous pouvez écrire {group}nom_groupe.
+Ensuite, en effectuant une exploration avec cette configuration, un index consultable uniquement par les utilisateurs créés sera créé.
+
+Connexion
+------
+
+Déconnectez-vous de l'interface d'administration.
+Connectez-vous avec un utilisateur appartenant à Role1.
+En cas de succès de la connexion, vous serez redirigé vers la page d'accueil de recherche.
+
+En effectuant une recherche normale, seuls les éléments configurés avec le rôle Role1 dans la configuration de l'exploration seront affichés.
+
+De plus, une recherche sans être connecté sera effectuée en tant qu'utilisateur invité.
+
+Déconnexion
+--------
+
+En sélectionnant la déconnexion sur l'écran de recherche alors que vous êtes connecté avec un utilisateur autre que l'administrateur, vous serez déconnecté.

--- a/fr/15.3/config/security-virtual-host.rst
+++ b/fr/15.3/config/security-virtual-host.rst
@@ -1,0 +1,53 @@
+========
+Hôtes virtuels
+========
+
+À propos des hôtes virtuels
+==============
+
+|Fess| peut différencier les résultats de recherche en fonction du nom d'hôte (partie hôte de l'URL) lors de l'accès.
+Comme les résultats de recherche sont affichés dans leurs JSP respectifs, il est également possible de modifier le design.
+
+Configuration système
+----------
+
+Configurez « Hôte virtuel » dans :doc:`Guide administrateur > Configuration générale <../admin/general-guide>`. Spécifiez le nom d'hôte virtuel configuré ici dans la configuration de l'exploration.
+
+**Format**
+
+::
+
+   Host:nom_hôte[:numéro_port]=nom_hôte_virtuel
+
+.. list-table::
+
+   * - *nom_hôte*
+     - Nom d'hôte ou adresse IP résolvable (DNS) par le système
+   * - *numéro_port*
+     - Optionnel. Par défaut 80.
+   * - *nom_hôte_virtuel*
+     - Nom d'hôte virtuel à spécifier dans la configuration de l'exploration
+
+**Exemple**
+
+::
+
+   Host:abc.example.com:8080=host1
+   Host:192.168.1.123:8080=host2
+
+Une fois la configuration effectuée, les JSP de la page de recherche sont générés dans ``WEB-INF/view/nom_hôte_virtuel``.
+En les modifiant, il est également possible de changer le design de la page pour chaque hôte virtuel.
+
+
+Configuration de l'exploration
+---------
+
+Spécifiez « Hôte virtuel » dans l'une des configurations suivantes : configuration de l'exploration Web, configuration de l'exploration de fichiers ou configuration de l'exploration de banques de données.
+« Hôte virtuel » spécifie l'un des noms d'hôtes virtuels configurés dans la configuration système.
+
+**Exemple**
+
+.. list-table::
+
+   * - *Hôte virtuel*
+     - ``host1``

--- a/fr/15.3/config/setup-memory.rst
+++ b/fr/15.3/config/setup-memory.rst
@@ -1,0 +1,413 @@
+==================
+Configuration de la mémoire
+==================
+
+Vue d'ensemble
+====
+
+Pour les applications Java, il est nécessaire de configurer la mémoire heap maximale utilisée par chaque processus.
+Dans |Fess|, les paramètres de mémoire sont configurés pour les trois composants suivants.
+
+- Application web Fess
+- Processus de crawl
+- OpenSearch
+
+Une configuration mémoire appropriée permet d'améliorer les performances et d'assurer un fonctionnement stable.
+
+Configuration de la mémoire de l'application web Fess
+======================================
+
+Quand configurer
+----------------
+
+Envisagez d'ajuster la taille de la mémoire dans les cas suivants.
+
+- Les erreurs OutOfMemory sont enregistrées dans ``fess.log``
+- Vous devez traiter un grand nombre d'accès simultanés
+- Les opérations de l'interface d'administration sont lentes ou expirent
+
+La taille de mémoire par défaut est suffisante pour une utilisation générale, mais une augmentation est nécessaire dans les environnements à forte charge.
+
+Configuration par variable d'environnement
+------------------
+
+Définissez la variable d'environnement ``FESS_HEAP_SIZE``.
+
+::
+
+    export FESS_HEAP_SIZE=2g
+
+Unités :
+
+- ``m`` : mégaoctets
+- ``g`` : gigaoctets
+
+Pour les packages RPM/DEB
+------------------------
+
+Si vous avez installé avec le package RPM, éditez ``/etc/sysconfig/fess``.
+
+::
+
+    FESS_HEAP_SIZE=2g
+
+Pour le package DEB, éditez ``/etc/default/fess``.
+
+::
+
+    FESS_HEAP_SIZE=2g
+
+.. warning::
+   Après avoir modifié la taille de la mémoire, vous devez redémarrer le service |Fess|.
+
+Tailles de mémoire recommandées
+----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Environnement
+     - Taille heap recommandée
+     - Remarques
+   * - Environnement de développement/test
+     - 512m〜1g
+     - Index de petite taille
+   * - Environnement de production à petite échelle
+     - 1g〜2g
+     - Dizaines à centaines de milliers de documents
+   * - Environnement de production à moyenne échelle
+     - 2g〜4g
+     - Centaines de milliers à millions de documents
+   * - Environnement de production à grande échelle
+     - 4g〜8g
+     - Plusieurs millions de documents et plus
+
+Configuration de la mémoire du crawler
+======================
+
+Quand configurer
+----------------
+
+Vous devez augmenter la taille de mémoire du crawler dans les cas suivants.
+
+- Lorsque vous augmentez le nombre de crawls parallèles
+- Lors du crawl de fichiers volumineux
+- Lorsque des erreurs OutOfMemory se produisent pendant l'exécution du crawl
+
+Méthode de configuration
+--------
+
+Éditez ``app/WEB-INF/classes/fess_config.properties`` ou ``/etc/fess/fess_config.properties``.
+
+::
+
+    jvm.crawler.options=-Xmx512m
+
+Par exemple, pour passer à 1 Go :
+
+::
+
+    jvm.crawler.options=-Xmx1g
+
+.. note::
+   Ce paramètre est appliqué par processus de crawl (par tâche du planificateur).
+   Si vous exécutez plusieurs tâches de crawl simultanément, chaque tâche utilisera la mémoire spécifiée.
+
+Paramètres recommandés
+--------
+
+- **Crawl web normal** : 512m〜1g
+- **Crawl parallèle intensif** : 1g〜2g
+- **Crawl de fichiers volumineux** : 2g〜4g
+
+Options JVM détaillées
+------------------
+
+Les options JVM détaillées pour le crawler peuvent être configurées avec ``jvm.crawler.options``.
+Les paramètres par défaut incluent les optimisations suivantes.
+
+**Options principales :**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Option
+     - Description
+   * - ``-Xms128m -Xmx512m``
+     - Taille heap initiale et maximale
+   * - ``-XX:MaxMetaspaceSize=128m``
+     - Taille maximale du Metaspace
+   * - ``-XX:+UseG1GC``
+     - Utilisation du collecteur de déchets G1
+   * - ``-XX:MaxGCPauseMillis=60000``
+     - Temps d'arrêt GC cible (60 secondes)
+   * - ``-XX:-HeapDumpOnOutOfMemoryError``
+     - Désactivation du dump heap lors d'OutOfMemory
+
+Configuration de la mémoire OpenSearch
+=======================
+
+Considérations importantes
+--------------
+
+Pour OpenSearch, vous devez configurer la mémoire en tenant compte des deux points suivants.
+
+1. **Mémoire heap Java** : Utilisée par le processus OpenSearch
+2. **Cache du système de fichiers OS** : Important pour les performances de recherche
+
+.. warning::
+   Si vous augmentez trop la mémoire heap Java, la mémoire disponible pour
+   le cache du système de fichiers OS diminue, ce qui peut dégrader les performances de recherche.
+
+Méthode de configuration
+--------
+
+Environnement Linux
+~~~~~~~~~
+
+La mémoire heap OpenSearch est spécifiée via une variable d'environnement ou le fichier de configuration OpenSearch.
+
+Configuration par variable d'environnement :
+
+::
+
+    export OPENSEARCH_HEAP_SIZE=2g
+
+Ou éditez ``config/jvm.options`` :
+
+::
+
+    -Xms2g
+    -Xmx2g
+
+.. note::
+   Il est recommandé de définir la taille heap minimale (``-Xms``) et maximale (``-Xmx``) à la même valeur.
+
+Environnement Windows
+~~~~~~~~~~~
+
+Éditez le fichier ``config\jvm.options``.
+
+::
+
+    -Xms2g
+    -Xmx2g
+
+Tailles de mémoire recommandées
+----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Taille de l'index
+     - Taille heap recommandée
+     - Mémoire totale recommandée
+   * - 〜10GB
+     - 2g
+     - 4 Go ou plus
+   * - 10GB〜50GB
+     - 4g
+     - 8 Go ou plus
+   * - 50GB〜100GB
+     - 8g
+     - 16 Go ou plus
+   * - 100 Go et plus
+     - 16g〜31g
+     - 32 Go ou plus
+
+.. warning::
+   Ne configurez pas la mémoire heap OpenSearch au-delà de 32 Go.
+   Au-delà de 32 Go, Compressed OOP est désactivé, ce qui réduit l'efficacité de la mémoire.
+
+Bonnes pratiques
+------------------
+
+1. **Allouer 50% de la mémoire physique au heap**
+
+   Allouez environ 50% de la mémoire physique du serveur au heap OpenSearch.
+   Le reste est utilisé pour l'OS et le cache du système de fichiers.
+
+2. **Maximum 31 Go**
+
+   La taille heap doit être limitée à 31 Go maximum. Si vous avez besoin de plus, augmentez le nombre de nœuds.
+
+3. **Vérification en production**
+
+   Consultez la documentation officielle OpenSearch pour optimiser la configuration selon votre environnement.
+
+Configuration de la mémoire pour les processus de suggestion et de miniature
+======================================
+
+Processus de génération de suggestions
+----------------------
+
+Les paramètres de mémoire pour le processus de génération de suggestions sont configurés avec ``jvm.suggest.options``.
+
+::
+
+    jvm.suggest.options=-Xmx256m
+
+Par défaut, les paramètres suivants sont utilisés :
+
+- Heap initial : 128 Mo
+- Heap maximal : 256 Mo
+- Metaspace maximal : 128 Mo
+
+Processus de génération de miniatures
+----------------------
+
+Les paramètres de mémoire pour le processus de génération de miniatures sont configurés avec ``jvm.thumbnail.options``.
+
+::
+
+    jvm.thumbnail.options=-Xmx256m
+
+Par défaut, les paramètres suivants sont utilisés :
+
+- Heap initial : 128 Mo
+- Heap maximal : 256 Mo
+- Metaspace maximal : 128 Mo
+
+.. note::
+   Si vous traitez de grandes images lors de la génération de miniatures, vous devrez augmenter la mémoire.
+
+Surveillance et optimisation de la mémoire
+========================
+
+Vérification de l'utilisation de la mémoire
+--------------------
+
+Utilisation de la mémoire Fess
+~~~~~~~~~~~~~~~~~~~~~
+
+Vous pouvez vérifier dans « Informations système » de l'interface d'administration.
+
+Ou utilisez les outils de surveillance JVM :
+
+::
+
+    jps -l  # Vérifier le processus Fess
+    jstat -gcutil <PID> 1000  # Afficher les statistiques GC toutes les secondes
+
+Utilisation de la mémoire OpenSearch
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    curl -X GET "localhost:9201/_nodes/stats/jvm?pretty"
+    curl -X GET "localhost:9201/_cat/nodes?v&h=heap.percent,ram.percent"
+
+Signes de manque de mémoire
+----------------
+
+Si les symptômes suivants apparaissent, il peut y avoir un manque de mémoire.
+
+**Application web Fess :**
+
+- Réponses lentes
+- ``OutOfMemoryError`` enregistré dans les journaux
+- Arrêt inattendu du processus
+
+**Crawler :**
+
+- Le crawl s'arrête en cours d'exécution
+- ``OutOfMemoryError`` enregistré dans ``fess_crawler.log``
+- Échec du crawl de fichiers volumineux
+
+**OpenSearch :**
+
+- Recherche lente
+- Création d'index lente
+- Erreurs ``circuit_breaker_exception``
+
+Procédure d'optimisation
+----------------
+
+1. **Vérifier l'utilisation actuelle de la mémoire**
+
+   Surveillez l'utilisation de la mémoire de chaque composant.
+
+2. **Identifier les goulots d'étranglement**
+
+   Identifiez quel composant manque de mémoire.
+
+3. **Augmenter progressivement**
+
+   N'augmentez pas de manière excessive en une fois, augmentez de 25-50% et vérifiez l'effet.
+
+4. **Considérer l'équilibre global du système**
+
+   Assurez-vous que la mémoire totale de tous les composants ne dépasse pas la mémoire physique.
+
+5. **Surveillance continue**
+
+   Surveillez en continu l'utilisation de la mémoire et ajustez si nécessaire.
+
+Prévention des fuites mémoire
+----------------
+
+En cas de suspicion de fuite mémoire :
+
+1. **Obtenir un dump heap**
+
+::
+
+    jmap -dump:format=b,file=heap.bin <PID>
+
+2. **Analyser le dump heap**
+
+   Analysez avec des outils comme Eclipse Memory Analyzer (MAT).
+
+3. **Signaler le problème**
+
+   Si vous découvrez une fuite mémoire, signalez-la sur GitHub Issues.
+
+Dépannage
+======================
+
+OutOfMemoryError se produit
+---------------------------
+
+**Application web Fess :**
+
+1. Augmentez ``FESS_HEAP_SIZE``.
+2. Limitez le nombre d'accès simultanés.
+3. Réduisez le niveau de journalisation pour diminuer l'utilisation de la mémoire par les journaux.
+
+**Crawler :**
+
+1. Augmentez ``-Xmx`` dans ``jvm.crawler.options``.
+2. Réduisez le nombre de crawls parallèles.
+3. Ajustez la configuration du crawl pour exclure les fichiers volumineux.
+
+**OpenSearch :**
+
+1. Augmentez la taille heap (jusqu'à 31 Go maximum).
+2. Revoyez le nombre de shards de l'index.
+3. Vérifiez la complexité des requêtes.
+
+Temps d'arrêt GC prolongé
+----------------------
+
+1. Ajustez les paramètres G1GC.
+2. Configurez correctement la taille heap (un GC fréquent se produit si elle est trop grande ou trop petite).
+3. Envisagez de mettre à jour vers une version Java plus récente.
+
+Les performances ne s'améliorent pas après la configuration de la mémoire
+------------------------------
+
+1. Vérifiez d'autres ressources comme le CPU, les E/S disque et le réseau.
+2. Optimisez l'index.
+3. Revoyez les paramètres de requête et de crawl.
+
+Informations de référence
+========
+
+- :doc:`setup-port-network` - Configuration du port et du réseau
+- :doc:`crawler-advanced` - Configuration avancée du crawler
+- :doc:`admin-logging` - Configuration des journaux
+- `OpenSearch Memory Settings <https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/#important-settings>`_
+- `Java GC Tuning <https://docs.oracle.com/en/java/javase/11/gctuning/>`_

--- a/fr/15.3/config/setup-port-network.rst
+++ b/fr/15.3/config/setup-port-network.rst
@@ -1,0 +1,397 @@
+======================
+Configuration du port et du réseau
+======================
+
+Vue d'ensemble
+====
+
+Cette section décrit les paramètres liés au réseau de |Fess|.
+Elle couvre les paramètres relatifs aux connexions réseau, tels que la modification des numéros de port, la configuration du proxy et les paramètres de communication HTTP.
+
+Configuration des ports utilisés
+================
+
+Ports par défaut
+----------------
+
+|Fess| utilise les ports suivants par défaut.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Service
+     - Numéro de port
+   * - Application web Fess
+     - 8080
+   * - OpenSearch (HTTP)
+     - 9201
+   * - OpenSearch (Transport)
+     - 9301
+
+Modification du port de l'application web Fess
+--------------------------------------
+
+Configuration sous Linux
+~~~~~~~~~~~~~~~~~
+
+Pour modifier le numéro de port sous Linux, éditez ``bin/fess.in.sh``.
+
+::
+
+    FESS_JAVA_OPTS="$FESS_JAVA_OPTS -Dfess.port=8080"
+
+Par exemple, pour utiliser le port 80 :
+
+::
+
+    FESS_JAVA_OPTS="$FESS_JAVA_OPTS -Dfess.port=80"
+
+.. note::
+   Pour utiliser un numéro de port inférieur ou égal à 1024, vous devez disposer des privilèges root ou d'une configuration de privilèges appropriée (CAP_NET_BIND_SERVICE).
+
+Configuration par variable d'environnement
+~~~~~~~~~~~~~~~~~~
+
+Vous pouvez également spécifier le numéro de port via une variable d'environnement.
+
+::
+
+    export FESS_PORT=8080
+
+Pour les packages RPM/DEB
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pour le package RPM, éditez ``/etc/sysconfig/fess``, et pour le package DEB, éditez ``/etc/default/fess``.
+
+::
+
+    FESS_PORT=8080
+
+Configuration sous Windows
+~~~~~~~~~~~~~~~~~~~
+
+Sous Windows, éditez ``bin\fess.in.bat``.
+
+::
+
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.port=8080
+
+Lors de l'enregistrement en tant que service Windows
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Lorsque vous utilisez un enregistrement en tant que service sous Windows, modifiez également les paramètres de port dans ``bin\service.bat``.
+Consultez :doc:`setup-windows-service` pour plus de détails.
+
+Configuration du chemin de contexte
+----------------------
+
+Si vous publiez |Fess| dans un sous-répertoire, vous pouvez configurer le chemin de contexte.
+
+::
+
+    FESS_JAVA_OPTS="$FESS_JAVA_OPTS -Dfess.context.path=/search"
+
+Avec cette configuration, vous pourrez accéder à ``http://localhost:8080/search/``.
+
+.. warning::
+   Si vous modifiez le chemin de contexte, vous devez également configurer correctement le chemin des fichiers statiques.
+
+Configuration du proxy
+============
+
+Vue d'ensemble
+----
+
+Lors du crawl de sites externes depuis un intranet ou de l'accès à des API externes,
+les communications peuvent être bloquées par un pare-feu.
+Dans de tels environnements, il est nécessaire de configurer la communication via un serveur proxy.
+
+Configuration du proxy pour le crawler
+--------------------------
+
+Configuration de base
+~~~~~~~~
+
+Dans l'interface d'administration, spécifiez dans les paramètres de configuration du crawl comme suit.
+
+::
+
+    client.proxyHost=proxy.example.com
+    client.proxyPort=8080
+
+Configuration d'un proxy avec authentification
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Si le serveur proxy nécessite une authentification, ajoutez ce qui suit.
+
+::
+
+    client.proxyHost=proxy.example.com
+    client.proxyPort=8080
+    client.proxyUsername=proxyuser
+    client.proxyPassword=proxypass
+
+Exclusion d'hôtes spécifiques du proxy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pour se connecter à des hôtes spécifiques (comme des serveurs intranet) sans passer par le proxy :
+
+::
+
+    client.proxyHost=proxy.example.com
+    client.proxyPort=8080
+    client.nonProxyHosts=localhost|*.local|192.168.*
+
+Configuration du proxy HTTP à l'échelle du système
+------------------------------
+
+Pour utiliser un proxy HTTP pour l'ensemble de l'application |Fess|, configurez dans ``fess_config.properties``.
+
+::
+
+    http.proxy.host=proxy.example.com
+    http.proxy.port=8080
+    http.proxy.username=proxyuser
+    http.proxy.password=proxypass
+
+.. warning::
+   Les mots de passe sont stockés sans chiffrement. Configurez les permissions de fichier appropriées.
+
+Configuration de la communication HTTP
+============
+
+Limitation du téléchargement de fichiers
+--------------------------
+
+Vous pouvez limiter la taille des fichiers téléchargés depuis l'interface d'administration.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Élément de configuration
+     - Description
+   * - ``http.fileupload.max.size``
+     - Taille maximale de téléchargement de fichier (par défaut : 262144000 octets = 250 Mo)
+   * - ``http.fileupload.threshold.size``
+     - Taille de seuil pour la conservation en mémoire (par défaut : 262144 octets = 256 Ko)
+   * - ``http.fileupload.max.file.count``
+     - Nombre de fichiers pouvant être téléchargés en une fois (par défaut : 10)
+
+Exemple de configuration dans ``fess_config.properties`` :
+
+::
+
+    http.fileupload.max.size=524288000
+    http.fileupload.threshold.size=524288
+    http.fileupload.max.file.count=20
+
+Configuration du délai de connexion
+--------------------
+
+Vous pouvez configurer le délai de connexion à OpenSearch.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Élément de configuration
+     - Description
+   * - ``search_engine.http.url``
+     - URL d'OpenSearch (par défaut : http://localhost:9201)
+   * - ``search_engine.heartbeat_interval``
+     - Intervalle de vérification de santé (millisecondes, par défaut : 10000)
+
+Modification de la destination de connexion OpenSearch
+----------------------
+
+Pour se connecter à un cluster OpenSearch externe :
+
+::
+
+    search_engine.http.url=http://opensearch-cluster.example.com:9200
+
+Connexion à plusieurs nœuds
+~~~~~~~~~~~~~~~~~~
+
+Pour se connecter à plusieurs nœuds OpenSearch, spécifiez-les séparés par des virgules.
+
+::
+
+    search_engine.http.url=http://node1:9200,http://node2:9200,http://node3:9200
+
+Configuration de la connexion SSL/TLS
+-----------------
+
+Pour se connecter à OpenSearch via HTTPS :
+
+::
+
+    search_engine.http.url=https://opensearch.example.com:9200
+    search_engine.http.ssl.certificate_authorities=/path/to/ca.crt
+    search_engine.username=admin
+    search_engine.password=admin_password
+
+.. note::
+   Pour effectuer la vérification du certificat, spécifiez le chemin du certificat CA dans ``certificate_authorities``.
+
+Configuration de l'hôte virtuel
+==============
+
+Vue d'ensemble
+----
+
+Vous pouvez différencier les résultats de recherche en fonction du nom d'hôte utilisé pour accéder à |Fess|.
+Consultez :doc:`security-virtual-host` pour plus de détails.
+
+Configuration de base
+--------
+
+Configurez l'en-tête de l'hôte virtuel dans ``fess_config.properties``.
+
+::
+
+    virtual.host.headers=X-Forwarded-Host,Host
+
+Intégration avec un reverse proxy
+========================
+
+Exemple de configuration Nginx
+--------------
+
+::
+
+    server {
+        listen 80;
+        server_name search.example.com;
+
+        location / {
+            proxy_pass http://localhost:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+        }
+    }
+
+Exemple de configuration Apache
+---------------
+
+::
+
+    <VirtualHost *:80>
+        ServerName search.example.com
+
+        ProxyPreserveHost On
+        ProxyPass / http://localhost:8080/
+        ProxyPassReverse / http://localhost:8080/
+
+        RequestHeader set X-Forwarded-Proto "http"
+        RequestHeader set X-Forwarded-Host "search.example.com"
+    </VirtualHost>
+
+Terminaison SSL/TLS
+-----------
+
+Exemple de configuration pour la terminaison SSL/TLS sur le reverse proxy (Nginx) :
+
+::
+
+    server {
+        listen 443 ssl http2;
+        server_name search.example.com;
+
+        ssl_certificate /path/to/cert.pem;
+        ssl_certificate_key /path/to/key.pem;
+
+        location / {
+            proxy_pass http://localhost:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Host $host;
+        }
+    }
+
+Configuration du pare-feu
+====================
+
+Ouverture des ports nécessaires
+------------------
+
+Pour rendre |Fess| accessible depuis l'extérieur, ouvrez les ports suivants.
+
+**Exemple de configuration iptables :**
+
+::
+
+    # Application web Fess
+    iptables -A INPUT -p tcp --dport 8080 -j ACCEPT
+
+    # Pour accès HTTPS (via reverse proxy)
+    iptables -A INPUT -p tcp --dport 443 -j ACCEPT
+
+**Exemple de configuration firewalld :**
+
+::
+
+    # Application web Fess
+    firewall-cmd --permanent --add-port=8080/tcp
+    firewall-cmd --reload
+
+Configuration du groupe de sécurité (environnements cloud)
+------------------------------------------
+
+Dans les environnements cloud comme AWS, GCP ou Azure, ouvrez les ports appropriés
+avec les groupes de sécurité ou les ACL réseau.
+
+Configuration recommandée :
+- Entrant : ports 80/443 (via reverse proxy HTTP)
+- Restreindre l'accès au port 8080 uniquement depuis l'interne
+- Restreindre l'accès aux ports 9201/9301 d'OpenSearch uniquement depuis l'interne
+
+Dépannage
+======================
+
+Impossible d'accéder après modification du port
+------------------------------
+
+1. Vérifiez si vous avez redémarré |Fess|.
+2. Vérifiez si le port correspondant est ouvert dans le pare-feu.
+3. Vérifiez les erreurs dans le fichier journal (``fess.log``).
+
+Impossible de crawler via le proxy
+------------------------------
+
+1. Vérifiez si le nom d'hôte et le port du serveur proxy sont corrects.
+2. Si le serveur proxy nécessite une authentification, configurez le nom d'utilisateur et le mot de passe.
+3. Vérifiez si les tentatives de connexion sont enregistrées dans les journaux du serveur proxy.
+4. Vérifiez si la configuration de ``nonProxyHosts`` est appropriée.
+
+Impossible de se connecter à OpenSearch
+-------------------------
+
+1. Vérifiez si OpenSearch est démarré.
+2. Vérifiez si la configuration de ``search_engine.http.url`` est correcte.
+3. Vérifiez la connexion réseau : ``curl http://localhost:9201``
+4. Vérifiez les erreurs dans les journaux d'OpenSearch.
+
+Fonctionnement anormal lors de l'accès via reverse proxy
+----------------------------------------------------
+
+1. Vérifiez si l'en-tête ``X-Forwarded-Host`` est correctement configuré.
+2. Vérifiez si l'en-tête ``X-Forwarded-Proto`` est correctement configuré.
+3. Vérifiez si le chemin de contexte est correctement configuré.
+4. Vérifiez les erreurs dans les journaux du reverse proxy.
+
+Informations de référence
+========
+
+- :doc:`setup-memory` - Configuration de la mémoire
+- :doc:`setup-windows-service` - Configuration du service Windows
+- :doc:`security-virtual-host` - Configuration de l'hôte virtuel
+- :doc:`crawler-advanced` - Configuration avancée du crawler
+- `OpenSearch Configuration <https://opensearch.org/docs/latest/install-and-configure/configuration/>`_

--- a/fr/15.3/config/setup-windows-service.rst
+++ b/fr/15.3/config/setup-windows-service.rst
@@ -1,0 +1,78 @@
+===================
+Enregistrement en tant que service Windows
+===================
+
+Enregistrement en tant que service Windows
+======================
+
+|Fess| peut être enregistré en tant que service Windows.
+Pour exécuter |Fess|, OpenSearch doit être démarré au préalable.
+Nous supposons ici que |Fess| est installé dans ``c:\opt\fess`` et OpenSearch dans ``c:\opt\opensearch``.
+
+Préparation préalable
+------
+
+Veuillez définir JAVA_HOME comme variable d'environnement système.
+
+Enregistrement d'OpenSearch en tant que service
+-------------------------
+
+| Exécutez ``c:\opt\opensearch\bin\opensearch-service.bat`` en tant qu'administrateur depuis l'invite de commandes.
+
+::
+
+    > cd c:\opt\opensearch\bin
+    > opensearch-service.bat install
+    ...
+    The service 'opensearch-service-x64' has been installed.
+
+Pour plus de détails, consultez la `documentation OpenSearch <https://opensearch.org/docs/2.4/install-and-configure/install-opensearch/windows/>`_.
+
+Configuration
+----
+
+Éditez ``c:\opt\fess\bin\fess.in.bat`` et configurez SEARCH_ENGINE_HOME avec le répertoire d'installation d'OpenSearch.
+
+::
+
+    set SEARCH_ENGINE_HOME=c:/opt/opensearch
+
+Le numéro de port par défaut pour l'interface de recherche et d'administration de |Fess| est 8080. Pour le changer en 80, modifiez fess.port dans ``c:\opt\fess\bin\fess.in.bat``.
+
+::
+
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.port=80
+
+
+Méthode d'enregistrement
+------
+
+Exécutez ``c:\opt\fess\bin\service.bat`` en tant qu'administrateur depuis l'invite de commandes.
+
+::
+
+    > cd c:\opt\fess\bin
+    > service.bat install
+    ...
+    The service 'fess-service-x64' has been installed.
+
+
+Configuration du service
+-----------
+
+Pour démarrer le service manuellement, démarrez d'abord le service OpenSearch, puis démarrez le service |Fess|.
+Pour un démarrage automatique, ajoutez une dépendance.
+
+1. Dans les paramètres généraux du service, définissez le type de démarrage sur « Automatique (début différé) ».
+2. Les dépendances du service sont configurées dans le registre.
+
+Ajoutez la clé et la valeur suivantes dans l'éditeur de registre (regedit).
+
+.. list-table::
+
+   * - *Clé*
+     - ``Ordinateur\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services \fess-service-x64\DependOnService``
+   * - *Valeur*
+     - ``opensearch-service-x64``
+
+Une fois ajouté, opensearch-service-x64 apparaîtra dans les dépendances des propriétés du service |Fess|.


### PR DESCRIPTION
This commit adds comprehensive French translations for all 19 configuration guide documents for Fess 15.3, providing commercial-quality documentation for French-speaking users.

Files translated:
- Index and introduction
- Setup configuration (memory, network/ports, Windows service)
- Crawler configuration (basic, advanced, thumbnail)
- Search configuration (basic, advanced, geosearch, scroll, form integration)
- Security configuration (role-based, virtual host)
- Admin configuration (logging, index backup, analyzer, OpenSearch Dashboards)

All translations maintain:
- Professional French suitable for commercial product documentation
- Exact RST formatting and structure
- Technical terms and code examples
- All URLs, commands, and configuration values
- Cross-references and external links