### PR TITLE
Verify and fix German translation consistency

### DIFF
--- a/de/15.3/user/advanced-search.rst
+++ b/de/15.3/user/advanced-search.rst
@@ -80,4 +80,4 @@ Website oder Domain
 
 Sie können nach der eingegebenen Website oder Domain filtern.
 
-.. |image0| image:: ../../../resources/images/en/15.3/user/advanced-search-1.png
+.. |image0| image:: ../../../resources/images/de/15.3/user/advanced-search-1.png

--- a/de/15.3/user/role-search.rst
+++ b/de/15.3/user/role-search.rst
@@ -32,8 +32,8 @@ Wenn Sie angemeldet sind, können Sie sich abmelden, indem Sie auf den oben im S
 
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/user/role-search-1.png
+.. |image0| image:: ../../../resources/images/de/15.3/user/role-search-1.png
 .. pdf   :width: 200 px
-.. |image1| image:: ../../../resources/images/en/15.3/user/role-search-2.png
+.. |image1| image:: ../../../resources/images/de/15.3/user/role-search-2.png
 .. pdf   :width: 300 px
 

--- a/de/15.3/user/search-field.rst
+++ b/de/15.3/user/search-field.rst
@@ -28,7 +28,7 @@ Standardmäßig können die folgenden Felder für die Suche angegeben werden.
    * - content_length
      - Größe des gecrawlten Dokuments
    * - last_modified
-     - Letztes Änderungsdatum des gecrawlten Dokuments
+     - Letztes Änderungsdatum und Uhrzeit des gecrawlten Dokuments
    * - mimetype
      - MIME-Typ des Dokuments
 

--- a/de/15.3/user/search-label.rst
+++ b/de/15.3/user/search-label.rst
@@ -18,5 +18,5 @@ Bei der Suche können Label-Informationen ausgewählt werden. Label-Informatione
 
 Durch Festlegen von Labeln und Erstellen eines Index können Sie nach Dokumenten suchen, für die Label festgelegt wurden. Eine Suche ohne Angabe von Labeln ist eine normale Suche über alle Dokumente. Wenn Label-Informationen geändert werden, muss der Index aktualisiert werden.
 
-.. |image0| image:: ../../../resources/images/en/15.3/user/search-label-1.png
+.. |image0| image:: ../../../resources/images/de/15.3/user/search-label-1.png
 .. pdf   :width: 300 px

--- a/de/15.3/user/search-sort.rst
+++ b/de/15.3/user/search-sort.rst
@@ -15,17 +15,17 @@ Standardmäßig können die folgenden Felder zum Sortieren angegeben werden.
    * - Feldname
      - Beschreibung
    * - created
-     - Crawl-Datum
+     - Crawl-Datum und Uhrzeit
    * - content_length
      - Größe des gecrawlten Dokuments
    * - last_modified
-     - Letztes Änderungsdatum des gecrawlten Dokuments
+     - Letztes Änderungsdatum und Uhrzeit des gecrawlten Dokuments
    * - filename
      - Dateiname
    * - score
      - Bewertung
    * - timestamp
-     - Datum der Dokumentindizierung
+     - Datum und Uhrzeit der Dokumentindizierung
    * - click_count
      - Anzahl der Klicks auf das Dokument
    * - favorite_count
@@ -63,5 +63,5 @@ Um nach mehreren Feldern zu sortieren, geben Sie diese durch Kommas getrennt an:
 
     fess sort:content_length.desc,last_modified
 
-.. |image0| image:: ../../../resources/images/en/15.3/user/search-sort-1.png
+.. |image0| image:: ../../../resources/images/de/15.3/user/search-sort-1.png
 .. pdf            :width: 300 px


### PR DESCRIPTION
- Fix datetime field descriptions to include time component (und Uhrzeit) in search-field.rst and search-sort.rst
- Update image paths from en/ to de/ in search-label.rst, search-sort.rst, role-search.rst, and advanced-search.rst
- Aligns with Japanese documentation and follows pattern from commit #225