### PR TITLE
Create French admin guide documentation

### DIFF
--- a/fr/15.3/admin/accesstoken-guide.rst
+++ b/fr/15.3/admin/accesstoken-guide.rst
@@ -1,0 +1,63 @@
+==================
+Jeton d'accès
+==================
+
+Présentation
+============
+
+La page de configuration des jetons d'accès gère les jetons d'accès.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration des jetons d'accès illustrée ci-dessous, cliquez sur [Système > Jeton d'accès] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration des jetons d'accès.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom
+::::
+
+Spécifiez un nom pour décrire ce jeton d'accès.
+
+Permission
+::::::::::
+
+Configure la permission du jeton d'accès.
+Décrivez au format « {user|group|role}nom ».
+Par exemple, pour qu'un utilisateur appartenant au groupe developer affiche les résultats de recherche, configurez la permission « {group}developer ».
+
+Nom du paramètre
+::::::::::::::::
+
+Spécifiez le nom du paramètre de requête pour spécifier la permission comme requête de recherche.
+
+Date d'expiration
+:::::::::::::::::
+
+Spécifie la date d'expiration du jeton d'accès.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/accesstoken-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/accesstoken-2.png

--- a/fr/15.3/admin/backup-guide.rst
+++ b/fr/15.3/admin/backup-guide.rst
@@ -1,0 +1,74 @@
+================
+Sauvegarde
+================
+
+Présentation
+============
+
+La page de sauvegarde permet de télécharger et de téléverser les informations de configuration de |Fess|.
+
+Téléchargement
+--------------
+
+|Fess| conserve les informations de configuration sous forme d'index.
+Pour télécharger, cliquez sur le nom de l'index.
+
+|image0|
+
+fess_config.bulk
+::::::::::::::::
+
+fess_config.bulk contient les informations de configuration de |Fess|.
+
+fess_basic_config.bulk
+::::::::::::::::::::::
+
+fess_basic_config.bulk contient les informations de configuration de |Fess| à l'exception des URL en échec.
+
+fess_user.bulk
+::::::::::::::
+
+fess_user.bulk contient les informations des utilisateurs, rôles et groupes.
+
+system.properties
+:::::::::::::::::
+
+system.properties contient les informations de configuration générale.
+
+fess.json
+:::::::::
+
+fess.json contient les informations de configuration de l'index fess.
+
+doc.json
+::::::::
+
+doc.json contient les informations de mapping de l'index fess.
+
+click_log.ndjson
+::::::::::::::::
+
+click_log.ndjson contient les informations du journal des clics.
+
+favorite_log.ndjson
+:::::::::::::::::::
+
+favorite_log.ndjson contient les informations du journal des favoris.
+
+search_log.ndjson
+:::::::::::::::::
+
+search_log.ndjson contient les informations du journal de recherche.
+
+user_info.ndjson
+::::::::::::::::
+
+user_info.ndjson contient les informations des utilisateurs de recherche.
+
+Téléversement
+-------------
+
+Vous pouvez téléverser et importer les informations de configuration.
+Les fichiers qui peuvent être restaurés sont \*.bulk et system.properties.
+
+  .. |image0| image:: ../../../resources/images/ja/15.3/admin/backup-1.png

--- a/fr/15.3/admin/badword-guide.rst
+++ b/fr/15.3/admin/badword-guide.rst
@@ -1,0 +1,85 @@
+==============
+Mots exclus
+==============
+
+Présentation
+============
+
+Cette section explique la configuration des mots exclus des suggestions.
+Les suggestions sont affichées en fonction des termes de recherche, mais vous pouvez configurer ces mots pour qu'ils ne soient pas affichés dans les suggestions.
+
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration des mots exclus des suggestions illustrée ci-dessous, cliquez sur [Suggestion > Mots exclus] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Pour ouvrir la page de création de mots exclus des suggestions, cliquez sur le bouton Nouvelle création.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Candidat de suggestion
+::::::::::::::::::::::
+
+Enregistre les mots NG.
+Les mots enregistrés ici ne seront plus affichés dans les suggestions.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+Téléchargement
+==============
+
+Télécharge les mots enregistrés au format CSV.
+
+|image2|
+
+Contenu du CSV
+--------------
+
+La première ligne est l'en-tête.
+Les mots exclus sont listés à partir de la deuxième ligne.
+
+::
+
+"BadWord"
+"検索エンジン"
+
+Téléversement
+=============
+
+Enregistre les mots au format CSV.
+
+|image3|
+
+Contenu du CSV
+--------------
+
+La première ligne est l'en-tête.
+Décrivez les mots exclus à partir de la deuxième ligne.
+
+::
+
+"BadWord"
+"検索エンジン"
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/badword-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/badword-2.png
+.. |image2| image:: ../../../resources/images/ja/15.3/admin/badword-3.png
+.. |image3| image:: ../../../resources/images/ja/15.3/admin/badword-4.png

--- a/fr/15.3/admin/boostdoc-guide.rst
+++ b/fr/15.3/admin/boostdoc-guide.rst
@@ -1,0 +1,58 @@
+=====================
+Boost de document
+=====================
+
+Présentation
+============
+
+Cette section explique la configuration du boost de document.
+En configurant le boost de document, vous pouvez positionner des documents en haut des résultats de recherche indépendamment du terme de recherche.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration du boost de document illustrée ci-dessous, cliquez sur [Crawler > Boost de document] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration du boost de document.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Condition
+:::::::::
+
+Spécifie la condition des documents que vous souhaitez positionner en haut.
+Par exemple, pour afficher en haut les URL contenant https://www.n2sm.net/, décrivez url.matches("https://www.n2sm.net/.*").
+Les conditions peuvent être écrites en Groovy.
+
+Expression de valeur de boost
+::::::::::::::::::::::::::::::
+
+Spécifie la valeur de pondération du document.
+L'expression peut être écrite en Groovy.
+
+Ordre de tri
+::::::::::::
+
+Configure l'ordre de tri du boost de document.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation. Appuyer sur le bouton Supprimer supprimera la configuration.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/boostdoc-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/boostdoc-2.png

--- a/fr/15.3/admin/crawlinginfo-guide.rst
+++ b/fr/15.3/admin/crawlinginfo-guide.rst
@@ -1,0 +1,93 @@
+=====================
+Informations de crawl
+=====================
+
+Présentation
+============
+
+Les résultats d'exécution du crawl sont enregistrés et les informations de crawl peuvent être vérifiées dans cet écran d'administration.
+
+Gestion
+=======
+
+Liste
+=====
+
+Chaque fois qu'un crawl est exécuté, il est enregistré comme informations de crawl.
+Dans la liste, vous pouvez vérifier le nom de session du crawl exécuté et l'heure d'exécution.
+Si vous souhaitez vérifier les détails des informations de crawl, cliquez sur les informations de crawl cibles.
+
+|image0|
+
+Détails
+=======
+
+En cliquant sur l'ID de session des informations de crawl dans la liste, les détails des informations de crawl cibles s'affichent.
+
+|image1|
+
+Liste des éléments
+------------------
+
+ID de session
+:::::::::::::
+
+ID de session lors de l'exécution du crawl.
+
+Heure de début du crawler
+::::::::::::::::::::::::::
+
+Heure de début de l'ensemble du crawl.
+
+Heure de début du crawl (Web/Fichier)
+::::::::::::::::::::::::::::::::::::::
+
+Heure de début du crawl Web et du système de fichiers.
+
+Heure de début du crawl (Magasin de données)
+:::::::::::::::::::::::::::::::::::::::::::::
+
+Heure de début du crawl du magasin de données.
+
+Heure de fin du crawl (Web/Fichier)
+::::::::::::::::::::::::::::::::::::
+
+Heure de fin du crawl Web et du système de fichiers.
+
+Durée d'exécution du crawl (Magasin de données)
+::::::::::::::::::::::::::::::::::::::::::::::::
+
+Durée d'exécution du crawl du magasin de données (en millisecondes).
+
+Durée d'exécution de l'indexation (Magasin de données)
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Temps nécessaire pour indexer les résultats du crawl Web et du système de fichiers (en millisecondes).
+
+Taille de l'index (Magasin de données)
+:::::::::::::::::::::::::::::::::::::::
+
+Nombre de documents indexés.
+
+Heure de fin du crawl (Magasin de données)
+:::::::::::::::::::::::::::::::::::::::::::
+
+Heure de fin du crawl du magasin de données.
+
+État du crawler
+:::::::::::::::
+
+Si le crawl a réussi ou non.
+
+Heure de fin du crawler
+::::::::::::::::::::::::
+
+Heure de fin de l'ensemble du crawl.
+
+Durée d'exécution du crawler
+:::::::::::::::::::::::::::::
+
+Durée d'exécution de l'ensemble du crawl (en millisecondes).
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/crawlinginfo-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/crawlinginfo-2.png

--- a/fr/15.3/admin/dashboard-guide.rst
+++ b/fr/15.3/admin/dashboard-guide.rst
@@ -1,0 +1,57 @@
+==================
+Tableau de bord
+==================
+
+Présentation
+============
+
+Le tableau de bord fournit un outil d'administration Web pour gérer les clusters et les index OpenSearch auxquels |Fess| accède.
+
+|image0|
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table:: Index gérés par |Fess|
+   :header-rows: 1
+
+   * - Nom de l'index
+     - Description
+   * - fess.YYYYMMDD
+     - Documents indexés
+   * - fess_log
+     - Journaux d'accès
+   * - fess.suggest.YYYYMMDD
+     - Mots suggérés
+   * - fess_config
+     - Configuration de |Fess|
+   * - fess_user
+     - Données utilisateur/rôle/groupe
+   * - configsync
+     - Configuration du dictionnaire
+   * - fess_suggest
+     - Métadonnées de suggestion
+   * - fess_suggest_array
+     - Métadonnées de suggestion
+   * - fess_suggest_badword
+     - Liste de mots interdits pour la suggestion
+   * - fess_suggest_analyzer
+     - Métadonnées de suggestion
+   * - fess_crawler
+     - Informations de crawl
+
+
+Les index dont le nom commence par un point (.) sont des index système et ne sont donc pas affichés.
+Pour afficher également les index système, cochez la case « special ».
+
+Vérification du nombre de documents indexés
+============================================
+
+Le nombre de documents indexés est affiché dans l'index fess comme illustré ci-dessous.
+
+|image1|
+
+Cliquer sur l'icône en haut à droite de chaque index affiche un menu d'opérations pour cet index.
+Pour supprimer des documents indexés, utilisez l'écran de recherche d'administration. Veillez à ne pas supprimer avec « delete index ».
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/dashboard-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/dashboard-2.png
+.. pdf            :width: 400 px

--- a/fr/15.3/admin/dataconfig-guide.rst
+++ b/fr/15.3/admin/dataconfig-guide.rst
@@ -1,0 +1,430 @@
+=======================
+Crawl de magasin de données
+=======================
+
+Présentation
+============
+
+Dans |Fess|, vous pouvez cibler des sources de données telles que des bases de données ou des fichiers CSV pour le crawl.
+Cette section explique la configuration du magasin de données nécessaire à cet effet.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste pour configurer le magasin de données illustrée ci-dessous, cliquez sur [Crawler > Magasin de données] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration du magasin de données.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom
+::::
+
+Spécifie le nom de la configuration de crawl.
+
+Nom du gestionnaire
+:::::::::::::::::::
+
+Nom du gestionnaire qui traite le magasin de données.
+
+* DatabaseDataStore : Crawler une base de données
+* CsvDataStore : Crawler des fichiers CSV/TSV cibles
+* CsvListDataStore : Crawler un fichier CSV décrivant les chemins de fichiers cibles d'indexation
+
+Paramètres
+::::::::::
+
+Spécifie les paramètres relatifs au magasin de données.
+
+Script
+::::::
+
+Spécifie dans quel champ définir les valeurs obtenues du magasin de données.
+Les expressions peuvent être écrites en Groovy.
+
+Valeur de boost
+:::::::::::::::
+
+Spécifie la valeur de boost des documents lors du crawl avec cette configuration.
+
+Permission
+::::::::::
+
+Spécifie la permission pour cette configuration.
+Pour la méthode de spécification de permission, par exemple, pour afficher les résultats de recherche aux utilisateurs appartenant au groupe developer, spécifiez {group}developer.
+La spécification par utilisateur est {user}nom_utilisateur, par rôle {role}nom_rôle, par groupe {group}nom_groupe.
+
+Hôte virtuel
+::::::::::::
+
+Spécifie le nom d'hôte de l'hôte virtuel.
+Pour plus de détails, consultez :doc:`Configuration de l'hôte virtuel dans le guide de configuration <../config/virtual-host>`.
+
+État
+::::
+
+Spécifie si cette configuration de crawl doit être utilisée.
+
+Description
+:::::::::::
+
+Vous pouvez saisir une description.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+Exemples
+========
+
+DatabaseDataStore
+-----------------
+
+Explication du crawl de base de données.
+
+À titre d'exemple, supposons qu'il y ait une table comme suit dans une base de données appelée testdb dans MySQL, et qu'elle puisse être connectée avec le nom d'utilisateur hoge et le mot de passe fuga.
+
+::
+
+    CREATE TABLE doc (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        title VARCHAR(100) NOT NULL,
+        content VARCHAR(255) NOT NULL,
+        latitude VARCHAR(20),
+        longitude VARCHAR(20),
+        versionNo INTEGER NOT NULL,
+        PRIMARY KEY (id)
+    );
+
+Ici, les données suivantes sont insérées.
+
+::
+
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 1', 'コンテンツ 1 です．', '37.77493', ' -122.419416', 1);
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 2', 'コンテンツ 2 です．', '34.701909', '135.494977', 1);
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 3', 'コンテンツ 3 です．', '-33.868901', '151.207091', 1);
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 4', 'コンテンツ 4 です．', '51.500152', '-0.113736', 1);
+    INSERT INTO doc (title, content, latitude, longitude, versionNo) VALUES ('タイトル 5', 'コンテンツ 5 です．', '35.681137', '139.766084', 1);
+
+Paramètres
+::::::::::
+
+Un exemple de configuration des paramètres est le suivant.
+
+::
+
+    driver=com.mysql.jdbc.Driver
+    url=jdbc:mysql://localhost:3306/testdb?useUnicode=true&characterEncoding=UTF-8
+    username=hoge
+    password=fuga
+    sql=select * from doc
+
+Les paramètres sont au format « clé=valeur ». La description des clés est la suivante.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - driver
+     - Nom de la classe du pilote
+   * - url
+     - URL
+   * - username
+     - Nom d'utilisateur pour se connecter à la DB
+   * - password
+     - Mot de passe pour se connecter à la DB
+   * - sql
+     - Instruction SQL pour obtenir les cibles de crawl
+
+Tableau : Exemple de paramètres de configuration pour DB
+
+
+Script
+::::::
+
+Un exemple de configuration du script est le suivant.
+
+::
+
+    url="http://SERVERNAME/" + id
+    host="SERVERNAME"
+    site="SERVERNAME"
+    title=title
+    content=content
+    cache=content
+    digest=content
+    anchor=
+    content_length=content.length()
+    last_modified=new java.util.Date()
+    location=latitude + "," + longitude
+    latitude=latitude
+    longitude=longitude
+
+Les paramètres sont au format « clé=valeur ». La description des clés est la suivante.
+
+Le côté valeur est écrit en Groovy.
+Les chaînes doivent être fermées par des guillemets doubles. En accédant par le nom de colonne de la base de données, vous obtenez cette valeur.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - url
+     - URL (configurez une URL accessible aux données selon votre environnement)
+   * - host
+     - Nom d'hôte
+   * - site
+     - Chemin du site
+   * - title
+     - Titre
+   * - content
+     - Contenu du document (chaîne cible d'indexation)
+   * - cache
+     - Cache du document (non cible d'indexation)
+   * - digest
+     - Partie digest affichée dans les résultats de recherche
+   * - anchor
+     - Liens contenus dans le document (généralement pas besoin de spécifier)
+   * - content_length
+     - Longueur du document
+   * - last_modified
+     - Date de dernière modification du document
+
+Tableau : Contenu de la configuration du script
+
+
+Pilote
+::::::
+
+Un pilote est nécessaire pour se connecter à la base de données. Placez le fichier jar dans app/WEB-INF/lib.
+
+CsvDataStore
+------------
+
+Explication du crawl ciblant les fichiers CSV.
+
+Par exemple, créez le fichier test.csv dans le répertoire /home/taro/csv avec le contenu suivant.
+L'encodage du fichier est Shift_JIS.
+
+::
+
+    1,タイトル 1,テスト1です。
+    2,タイトル 2,テスト2です。
+    3,タイトル 3,テスト3です。
+    4,タイトル 4,テスト4です。
+    5,タイトル 5,テスト5です。
+    6,タイトル 6,テスト6です。
+    7,タイトル 7,テスト7です。
+    8,タイトル 8,テスト8です。
+    9,タイトル 9,テスト9です。
+
+
+Paramètres
+::::::::::
+
+Un exemple de configuration des paramètres est le suivant.
+
+::
+
+    directories=/home/taro/csv
+    fileEncoding=Shift_JIS
+
+Les paramètres sont au format « clé=valeur ». La description des clés est la suivante.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - directories
+     - Répertoire contenant les fichiers CSV (.csv ou .tsv)
+   * - files
+     - Fichier CSV (en cas de spécification directe)
+   * - fileEncoding
+     - Encodage du fichier CSV
+   * - separatorCharacter
+     - Caractère de séparation
+
+
+Tableau : Exemple de paramètres de configuration pour fichiers CSV
+
+
+Script
+::::::
+
+Un exemple de configuration du script est le suivant.
+
+::
+
+    url="http://SERVERNAME/" + cell1
+    host="SERVERNAME"
+    site="SERVERNAME"
+    title=cell2
+    content=cell3
+    cache=cell3
+    digest=cell3
+    anchor=
+    content_length=cell3.length()
+    last_modified=new java.util.Date()
+
+Les paramètres sont au format « clé=valeur ».
+Les clés sont les mêmes que pour le crawl de base de données.
+Les données dans le fichier CSV sont conservées dans cell[nombre] (le nombre commence à 1).
+Si aucune donnée n'existe dans la cellule du fichier CSV, elle peut être null.
+
+EsDataStore
+-----------
+
+La source d'obtention des données est elasticsearch, mais l'utilisation de base est la même que CsvDataStore.
+
+Paramètres
+::::::::::
+
+Un exemple de configuration des paramètres est le suivant.
+
+::
+
+    settings.cluster.name=elasticsearch
+    hosts=SERVERNAME:9300
+    index=logindex
+    type=data
+
+Les paramètres sont au format « clé=valeur ». La description des clés est la suivante.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - settings.*
+     - Informations de paramètres d'elasticsearch
+   * - hosts
+     - Elasticsearch de destination de connexion
+   * - index
+     - Nom de l'index
+   * - type
+     - Nom du type
+   * - query
+     - Requête de condition pour obtenir
+
+Tableau : Exemple de paramètres de configuration pour elasticsearch
+
+
+Script
+::::::
+
+Un exemple de configuration du script est le suivant.
+
+::
+
+    url=source.url
+    host="SERVERNAME"
+    site="SERVERNAME"
+    title=source.title
+    content=source.content
+    digest=
+    anchor=
+    content_length=source.size
+    last_modified=new java.util.Date()
+
+Les paramètres sont au format « clé=valeur ».
+Les clés sont les mêmes que pour le crawl de base de données.
+Vous pouvez obtenir et configurer les valeurs avec source.*.
+
+CsvListDataStore
+----------------
+
+Utilisé pour crawler un grand nombre de fichiers.
+En plaçant un fichier CSV contenant les chemins des fichiers mis à jour et en ne crawlant que les chemins spécifiés, vous pouvez réduire le temps d'exécution du crawl.
+
+Le format pour décrire les chemins est le suivant.
+
+::
+
+    [action]<caractère de séparation>[chemin]
+
+Pour l'action, spécifiez l'un des suivants :
+
+* create : Le fichier a été créé
+* modify : Le fichier a été mis à jour
+* delete : Le fichier a été supprimé
+
+Par exemple, créez le fichier test.csv dans le répertoire /home/taro/csv avec le contenu suivant.
+L'encodage du fichier est Shift_JIS.
+
+Les chemins sont décrits dans la même notation que lors de la spécification du chemin cible de crawl dans le crawl de fichiers.
+Spécifiez comme suit : « file:/[chemin] » ou « smb://[chemin] ».
+
+::
+
+    modify,smb://servername/data/testfile1.txt
+    modify,smb://servername/data/testfile2.txt
+    modify,smb://servername/data/testfile3.txt
+    modify,smb://servername/data/testfile4.txt
+    modify,smb://servername/data/testfile5.txt
+    modify,smb://servername/data/testfile6.txt
+    modify,smb://servername/data/testfile7.txt
+    modify,smb://servername/data/testfile8.txt
+    modify,smb://servername/data/testfile9.txt
+    modify,smb://servername/data/testfile10.txt
+
+
+Paramètres
+::::::::::
+
+Un exemple de configuration des paramètres est le suivant.
+
+::
+
+    directories=/home/taro/csv
+    fileEncoding=Shift_JIS
+
+Les paramètres sont au format « clé=valeur ». La description des clés est la suivante.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - directories
+     - Répertoire contenant les fichiers CSV (.csv ou .tsv)
+   * - fileEncoding
+     - Encodage du fichier CSV
+   * - separatorCharacter
+     - Caractère de séparation
+
+
+Tableau : Exemple de paramètres de configuration pour fichiers CSV
+
+
+Script
+::::::
+
+Un exemple de configuration du script est le suivant.
+
+::
+
+    event_type=cell1
+    url=cell2
+
+Les paramètres sont au format « clé=valeur ».
+Les clés sont les mêmes que pour le crawl de base de données.
+
+Si une authentification est requise à la destination du crawl, vous devez également configurer ce qui suit.
+
+::
+
+    crawler.file.auth=example
+    crawler.file.auth.example.scheme=SAMBA
+    crawler.file.auth.example.username=username
+    crawler.file.auth.example.password=password
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/dataconfig-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/dataconfig-2.png

--- a/fr/15.3/admin/design-guide.rst
+++ b/fr/15.3/admin/design-guide.rst
@@ -1,0 +1,101 @@
+==================
+Conception de page
+==================
+
+Présentation
+============
+
+Cette section explique les paramètres de configuration concernant la conception de l'écran de recherche.
+
+Méthode de configuration
+=========================
+
+Affichage
+---------
+
+Pour ouvrir la page de liste pour configurer la conception de page illustrée ci-dessous, cliquez sur [Système > Conception de page] dans le menu de gauche.
+
+|image0|
+
+
+Gestionnaire de fichiers
+-------------------------
+
+Vous pouvez télécharger ou supprimer des fichiers disponibles sur l'écran de recherche.
+
+Affichage des fichiers de page
+-------------------------------
+
+Vous pouvez modifier les fichiers JSP de l'écran de recherche.
+Vous pouvez modifier le fichier JSP cible en appuyant sur le bouton Modifier.
+De plus, en appuyant sur le bouton Utiliser par défaut, vous pouvez modifier comme le fichier JSP lors de l'installation.
+La sauvegarde avec le bouton Mettre à jour sur l'écran de modification appliquera les modifications.
+
+Voici un résumé des pages modifiables.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+
+   * - /index.jsp
+     - Fichier JSP de la page d'accueil de recherche. Ce fichier JSP inclut les fichiers JSP de chaque partie.
+   * - /header.jsp
+     - Fichier JSP de l'en-tête.
+   * - /footer.jsp
+     - Fichier JSP du pied de page.
+   * - /search.jsp
+     - Fichier JSP de la page de liste des résultats de recherche. Ce fichier JSP inclut les fichiers JSP de chaque partie.
+   * - /searchResults.jsp
+     - Fichier JSP qui représente la partie des résultats de recherche de la page de liste des résultats. C'est le fichier JSP utilisé lorsqu'il y a des résultats de recherche. Modifiez-le si vous souhaitez personnaliser la présentation des résultats.
+   * - /searchNoResult.jsp
+     - Fichier JSP qui représente la partie des résultats de recherche de la page de liste des résultats. C'est le fichier JSP utilisé lorsqu'il n'y a pas de résultats de recherche.
+   * - /searchOptions.jsp
+     - Fichier JSP de l'écran des options de recherche.
+   * - /advance.jsp
+     - Fichier JSP de l'écran de recherche avancée.
+   * - /help.jsp
+     - Fichier JSP de la page d'aide.
+   * - /error/error.jsp
+     - Fichier JSP de la page d'erreur de recherche. Modifiez-le si vous souhaitez personnaliser la présentation des erreurs de recherche.
+   * - /error/notFound.jsp
+     - Fichier JSP de la page d'erreur affiché lorsque la page n'est pas trouvée.
+   * - /error/system.jsp
+     - Fichier JSP de la page d'erreur affiché en cas d'erreur système.
+   * - /error/redirect.jsp
+     - Fichier JSP de la page d'erreur affiché lors d'une redirection HTTP.
+   * - /error/badRequest.jsp
+     - Fichier JSP de la page d'erreur affiché en cas de requête incorrecte.
+   * - /cache.hbs
+     - Fichier pour afficher le cache des résultats de recherche.
+   * - /login/index.jsp
+     - Fichier JSP de l'écran de connexion.
+   * - /profile/index.jsp
+     - JSP de l'écran de modification du mot de passe utilisateur.
+   * - /profile/newpassword.jsp
+     - JSP de l'écran de mise à jour du mot de passe administrateur. Si le nom d'utilisateur et le mot de passe sont la même chaîne lors de la connexion, un changement de mot de passe est requis.
+
+
+Tableau : Fichiers JSP modifiables
+
+|image1|
+
+Fichiers à téléverser
+---------------------
+
+Vous pouvez téléverser des fichiers à utiliser sur l'écran de recherche.
+Les noms de fichiers image pris en charge sont jpg, gif, png, css, js.
+
+Téléversement de fichier
+:::::::::::::::::::::::::
+
+Spécifiez le fichier à téléverser.
+
+Nom de fichier (optionnel)
+:::::::::::::::::::::::::::
+
+Utilisez-le si vous souhaitez spécifier un nom de fichier pour le fichier à téléverser.
+Si omis, le nom du fichier téléversé sera utilisé.
+Par exemple, si vous spécifiez logo.png, l'image de la page d'accueil de recherche sera modifiée.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/design-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/design-2.png

--- a/fr/15.3/admin/dict-guide.rst
+++ b/fr/15.3/admin/dict-guide.rst
@@ -1,0 +1,60 @@
+===============
+Dictionnaire
+===============
+
+Présentation
+============
+
+Cette section explique les paramètres de configuration concernant les dictionnaires.
+
+Les modifications du dictionnaire doivent être effectuées avec une compréhension des spécifications de chaque dictionnaire.
+Un échec lors de la modification du dictionnaire peut rendre l'index inaccessible.
+
+Liste
+=====
+
+Pour ouvrir la page de liste des dictionnaires gérables illustrée ci-dessous, cliquez sur [Système > Dictionnaire] dans le menu de gauche.
+
+
+|image0|
+
+
+Kuromoji
+========
+
+Gère le dictionnaire pour l'analyse morphologique japonaise.
+ja/kuromoji.txt est le fichier de dictionnaire pour l'analyse morphologique japonaise.
+
+Synonyme
+========
+
+Gère le dictionnaire de synonymes.
+synonym.txt est le fichier de dictionnaire de synonymes utilisé en commun pour toutes les langues.
+
+Mapping
+=======
+
+Gère le dictionnaire de remplacement de caractères.
+mapping.txt est le fichier de dictionnaire de remplacement de mots commun à toutes les langues ou pour chaque langue.
+
+Protwords
+=========
+
+Gère le dictionnaire de mots protégés.
+protwords.txt est placé pour chaque langue et est un fichier de liste de mots à exclure du stemming.
+
+Mots vides
+==========
+
+Gère le dictionnaire de mots vides.
+stopwords.txt est placé pour chaque langue et est un fichier de liste de mots à exclure lors de la création de l'index.
+
+Remplacement de Stemmer
+========================
+
+Gère le dictionnaire de remplacement de stemmer.
+stemmer_override.txt est placé pour chaque langue et est un fichier de dictionnaire de remplacement de mots pour remplacer le traitement de stemming.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/dict-1.png
+            :height: 940px

--- a/fr/15.3/admin/duplicatehost-guide.rst
+++ b/fr/15.3/admin/duplicatehost-guide.rst
@@ -1,0 +1,51 @@
+==================
+Hôte en double
+==================
+
+Présentation
+============
+
+Cette section explique la configuration des hôtes en double.
+Les hôtes en double sont utilisés lors du crawl lorsque vous souhaitez traiter différents noms d'hôte comme identiques.
+Par exemple, cela peut être utilisé lorsque vous souhaitez traiter www.example.com et example.com comme le même site.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste pour configurer les hôtes en double illustrée ci-dessous, cliquez sur [Crawler > Hôte en double] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration des hôtes en double.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom canonique
+::::::::::::::
+
+Spécifie le nom d'hôte canonique. Les noms d'hôte en double seront remplacés par le nom d'hôte canonique.
+
+Nom en double
+::::::::::::::
+
+Spécifie le nom d'hôte en double. Spécifiez le nom d'hôte que vous souhaitez remplacer.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/duplicatehost-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/duplicatehost-2.png

--- a/fr/15.3/admin/elevateword-guide.rst
+++ b/fr/15.3/admin/elevateword-guide.rst
@@ -1,0 +1,106 @@
+================
+Mots ajoutés
+================
+
+Présentation
+============
+
+Cette section explique la configuration des candidats de mots ajoutés pour les suggestions. Les suggestions sont affichées en fonction des termes de recherche, et vous pouvez ajouter ces mots.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste pour configurer les mots ajoutés illustrée ci-dessous, cliquez sur [Suggestion > Mots ajoutés] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration des mots ajoutés.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Mot
+::::
+
+Spécifie le mot à afficher comme candidat de suggestion.
+
+Lecture
+:::::::
+
+Spécifie la lecture phonétique du mot candidat de suggestion.
+
+Permission
+::::::::::
+
+Configure les informations de rôle pour le mot.
+La suggestion n'est affichée que pour les utilisateurs ayant le rôle configuré.
+
+Étiquette
+:::::::::
+
+Configure l'étiquette pour le mot.
+Si une étiquette autre que celle configurée est sélectionnée, elle ne sera pas affichée dans les suggestions.
+
+Valeur de boost
+:::::::::::::::
+
+Configure la valeur de boost pour le mot.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+
+Téléchargement
+==============
+
+Télécharge les mots enregistrés au format CSV.
+
+|image2|
+
+Contenu du CSV
+--------------
+
+La première ligne est l'en-tête.
+Les mots ajoutés sont listés à partir de la deuxième ligne.
+
+::
+
+"SuggestWord","Reading","Role","Label","Boost"
+"fess","ふぇす","role1","label1","100"
+
+Téléversement
+=============
+
+Enregistre les mots au format CSV.
+
+|image3|
+
+Contenu du CSV
+--------------
+
+La première ligne est l'en-tête.
+Décrivez les mots ajoutés à partir de la deuxième ligne.
+
+::
+
+"SuggestWord","Reading","Role","Label","Boost"
+"fess","ふぇす","role1","label1","100"
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/elevateword-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/elevateword-2.png
+.. |image2| image:: ../../../resources/images/ja/15.3/admin/elevateword-3.png
+.. |image3| image:: ../../../resources/images/ja/15.3/admin/elevateword-4.png

--- a/fr/15.3/admin/esreq-guide.rst
+++ b/fr/15.3/admin/esreq-guide.rst
@@ -1,0 +1,40 @@
+====================
+Requête de recherche
+====================
+
+Présentation
+============
+
+Cette page envoie des requêtes de recherche de fichiers JSON à OpenSearch.
+
+|image0|
+
+Méthode d'opération
+===================
+
+Envoi de requête
+----------------
+
+Après vous être connecté en tant qu'administrateur, entrez /admin/esreq/ comme chemin d'URL.
+Créez la requête de recherche que vous souhaitez envoyer à OpenSearch sous forme de fichier JSON, sélectionnez ce fichier JSON comme « Fichier de requête », cliquez sur le bouton « Envoyer » pour envoyer la requête à OpenSearch.
+La réponse est téléchargée sous forme de fichier.
+
+Paramètres de configuration
+----------------------------
+
+Fichier de requête
+::::::::::::::::::
+
+Spécifiez le fichier JSON décrivant le DSL de requête.
+Par exemple, le contenu du fichier JSON serait comme suit.
+
+::
+
+    POST /_search
+    {
+      "query": {
+        "match_all": {}
+      }
+    }
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/esreq-1.png

--- a/fr/15.3/admin/failureurl-guide.rst
+++ b/fr/15.3/admin/failureurl-guide.rst
@@ -1,0 +1,66 @@
+==================
+URL en échec
+==================
+
+Présentation
+============
+
+Cette section explique les URL en échec.
+Les URL qui n'ont pas pu être obtenues lors du crawl sont enregistrées et peuvent être vérifiées comme URL en échec.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste pour vérifier les URL en échec, cliquez sur [Informations système > URL en échec] dans le menu de gauche.
+
+|image0|
+
+En cliquant sur le lien de vérification de l'URL en échec, les détails s'affichent.
+
+Détails de l'URL en échec
+==========================
+
+Les détails de l'URL en échec enregistrent les exceptions survenues lors du crawl.
+
+|image1|
+
+Contenu des détails
+-------------------
+
+URL
+::::
+
+URL où l'exception s'est produite.
+
+Nom du thread
+:::::::::::::
+
+Nom du thread qui exécutait le crawl.
+Peut être utilisé lors de la vérification des fichiers journaux.
+
+Type
+::::
+
+Type d'exception.
+
+Journal
+:::::::
+
+Contenu de l'exception.
+
+Nombre d'erreurs
+::::::::::::::::
+
+Nombre de fois où cette exception s'est produite.
+
+Date du dernier accès
+:::::::::::::::::::::
+
+Heure à laquelle cette exception s'est produite.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/failureurl-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/failureurl-2.png

--- a/fr/15.3/admin/fileauth-guide.rst
+++ b/fr/15.3/admin/fileauth-guide.rst
@@ -1,0 +1,80 @@
+==========================
+Authentification de fichier
+==========================
+
+Présentation
+============
+
+Cette section explique la méthode de configuration lorsqu'une authentification de fichier est requise pour le crawl ciblant les fichiers.
+|Fess| prend en charge l'authentification FTP ou pour les dossiers partagés Windows.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste pour configurer l'authentification de fichier illustrée ci-dessous, cliquez sur [Crawler > Authentification de fichier] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration d'authentification de fichier.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom d'hôte
+::::::::::
+
+Spécifie le nom d'hôte du site nécessitant une authentification.
+
+Port
+::::
+
+Spécifie le port du site nécessitant une authentification.
+
+Schéma
+::::::
+
+Sélectionnez la méthode d'authentification.
+Vous pouvez utiliser FTP ou SAMBA (authentification de dossier partagé Windows).
+
+Nom d'utilisateur
+:::::::::::::::::
+
+Spécifie le nom d'utilisateur pour se connecter au site d'authentification.
+
+Mot de passe
+::::::::::::
+
+Spécifie le mot de passe pour se connecter au site d'authentification.
+
+Paramètres
+::::::::::
+
+Configure s'il existe des valeurs de configuration nécessaires pour se connecter au site d'authentification. Pour SAMBA, vous pouvez définir la valeur de domain. Pour la configurer, décrivez comme suit :
+
+::
+
+    domain=FUGA
+
+Configuration de crawl de fichiers
+:::::::::::::::::::::::::::::::::::
+
+Spécifie la configuration de crawl qui utilisera ces paramètres d'authentification.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/fileauth-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/fileauth-2.png

--- a/fr/15.3/admin/fileconfig-guide.rst
+++ b/fr/15.3/admin/fileconfig-guide.rst
@@ -1,0 +1,180 @@
+==========================
+Crawl de système de fichiers
+==========================
+
+Présentation
+============
+
+La page de configuration de crawl de fichiers permet de gérer la configuration pour crawler les fichiers sur le système de fichiers ou les dossiers partagés sur le réseau.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste pour configurer le crawl de fichiers illustrée ci-dessous, cliquez sur [Crawler > Système de fichiers] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration de crawl de fichiers.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom
+::::
+
+Nom de la configuration.
+
+Chemin
+::::::
+
+Ce chemin spécifie l'emplacement de départ du crawl (ex. : file:/ ou smb://).
+
+Chemins à crawler
+:::::::::::::::::
+
+Les chemins correspondant à l'expression régulière (format Java) spécifiée dans cet élément seront ciblés par le crawler |Fess|.
+
+Chemins exclus du crawl
+:::::::::::::::::::::::
+
+Les chemins correspondant à l'expression régulière (format Java) spécifiée dans cet élément ne seront pas ciblés par le crawler |Fess|.
+
+Chemins à indexer
+:::::::::::::::::
+
+Les chemins correspondant à l'expression régulière (format Java) spécifiée dans cet élément seront ciblés pour la recherche.
+
+Chemins exclus de l'indexation
+:::::::::::::::::::::::::::::::
+
+Les chemins correspondant à l'expression régulière (format Java) spécifiée dans cet élément ne seront pas ciblés pour la recherche.
+
+Paramètres de configuration
+::::::::::::::::::::::::::::
+
+Vous pouvez spécifier les informations de configuration du crawl.
+
+Profondeur
+::::::::::
+
+Spécifie la profondeur de la structure du système de fichiers à crawler.
+
+Nombre maximum d'accès
+::::::::::::::::::::::
+
+Spécifie le nombre de chemins à indexer.
+
+Nombre de threads
+:::::::::::::::::
+
+Spécifie le nombre de threads à utiliser pour cette configuration.
+
+Intervalle
+::::::::::
+
+Spécifie le temps d'attente pour chaque thread lors du crawl des chemins.
+
+Valeur de boost
+:::::::::::::::
+
+La valeur de boost est la priorité des documents indexés par cette configuration.
+
+Permission
+::::::::::
+
+Spécifie la permission pour cette configuration.
+Pour la méthode de spécification de permission, par exemple, pour afficher les résultats de recherche aux utilisateurs appartenant au groupe developer, spécifiez {group}developer.
+La spécification par utilisateur est {user}nom_utilisateur, par rôle {role}nom_rôle, par groupe {group}nom_groupe.
+
+Hôte virtuel
+::::::::::::
+
+Spécifie le nom d'hôte de l'hôte virtuel.
+Pour plus de détails, consultez :doc:`Configuration de l'hôte virtuel dans le guide de configuration <../config/virtual-host>`.
+
+État
+::::
+
+Lorsque cette configuration est active, la tâche du crawler par défaut effectue le crawl en incluant cette configuration.
+
+Description
+:::::::::::
+
+Vous pouvez saisir une description.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation. Appuyer sur le bouton Supprimer supprimera la configuration.
+
+Exemples
+========
+
+Crawler les fichiers locaux
+----------------------------
+
+Pour crawler les fichiers sous /home/share, la configuration serait la suivante.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Nom
+     - Valeur
+   * - Nom
+     - Répertoire partagé
+   * - Chemin
+     - file:/home/share
+
+Les autres paramètres peuvent utiliser la configuration par défaut.
+
+Crawler les dossiers partagés Windows
+--------------------------------------
+
+Pour crawler les fichiers sous \\SERVER\SharedFolder, la configuration serait la suivante.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Nom
+     - Valeur
+   * - Nom
+     - Dossier partagé
+   * - Chemin
+     - smb://SERVER/SharedFolder/
+
+Si l'accès au dossier partagé nécessite un nom d'utilisateur/mot de passe, vous devez créer une configuration d'authentification de fichier depuis [Crawler > Authentification de fichier] dans le menu de gauche.
+La configuration serait alors la suivante.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Nom
+     - Valeur
+   * - Nom d'hôte
+     - SERVER
+   * - Schéma
+     - SAMBA
+   * - Nom d'utilisateur
+     - (Veuillez saisir)
+   * - Mot de passe
+     - (Veuillez saisir)
+
+
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/fileconfig-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/fileconfig-2.png
+.. pdf            :height: 940 px

--- a/fr/15.3/admin/general-guide.rst
+++ b/fr/15.3/admin/general-guide.rst
@@ -1,0 +1,294 @@
+========
+Général
+========
+
+Présentation
+============
+
+Cette page d'administration vous permet de gérer les paramètres de |Fess|.
+Vous pouvez modifier divers paramètres de |Fess| sans redémarrer |Fess|.
+
+|image0|
+
+Contenu de la configuration
+============================
+
+Système
+-------
+
+Réponse JSON
+::::::::::::
+
+Spécifie s'il faut activer l'API JSON.
+
+Connexion requise
+:::::::::::::::::
+
+Spécifie si la connexion est requise pour la fonction de recherche.
+
+Afficher le lien de connexion
+::::::::::::::::::::::::::::::
+
+Configure l'affichage du lien vers la page de connexion sur l'écran de recherche.
+
+Replier les résultats en double
+::::::::::::::::::::::::::::::::
+
+Configure l'activation du repliement des résultats en double.
+
+Affichage des vignettes
+::::::::::::::::::::::::
+
+Configure l'activation de l'affichage des vignettes.
+
+Valeur d'étiquette par défaut
+::::::::::::::::::::::::::::::
+
+Décrit la valeur d'étiquette à ajouter aux critères de recherche par défaut.
+Pour spécifier par rôle ou groupe, ajoutez « role: » ou « group: » comme « role:admin=label1 ».
+
+Valeur de tri par défaut
+:::::::::::::::::::::::::
+
+Décrit la valeur de tri à ajouter aux critères de recherche par défaut.
+Pour spécifier par rôle ou groupe, ajoutez « role: » ou « group: » comme « role:admin=content_length.desc ».
+
+Hôte virtuel
+::::::::::::
+
+Configure l'hôte virtuel.
+Pour plus de détails, consultez :doc:`Configuration de l'hôte virtuel dans le guide de configuration <../config/virtual-host>`.
+
+Réponse des mots populaires
+::::::::::::::::::::::::::::
+
+Spécifie s'il faut activer l'API des mots populaires.
+
+Encodage du fichier CSV
+::::::::::::::::::::::::
+
+Spécifie l'encodage des fichiers CSV à télécharger.
+
+Ajouter des paramètres de recherche
+::::::::::::::::::::::::::::::::::::
+
+Active le passage de paramètres à l'affichage des résultats de recherche.
+
+E-mail de notification
+::::::::::::::::::::::
+
+Spécifie l'adresse e-mail pour la notification à la fin du crawl.
+Plusieurs adresses peuvent être spécifiées séparées par des virgules. Un serveur de messagerie est requis pour l'utilisation.
+
+Crawler
+-------
+
+Vérifier la date de dernière modification
+::::::::::::::::::::::::::::::::::::::::::
+
+Active le crawl différentiel.
+
+Configuration du crawler simultané
+:::::::::::::::::::::::::::::::::::
+
+Spécifie le nombre de configurations de crawl à exécuter simultanément.
+
+Supprimer les documents précédents
+:::::::::::::::::::::::::::::::::::
+
+Spécifie le nombre de jours de la période de validité après l'indexation.
+
+Types d'erreur exclus
+:::::::::::::::::::::
+
+Les URL en échec qui dépassent le seuil sont exclues des cibles de crawl, mais les noms d'exception spécifiés ici seront des cibles de crawl même si elles dépassent le seuil.
+
+Seuil du nombre d'échecs
+:::::::::::::::::::::::::
+
+Si le document cible de crawl est enregistré dans les URL en échec plus que le nombre de fois spécifié ici, il sera exclu du prochain crawl.
+
+Journalisation
+--------------
+
+Journal de recherche
+::::::::::::::::::::
+
+Spécifie s'il faut activer l'enregistrement du journal de recherche.
+
+Journal utilisateur
+:::::::::::::::::::
+
+Spécifie s'il faut activer l'enregistrement du journal utilisateur.
+
+Journal des favoris
+:::::::::::::::::::
+
+Spécifie s'il faut activer l'enregistrement du journal des favoris.
+
+Supprimer les journaux de recherche précédents
+:::::::::::::::::::::::::::::::::::::::::::::::
+
+Supprime les journaux de recherche antérieurs au nombre de jours spécifié.
+
+Supprimer les journaux de tâches précédents
+::::::::::::::::::::::::::::::::::::::::::::
+
+Supprime les journaux de tâches antérieurs au nombre de jours spécifié.
+
+Supprimer les journaux utilisateur précédents
+::::::::::::::::::::::::::::::::::::::::::::::
+
+Supprime les journaux utilisateur antérieurs au nombre de jours spécifié.
+
+Nom de bot pour supprimer les journaux
+:::::::::::::::::::::::::::::::::::::::
+
+Spécifie le nom du bot à exclure des journaux de recherche.
+
+Niveau de journalisation
+:::::::::::::::::::::::::
+
+Spécifie le niveau de journalisation de fess.log.
+
+Suggestion
+----------
+
+Suggestion avec mots de recherche
+::::::::::::::::::::::::::::::::::
+
+Spécifie s'il faut générer des candidats de suggestion à partir des journaux de recherche.
+
+Suggestion avec documents
+:::::::::::::::::::::::::
+
+Spécifie s'il faut générer des candidats de suggestion à partir des documents indexés.
+
+Supprimer les informations de suggestion précédentes
+:::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+Supprime les données de suggestion antérieures au nombre de jours spécifié.
+
+LDAP
+----
+
+URL LDAP
+::::::::
+
+Spécifie l'URL du serveur LDAP.
+
+Base DN
+:::::::
+
+Spécifie le nom distinctif de base pour se connecter à l'écran de recherche.
+
+Bind DN
+:::::::
+
+Spécifie le Bind DN de l'administrateur.
+
+Mot de passe
+::::::::::::
+
+Spécifie le mot de passe du Bind DN.
+
+User DN
+:::::::
+
+Spécifie le nom distinctif de l'utilisateur.
+
+Filtre de compte
+::::::::::::::::
+
+Spécifie le nom commun de l'utilisateur, l'uid, etc.
+
+Filtre de groupe
+::::::::::::::::
+
+Spécifie les conditions de filtre pour les groupes à récupérer.
+
+Attribut memberOf
+:::::::::::::::::
+
+Spécifie le nom de l'attribut memberOf disponible sur le serveur LDAP.
+Pour Active Directory, c'est memberOf.
+Pour d'autres serveurs LDAP, cela peut être isMemberOf.
+
+
+Affichage des annonces
+----------------------
+
+Page de connexion
+:::::::::::::::::
+
+Décrit le message à afficher sur l'écran de connexion.
+
+Page d'accueil de recherche
+::::::::::::::::::::::::::::
+
+Décrit le message à afficher sur l'écran d'accueil de recherche.
+
+Stockage
+--------
+
+Après avoir configuré chaque élément, un menu [Système > Stockage] apparaîtra dans le menu de gauche.
+Pour la gestion des fichiers, consultez :doc:`Stockage <../admin/storage-guide>`.
+
+Point de terminaison
+::::::::::::::::::::
+
+Spécifie l'URL du point de terminaison du serveur MinIO.
+
+Clé d'accès
+:::::::::::
+
+Spécifie la clé d'accès du serveur MinIO.
+
+Clé secrète
+:::::::::::
+
+Spécifie la clé secrète du serveur MinIO.
+
+Bucket
+::::::
+
+Spécifie le nom du bucket à gérer.
+
+Exemples
+========
+
+Exemples de configuration LDAP
+-------------------------------
+
+.. tabularcolumns:: |p{4cm}|p{4cm}|p{4cm}|
+.. list-table:: Configuration LDAP/Active Directory
+   :header-rows: 1
+
+   * - Nom
+     - Valeur (LDAP)
+     - Valeur (Active Directory)
+   * - URL LDAP
+     - ldap://SERVERNAME:389
+     - ldap://SERVERNAME:389
+   * - Base DN
+     - cn=Directory Manager
+     - dc=fess,dc=codelibs,dc=org
+   * - Bind DN
+     - uid=%s,ou=People,dc=fess,dc=codelibs,dc=org
+     - manager@fess.codelibs.org
+   * - User DN
+     - uid=%s,ou=People,dc=fess,dc=codelibs,dc=org
+     - %s@fess.codelibs.org
+   * - Filtre de compte
+     - cn=%s ou uid=%s
+     - (&(objectClass=user)(sAMAccountName=%s))
+   * - Filtre de groupe
+     -
+     - (member:1.2.840.113556.1.4.1941:=%s)
+   * - memberOf
+     - isMemberOf
+     - memberOf
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/general-1.png
+.. pdf            :height: 940 px

--- a/fr/15.3/admin/group-guide.rst
+++ b/fr/15.3/admin/group-guide.rst
@@ -1,0 +1,45 @@
+========
+Groupe
+========
+
+Présentation
+============
+
+Vous pouvez gérer les groupes auxquels les utilisateurs appartiennent.
+Cela peut être utilisé pour l'intégration LDAP, par exemple.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste pour configurer les groupes illustrée ci-dessous, cliquez sur [Utilisateur > Groupe] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration des groupes.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom
+::::
+
+Nom du groupe.
+
+Méthode de suppression
+----------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/group-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/group-2.png

--- a/fr/15.3/admin/index.rst
+++ b/fr/15.3/admin/index.rst
@@ -1,0 +1,52 @@
+Guide de l'administrateur |Fess|
+=================================
+
+.. toctree::
+   :maxdepth: 3
+
+   intro
+   dashboard-guide
+   wizard-guide
+   general-guide
+   scheduler-guide
+   design-guide
+   dict-guide
+   kuromoji-guide
+   synonym-guide
+   mapping-guide
+   protwords-guide
+   stopwords-guide
+   stemmeroverride-guide
+   accesstoken-guide
+   plugin-guide
+   storage-guide
+   webconfig-guide
+   fileconfig-guide
+   dataconfig-guide
+   labeltype-guide
+   keymatch-guide
+   boostdoc-guide
+   relatedcontent-guide
+   relatedquery-guide
+   pathmap-guide
+   webauth-guide
+   fileauth-guide
+   reqheader-guide
+   duplicatehost-guide
+   user-guide
+   role-guide
+   group-guide
+   suggest-guide
+   elevateword-guide
+   badword-guide
+   systeminfo-guide
+   searchlog-guide
+   joblog-guide
+   crawlinginfo-guide
+   log-guide
+   failureurl-guide
+   searchlist-guide
+   backup-guide
+   maintenance-guide
+   esreq-guide
+

--- a/fr/15.3/admin/intro.rst
+++ b/fr/15.3/admin/intro.rst
@@ -1,0 +1,34 @@
+============
+Introduction
+============
+
+Public concerné
+===============
+
+Ce document s'adresse aux utilisateurs chargés de l'administration de |Fess|.
+
+Avant de commencer
+==================
+
+Ce document décrit les méthodes de gestion de la configuration de |Fess|. Une connaissance de base de l'utilisation des ordinateurs est requise.
+
+Accès en ligne
+==============
+
+Pour les téléchargements, les services professionnels, le support et d'autres informations destinées aux développeurs, veuillez consulter :
+
+-  Site du projet :
+   `https://fess.codelibs.org/ <https://fess.codelibs.org/>`__
+
+Contact pour le support technique
+==================================
+
+Si vous avez des questions techniques concernant ce produit et que vous ne trouvez pas de solution dans la documentation, veuillez consulter :
+
+-  Issues :
+   `https://github.com/codelibs/fess/issues <https://github.com/codelibs/fess/issues>`__
+
+Support commercial
+------------------
+
+Si vous avez besoin d'un support commercial pour l'assistance technique ou la maintenance de ce produit, veuillez contacter `N2SM, Inc. <https://www.n2sm.net/>`__.

--- a/fr/15.3/admin/joblog-guide.rst
+++ b/fr/15.3/admin/joblog-guide.rst
@@ -1,0 +1,68 @@
+==================
+Journal des tâches
+==================
+
+Présentation
+============
+
+Affiche les résultats des tâches exécutées sous forme de liste.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de vérification du journal des tâches illustrée ci-dessous, cliquez sur [Informations système > Journal des tâches] dans le menu de gauche.
+
+|image0|
+
+Détails du journal des tâches
+------------------------------
+
+Vous pouvez vérifier le contenu du journal des tâches. Affiche le nom de la tâche, l'état, les heures de début et de fin, les résultats, etc.
+
+|image1|
+
+Nom
+::::
+
+Nom de la tâche exécutée.
+
+État
+::::
+
+Résultat de l'exécution de la tâche.
+
+Cible
+:::::
+
+Cible d'exécution de la tâche.
+
+Heure de début
+::::::::::::::
+
+Heure UNIX de début de la tâche.
+
+Heure de fin
+::::::::::::
+
+Heure UNIX de fin de la tâche.
+
+Méthode d'exécution
+:::::::::::::::::::
+
+Environnement d'exécution dans lequel la tâche a été exécutée.
+
+Script
+::::::
+
+Contenu d'exécution de la tâche.
+
+Résultat
+::::::::
+
+Résultat de l'exécution de la tâche.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/joblog-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/joblog-2.png

--- a/fr/15.3/admin/keymatch-guide.rst
+++ b/fr/15.3/admin/keymatch-guide.rst
@@ -1,0 +1,66 @@
+=====================
+Correspondance de clés
+=====================
+
+Présentation
+============
+
+Cette section explique la configuration de la correspondance de clés.
+En configurant la correspondance de clés, vous pouvez positionner des documents en haut des résultats de recherche lorsqu'une recherche est effectuée avec le terme de recherche enregistré.
+Une utilisation courante est la publicité.
+
+Gestion
+=======
+
+Affichage
+---------
+Pour ouvrir la page de liste de configuration de correspondance de clés illustrée ci-dessous, cliquez sur [Crawler > Correspondance de clés] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration de correspondance de clés.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Terme de recherche
+::::::::::::::::::
+
+La pondération n'est appliquée que dans les résultats de recherche pour ce terme de recherche.
+
+Requête
+:::::::
+
+Les documents cibles à positionner en haut sont déterminés par la requête de recherche.
+
+Taille
+::::::
+
+Spécifie le nombre maximum de documents correspondant à la requête.
+
+Valeur de boost
+:::::::::::::::
+
+Spécifie la valeur de pondération du document.
+
+Hôte virtuel
+::::::::::::
+
+Spécifie le nom d'hôte de l'hôte virtuel.
+Pour plus de détails, consultez :doc:`Configuration de l'hôte virtuel dans le guide de configuration <../config/virtual-host>`.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/keymatch-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/keymatch-2.png

--- a/fr/15.3/admin/kuromoji-guide.rst
+++ b/fr/15.3/admin/kuromoji-guide.rst
@@ -1,0 +1,76 @@
+====================
+Dictionnaire Kuromoji
+====================
+
+Présentation
+============
+
+Vous pouvez enregistrer des noms de personnes, des noms propres, des termes spécialisés, etc. pour l'analyse morphologique.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration Kuromoji illustrée ci-dessous, sélectionnez [Système > Dictionnaire] dans le menu de gauche, puis cliquez sur kuromoji.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Méthode de configuration
+-------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration Kuromoji.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Jeton
+:::::
+
+Entrez le mot à traiter lors de l'analyse morphologique.
+
+Division
+::::::::
+
+Si le mot est composé d'un mot composé, vous pouvez le faire correspondre même lorsqu'il est recherché avec des mots divisés.
+Par exemple, en entrant « 全文 検索 エンジン » pour « 全文検索エンジン », vous pouvez également effectuer une recherche avec des mots divisés.
+
+Lecture
+:::::::
+
+Entrez la lecture du mot entré comme jeton en katakana.
+Si une division est effectuée, entrez-la de manière divisée.
+Par exemple, entrez « ゼンブン ケンサク エンジン ».
+
+Partie du discours
+::::::::::::::::::
+
+Entrez la partie du discours du mot entré.
+
+Téléchargement
+==============
+
+Vous pouvez télécharger au format de dictionnaire Kuromoji.
+
+Téléversement
+=============
+
+Vous pouvez téléverser au format de dictionnaire Kuromoji.
+Le format de dictionnaire Kuromoji est séparé par des virgules (,) et suit le format « jeton,jeton divisé,lecture du jeton divisé,partie du discours ».
+Les jetons divisés sont séparés par des espaces.
+Si aucune division n'est nécessaire, le jeton et le jeton divisé sont égaux.
+Par exemple, cela ressemble à ce qui suit.
+
+::
+
+    朝青龍,朝青龍,アサショウリュウ,カスタム名詞
+    関西国際空港,関西 国際 空港,カンサイ コクサイ クウコウ,カスタム名詞
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/kuromoji-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/kuromoji-2.png

--- a/fr/15.3/admin/labeltype-guide.rst
+++ b/fr/15.3/admin/labeltype-guide.rst
@@ -1,0 +1,87 @@
+==========
+Étiquette
+==========
+
+Présentation
+============
+
+
+Cette section explique la configuration des étiquettes.
+Les étiquettes permettent de classifier les documents affichés dans les résultats de recherche.
+La configuration des étiquettes spécifie les chemins auxquels ajouter des étiquettes par expression régulière.
+Si des étiquettes sont enregistrées, une liste déroulante d'étiquettes s'affiche dans les options de recherche.
+
+Cette configuration d'étiquette est appliquée aux configurations de crawl Web ou de système de fichiers.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration des étiquettes illustrée ci-dessous, cliquez sur [Crawler > Étiquette] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration des étiquettes.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom
+::::
+
+Spécifie le nom affiché dans la liste déroulante de sélection d'étiquette lors de la recherche.
+
+Valeur
+::::::
+
+Spécifie l'identifiant lors de la classification des documents.
+Spécifiez en caractères alphanumériques.
+
+Chemins cibles
+::::::::::::::
+
+Configure les chemins auxquels ajouter l'étiquette par expression régulière.
+Vous pouvez en spécifier plusieurs en écrivant sur plusieurs lignes.
+L'étiquette sera définie pour les documents correspondant aux chemins spécifiés ici.
+
+Chemins exclus
+::::::::::::::
+
+Configure par expression régulière ce que vous souhaitez exclure des chemins cibles de crawl.
+Vous pouvez en spécifier plusieurs en écrivant sur plusieurs lignes.
+
+Permission
+::::::::::
+
+Spécifie la permission pour cette configuration.
+Pour la méthode de spécification de permission, par exemple, pour afficher les résultats de recherche aux utilisateurs appartenant au groupe developer, spécifiez {group}developer.
+La spécification par utilisateur est {user}nom_utilisateur, par rôle {role}nom_rôle, par groupe {group}nom_groupe.
+
+Hôte virtuel
+::::::::::::
+
+Spécifie le nom d'hôte de l'hôte virtuel.
+Pour plus de détails, consultez :doc:`Configuration de l'hôte virtuel dans le guide de configuration <../config/virtual-host>`.
+
+Ordre d'affichage
+:::::::::::::::::
+
+Spécifie l'ordre d'affichage des étiquettes.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/labeltype-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/labeltype-2.png

--- a/fr/15.3/admin/log-guide.rst
+++ b/fr/15.3/admin/log-guide.rst
@@ -1,0 +1,70 @@
+==================
+Fichiers journaux
+==================
+
+Présentation
+============
+
+Cette section explique le téléchargement des fichiers journaux générés par |Fess|.
+
+Méthode de configuration
+=========================
+
+Affichage
+---------
+
+Pour ouvrir la page des fichiers journaux illustrée ci-dessous, cliquez sur [Informations système > Fichiers journaux] dans le menu de gauche.
+
+|image0|
+
+Téléchargement
+--------------
+
+Vous pouvez télécharger un fichier journal en cliquant sur le nom du fichier journal affiché.
+
+``server_*.log``
+::::::::::::::::
+
+Les journaux de |Fess| en tant que serveur d'application sont enregistrés.
+
+fess.log
+::::::::
+
+Les journaux de |Fess| en tant qu'application sont enregistrés.
+
+fess-crawler.log
+::::::::::::::::
+
+Les journaux du crawler sont enregistrés.
+
+audit.log
+:::::::::
+
+Les informations de connexion et les journaux d'accès à l'écran d'administration sont enregistrés.
+
+fess-thumbnail.log
+::::::::::::::::::
+
+Les journaux de la fonctionnalité de vignettes sont enregistrés.
+
+fess-suggest.log
+::::::::::::::::
+
+Les journaux de la fonctionnalité de suggestion sont enregistrés.
+
+fess-urls.log
+:::::::::::::
+
+Le temps nécessaire pour un crawl est enregistré.
+
+search.log
+::::::::::
+
+Les journaux de recherche sont enregistrés.
+
+gc-crawler.log
+::::::::::::::
+
+Les journaux GC de fess sont enregistrés.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/log-1.png

--- a/fr/15.3/admin/maintenance-guide.rst
+++ b/fr/15.3/admin/maintenance-guide.rst
@@ -1,0 +1,67 @@
+==============
+Maintenance
+==============
+
+Présentation
+============
+
+La page de maintenance est utilisée pour exécuter des opérations de données système.
+
+|image0|
+
+Méthode d'opération
+===================
+
+Réindexation
+------------
+
+Vous pouvez recréer un nouvel index à partir de l'index fess existant.
+Exécutez cela lorsque vous souhaitez modifier le mapping de l'index, par exemple.
+
+
+Paramètres de configuration
+----------------------------
+
+Mise à jour de l'alias
+::::::::::::::::::::::
+
+En l'activant, après la fin de la réindexation, vous pouvez réattribuer les alias fess.search et fess.update assignés à l'index existant au nouvel index.
+
+
+Initialisation du dictionnaire
+:::::::::::::::::::::::::::::::
+
+En l'activant, vous pouvez initialiser la configuration du dictionnaire.
+
+
+Nombre de shards
+::::::::::::::::
+
+Vous pouvez spécifier le nombre de shards OpenSearch (index.number_of_shards).
+
+
+Nombre maximum de réplicas
+:::::::::::::::::::::::::::
+
+Vous pouvez spécifier le nombre maximum de réplicas OpenSearch (index.auto_expand_replicas).
+
+
+Rechargement de l'index de documents
+-------------------------------------
+
+Vous pouvez recharger l'index de documents pour appliquer la configuration de l'index.
+
+
+Index Crawler
+-------------
+
+Vous pouvez supprimer l'index fess_crawler (informations de crawl).
+Ne l'exécutez pas pendant l'exécution du crawler.
+
+
+Diagnostic
+----------
+
+Vous pouvez télécharger les fichiers journaux au format zip.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/maintenance-1.png

--- a/fr/15.3/admin/mapping-guide.rst
+++ b/fr/15.3/admin/mapping-guide.rst
@@ -1,0 +1,55 @@
+=====================
+Dictionnaire de mapping
+=====================
+
+Présentation
+============
+
+Vous pouvez mapper des caractères spécifiques (symboles, codes de caractères, pleine/demi-largeur) vers d'autres caractères.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration de mapping illustrée ci-dessous, sélectionnez [Système > Dictionnaire] dans le menu de gauche, puis cliquez sur mapping.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Méthode de configuration
+-------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration de mapping.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Source de conversion
+:::::::::::::::::::::
+
+Entrez les caractères (symboles, codes de caractères, pleine/demi-largeur) à mapper.
+
+Après conversion
+::::::::::::::::
+
+Développe les caractères entrés dans la source de conversion avec les caractères après conversion.
+
+Téléchargement
+==============
+
+Vous pouvez télécharger au format de dictionnaire de mapping.
+
+Téléversement
+=============
+
+Vous pouvez téléverser au format de dictionnaire de mapping.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/mapping-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/mapping-2.png
+

--- a/fr/15.3/admin/pathmap-guide.rst
+++ b/fr/15.3/admin/pathmap-guide.rst
@@ -1,0 +1,67 @@
+=====================
+Mappage de chemin
+=====================
+
+Présentation
+============
+
+Cette section explique la configuration du mappage de chemin.
+Le mappage de chemin peut être utilisé lorsque vous souhaitez remplacer les liens affichés dans les résultats de recherche.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration du mappage de chemin illustrée ci-dessous, cliquez sur [Crawler > Mappage de chemin] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration du mappage de chemin.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Expression régulière
+::::::::::::::::::::
+
+Spécifie la chaîne de caractères à remplacer.
+La méthode de description suit les expressions régulières Java.
+
+Remplacement
+::::::::::::
+
+Spécifie la chaîne de caractères pour remplacer l'expression régulière correspondante.
+
+Type de traitement
+::::::::::::::::::
+
+Spécifie le moment du remplacement.
+
+* Crawl : Lors du crawl, remplace l'URL après l'obtention du document et avant l'indexation.
+* Affichage : Lors de la recherche, remplace l'URL avant l'affichage.
+* Crawl/Affichage : Remplace l'URL lors du crawl et de l'affichage.
+* URL enregistrée : Lors du crawl, remplace l'URL avant l'obtention du document.
+
+Ordre d'affichage
+:::::::::::::::::
+
+Vous pouvez spécifier l'ordre de traitement du mappage de chemin.
+Le traitement s'effectue dans l'ordre croissant.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/pathmap-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/pathmap-2.png

--- a/fr/15.3/admin/plugin-guide.rst
+++ b/fr/15.3/admin/plugin-guide.rst
@@ -1,0 +1,32 @@
+=========
+Plugins
+=========
+
+Présentation
+============
+
+La page de configuration des plugins gère les plugins.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste des plugins installés illustrée ci-dessous, cliquez sur [Système > Plugins] dans le menu de gauche.
+
+|image0|
+
+Pour désinstaller, cliquez sur le bouton Supprimer.
+
+Installation
+------------
+
+Pour installer un nouveau plugin, cliquez sur le bouton Installer.
+
+|image1|
+
+Sélectionnez le plugin que vous souhaitez installer dans le menu déroulant et cliquez sur le bouton Installer pour démarrer l'installation.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/plugin-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/plugin-2.png

--- a/fr/15.3/admin/protwords-guide.rst
+++ b/fr/15.3/admin/protwords-guide.rst
@@ -1,0 +1,52 @@
+=======================
+Dictionnaire Protwords
+=======================
+
+Présentation
+============
+
+Vous pouvez gérer les mots à exclure du traitement de stemming.
+Le traitement de stemming étant essentiellement basé sur des règles, une normalisation non intentionnelle peut se produire.
+Par exemple, le mot Maine (nom d'un état américain) serait normalisé en main.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration Protwords illustrée ci-dessous, sélectionnez [Système > Dictionnaire] dans le menu de gauche, puis cliquez sur protwords.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Méthode de configuration
+-------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration Protwords.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Informations sur les mots
+::::::::::::::::::::::::::
+
+Entrez les mots à exclure du traitement de stemming.
+
+
+Téléchargement
+==============
+
+Vous pouvez télécharger au format de dictionnaire Protwords.
+
+Téléversement
+=============
+
+Vous pouvez téléverser au format de dictionnaire Protwords.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/protwords-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/protwords-2.png

--- a/fr/15.3/admin/relatedcontent-guide.rst
+++ b/fr/15.3/admin/relatedcontent-guide.rst
@@ -1,0 +1,57 @@
+====================
+Contenu associé
+====================
+
+Présentation
+============
+
+
+Cette section explique la configuration du contenu associé.
+Lorsque la requête de recherche correspond au terme de recherche spécifié, vous pouvez afficher le contenu associé en haut des résultats de recherche.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste pour configurer le contenu associé illustrée ci-dessous, cliquez sur [Crawler > Contenu associé] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration du contenu associé.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Terme de recherche
+::::::::::::::::::
+
+Spécifie le terme de recherche à faire correspondre avec la requête de recherche.
+
+Contenu
+:::::::
+
+Spécifie le contenu à afficher dans les résultats de recherche.
+
+Hôte virtuel
+::::::::::::
+
+Spécifie le nom d'hôte de l'hôte virtuel.
+Pour plus de détails, consultez :doc:`Configuration de l'hôte virtuel dans le guide de configuration <../config/virtual-host>`.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/relatedcontent-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/relatedcontent-2.png

--- a/fr/15.3/admin/relatedquery-guide.rst
+++ b/fr/15.3/admin/relatedquery-guide.rst
@@ -1,0 +1,59 @@
+==================
+Requête associée
+==================
+
+Présentation
+============
+
+Cette section explique la configuration des requêtes associées.
+Vous pouvez améliorer les résultats de recherche avec les requêtes associées enregistrées.
+Les requêtes associées peuvent être utilisées comme mots alternatifs pour les termes de recherche.
+
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste pour configurer les requêtes associées illustrée ci-dessous, cliquez sur [Crawler > Requête associée] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration des requêtes associées.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Terme de recherche
+::::::::::::::::::
+
+Spécifie le terme de recherche à faire correspondre avec la requête de recherche.
+
+Requête
+:::::::
+
+Spécifie la requête.
+
+Hôte virtuel
+::::::::::::
+
+Spécifie le nom d'hôte de l'hôte virtuel.
+Pour plus de détails, consultez :doc:`Configuration de l'hôte virtuel dans le guide de configuration <../config/virtual-host>`.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/relatedquery-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/relatedquery-2.png

--- a/fr/15.3/admin/reqheader-guide.rst
+++ b/fr/15.3/admin/reqheader-guide.rst
@@ -1,0 +1,57 @@
+=====================
+En-tête de requête
+=====================
+
+Présentation
+============
+
+Cette section explique la configuration des en-têtes de requête.
+La fonctionnalité d'en-tête de requête constitue les informations d'en-tête de requête ajoutées à la requête lors de l'obtention de documents par crawl.
+Par exemple, elle peut être utilisée lorsqu'un système d'authentification examine les informations d'en-tête et se connecte automatiquement si une valeur spécifique est présente.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration des en-têtes de requête illustrée ci-dessous, cliquez sur [Crawler > En-tête de requête] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration des en-têtes de requête.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom
+::::
+
+Spécifie le nom de l'en-tête de requête lors de l'ajout à la requête.
+
+Valeur
+::::::
+
+Spécifie la valeur de l'en-tête de requête lors de l'ajout à la requête.
+
+Configuration Web
+:::::::::::::::::
+
+Sélectionnez le nom de configuration de crawl Web auquel ajouter l'en-tête de requête.
+L'en-tête de requête sera ajouté uniquement pour la configuration de crawl sélectionnée.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/reqheader-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/reqheader-2.png

--- a/fr/15.3/admin/role-guide.rst
+++ b/fr/15.3/admin/role-guide.rst
@@ -1,0 +1,46 @@
+======
+Rôle
+======
+
+Présentation
+============
+
+Vous pouvez gérer les rôles auxquels les utilisateurs appartiennent.
+Cela peut être utilisé pour l'intégration LDAP, par exemple.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration des rôles illustrée ci-dessous, cliquez sur [Utilisateur > Rôle] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration des rôles.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom
+::::
+
+Nom du rôle.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/role-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/role-2.png

--- a/fr/15.3/admin/scheduler-guide.rst
+++ b/fr/15.3/admin/scheduler-guide.rst
@@ -1,0 +1,105 @@
+=======================
+Planificateur de tâches
+=======================
+
+Présentation
+============
+
+Cette section explique les paramètres de configuration du planificateur de tâches.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration du planificateur de tâches illustrée ci-dessous, cliquez sur [Système > Planificateur] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration du planificateur.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom
+::::
+
+Nom affiché dans la liste.
+
+Cible
+:::::
+
+La cible peut être utilisée comme identifiant pour déterminer si la tâche doit être exécutée lors de l'exécution directe de commandes par lots, etc.
+Si vous n'exécutez pas de crawl par commande, spécifiez « all ».
+
+Planification
+:::::::::::::
+
+Configure la planification.
+La tâche décrite dans le script sera exécutée selon la planification configurée ici.
+
+Le format de description est le format CRON et s'écrit sous la forme « minute heure jour mois jour_de_la_semaine ».
+Par exemple, « 0 12 \* \* 3 » exécutera la tâche tous les mercredis à 12:00 pm.
+
+Méthode d'exécution
+:::::::::::::::::::
+
+Spécifie l'environnement d'exécution du script.
+Actuellement, seul « groovy » est pris en charge.
+
+Script
+::::::
+
+Décrit le contenu d'exécution de la tâche dans le langage spécifié dans la méthode d'exécution.
+
+Par exemple, si vous souhaitez exécuter uniquement trois configurations de crawl comme tâche de crawl, décrivez comme suit (en supposant que les ID des configurations de crawl Web sont 1 et 2 et que l'ID de la configuration de crawl du système de fichiers est 1).
+
+::
+
+    return container.getComponent("crawlJob").logLevel("info").webConfigIds(["1", "2"] as String[]).fileConfigIds(["1"] as String[]).dataConfigIds([] as String[]).execute(executor);
+
+Journalisation
+::::::::::::::
+
+L'activation enregistre dans le journal des tâches.
+
+Tâche de crawl
+::::::::::::::
+
+L'activation traite comme une tâche de crawl.
+En configurant job.max.crawler.processes dans fess_config.properties, vous pouvez empêcher le démarrage excessif du crawler.
+Par défaut, il n'y a aucune limite au nombre de démarrages du crawler.
+
+État
+::::
+
+Spécifie l'état actif/inactif de la tâche.
+Si désactivé, la tâche ne sera pas exécutée.
+
+Ordre d'affichage
+:::::::::::::::::
+
+Spécifie l'ordre d'affichage dans la liste des tâches.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+Méthode de crawl manuel
+=======================
+
+Cliquez sur « Default Crawler » dans « Planificateur », puis cliquez sur le bouton « Démarrer maintenant ».
+Pour arrêter le crawler, cliquez sur « Default Crawler », puis cliquez sur le bouton « Arrêter ».
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/scheduler-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/scheduler-2.png

--- a/fr/15.3/admin/searchlist-guide.rst
+++ b/fr/15.3/admin/searchlist-guide.rst
@@ -1,0 +1,33 @@
+=========
+Recherche
+=========
+
+Présentation
+============
+
+Cette section explique la recherche d'administration.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de recherche illustrée ci-dessous, cliquez sur [Informations système > Recherche] dans le menu de gauche.
+
+|image0|
+
+Liste de recherche
+------------------
+
+Vous pouvez effectuer une recherche avec les conditions spécifiées.
+Dans l'écran de recherche normal, les conditions de rôle et de navigateur sont ajoutées implicitement, mais elles ne le sont pas dans cette recherche d'administration.
+Vous pouvez également supprimer des documents spécifiques de l'index à partir des résultats de recherche affichés.
+
+Suppression en masse
+--------------------
+
+Si vous souhaitez supprimer tous les documents de l'index, cliquez sur le bouton « Tout supprimer avec cette requête » avec « \*:\* » pour les supprimer.
+Il est également possible de supprimer uniquement les documents cibles en spécifiant les conditions de recherche.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/searchlist-1.png

--- a/fr/15.3/admin/searchlog-guide.rst
+++ b/fr/15.3/admin/searchlog-guide.rst
@@ -1,0 +1,30 @@
+==================
+Journal de recherche
+==================
+
+Présentation
+============
+
+Les résultats d'exécution des recherches, clics et favoris sont enregistrés, et les journaux de recherche peuvent être vérifiés dans cet écran d'administration.
+
+Gestion
+=======
+
+Liste
+=====
+
+Dans la liste, vous pouvez vérifier les journaux de recherche, de clics et de favoris.
+Si vous souhaitez vérifier les détails d'un journal de recherche, cliquez sur le journal de recherche cible.
+
+|image0|
+
+Détails
+=======
+
+En cliquant sur un journal de recherche dans la liste, les détails du journal de recherche cible s'affichent.
+
+|image1|
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/searchlog-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/searchlog-2.png

--- a/fr/15.3/admin/stemmeroverride-guide.rst
+++ b/fr/15.3/admin/stemmeroverride-guide.rst
@@ -1,0 +1,55 @@
+===================================
+Dictionnaire de remplacement Stemmer
+===================================
+
+Présentation
+============
+
+Vous pouvez remplacer le stemming de caractères spécifiques (symboles, codes de caractères, pleine/demi-largeur) par d'autres caractères.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration de remplacement Stemmer illustrée ci-dessous, sélectionnez [Système > Dictionnaire] dans le menu de gauche, puis cliquez sur stemmeroverride.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Méthode de configuration
+-------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration de remplacement Stemmer.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Source de conversion
+:::::::::::::::::::::
+
+Entrez les caractères (symboles, codes de caractères, pleine/demi-largeur) à traiter pour le remplacement Stemmer.
+
+Après conversion
+::::::::::::::::
+
+Développe les caractères entrés dans la source de conversion avec les caractères après conversion.
+
+Téléchargement
+==============
+
+Vous pouvez télécharger au format de dictionnaire de remplacement Stemmer.
+
+Téléversement
+=============
+
+Vous pouvez téléverser au format de dictionnaire de remplacement Stemmer.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/stemmeroverride-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/stemmeroverride-2.png
+

--- a/fr/15.3/admin/stopwords-guide.rst
+++ b/fr/15.3/admin/stopwords-guide.rst
@@ -1,0 +1,55 @@
+========================
+Dictionnaire de mots vides
+========================
+
+Présentation
+============
+
+Vous pouvez transformer des caractères spécifiques (symboles, codes de caractères, pleine/demi-largeur) en mots vides.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration des mots vides illustrée ci-dessous, sélectionnez [Système > Dictionnaire] dans le menu de gauche, puis cliquez sur stopwords.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Méthode de configuration
+-------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration des mots vides.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Source de conversion
+:::::::::::::::::::::
+
+Entrez les caractères (symboles, codes de caractères, pleine/demi-largeur) à traiter comme mots vides.
+
+Après conversion
+::::::::::::::::
+
+Développe les caractères entrés dans la source de conversion avec les caractères après conversion.
+
+Téléchargement
+==============
+
+Vous pouvez télécharger au format de dictionnaire de mots vides.
+
+Téléversement
+=============
+
+Vous pouvez téléverser au format de dictionnaire de mots vides.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/stopwords-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/stopwords-2.png
+

--- a/fr/15.3/admin/storage-guide.rst
+++ b/fr/15.3/admin/storage-guide.rst
@@ -1,0 +1,73 @@
+=========
+Stockage
+=========
+
+Présentation
+============
+
+La page Stockage permet de gérer les fichiers sur MinIO, un stockage d'objets compatible Amazon S3.
+
+Gestion
+=======
+
+Configuration du serveur de stockage d'objets
+----------------------------------------------
+
+Ouvrez la configuration du stockage depuis [Système > Général] et configurez les éléments suivants :
+
+- Point de terminaison : URL du point de terminaison du serveur de stockage
+- Clé d'accès : Clé d'accès du serveur de stockage
+- Clé secrète : Clé secrète du serveur de stockage
+- Bucket : Nom du bucket à gérer
+
+
+Affichage
+---------
+
+Pour ouvrir la page de liste d'objets illustrée ci-dessous, cliquez sur [Système > Stockage] dans le menu de gauche.
+
+|image0|
+
+
+Nom
+::::
+
+Nom de fichier de l'objet
+
+
+Taille
+::::::
+
+Taille de l'objet
+
+
+Date de dernière modification
+::::::::::::::::::::::::::::::
+
+Date de dernière modification de l'objet
+
+Téléchargement
+--------------
+
+Vous pouvez télécharger un objet en cliquant sur le bouton Télécharger.
+
+
+Suppression
+-----------
+
+Vous pouvez supprimer un objet en cliquant sur le bouton Supprimer.
+
+
+Téléversement
+-------------
+
+Vous pouvez ouvrir la fenêtre de téléversement de fichier en cliquant sur le bouton Téléverser le fichier en haut à droite.
+
+
+Création de dossier
+-------------------
+
+Vous pouvez ouvrir la fenêtre de création de dossier en cliquant sur le bouton Créer le dossier à droite de l'affichage du chemin. Notez que vous ne pouvez pas créer de dossiers vides.
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/storage-1.png

--- a/fr/15.3/admin/suggest-guide.rst
+++ b/fr/15.3/admin/suggest-guide.rst
@@ -1,0 +1,37 @@
+=====================
+Mots de suggestion
+=====================
+
+Présentation
+============
+
+La page Mots de suggestion gère les mots à afficher dans les suggestions de mots-clés.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste des mots de suggestion illustrée ci-dessous, cliquez sur [Suggestion > Mots de suggestion] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le bouton Supprimer si vous souhaitez supprimer.
+
+
+Type de mot
+:::::::::::
+
+- Tous : Tous les mots enregistrés
+- Document : Mots générés à partir de documents indexés
+- Terme de recherche : Mots générés à partir des journaux de recherche
+
+Nombre de mots
+::::::::::::::
+
+Nombre de mots enregistrés
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/suggest-1.png
+

--- a/fr/15.3/admin/synonym-guide.rst
+++ b/fr/15.3/admin/synonym-guide.rst
@@ -1,0 +1,81 @@
+=======================
+Dictionnaire de synonymes
+=======================
+
+Présentation
+============
+
+Vous pouvez gérer les synonymes de mots ayant la même signification (comme GB, gigabyte, etc.).
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration des synonymes illustrée ci-dessous, sélectionnez [Système > Dictionnaire] dans le menu de gauche, puis cliquez sur synonym.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Méthode de configuration
+-------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration des synonymes.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Concernant la création d'index, comme la configuration standard est bi-gram, il est nécessaire de s'assurer que le mot après conversion ne soit pas un caractère unique.
+De plus, lors de l'enregistrement de synonymes, il est nécessaire de s'enregistrer comme suit :
+
+* Enregistrer les hiragana en katakana
+* Enregistrer les petits katakana en grands katakana
+* Enregistrer les caractères alphanumériques pleine largeur en demi-largeur
+* Ne pas enregistrer les synonymes en double
+
+Source de conversion
+:::::::::::::::::::::
+
+Entrez le mot à traiter comme synonyme.
+
+Après conversion
+::::::::::::::::
+
+Développe le mot entré dans la source de conversion avec le mot après conversion.
+Par exemple, si vous souhaitez traiter « TV » comme « TV » et « テレビ », entrez « TV » dans la source de conversion et entrez « TV » et « テレビ » dans l'après conversion.
+
+Téléchargement
+==============
+
+Vous pouvez télécharger au format de dictionnaire de synonymes fourni par Apache Lucene.
+
+Téléversement
+=============
+
+Vous pouvez téléverser au format de dictionnaire de synonymes fourni par Apache Lucene.
+Comme les synonymes sont un remplacement d'un groupe de mots par un autre groupe de mots, la description du dictionnaire utilise la virgule (,) et la conversion (=>).
+Par exemple, pour remplacer « TV » par « テレビ », utilisez => et décrivez comme suit.
+
+::
+
+    TV=>テレビ
+
+Pour traiter « fess » et « フェス » de manière similaire, décrivez comme suit.
+
+::
+
+    fess,フエス=>fess,フエス
+
+Dans le cas ci-dessus, vous pouvez également omettre => et décrire comme suit.
+
+::
+
+    fess,フエス
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/synonym-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/synonym-2.png

--- a/fr/15.3/admin/systeminfo-guide.rst
+++ b/fr/15.3/admin/systeminfo-guide.rst
@@ -1,0 +1,44 @@
+==================
+Informations système
+==================
+
+Présentation
+============
+
+Ici, vous pouvez vérifier les informations de propriété telles que les variables d'environnement concernant le système actuellement en cours d'exécution.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page d'informations système illustrée ci-dessous, cliquez sur [Informations système > Informations de configuration] dans le menu de gauche.
+
+|image0|
+
+Éléments affichés
+-----------------
+
+Propriétés des variables d'environnement
+:::::::::::::::::::::::::::::::::::::::::
+
+Vous pouvez lister les variables d'environnement du serveur.
+
+Propriétés du système
+::::::::::::::::::::::
+
+Vous pouvez lister les propriétés système configurées dans |Fess|.
+
+Propriétés de l'application
+::::::::::::::::::::::::::::
+
+Vous pouvez vérifier les informations de configuration de |Fess|.
+
+Propriétés de rapport de bogue
+:::::::::::::::::::::::::::::::
+
+C'est une liste de propriétés à joindre lors du signalement d'un bogue.
+Elle extrait les valeurs qui ne contiennent pas d'informations personnelles.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/systeminfo-1.png

--- a/fr/15.3/admin/upgrade-guide.rst
+++ b/fr/15.3/admin/upgrade-guide.rst
@@ -1,0 +1,8 @@
+==============
+Mise à niveau
+==============
+
+Référence
+=========
+
+Veuillez consulter le `Guide d'installation <https://fess.codelibs.org/ja/15.3/install/index.html>`__.

--- a/fr/15.3/admin/user-guide.rst
+++ b/fr/15.3/admin/user-guide.rst
@@ -1,0 +1,54 @@
+===========
+Utilisateur
+===========
+
+Présentation
+============
+
+Vous pouvez gérer les utilisateurs qui se connectent à |Fess|.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration des utilisateurs illustrée ci-dessous, cliquez sur [Utilisateur > Utilisateur] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration des utilisateurs.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom d'utilisateur
+:::::::::::::::::
+
+Nom d'utilisateur.
+
+Rôle
+::::
+
+Spécifie les rôles auxquels l'utilisateur appartient.
+
+Groupe
+::::::
+
+Spécifie les groupes auxquels l'utilisateur appartient.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/user-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/user-2.png

--- a/fr/15.3/admin/webauth-guide.rst
+++ b/fr/15.3/admin/webauth-guide.rst
@@ -1,0 +1,93 @@
+====================
+Authentification Web
+====================
+
+Présentation
+============
+
+Cette section explique la méthode de configuration lorsqu'une authentification Web est requise pour le crawl ciblant le Web.
+|Fess| prend en charge le crawl pour l'authentification BASIC, DIGEST et NTLM.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration d'authentification Web illustrée ci-dessous, cliquez sur [Crawler > Authentification Web] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Nouvelle création pour ouvrir la page de configuration d'authentification Web.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom d'hôte
+::::::::::
+
+Spécifie le nom d'hôte du site nécessitant une authentification.
+Si omis, il sera appliqué à tout nom d'hôte dans la configuration de crawl Web spécifiée.
+
+Port
+::::
+
+Spécifie le port du site nécessitant une authentification.
+Pour l'appliquer à tous les ports, spécifiez -1.
+Dans ce cas, il sera appliqué à tout port dans la configuration de crawl Web spécifiée.
+
+Domaine
+:::::::
+
+Spécifie le nom de domaine du site nécessitant une authentification.
+Si omis, il sera appliqué à tout nom de domaine dans la configuration de crawl Web spécifiée.
+
+Schéma
+::::::
+
+Sélectionnez la méthode d'authentification.
+Vous pouvez utiliser l'authentification BASIC, DIGEST, NTLM ou FORM.
+
+Nom d'utilisateur
+:::::::::::::::::
+
+Spécifie le nom d'utilisateur pour se connecter au site d'authentification.
+
+Mot de passe
+::::::::::::
+
+Spécifie le mot de passe pour se connecter au site d'authentification.
+
+Paramètres
+::::::::::
+
+Configure s'il existe des valeurs de configuration nécessaires pour se connecter au site d'authentification.
+Pour l'authentification NTLM, vous pouvez définir les valeurs de workstation et domain.
+Pour les configurer, décrivez comme suit :
+
+::
+
+    workstation=HOGE
+    domain=FUGA
+
+Configuration Web
+:::::::::::::::::
+
+Sélectionnez le nom de configuration Web auquel appliquer les paramètres d'authentification ci-dessus.
+Vous devez enregistrer la configuration de crawl Web au préalable.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation.
+Appuyer sur le bouton Supprimer supprimera la configuration.
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/webauth-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/webauth-2.png

--- a/fr/15.3/admin/webconfig-guide.rst
+++ b/fr/15.3/admin/webconfig-guide.rst
@@ -1,0 +1,250 @@
+==============
+Crawl Web
+==============
+
+Présentation
+============
+
+La page de configuration de crawl Web configure le crawl Web.
+
+Gestion
+=======
+
+Affichage
+---------
+
+Pour ouvrir la page de liste de configuration de crawl Web illustrée ci-dessous, cliquez sur [Crawler > Web] dans le menu de gauche.
+
+|image0|
+
+Cliquez sur le nom de la configuration pour la modifier.
+
+Création de configuration
+--------------------------
+
+Cliquez sur le bouton Créer pour ouvrir la page de configuration de crawl Web.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom
+::::
+
+Nom de la configuration.
+
+URL
+::::
+
+URL de départ du crawl.
+
+URL à crawler
+:::::::::::::
+
+Les URL correspondant à l'expression régulière (format Java) spécifiée dans cet élément seront ciblées par le crawler |Fess|.
+
+URL exclues du crawl
+::::::::::::::::::::
+
+Les URL correspondant à l'expression régulière (format Java) spécifiée dans cet élément ne seront pas ciblées par le crawler |Fess|.
+
+URL à indexer
+:::::::::::::
+
+Les URL correspondant à l'expression régulière (format Java) spécifiée dans cet élément seront ciblées pour la recherche.
+
+URL exclues de l'indexation
+::::::::::::::::::::::::::::
+
+Les URL correspondant à l'expression régulière (format Java) spécifiée dans cet élément ne seront pas ciblées pour la recherche.
+
+Paramètres de configuration
+::::::::::::::::::::::::::::
+
+Vous pouvez spécifier les informations de configuration du crawl.
+
+Profondeur
+::::::::::
+
+Vous pouvez spécifier la profondeur lors du suivi des liens contenus dans les documents crawlés.
+
+Nombre maximum d'accès
+::::::::::::::::::::::
+
+Nombre d'URL à indexer.
+
+Agent utilisateur
+:::::::::::::::::
+
+Nom du crawler |Fess|.
+
+Nombre de threads
+:::::::::::::::::
+
+Nombre de threads pour crawler dans cette configuration.
+
+Intervalle
+::::::::::
+
+Intervalle de temps pour chaque thread lors du crawl d'URL.
+
+Valeur de boost
+:::::::::::::::
+
+Poids des documents indexés dans cette configuration.
+
+Permission
+::::::::::
+
+Spécifie la permission pour cette configuration.
+Pour la méthode de spécification de permission, par exemple, pour afficher les résultats de recherche aux utilisateurs appartenant au groupe developer, spécifiez {group}developer.
+La spécification par utilisateur est {user}nom_utilisateur, par rôle {role}nom_rôle, par groupe {group}nom_groupe.
+
+Hôte virtuel
+::::::::::::
+
+Spécifie le nom d'hôte de l'hôte virtuel.
+Pour plus de détails, consultez :doc:`../config/virtual-host`.
+
+État
+::::
+
+Si activé, la tâche planifiée du crawler par défaut inclura cette configuration.
+
+Description
+:::::::::::
+
+Vous pouvez saisir une description.
+
+Suppression de configuration
+-----------------------------
+
+Cliquez sur le nom de la configuration dans la page de liste, puis cliquez sur le bouton Supprimer pour afficher l'écran de confirmation. Appuyer sur le bouton Supprimer supprimera la configuration.
+
+Exemples
+========
+
+Crawler fess.codelibs.org
+-------------------------
+
+Pour créer une configuration de crawl Web qui crawle les pages sous https://fess.codelibs.org/, les valeurs de configuration seraient les suivantes.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Élément de configuration
+     - Valeur de configuration
+   * - Nom
+     - Fess
+   * - URL
+     - https://fess.codelibs.org/
+   * - URL à crawler
+     - https://fess.codelibs.org/.*
+
+Les autres valeurs de configuration utilisent les valeurs par défaut.
+
+Crawl Web de site avec authentification Web
+--------------------------------------------
+
+Fess prend en charge le crawl pour l'authentification BASIC, DIGEST et NTLM.
+Pour plus de détails sur l'authentification Web, consultez la page d'authentification Web.
+
+Redmine
+:::::::
+
+Pour créer une configuration de crawl Web qui crawle les pages de Redmine protégées par mot de passe (ex. https://<serveur>/), les valeurs de configuration seraient les suivantes.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Élément de configuration
+     - Valeur de configuration
+   * - Nom
+     - Redmine
+   * - URL
+     - https://<serveur>/my/page
+   * - URL à crawler
+     - https://<serveur>/.*
+   * - Paramètres de configuration
+     - client.robotsTxtEnabled=false (Optionnel)
+
+Ensuite, créez la configuration d'authentification Web avec les valeurs suivantes.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Élément de configuration
+     - Valeur de configuration
+   * - Schéma
+     - Form
+   * - Nom d'utilisateur
+     - (Compte pour le crawl)
+   * - Mot de passe
+     - (Mot de passe du compte)
+   * - Paramètres
+     - | encoding=UTF-8
+       | token_method=GET
+       | token_url=https://<serveur>/login
+       | token_pattern=name="authenticity_token"[^>]+value="([^"]+)"
+       | token_name=authenticity_token
+       | login_method=POST
+       | login_url=https://<serveur>/login
+       | login_parameters=username=${username}&password=${password}
+   * - Authentification Web
+     - Redmine
+
+
+XWiki
+:::::
+
+Pour créer une configuration de crawl Web qui crawle les pages de XWiki (ex. https://<serveur>/xwiki/), les valeurs de configuration seraient les suivantes.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Élément de configuration
+     - Valeur de configuration
+   * - Nom
+     - XWiki
+   * - URL
+     - https://<serveur>/xwiki/bin/view/Main/
+   * - URL à crawler
+     - https://<serveur>/.*
+   * - Paramètres de configuration
+     - client.robotsTxtEnabled=false (Optionnel)
+
+Ensuite, créez la configuration d'authentification Web avec les valeurs suivantes.
+
+.. tabularcolumns:: |p{4cm}|p{8cm}|
+.. list-table::
+   :header-rows: 1
+
+   * - Élément de configuration
+     - Valeur de configuration
+   * - Schéma
+     - Form
+   * - Nom d'utilisateur
+     - (Compte pour le crawl)
+   * - Mot de passe
+     - (Mot de passe du compte)
+   * - Paramètres
+     - | encoding=UTF-8
+       | token_method=GET
+       | token_url=http://<serveur>/xwiki/bin/login/XWiki/XWikiLogin
+       | token_pattern=name="form_token" +value="([^"]+)"
+       | token_name=form_token
+       | login_method=POST
+       | login_url=http://<serveur>/xwiki/bin/loginsubmit/XWiki/XWikiLogin
+       | login_parameters=j_username=${username}&j_password=${password}
+   * - Authentification Web
+     - XWiki
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/webconfig-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/webconfig-2.png
+.. pdf            :height: 940 px

--- a/fr/15.3/admin/wizard-guide.rst
+++ b/fr/15.3/admin/wizard-guide.rst
@@ -1,0 +1,57 @@
+=======================
+Assistant de configuration
+=======================
+
+Présentation
+============
+
+La page Assistant fournit un outil de configuration simplifié pour enregistrer les configurations de crawl.
+
+Configuration simplifiée
+-------------------------
+
+Cette page est une page de démarrage pour enregistrer la configuration de crawl.
+
+|image0|
+
+Configuration du crawl
+----------------------
+
+Cette page vous permet de créer une configuration de crawl.
+
+|image1|
+
+Paramètres de configuration
+----------------------------
+
+Nom
+::::
+
+Spécifiez le nom de la configuration (par exemple : Site Fess).
+
+Chemin de crawl
+::::::::::::::::
+
+Spécifiez l'URL ou le chemin du fichier du point de départ du crawl (par exemple : https://fess.codelibs.org/).
+
+Nombre maximum d'accès
+::::::::::::::::::::::
+
+Définit la limite supérieure du nombre de pages à crawler.
+
+Profondeur
+::::::::::
+
+Définit la profondeur lors du suivi des liens contenus dans les documents crawlés.
+
+Crawler
+-------
+
+Pour démarrer le crawler |Fess|, cliquez sur le bouton Démarrer le crawl. Si vous ne souhaitez pas encore crawler, cliquez sur le bouton Ignorer.
+
+|image2|
+
+
+.. |image0| image:: ../../../resources/images/ja/15.3/admin/wizard-1.png
+.. |image1| image:: ../../../resources/images/ja/15.3/admin/wizard-2.png
+.. |image2| image:: ../../../resources/images/ja/15.3/admin/wizard-3.png


### PR DESCRIPTION
Translate the complete administrator guide documentation from Japanese (ja/15.3/admin) to French (fr/15.3/admin) with commercial-grade quality. This includes all 46 RST files covering system configuration, crawling, authentication, user management, monitoring, and maintenance.

Key sections translated:
- System configuration (general, scheduler, design)
- Dictionary management (Kuromoji, synonyms, mappings)
- Crawl configurations (web, file, data store)
- Authentication (web, file, request headers)
- User management (users, roles, groups)
- Search enhancements (key match, boost, related content)
- Monitoring (system info, logs, crawl info)
- Maintenance and backup