### PR TITLE
Fix Chinese admin documentation translation

### DIFF
--- a/zh-cn/15.3/admin/upgrade-guide.rst
+++ b/zh-cn/15.3/admin/upgrade-guide.rst
@@ -5,4 +5,4 @@
 参考
 ====
 
-请参考 `Installation Guide <https://fess.codelibs.org/ja/15.3/install/index.html>`__。
+请参考 `Installation Guide <https://fess.codelibs.org/zh-cn/15.3/install/index.html>`__。


### PR DESCRIPTION
…path

- Changed upgrade-guide.rst to reference Chinese installation guide (/zh-cn/15.3/install/) instead of Japanese (/ja/15.3/install/)
- Reviewed all zh-cn/15.3/admin/*.rst files for translation quality
- All other translations are accurate and consistent with Japanese source