### PR TITLE
Fix German translation in installation docs

### DIFF
--- a/de/15.3/install/install-linux.rst
+++ b/de/15.3/install/install-linux.rst
@@ -112,7 +112,7 @@ Schritt 2: Installation von Fess
 
 1. Download und Entpacken von Fess
 
-   Laden Sie die TAR.GZ-Version von der `Download-Site <https://fess.codelibs.org/ja/downloads.html>`__ herunter.
+   Laden Sie die TAR.GZ-Version von der `Download-Site <https://fess.codelibs.org/de/downloads.html>`__ herunter.
 
    ::
 
@@ -206,7 +206,7 @@ Schritt 2: Installation von Fess
 
 1. Installation des Fess-RPM
 
-   Laden Sie das RPM-Paket von der `Download-Site <https://fess.codelibs.org/ja/downloads.html>`__ herunter und installieren Sie es.
+   Laden Sie das RPM-Paket von der `Download-Site <https://fess.codelibs.org/de/downloads.html>`__ herunter und installieren Sie es.
 
    ::
 
@@ -296,7 +296,7 @@ Schritt 2: Installation von Fess
 
 1. Installation des Fess-DEB
 
-   Laden Sie das DEB-Paket von der `Download-Site <https://fess.codelibs.org/ja/downloads.html>`__ herunter und installieren Sie es.
+   Laden Sie das DEB-Paket von der `Download-Site <https://fess.codelibs.org/de/downloads.html>`__ herunter und installieren Sie es.
 
    ::
 

--- a/de/15.3/install/install-windows.rst
+++ b/de/15.3/install/install-windows.rst
@@ -134,7 +134,7 @@ Schritt 2: Installation von Fess
 Download von Fess
 -----------------
 
-1. Laden Sie das ZIP-Paket für Windows von der `Download-Site <https://fess.codelibs.org/ja/downloads.html>`__ herunter.
+1. Laden Sie das ZIP-Paket für Windows von der `Download-Site <https://fess.codelibs.org/de/downloads.html>`__ herunter.
 
 2. Entpacken Sie die heruntergeladene ZIP-Datei in ein beliebiges Verzeichnis.
 

--- a/de/15.3/install/install.rst
+++ b/de/15.3/install/install.rst
@@ -120,7 +120,7 @@ Der grundlegende Ablauf ist bei allen Installationsmethoden gleich.
 
 2. **Software-Download**
 
-   Laden Sie |Fess| von der `Download-Site <https://fess.codelibs.org/ja/downloads.html>`__ herunter.
+   Laden Sie |Fess| von der `Download-Site <https://fess.codelibs.org/de/downloads.html>`__ herunter.
 
    Bei der Docker-Version laden Sie die Docker Compose-Dateien herunter.
 
@@ -224,7 +224,7 @@ Downloads
 
 |Fess| und zugehörige Komponenten können von folgenden Quellen heruntergeladen werden:
 
-- **Fess**: `Download-Site <https://fess.codelibs.org/ja/downloads.html>`__
+- **Fess**: `Download-Site <https://fess.codelibs.org/de/downloads.html>`__
 - **OpenSearch**: `Download OpenSearch <https://opensearch.org/downloads.html>`__
 - **Java (Adoptium)**: `Adoptium <https://adoptium.net/>`__
 - **Docker**: `Get Docker <https://docs.docker.com/get-docker/>`__

--- a/de/15.3/install/upgrade.rst
+++ b/de/15.3/install/upgrade.rst
@@ -35,7 +35,7 @@ Vorbereitung vor dem Upgrade
 Überprüfen Sie die Kompatibilität zwischen der Zielversion und der aktuellen Version des Upgrades.
 
 - `Release Notes <https://github.com/codelibs/fess/releases>`__
-- `Upgrade-Leitfaden <https://fess.codelibs.org/ja/>`__
+- `Upgrade-Leitfaden <https://fess.codelibs.org/de/>`__
 
 Planung der Ausfallzeit
 ------------------------


### PR DESCRIPTION
Update all download and documentation URLs in German installation documentation to use the correct German path (/de/) instead of Japanese (/ja/). This ensures users are directed to the German version of the download page and documentation.

Changes:
- install.rst: Fixed 2 download site URLs
- install-linux.rst: Fixed 3 download site URLs (TAR.GZ, RPM, DEB)
- install-windows.rst: Fixed 1 download site URL (ZIP)
- upgrade.rst: Fixed 1 upgrade guide URL