### PR TITLE
Fix Korean translation in installation guide

### DIFF
--- a/ko/15.3/install/install-linux.rst
+++ b/ko/15.3/install/install-linux.rst
@@ -112,7 +112,7 @@ TAR.GZ 버전 설치
 
 1. Fess 다운로드 및 압축 해제
 
-   `다운로드 사이트 <https://fess.codelibs.org/ja/downloads.html>`__ 에서 TAR.GZ 버전을 다운로드합니다.
+   `다운로드 사이트 <https://fess.codelibs.org/ko/downloads.html>`__ 에서 TAR.GZ 버전을 다운로드합니다.
 
    ::
 
@@ -206,7 +206,7 @@ RPM 버전은 Red Hat Enterprise Linux, CentOS, Fedora 등 RPM 기반 Linux 배�
 
 1. Fess RPM 설치
 
-   `다운로드 사이트 <https://fess.codelibs.org/ja/downloads.html>`__ 에서 RPM 패키지를 다운로드하여 설치합니다.
+   `다운로드 사이트 <https://fess.codelibs.org/ko/downloads.html>`__ 에서 RPM 패키지를 다운로드하여 설치합니다.
 
    ::
 
@@ -296,7 +296,7 @@ DEB 버전은 Debian, Ubuntu 등 DEB 기반 Linux 배포판에서 사용합니�
 
 1. Fess DEB 설치
 
-   `다운로드 사이트 <https://fess.codelibs.org/ja/downloads.html>`__ 에서 DEB 패키지를 다운로드하여 설치합니다.
+   `다운로드 사이트 <https://fess.codelibs.org/ko/downloads.html>`__ 에서 DEB 패키지를 다운로드하여 설치합니다.
 
    ::
 

--- a/ko/15.3/install/install-windows.rst
+++ b/ko/15.3/install/install-windows.rst
@@ -134,7 +134,7 @@ OpenSearch 설정
 Fess 다운로드
 -----------------
 
-1. `다운로드 사이트 <https://fess.codelibs.org/ja/downloads.html>`__ 에서 Windows용 ZIP 패키지를 다운로드합니다.
+1. `다운로드 사이트 <https://fess.codelibs.org/ko/downloads.html>`__ 에서 Windows용 ZIP 패키지를 다운로드합니다.
 
 2. 다운로드한 ZIP 파일을 임의의 디렉터리에 압축 해제합니다.
 

--- a/ko/15.3/install/install.rst
+++ b/ko/15.3/install/install.rst
@@ -120,7 +120,7 @@ Windows 버전 (ZIP)
 
 2. **소프트웨어 다운로드**
 
-   `다운로드 사이트 <https://fess.codelibs.org/ja/downloads.html>`__ 에서 |Fess| 를 다운로드합니다.
+   `다운로드 사이트 <https://fess.codelibs.org/ko/downloads.html>`__ 에서 |Fess| 를 다운로드합니다.
 
    Docker 버전의 경우 Docker Compose 파일을 가져옵니다.
 
@@ -224,7 +224,7 @@ A: 예, 가능합니다. Fess와 OpenSearch를 별도의 서버에서 실행할 
 
 |Fess| 및 관련 구성요소는 다음에서 다운로드할 수 있습니다:
 
-- **Fess**: `다운로드 사이트 <https://fess.codelibs.org/ja/downloads.html>`__
+- **Fess**: `다운로드 사이트 <https://fess.codelibs.org/ko/downloads.html>`__
 - **OpenSearch**: `Download OpenSearch <https://opensearch.org/downloads.html>`__
 - **Java (Adoptium)**: `Adoptium <https://adoptium.net/>`__
 - **Docker**: `Get Docker <https://docs.docker.com/get-docker/>`__

--- a/ko/15.3/install/upgrade.rst
+++ b/ko/15.3/install/upgrade.rst
@@ -35,7 +35,7 @@
 업그레이드 대상 버전과 현재 버전의 호환성을 확인하십시오.
 
 - `릴리스 노트 <https://github.com/codelibs/fess/releases>`__
-- `업그레이드 가이드 <https://fess.codelibs.org/ja/>`__
+- `업그레이드 가이드 <https://fess.codelibs.org/ko/>`__
 
 다운타임 계획
 ----------------


### PR DESCRIPTION
Update all download and documentation URLs in Korean installation documentation to use the correct Korean path (/ko/) instead of Japanese (/ja/). This ensures users are directed to the Korean version of the download page and documentation.

Changes:
- install.rst: Fixed 2 download site URLs
- install-linux.rst: Fixed 3 download site URLs (TAR.GZ, RPM, DEB)
- install-windows.rst: Fixed 1 download site URL (ZIP)
- upgrade.rst: Fixed 1 upgrade guide URL