### PR TITLE
Create French API guide documentation

### DIFF
--- a/fr/15.3/api/api-gsa.rst
+++ b/fr/15.3/api/api-gsa.rst
@@ -1,0 +1,19 @@
+===================================
+API compatible Google Search Appliance
+===================================
+
+|Fess| fournit également une API qui retourne les résultats de recherche dans un format XML compatible avec Google Search Appliance (GSA).
+Pour plus d'informations sur le format XML, veuillez consulter la `documentation officielle de GSA <https://www.google.com/support/enterprise/static/gsa/docs/admin/74/gsa_doc_set/xml_reference/results_format.html>`__\ .
+
+Configuration
+=============
+
+Ajoutez ``web.api.gsa=true`` à system.properties pour activer l'API compatible Google Search Appliance.
+
+Requête
+=======
+
+En envoyant à |Fess| une requête de type
+``http://localhost:8080/gsa/?q=mot_recherche``,
+vous pouvez recevoir les résultats de recherche au format XML compatible GSA.
+Les valeurs pouvant être spécifiées comme paramètres de requête sont les mêmes que celles de l'`API de recherche avec réponse JSON <api-search.html>`__\ .

--- a/fr/15.3/api/api-health.rst
+++ b/fr/15.3/api/api-health.rst
@@ -1,0 +1,60 @@
+===========
+API Health
+===========
+
+Obtention de l'état
+===================
+
+Requête
+-------
+
+==================  ====================================================
+Méthode HTTP        GET
+Point de terminaison ``/api/v1/health``
+==================  ====================================================
+
+En envoyant une requête à |Fess| de type ``http://<Nom du serveur>/api/v1/health``, vous pouvez recevoir l'état du serveur |Fess| au format JSON.
+
+Paramètres de requête
+---------------------
+
+Aucun paramètre de requête ne peut être spécifié.
+
+Réponse
+-------
+
+Une réponse comme celle-ci est retournée.
+
+::
+
+    {
+      "data": {
+        "status": "green",
+        "timed_out": false
+      }
+    }
+
+Les éléments sont les suivants :
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Informations de réponse
+
+   * - data
+     - Élément parent des résultats de recherche.
+   * - status
+     - État du système. ``green`` est retourné en cas de fonctionnement normal, ``yellow`` en cas d'avertissement, et ``red`` en cas d'erreur.
+   * - timed_out
+     - Présence ou non d'un timeout. ``false`` est retourné si la réponse est retournée dans le délai spécifié, ``true`` en cas de timeout.
+
+Réponse d'erreur
+================
+
+Lorsque l'API Health échoue, une réponse d'erreur comme celle-ci est retournée.
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Réponse d'erreur
+
+   * - Code de statut
+     - Description
+   * - 500 Internal Server Error
+     - Lorsqu'une erreur interne du serveur s'est produite

--- a/fr/15.3/api/api-label.rst
+++ b/fr/15.3/api/api-label.rst
@@ -1,0 +1,92 @@
+==============
+API d'étiquettes
+==============
+
+Obtention des étiquettes
+=========================
+
+Requête
+-------
+
+==================  ====================================================
+Méthode HTTP        GET
+Point de terminaison ``/api/v1/labels``
+==================  ====================================================
+
+En envoyant une requête à |Fess| de type ``http://<Nom du serveur>/api/v1/labels``, vous pouvez recevoir la liste des étiquettes enregistrées dans |Fess| au format JSON.
+
+Paramètres de requête
+---------------------
+
+Aucun paramètre de requête n'est disponible.
+
+
+Réponse
+-------
+
+Une réponse comme celle-ci est retournée.
+
+::
+
+    {
+      "record_count": 9,
+      "data": [
+        {
+          "label": "AWS",
+          "value": "aws"
+        },
+        {
+          "label": "Azure",
+          "value": "azure"
+        }
+      ]
+    }
+
+Les éléments sont les suivants :
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+
+.. list-table::
+
+   * - record_count
+     - Nombre d'étiquettes enregistrées.
+   * - data
+     - Élément parent des résultats de recherche.
+   * - label
+     - Nom de l'étiquette.
+   * - value
+     - Valeur de l'étiquette.
+
+Tableau : Informations de réponse
+
+Exemples d'utilisation
+=======================
+
+Exemple de requête avec la commande curl :
+
+::
+
+    curl "http://localhost:8080/api/v1/labels"
+
+Exemple de requête en JavaScript :
+
+::
+
+    fetch('http://localhost:8080/api/v1/labels')
+      .then(response => response.json())
+      .then(data => {
+        console.log('Liste des étiquettes:', data.data);
+      });
+
+Réponse d'erreur
+================
+
+Lorsque l'API d'étiquettes échoue, une réponse d'erreur comme celle-ci est retournée.
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Réponse d'erreur
+
+   * - Code de statut
+     - Description
+   * - 500 Internal Server Error
+     - Lorsqu'une erreur interne du serveur s'est produite

--- a/fr/15.3/api/api-overview.rst
+++ b/fr/15.3/api/api-overview.rst
@@ -1,0 +1,82 @@
+============
+Vue d'ensemble de l'API
+============
+
+
+API fournies par |Fess|
+========================
+
+Ce document décrit les API fournies par |Fess|.
+En utilisant les API, vous pouvez intégrer |Fess| comme serveur de recherche dans vos systèmes Web existants.
+
+URL de base
+===========
+
+Les points de terminaison de l'API de |Fess| sont fournis avec l'URL de base suivante :
+
+::
+
+    http://<Nom du serveur>/api/v1/
+
+Par exemple, si l'application s'exécute dans un environnement local, l'URL sera :
+
+::
+
+    http://localhost:8080/api/v1/
+
+Authentification
+================
+
+Dans la version actuelle, aucune authentification n'est requise pour utiliser les API.
+Cependant, vous devez activer les API dans les différents paramètres de l'interface d'administration.
+
+Méthode HTTP
+============
+
+Tous les points de terminaison de l'API sont accessibles via la méthode **GET**.
+
+Format de réponse
+=================
+
+Toutes les réponses de l'API sont retournées au **format JSON** (à l'exception de l'API compatible GSA).
+Le ``Content-Type`` de la réponse est ``application/json``.
+
+Gestion des erreurs
+===================
+
+Lorsqu'une requête API échoue, un code de statut HTTP approprié est retourné avec les informations d'erreur.
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Codes de statut HTTP
+
+   * - 200
+     - La requête a été traitée avec succès.
+   * - 400
+     - Les paramètres de la requête sont invalides.
+   * - 404
+     - La ressource demandée n'a pas été trouvée.
+   * - 500
+     - Une erreur interne du serveur s'est produite.
+
+Tableau : Codes de statut HTTP
+
+Types d'API
+===========
+
+|Fess| fournit les API suivantes :
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table::
+
+   * - search
+     - API pour obtenir les résultats de recherche.
+   * - popularword
+     - API pour obtenir les mots populaires.
+   * - label
+     - API pour obtenir la liste des étiquettes créées.
+   * - health
+     - API pour obtenir l'état du serveur.
+   * - suggest
+     - API pour obtenir les suggestions de mots.
+
+Tableau : Types d'API

--- a/fr/15.3/api/api-popularword.rst
+++ b/fr/15.3/api/api-popularword.rst
@@ -1,0 +1,74 @@
+=======================
+API des mots populaires
+=======================
+
+Obtention de la liste des mots populaires
+==========================================
+
+Requête
+-------
+
+==================  ====================================================
+Méthode HTTP        GET
+Point de terminaison ``/api/v1/popular-words``
+==================  ====================================================
+
+En envoyant une requête à |Fess| de type ``http://<Nom du serveur>/api/v1/popular-words?seed=123``, vous pouvez recevoir la liste des mots populaires enregistrés dans |Fess| au format JSON.
+Pour utiliser l'API des mots populaires, vous devez activer la réponse des mots populaires dans les paramètres généraux du système dans l'interface d'administration.
+
+Paramètres de requête
+---------------------
+
+Les paramètres de requête disponibles sont les suivants :
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Paramètres de requête
+
+   * - seed
+     - Seed pour obtenir les mots populaires (cette valeur permet d'obtenir différents ensembles de mots)
+   * - label
+     - Nom de l'étiquette filtrée
+   * - field
+     - Nom du champ pour générer les mots populaires
+
+
+Réponse
+-------
+
+Une réponse comme celle-ci est retournée.
+
+::
+
+    {
+      "record_count": 3,
+      "data": [
+        "python",
+        "java",
+        "javascript"
+      ]
+    }
+
+Les éléments sont les suivants :
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Informations de réponse
+
+   * - record_count
+     - Nombre de mots populaires enregistrés
+   * - data
+     - Tableau des mots populaires
+
+Réponse d'erreur
+================
+
+Lorsque l'API des mots populaires échoue, une réponse d'erreur comme celle-ci est retournée.
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Réponse d'erreur
+
+   * - Code de statut
+     - Description
+   * - 400 Bad Request
+     - Lorsque les paramètres de requête sont invalides
+   * - 500 Internal Server Error
+     - Lorsqu'une erreur interne du serveur s'est produite

--- a/fr/15.3/api/api-search.rst
+++ b/fr/15.3/api/api-search.rst
@@ -1,0 +1,249 @@
+===============
+API de recherche
+===============
+
+Obtention des résultats de recherche
+=====================================
+
+Requête
+-------
+
+==================  ====================================================
+Méthode HTTP        GET
+Point de terminaison ``/api/v1/documents``
+==================  ====================================================
+
+En envoyant une requête à |Fess| de type
+``http://<Nom du serveur>/api/v1/documents?q=mot_recherche``,
+vous pouvez recevoir les résultats de recherche de |Fess| au format JSON.
+Pour utiliser l'API de recherche, vous devez activer la réponse JSON dans les paramètres généraux du système dans l'interface d'administration.
+
+Paramètres de requête
+---------------------
+
+En spécifiant des paramètres de requête comme
+``http://<Nom du serveur>/api/v1/documents?q=mot_recherche&num=50&fields.label=fess``,
+vous pouvez effectuer des recherches plus avancées.
+Les paramètres de requête disponibles sont les suivants :
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table::
+
+   * - q
+     - Mot de recherche. Doit être encodé en URL.
+   * - start
+     - Position de départ du nombre de résultats. Commence à 0.
+   * - num
+     - Nombre de résultats à afficher. Par défaut, 20 résultats. Peut afficher jusqu'à 100 résultats.
+   * - sort
+     - Tri. Utilisé pour trier les résultats de recherche.
+   * - fields.label
+     - Valeur d'étiquette. Utilisé pour spécifier une étiquette.
+   * - facet.field
+     - Spécification du champ de facette. (Exemple) ``facet.field=label``
+   * - facet.query
+     - Spécification de la requête de facette. (Exemple) ``facet.query=timestamp:[now/d-1d TO *]``
+   * - facet.size
+     - Spécification du nombre maximum de facettes à obtenir. Valide lorsque facet.field est spécifié.
+   * - facet.minDocCount
+     - Obtient les facettes dont le nombre est supérieur ou égal à cette valeur. Valide lorsque facet.field est spécifié.
+   * - geo.location.point
+     - Spécification de la latitude et de la longitude. (Exemple) ``geo.location.point=35.0,139.0``
+   * - geo.location.distance
+     - Spécification de la distance depuis le point central. (Exemple) ``geo.location.distance=10km``
+   * - lang
+     - Spécification de la langue de recherche. (Exemple) ``lang=en``
+   * - preference
+     - Chaîne de caractères spécifiant le shard lors de la recherche. (Exemple) ``preference=abc``
+   * - callback
+     - Nom du callback pour utiliser JSONP. Pas besoin de spécifier si JSONP n'est pas utilisé.
+
+Tableau : Paramètres de requête
+
+
+Réponse
+-------
+
+| Une réponse comme celle-ci est retournée.
+| (Formatée pour plus de clarté)
+
+::
+
+    {
+      "q": "Fess",
+      "query_id": "bd60f9579a494dfd8c03db7c8aa905b0",
+      "exec_time": 0.21,
+      "query_time": 0,
+      "page_size": 20,
+      "page_number": 1,
+      "record_count": 31625,
+      "page_count": 1,
+      "highlight_params": "&hq=n2sm&hq=Fess",
+      "next_page": true,
+      "prev_page": false,
+      "start_record_number": 1,
+      "end_record_number": 20,
+      "page_numbers": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5"
+      ],
+      "partial": false,
+      "search_query": "(Fess OR n2sm)",
+      "requested_time": 1507822131845,
+      "related_query": [
+        "aaa"
+      ],
+      "related_contents": [],
+      "data": [
+        {
+          "filetype": "html",
+          "title": "Open Source Enterprise Search Server: Fess — Fess 11.0 documentation",
+          "content_title": "Open Source Enterprise Search Server: Fess — Fe...",
+          "digest": "Docs » Open Source Enterprise Search Server: Fess Commercial Support Open Source Enterprise Search Server: Fess What is Fess ? Fess is very powerful and easily deployable Enterprise Search Server. ...",
+          "host": "fess.codelibs.org",
+          "last_modified": "2017-10-09T22:28:56.000Z",
+          "content_length": "29624",
+          "timestamp": "2017-10-09T22:28:56.000Z",
+          "url_link": "https://fess.codelibs.org/",
+          "created": "2017-10-10T15.30:48.609Z",
+          "site_path": "fess.codelibs.org/",
+          "doc_id": "e79fbfdfb09d4bffb58ec230c68f6f7e",
+          "url": "https://fess.codelibs.org/",
+          "content_description": "Enterprise Search Server: <strong>Fess</strong> Commercial Support Open...Search Server: <strong>Fess</strong> What is <strong>Fess</strong> ? <strong>Fess</strong> is very powerful...You can install and run <strong>Fess</strong> quickly on any platforms...Java runtime environment. <strong>Fess</strong> is provided under Apache...Apache license. Demo <strong>Fess</strong> is OpenSearch-based search",
+          "site": "fess.codelibs.org/",
+          "boost": "10.0",
+          "mimetype": "text/html"
+        }
+      ]
+    }
+
+Les éléments sont les suivants :
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Informations de réponse
+
+   * - q
+     - Mot de recherche
+   * - exec_time
+     - Temps de réponse (en secondes)
+   * - query_time
+     - Temps de traitement de la requête (en millisecondes)
+   * - page_size
+     - Nombre de résultats affichés
+   * - page_number
+     - Numéro de page
+   * - record_count
+     - Nombre de résultats correspondant au mot de recherche
+   * - page_count
+     - Nombre de pages de résultats correspondant au mot de recherche
+   * - highlight_params
+     - Paramètres de surlignage
+   * - next_page
+     - true : la page suivante existe. false : la page suivante n'existe pas.
+   * - prev_page
+     - true : la page précédente existe. false : la page précédente n'existe pas.
+   * - start_record_number
+     - Position de départ du numéro d'enregistrement
+   * - end_record_number
+     - Position de fin du numéro d'enregistrement
+   * - page_numbers
+     - Tableau des numéros de page
+   * - partial
+     - Devient true lorsque les résultats de recherche sont tronqués, par exemple en cas de timeout.
+   * - search_query
+     - Requête de recherche
+   * - requested_time
+     - Heure de la requête (en millisecondes epoch)
+   * - related_query
+     - Requêtes associées
+   * - related_contents
+     - Requêtes de contenu associé
+   * - facet_field
+     - Informations sur les documents correspondant au champ de facette donné (uniquement si ``facet.field`` est fourni dans les paramètres de requête)
+   * - facet_query
+     - Nombre de documents correspondant à la requête de facette donnée (uniquement si ``facet.query`` est fourni dans les paramètres de requête)
+   * - result
+     - Élément parent des résultats de recherche
+   * - filetype
+     - Type de fichier
+   * - created
+     - Date de création du document
+   * - title
+     - Titre du document
+   * - doc_id
+     - ID du document
+   * - url
+     - URL du document
+   * - site
+     - Nom du site
+   * - content_description
+     - Description du contenu
+   * - host
+     - Nom d'hôte
+   * - digest
+     - Chaîne de résumé du document
+   * - boost
+     - Valeur de boost du document
+   * - mimetype
+     - Type MIME
+   * - last_modified
+     - Date de dernière modification
+   * - content_length
+     - Taille du document
+   * - url_link
+     - URL en tant que résultat de recherche
+   * - timestamp
+     - Date de mise à jour du document
+
+
+Recherche de tous les documents
+================================
+
+Pour rechercher tous les documents cibles, envoyez la requête suivante :
+``http://<Nom du serveur>/api/v1/documents/all?q=mot_recherche``
+
+Pour utiliser cette fonctionnalité, vous devez définir api.search.scroll sur true dans fess_config.properties.
+
+Paramètres de requête
+---------------------
+
+Les paramètres de requête disponibles sont les suivants :
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table::
+
+   * - q
+     - Mot de recherche. Doit être encodé en URL.
+   * - num
+     - Nombre de résultats à afficher. Par défaut, 20 résultats. Peut afficher jusqu'à 100 résultats.
+   * - sort
+     - Tri. Utilisé pour trier les résultats de recherche.
+
+Tableau : Paramètres de requête
+
+Réponse d'erreur
+================
+
+Lorsque l'API de recherche échoue, une réponse d'erreur comme celle-ci est retournée.
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Réponse d'erreur
+
+   * - Code de statut
+     - Description
+   * - 400 Bad Request
+     - Lorsque les paramètres de requête sont invalides
+   * - 500 Internal Server Error
+     - Lorsqu'une erreur interne du serveur s'est produite
+
+Exemple de réponse d'erreur :
+
+::
+
+    {
+      "message": "Invalid request parameter",
+      "status": 400
+    }

--- a/fr/15.3/api/api-suggest.rst
+++ b/fr/15.3/api/api-suggest.rst
@@ -1,0 +1,92 @@
+==================
+API de suggestions
+==================
+
+Obtention de la liste des suggestions de mots
+==============================================
+
+Requête
+-------
+
+==================  ====================================================
+Méthode HTTP        GET
+Point de terminaison ``/api/v1/suggest-words``
+==================  ====================================================
+
+En envoyant une requête à |Fess| de type ``http://<Nom du serveur>/api/v1/suggest-words?q=mot_suggestion``, vous pouvez recevoir la liste des suggestions de mots enregistrées dans |Fess| au format JSON.
+Pour utiliser l'API de suggestions de mots, vous devez activer « Suggérer à partir des documents » ou « Suggérer à partir des mots de recherche » dans les paramètres généraux du système dans l'interface d'administration.
+
+Paramètres de requête
+---------------------
+
+Les paramètres de requête disponibles sont les suivants :
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Paramètres de requête
+
+   * - q
+     - Mot-clé pour la suggestion. (Exemple) ``q=fess``
+   * - num
+     - Nombre de mots suggérés. Par défaut 10. (Exemple) ``num=20``
+   * - label
+     - Nom de l'étiquette filtrée. (Exemple) ``label=java``
+   * - fields
+     - Nom du champ pour affiner les cibles de suggestion. Par défaut, pas de filtrage. (Exemple) ``fields=content,title``
+   * - lang
+     - Spécification de la langue de recherche. (Exemple) ``lang=en``
+
+
+Réponse
+-------
+
+Une réponse comme celle-ci est retournée.
+
+::
+
+    {
+      "query_time": 18,
+      "record_count": 355,
+      "page_size": 10,
+      "data": [
+        {
+          "text": "fess",
+          "labels": [
+            "java",
+            "python"
+          ]
+        }
+      ]
+    }
+
+Les éléments sont les suivants :
+
+.. tabularcolumns:: |p{3cm}|p{12cm}|
+.. list-table:: Informations de réponse
+
+   * - query_time
+     - Temps de traitement de la requête (en millisecondes).
+   * - record_count
+     - Nombre de suggestions de mots enregistrées.
+   * - page_size
+     - Taille de page.
+   * - data
+     - Élément parent des résultats de recherche.
+   * - text
+     - Suggestion de mot.
+   * - labels
+     - Tableau des valeurs d'étiquettes.
+
+Réponse d'erreur
+================
+
+Lorsque l'API de suggestions échoue, une réponse d'erreur comme celle-ci est retournée.
+
+.. tabularcolumns:: |p{4cm}|p{11cm}|
+.. list-table:: Réponse d'erreur
+
+   * - Code de statut
+     - Description
+   * - 400 Bad Request
+     - Lorsque les paramètres de requête sont invalides
+   * - 500 Internal Server Error
+     - Lorsqu'une erreur interne du serveur s'est produite

--- a/fr/15.3/api/index.rst
+++ b/fr/15.3/api/index.rst
@@ -1,0 +1,13 @@
+Guide API |Fess|
+===============
+
+.. toctree::
+   :maxdepth: 2
+
+   intro
+   api-overview
+   api-search
+   api-label
+   api-popularword
+   api-suggest
+   api-health

--- a/fr/15.3/api/intro.rst
+++ b/fr/15.3/api/intro.rst
@@ -1,0 +1,66 @@
+============
+Introduction
+============
+
+Public visé
+===========
+
+Ce document s'adresse aux développeurs qui souhaitent utiliser les fonctionnalités API de |Fess|.
+Les connaissances suivantes sont requises :
+
+- Concepts de base des API REST
+- Format de données JSON
+- Connaissances de base du protocole HTTP
+
+Avant de commencer
+==================
+
+Ce document explique comment utiliser les API dans |Fess| 15.3.
+
+Prérequis pour l'utilisation de l'API
+=====================================
+
+Avant d'utiliser les API de |Fess|, les configurations suivantes sont nécessaires :
+
+- |Fess| 15.3 ou version ultérieure doit être installé et fonctionner correctement
+- Activer les paramètres nécessaires pour chaque API depuis l'interface d'administration (voir la documentation de chaque API)
+- Les points de terminaison de l'API doivent être accessibles via le réseau
+
+Accès en ligne
+==============
+
+Pour les téléchargements, les services professionnels, le support et d'autres informations pour les développeurs, veuillez consulter :
+
+-  Site du projet : https://fess.codelibs.org/
+
+Contact pour le support technique
+==================================
+
+Si vous avez des questions techniques sur ce produit et que vous ne trouvez pas de solution dans la documentation, veuillez consulter :
+
+-  Issues :
+   `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
+
+Support commercial
+------------------
+
+Si vous avez besoin d'un support commercial pour l'assistance technique ou la maintenance de ce produit, veuillez contacter `N2SM,
+Inc. <https://www.n2sm.net/>`__
+
+Référence aux sites Web tiers
+==============================
+
+Le projet |Fess|
+n'est pas responsable de la validité des sites Web tiers mentionnés dans ce document. Le projet |Fess|
+ne garantit pas et n'assume aucune responsabilité concernant le contenu, les publicités, les produits, les services ou autres documents disponibles via ces sites ou ressources.
+Le projet |Fess|
+n'assume aucune responsabilité pour les dommages ou préjudices résultant de l'utilisation ou de la confiance accordée au contenu, aux publicités, aux produits, aux services ou autres documents disponibles via ces sites ou ressources.
+
+Comment envoyer des commentaires et des suggestions
+====================================================
+
+Le projet |Fess|
+s'efforce d'améliorer ce document et accueille les commentaires et suggestions des lecteurs.
+
+-  Issues :
+   `https://github.com/codelibs/fess-docs/issues <https://github.com/codelibs/fess-docs/issues>`__


### PR DESCRIPTION
- Translate all API documentation files from Japanese to French
- Includes: index, intro, api-overview, api-search, api-label, api-popularword, api-suggest, api-health, and api-gsa
- Commercial product quality translation with professional terminology