### PR TITLE
Review and fix English admin documentation

### DIFF
--- a/en/15.3/admin/crawlinginfo-guide.rst
+++ b/en/15.3/admin/crawlinginfo-guide.rst
@@ -24,5 +24,68 @@ To display details for specific crawling session, click the row of crawling info
 
 |image1|
 
+Field List
+----------
+
+Session ID
+::::::::::
+
+The session ID during crawl execution.
+
+Crawler Start Time
+::::::::::::::::::
+
+The time when the entire crawl started.
+
+Crawl Start Time (Web/File)
+::::::::::::::::::::::::::::
+
+The time when web and file system crawling started.
+
+Crawl Start Time (Data Store)
+::::::::::::::::::::::::::::::
+
+The time when data store crawling started.
+
+Crawl End Time (Web/File)
+::::::::::::::::::::::::::
+
+The time when web and file system crawling ended.
+
+Crawl Execution Time (Data Store)
+::::::::::::::::::::::::::::::::::
+
+The execution time of data store crawling (in milliseconds).
+
+Indexing Execution Time (Data Store)
+:::::::::::::::::::::::::::::::::::::
+
+The time taken to index the results of web and file system crawling (in milliseconds).
+
+Index Size (Data Store)
+::::::::::::::::::::::::
+
+The number of indexed documents.
+
+Crawl End Time (Data Store)
+::::::::::::::::::::::::::::
+
+The time when data store crawling ended.
+
+Crawler Status
+::::::::::::::
+
+Whether the crawl was successful or not.
+
+Crawler End Time
+::::::::::::::::
+
+The time when the entire crawl ended.
+
+Crawler Execution Time
+::::::::::::::::::::::
+
+The total execution time of the crawl (in milliseconds).
+
 .. |image0| image:: ../../../resources/images/en/15.3/admin/crawlinginfo-1.png
 .. |image1| image:: ../../../resources/images/en/15.3/admin/crawlinginfo-2.png

--- a/en/15.3/admin/dataconfig-guide.rst
+++ b/en/15.3/admin/dataconfig-guide.rst
@@ -230,8 +230,8 @@ Set the file encoding to Shift_JIS.
     8,Title 8,This is test 8.
     9,Title 9,This is test 9.
 
-Parameter
-:::::::::
+Parameters
+::::::::::
 
 Here's an example of parameter configuration:
 

--- a/en/15.3/admin/failureurl-guide.rst
+++ b/en/15.3/admin/failureurl-guide.rst
@@ -18,4 +18,49 @@ Select System Info > Failure URL in the left menu to display a list page of fail
 
 |image0|
 
+Clicking a failure URL link displays the details.
+
+Failure URL Details
+===================
+
+Failure URL details record exceptions that occurred during crawling.
+
+|image1|
+
+Details Content
+---------------
+
+URL
+::::
+
+The URL where the exception occurred.
+
+Thread Name
+:::::::::::
+
+The thread name that was executing the crawl.
+Can be used when checking log files.
+
+Type
+::::
+
+The type of exception.
+
+Log
+::::
+
+The content of the exception.
+
+Error Count
+:::::::::::
+
+The number of times this exception occurred.
+
+Last Access Time
+::::::::::::::::
+
+The time when this exception occurred.
+
+
 .. |image0| image:: ../../../resources/images/en/15.3/admin/failureurl-1.png
+.. |image1| image:: ../../../resources/images/en/15.3/admin/failureurl-2.png

--- a/en/15.3/admin/fileconfig-guide.rst
+++ b/en/15.3/admin/fileconfig-guide.rst
@@ -129,7 +129,7 @@ To crawl files under /home/share, the configuration values are as follows:
 .. list-table::
    :header-rows: 1
 
-   * - Name
+   * - Configuration Item
      - Value
    * - Name
      - Share Directory
@@ -147,7 +147,7 @@ To crawl files under \\SERVER\SharedFolder, the configuration values are as foll
 .. list-table::
    :header-rows: 1
 
-   * - Name
+   * - Configuration Item
      - Value
    * - Name
      - Shared Folder
@@ -160,7 +160,7 @@ If a username and password are required to access the shared folder, you need to
 .. list-table::
    :header-rows: 1
 
-   * - Name
+   * - Configuration Item
      - Value
    * - Hostname
      - SERVER

--- a/en/15.3/admin/joblog-guide.rst
+++ b/en/15.3/admin/joblog-guide.rst
@@ -26,6 +26,45 @@ Click a job log on the list page to display the details.
 
 |image1|
 
+Name
+::::
+
+The name of the executed job.
+
+Status
+::::::
+
+The execution result of the job.
+
+Target
+::::::
+
+The target for job execution.
+
+Start Time
+::::::::::
+
+UNIX time when the job started.
+
+End Time
+::::::::
+
+UNIX time when the job ended.
+
+Executor
+::::::::
+
+The execution environment where the job was executed.
+
+Script
+::::::
+
+The execution content of the job.
+
+Result
+::::::
+
+The execution result of the job.
 
 .. |image0| image:: ../../../resources/images/en/15.3/admin/joblog-1.png
 .. |image1| image:: ../../../resources/images/en/15.3/admin/joblog-2.png

--- a/en/15.3/admin/webconfig-guide.rst
+++ b/en/15.3/admin/webconfig-guide.rst
@@ -67,7 +67,7 @@ Specifies crawl configuration information.
 Depth
 :::::
 
-The number of linked URLs.
+Specifies the depth for following links contained in crawled documents.
 
 Max Access Count
 ::::::::::::::::
@@ -134,7 +134,7 @@ To create a Web Crawling configuration to crawl pages under https://fess.codelib
 .. list-table::
    :header-rows: 1
 
-   * - Name
+   * - Configuration Item
      - Value
    * - Name
      - Fess
@@ -160,15 +160,15 @@ To crawl Redmine pages (ex. https://<server>/) with password protection, create 
 .. list-table::
    :header-rows: 1
 
-   * - Name
+   * - Configuration Item
      - Value
    * - Name
      - Redmine
-   * - URLs
+   * - URL
      - https://<server>/my/page
-   * - Included URLs For Crawling
+   * - Included URLs for Crawling
      - https://<server>/.*
-   * - Config Parameters
+   * - Configuration Parameters
      - client.robotsTxtEnabled=false (Optional)
 
 and then create the authentication setting on Web Auth page:
@@ -177,7 +177,7 @@ and then create the authentication setting on Web Auth page:
 .. list-table::
    :header-rows: 1
 
-   * - Name
+   * - Configuration Item
      - Value
    * - Scheme
      - Form
@@ -194,7 +194,7 @@ and then create the authentication setting on Web Auth page:
        | login_method=POST
        | login_url=https://<server>/login
        | login_parameters=username=${username}&password=${password}
-   * - Web Config
+   * - Web Configuration
      - Redmine
 
 XWiki
@@ -206,15 +206,15 @@ To crawl XWiki pages (ex. https://<server>/xwiki/), Web Crawling setting is:
 .. list-table::
    :header-rows: 1
 
-   * - Name
+   * - Configuration Item
      - Value
    * - Name
      - XWiki
-   * - URLs
+   * - URL
      - https://<server>/xwiki/bin/view/Main/
-   * - Included URLs For Crawling
+   * - Included URLs for Crawling
      - https://<server>/.*
-   * - Config Parameters
+   * - Configuration Parameters
      - client.robotsTxtEnabled=false (Optional)
 
 and the authentication setting is:
@@ -223,7 +223,7 @@ and the authentication setting is:
 .. list-table::
    :header-rows: 1
 
-   * - Name
+   * - Configuration Item
      - Value
    * - Scheme
      - Form
@@ -240,7 +240,7 @@ and the authentication setting is:
        | login_method=POST
        | login_url=http://<server>/xwiki/bin/loginsubmit/XWiki/XWikiLogin
        | login_parameters=j_username=${username}&j_password=${password}
-   * - Web Config
+   * - Web Configuration
      - XWiki
 
 


### PR DESCRIPTION
This commit addresses multiple translation accuracy and consistency issues in the English admin guide documentation (en/15.3/admin), using the Japanese documentation as the authoritative source:

Critical fixes - Missing content:
- failureurl-guide.rst: Added complete "Failure URL Details" section with field descriptions (URL, Thread Name, Type, Log, Error Count, Last Access Time)
- crawlinginfo-guide.rst: Added complete "Field List" section with 12 field descriptions for crawl execution details
- joblog-guide.rst: Added field descriptions section (Name, Status, Target, Start Time, End Time, Executor, Script, Result)

Moderate fixes - Terminology consistency:
- webconfig-guide.rst: Fixed table headers from "Name" to "Configuration Item", corrected "URLs" to "URL", standardized "Configuration Parameters", fixed Depth field description to accurately reflect link following depth
- fileconfig-guide.rst: Fixed all table headers from "Name" to "Configuration Item"
- dataconfig-guide.rst: Fixed inconsistent "Parameter" to "Parameters"

All changes ensure English documentation accurately reflects the Japanese source.