### PR TITLE
Review and fix German admin documentation

### DIFF
--- a/de/15.3/admin/upgrade-guide.rst
+++ b/de/15.3/admin/upgrade-guide.rst
@@ -5,4 +5,4 @@ Aktualisierung
 Referenz
 ========
 
-Bitte beziehen Sie sich auf den `Installationshandbuch <https://fess.codelibs.org/ja/15.3/install/index.html>`__.
+Bitte beziehen Sie sich auf den `Installationshandbuch <https://fess.codelibs.org/de/15.3/install/index.html>`__.


### PR DESCRIPTION
Changed the installation guide reference in upgrade-guide.rst from /ja/ to /de/ path to ensure German users are directed to the German version of the installation documentation.