### PR TITLE
Fix Spanish installation documentation

### DIFF
--- a/es/15.3/install/install-linux.rst
+++ b/es/15.3/install/install-linux.rst
@@ -69,7 +69,7 @@ Paso 1: Instalación de OpenSearch
        $ cd /path/to/opensearch-3.3.2
        $ ./bin/opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-fess:3.3.2
        $ ./bin/opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-extension:3.3.2
-       $ ./bin/opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-minhash:3.3.2
+       $ ./bin/opensearch-plugin install org.codelibs.opensearch:opensearch-minhash:3.3.2
        $ ./bin/opensearch-plugin install org.codelibs.opensearch:opensearch-configsync:3.3.2
 
    .. important::
@@ -180,7 +180,7 @@ Paso 1: Instalación de OpenSearch
 
        $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-fess:3.3.2
        $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-extension:3.3.2
-       $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-minhash:3.3.2
+       $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-minhash:3.3.2
        $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-configsync:3.3.2
 
 3. Configuración de OpenSearch
@@ -270,7 +270,7 @@ Paso 1: Instalación de OpenSearch
 
        $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-fess:3.3.2
        $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-extension:3.3.2
-       $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-minhash:3.3.2
+       $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-minhash:3.3.2
        $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-configsync:3.3.2
 
 3. Configuración de OpenSearch

--- a/es/15.3/install/install-windows.rst
+++ b/es/15.3/install/install-windows.rst
@@ -85,7 +85,7 @@ Abra el Símbolo del sistema **con privilegios de administrador** y ejecute los 
     C:\> cd C:\opensearch-3.3.2
     C:\opensearch-3.3.2> bin\opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-fess:3.3.2
     C:\opensearch-3.3.2> bin\opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-extension:3.3.2
-    C:\opensearch-3.3.2> bin\opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-minhash:3.3.2
+    C:\opensearch-3.3.2> bin\opensearch-plugin install org.codelibs.opensearch:opensearch-minhash:3.3.2
     C:\opensearch-3.3.2> bin\opensearch-plugin install org.codelibs.opensearch:opensearch-configsync:3.3.2
 
 .. important::

--- a/es/15.3/install/upgrade.rst
+++ b/es/15.3/install/upgrade.rst
@@ -216,7 +216,7 @@ Si también actualiza OpenSearch, siga estos procedimientos.
 
        $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-fess:3.3.2
        $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-extension:3.3.2
-       $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-analysis-minhash:3.3.2
+       $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-minhash:3.3.2
        $ sudo /usr/share/opensearch/bin/opensearch-plugin install org.codelibs.opensearch:opensearch-configsync:3.3.2
 
 3. Inicie OpenSearch::


### PR DESCRIPTION
Corrected the OpenSearch plugin name from
'opensearch-analysis-minhash' to 'opensearch-minhash' to match the Japanese source documentation.

Fixed in:
- es/15.3/install/install-linux.rst (TAR.GZ, RPM, DEB sections)
- es/15.3/install/install-windows.rst
- es/15.3/install/upgrade.rst