### PR TITLE
Verify and fix French API documentation

### DIFF
--- a/fr/15.3/api/index.rst
+++ b/fr/15.3/api/index.rst
@@ -1,5 +1,5 @@
 Guide API |Fess|
-===============
+=================
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
The header "Guide API |Fess|" (17 characters) had an underline of only 15 equals signs. In reStructuredText, the underline must match the title length. Fixed by extending the underline to 17 equals signs.