### PR TITLE
Fix Chinese user documentation translation

### DIFF
--- a/zh-cn/15.3/user/search-field.rst
+++ b/zh-cn/15.3/user/search-field.rst
@@ -28,7 +28,7 @@
    * - content_length
      - 爬取的文档大小
    * - last_modified
-     - 爬取的文档的最后修改日期
+     - 爬取的文档的最后修改日期和时间
    * - mimetype
      - 文档的 MIME 类型
 

--- a/zh-cn/15.3/user/search-sort.rst
+++ b/zh-cn/15.3/user/search-sort.rst
@@ -15,17 +15,17 @@
    * - 字段名
      - 说明
    * - created
-     - 爬取的日期
+     - 爬取的日期和时间
    * - content_length
      - 爬取的文档大小
    * - last_modified
-     - 爬取的文档的最后修改日期
+     - 爬取的文档的最后修改日期和时间
    * - filename
      - 文件名
    * - score
      - 评分值
    * - timestamp
-     - 文档索引的日期
+     - 文档索引的日期和时间
    * - click_count
      - 文档的点击次数
    * - favorite_count


### PR DESCRIPTION
Updated field descriptions in Chinese user documentation to properly indicate "date and time" rather than just "date" for datetime fields.

Changes:
- search-field.rst: Updated last_modified field description
- search-sort.rst: Updated created, last_modified, and timestamp field descriptions

These changes align the Chinese translation with the English and Japanese versions, which correctly specify "date and time" for these fields.