### PR TITLE
Review and fix Spanish admin documentation

### DIFF
--- a/es/15.3/admin/accesstoken-guide.rst
+++ b/es/15.3/admin/accesstoken-guide.rst
@@ -72,5 +72,5 @@ Al presionar el botón de eliminar, se eliminará la configuración.
 
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/accesstoken-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/accesstoken-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/accesstoken-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/accesstoken-2.png

--- a/es/15.3/admin/backup-guide.rst
+++ b/es/15.3/admin/backup-guide.rst
@@ -71,4 +71,4 @@ Carga
 Puede cargar e importar información de configuración.
 Los archivos que se pueden restaurar son \*.bulk y system.properties.
 
-  .. |image0| image:: ../../../resources/images/en/15.3/admin/backup-1.png
+  .. |image0| image:: ../../../resources/images/es/15.3/admin/backup-1.png

--- a/es/15.3/admin/badword-guide.rst
+++ b/es/15.3/admin/badword-guide.rst
@@ -79,7 +79,7 @@ Desde la segunda línea en adelante se describen las palabras excluidas.
 "BadWord"
 "検索エンジン"
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/badword-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/badword-2.png
-.. |image2| image:: ../../../resources/images/en/15.3/admin/badword-3.png
-.. |image3| image:: ../../../resources/images/en/15.3/admin/badword-4.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/badword-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/badword-2.png
+.. |image2| image:: ../../../resources/images/es/15.3/admin/badword-3.png
+.. |image3| image:: ../../../resources/images/es/15.3/admin/badword-4.png

--- a/es/15.3/admin/boostdoc-guide.rst
+++ b/es/15.3/admin/boostdoc-guide.rst
@@ -54,5 +54,5 @@ Eliminar configuración
 Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación. Al presionar el botón de eliminar, se eliminará la configuración.
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/boostdoc-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/boostdoc-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/boostdoc-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/boostdoc-2.png

--- a/es/15.3/admin/crawlinginfo-guide.rst
+++ b/es/15.3/admin/crawlinginfo-guide.rst
@@ -89,5 +89,5 @@ Tiempo de ejecución del rastreador
 
 Tiempo de ejecución de todo el rastreo (milisegundos).
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/crawlinginfo-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/crawlinginfo-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/crawlinginfo-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/crawlinginfo-2.png

--- a/es/15.3/admin/dashboard-guide.rst
+++ b/es/15.3/admin/dashboard-guide.rst
@@ -15,11 +15,11 @@ El panel de control proporciona una herramienta de administración web para gest
 
    * - Nombre del índice
      - Descripción
-   * - fess.AAAAMMDD
+   * - fess.YYYYMMDD
      - Documentos indexados
    * - fess_log
      - Registro de accesos
-   * - fess.suggest.AAAAMMDD
+   * - fess.suggest.YYYYMMDD
      - Palabras de sugerencia
    * - fess_config
      - Configuración de |Fess|
@@ -52,6 +52,6 @@ El número de documentos indexados se muestra en el índice fess, como se muestr
 Al hacer clic en el icono de la esquina superior derecha de cada índice, se muestra un menú de operaciones para el índice.
 Si desea eliminar documentos indexados, elimínelos desde la pantalla de búsqueda administrativa. Tenga cuidado de no eliminarlos con "delete index".
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/dashboard-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/dashboard-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/dashboard-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/dashboard-2.png
 .. pdf            :width: 400 px

--- a/es/15.3/admin/dataconfig-guide.rst
+++ b/es/15.3/admin/dataconfig-guide.rst
@@ -426,5 +426,5 @@ Si se requiere autenticación en el destino del rastreo, también es necesario c
     crawler.file.auth.example.username=username
     crawler.file.auth.example.password=password
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/dataconfig-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/dataconfig-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/dataconfig-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/dataconfig-2.png

--- a/es/15.3/admin/design-guide.rst
+++ b/es/15.3/admin/design-guide.rst
@@ -97,5 +97,5 @@ Si se omite, se utilizará el nombre del archivo cargado.
 Por ejemplo, si especifica logo.png, se cambiará la imagen de la página principal de búsqueda.
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/design-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/design-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/design-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/design-2.png

--- a/es/15.3/admin/dict-guide.rst
+++ b/es/15.3/admin/dict-guide.rst
@@ -56,5 +56,5 @@ Administra el diccionario de anulación de Stemmer.
 stemmer_override.txt se coloca para cada idioma y es un archivo de diccionario de sustitución de palabras para anular el procesamiento de stemming.
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/dict-1.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/dict-1.png
             :height: 940px

--- a/es/15.3/admin/duplicatehost-guide.rst
+++ b/es/15.3/admin/duplicatehost-guide.rst
@@ -47,5 +47,5 @@ Eliminar configuración
 Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
 Al presionar el botón de eliminar, se eliminará la configuración.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/duplicatehost-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/duplicatehost-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/duplicatehost-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/duplicatehost-2.png

--- a/es/15.3/admin/elevateword-guide.rst
+++ b/es/15.3/admin/elevateword-guide.rst
@@ -100,7 +100,7 @@ Desde la segunda línea en adelante se describen las palabras adicionales.
 "fess","ふぇす","role1","label1","100"
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/elevateword-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/elevateword-2.png
-.. |image2| image:: ../../../resources/images/en/15.3/admin/elevateword-3.png
-.. |image3| image:: ../../../resources/images/en/15.3/admin/elevateword-4.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/elevateword-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/elevateword-2.png
+.. |image2| image:: ../../../resources/images/es/15.3/admin/elevateword-3.png
+.. |image3| image:: ../../../resources/images/es/15.3/admin/elevateword-4.png

--- a/es/15.3/admin/esreq-guide.rst
+++ b/es/15.3/admin/esreq-guide.rst
@@ -37,4 +37,4 @@ Por ejemplo, el contenido del archivo JSON sería el siguiente.
       }
     }
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/esreq-1.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/esreq-1.png

--- a/es/15.3/admin/failureurl-guide.rst
+++ b/es/15.3/admin/failureurl-guide.rst
@@ -62,5 +62,5 @@ Fecha del último acceso
 Hora en la que ocurrió esta excepción.
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/failureurl-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/failureurl-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/failureurl-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/failureurl-2.png

--- a/es/15.3/admin/fileauth-guide.rst
+++ b/es/15.3/admin/fileauth-guide.rst
@@ -76,5 +76,5 @@ Eliminar configuración
 Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
 Al presionar el botón de eliminar, se eliminará la configuración.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/fileauth-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/fileauth-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/fileauth-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/fileauth-2.png

--- a/es/15.3/admin/fileconfig-guide.rst
+++ b/es/15.3/admin/fileconfig-guide.rst
@@ -175,6 +175,6 @@ En ese caso, la configuración sería la siguiente.
 
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/fileconfig-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/fileconfig-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/fileconfig-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/fileconfig-2.png
 .. pdf            :height: 940 px

--- a/es/15.3/admin/general-guide.rst
+++ b/es/15.3/admin/general-guide.rst
@@ -290,5 +290,5 @@ Ejemplo de configuración LDAP
      - memberOf
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/general-1.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/general-1.png
 .. pdf            :height: 940 px

--- a/es/15.3/admin/group-guide.rst
+++ b/es/15.3/admin/group-guide.rst
@@ -41,5 +41,5 @@ Método de eliminación
 Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
 Al presionar el botón de eliminar, se eliminará la configuración.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/group-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/group-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/group-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/group-2.png

--- a/es/15.3/admin/joblog-guide.rst
+++ b/es/15.3/admin/joblog-guide.rst
@@ -64,5 +64,5 @@ Resultado
 
 Resultado de la ejecución del trabajo.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/joblog-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/joblog-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/joblog-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/joblog-2.png

--- a/es/15.3/admin/keymatch-guide.rst
+++ b/es/15.3/admin/keymatch-guide.rst
@@ -62,5 +62,5 @@ Eliminar configuración
 Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
 Al presionar el botón de eliminar, se eliminará la configuración.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/keymatch-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/keymatch-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/keymatch-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/keymatch-2.png

--- a/es/15.3/admin/kuromoji-guide.rst
+++ b/es/15.3/admin/kuromoji-guide.rst
@@ -72,5 +72,5 @@ Por ejemplo, sería como sigue:
     関西国際空港,関西 国際 空港,カンサイ コクサイ クウコウ,カスタム名詞
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/kuromoji-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/kuromoji-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/kuromoji-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/kuromoji-2.png

--- a/es/15.3/admin/labeltype-guide.rst
+++ b/es/15.3/admin/labeltype-guide.rst
@@ -83,5 +83,5 @@ Eliminar configuración
 Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
 Al presionar el botón de eliminar, se eliminará la configuración.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/labeltype-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/labeltype-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/labeltype-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/labeltype-2.png

--- a/es/15.3/admin/log-guide.rst
+++ b/es/15.3/admin/log-guide.rst
@@ -67,4 +67,4 @@ gc-crawler.log
 
 Se registran los registros de GC de fess.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/log-1.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/log-1.png

--- a/es/15.3/admin/maintenance-guide.rst
+++ b/es/15.3/admin/maintenance-guide.rst
@@ -64,4 +64,4 @@ Diagnóstico
 
 Puede descargar archivos de registro en formato zip.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/maintenance-1.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/maintenance-1.png

--- a/es/15.3/admin/mapping-guide.rst
+++ b/es/15.3/admin/mapping-guide.rst
@@ -50,6 +50,6 @@ Carga
 Puede cargar en el formato de diccionario de mapeo.
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/mapping-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/mapping-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/mapping-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/mapping-2.png
 

--- a/es/15.3/admin/pathmap-guide.rst
+++ b/es/15.3/admin/pathmap-guide.rst
@@ -63,5 +63,5 @@ Eliminar configuración
 Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
 Al presionar el botón de eliminar, se eliminará la configuración.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/pathmap-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/pathmap-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/pathmap-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/pathmap-2.png

--- a/es/15.3/admin/plugin-guide.rst
+++ b/es/15.3/admin/plugin-guide.rst
@@ -28,5 +28,5 @@ Para instalar un nuevo complemento, haga clic en el botón de instalación.
 
 Seleccione el complemento que desea instalar en el menú desplegable y haga clic en el botón de instalación para comenzar la instalación.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/plugin-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/plugin-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/plugin-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/plugin-2.png

--- a/es/15.3/admin/protwords-guide.rst
+++ b/es/15.3/admin/protwords-guide.rst
@@ -48,5 +48,5 @@ Carga
 Puede cargar en el formato de diccionario de Protwords.
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/protwords-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/protwords-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/protwords-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/protwords-2.png

--- a/es/15.3/admin/relatedcontent-guide.rst
+++ b/es/15.3/admin/relatedcontent-guide.rst
@@ -53,5 +53,5 @@ Eliminar configuración
 Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
 Al presionar el botón de eliminar, se eliminará la configuración.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/relatedcontent-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/relatedcontent-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/relatedcontent-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/relatedcontent-2.png

--- a/es/15.3/admin/relatedquery-guide.rst
+++ b/es/15.3/admin/relatedquery-guide.rst
@@ -55,5 +55,5 @@ Haga clic en el nombre de la configuración en la página de lista y haga clic e
 Al presionar el botón de eliminar, se eliminará la configuración.
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/relatedquery-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/relatedquery-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/relatedquery-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/relatedquery-2.png

--- a/es/15.3/admin/reqheader-guide.rst
+++ b/es/15.3/admin/reqheader-guide.rst
@@ -53,5 +53,5 @@ Eliminar configuración
 Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
 Al presionar el botón de eliminar, se eliminará la configuración.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/reqheader-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/reqheader-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/reqheader-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/reqheader-2.png

--- a/es/15.3/admin/role-guide.rst
+++ b/es/15.3/admin/role-guide.rst
@@ -42,5 +42,5 @@ Haga clic en el nombre de la configuración en la página de lista y haga clic e
 Al presionar el botón de eliminar, se eliminará la configuración.
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/role-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/role-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/role-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/role-2.png

--- a/es/15.3/admin/scheduler-guide.rst
+++ b/es/15.3/admin/scheduler-guide.rst
@@ -101,5 +101,5 @@ Método de rastreo manual
 Haga clic en "Default Crawler" en "Programador" y luego haga clic en el botón "Iniciar ahora".
 Para detener el rastreador, haga clic en "Default Crawler" y luego haga clic en el botón "Detener".
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/scheduler-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/scheduler-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/scheduler-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/scheduler-2.png

--- a/es/15.3/admin/searchlist-guide.rst
+++ b/es/15.3/admin/searchlist-guide.rst
@@ -30,4 +30,4 @@ Eliminación masiva
 Si desea eliminar todos los documentos del índice, haga clic en el botón "Eliminar todo con esta consulta" con "\*:\*" para eliminarlos.
 También es posible especificar condiciones de búsqueda y eliminar solo los documentos objetivo.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/searchlist-1.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/searchlist-1.png

--- a/es/15.3/admin/searchlog-guide.rst
+++ b/es/15.3/admin/searchlog-guide.rst
@@ -26,5 +26,5 @@ Al hacer clic en un registro de búsqueda desde la lista, se muestran los detall
 |image1|
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/searchlog-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/searchlog-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/searchlog-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/searchlog-2.png

--- a/es/15.3/admin/stemmeroverride-guide.rst
+++ b/es/15.3/admin/stemmeroverride-guide.rst
@@ -50,6 +50,6 @@ Carga
 Puede cargar en el formato de diccionario de anulación de Stemmer.
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/stemmeroverride-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/stemmeroverride-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/stemmeroverride-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/stemmeroverride-2.png
 

--- a/es/15.3/admin/stopwords-guide.rst
+++ b/es/15.3/admin/stopwords-guide.rst
@@ -50,6 +50,6 @@ Carga
 Puede cargar en el formato de diccionario de palabras vacías.
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/stopwords-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/stopwords-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/stopwords-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/stopwords-2.png
 

--- a/es/15.3/admin/storage-guide.rst
+++ b/es/15.3/admin/storage-guide.rst
@@ -70,4 +70,4 @@ Crear carpeta
 Puede abrir la ventana de creación de carpeta haciendo clic en el botón de crear carpeta a la derecha de la visualización de ruta. Tenga en cuenta que no se pueden crear carpetas vacías.
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/storage-1.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/storage-1.png

--- a/es/15.3/admin/suggest-guide.rst
+++ b/es/15.3/admin/suggest-guide.rst
@@ -33,5 +33,5 @@ Número de palabras
 Número de palabras registradas
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/suggest-1.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/suggest-1.png
 

--- a/es/15.3/admin/synonym-guide.rst
+++ b/es/15.3/admin/synonym-guide.rst
@@ -77,5 +77,5 @@ En casos como el anterior, también puede omitir => y describirlo de la siguient
     fess,フエス
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/synonym-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/synonym-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/synonym-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/synonym-2.png

--- a/es/15.3/admin/systeminfo-guide.rst
+++ b/es/15.3/admin/systeminfo-guide.rst
@@ -41,4 +41,4 @@ Propiedades del informe de errores
 Es una lista de propiedades para adjuntar al informar un error.
 Extrae valores que no contienen información personal.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/systeminfo-1.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/systeminfo-1.png

--- a/es/15.3/admin/user-guide.rst
+++ b/es/15.3/admin/user-guide.rst
@@ -50,5 +50,5 @@ Eliminar configuración
 Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
 Al presionar el botón de eliminar, se eliminará la configuración.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/user-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/user-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/user-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/user-2.png

--- a/es/15.3/admin/webauth-guide.rst
+++ b/es/15.3/admin/webauth-guide.rst
@@ -89,5 +89,5 @@ Eliminar configuración
 Haga clic en el nombre de la configuración en la página de lista y haga clic en el botón de eliminar para que aparezca una pantalla de confirmación.
 Al presionar el botón de eliminar, se eliminará la configuración.
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/webauth-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/webauth-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/webauth-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/webauth-2.png

--- a/es/15.3/admin/webconfig-guide.rst
+++ b/es/15.3/admin/webconfig-guide.rst
@@ -245,6 +245,6 @@ Después de eso, cree la configuración de autenticación web con los siguientes
      - XWiki
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/webconfig-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/webconfig-2.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/webconfig-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/webconfig-2.png
 .. pdf            :height: 940 px

--- a/es/15.3/admin/wizard-guide.rst
+++ b/es/15.3/admin/wizard-guide.rst
@@ -52,6 +52,6 @@ Para iniciar el rastreador de |Fess|, haga clic en el botón "Iniciar rastreo". 
 |image2|
 
 
-.. |image0| image:: ../../../resources/images/en/15.3/admin/wizard-1.png
-.. |image1| image:: ../../../resources/images/en/15.3/admin/wizard-2.png
-.. |image2| image:: ../../../resources/images/en/15.3/admin/wizard-3.png
+.. |image0| image:: ../../../resources/images/es/15.3/admin/wizard-1.png
+.. |image1| image:: ../../../resources/images/es/15.3/admin/wizard-2.png
+.. |image2| image:: ../../../resources/images/es/15.3/admin/wizard-3.png


### PR DESCRIPTION
This commit fixes two types of issues in the Spanish (es/15.3/admin) documentation:

1. Image path references: Changed all image paths from 'en/15.3/admin' to 'es/15.3/admin' to correctly reference Spanish version images (44 files affected)

2. Date format placeholders: Fixed incorrect date format in dashboard-guide.rst from 'AAAAMMDD' to 'YYYYMMDD' to match the Japanese source

All translations were verified against the Japanese (ja/15.3/admin) documentation to ensure accuracy.