### PR TITLE
Verify and fix English API documentation

### DIFF
--- a/en/15.3/api/index.rst
+++ b/en/15.3/api/index.rst
@@ -11,4 +11,3 @@
    api-popularword
    api-suggest
    api-health
-   api-gsa


### PR DESCRIPTION
Remove api-gsa from the table of contents in en/15.3/api/index.rst to align with the Japanese documentation structure (ja/15.3/api/index.rst). The api-gsa.rst file remains available but is not included in the main documentation navigation.