### PR TITLE
Verify Spanish translation against Japanese reference

### DIFF
--- a/es/15.3/user/advanced-search.rst
+++ b/es/15.3/user/advanced-search.rst
@@ -63,7 +63,7 @@ Puede realizar búsquedas filtradas por información de etiquetas. Si no hay eti
 Fecha de actualización
 ::::::::::::::::::::::
 
-Puede realizar búsquedas filtradas por la fecha de actualización del documento.
+Puede realizar búsquedas filtradas por la fecha y hora de actualización del documento.
 
 Formato de archivo
 ::::::::::::::::::

--- a/es/15.3/user/search-field.rst
+++ b/es/15.3/user/search-field.rst
@@ -28,7 +28,7 @@ Por defecto, puede buscar especificando los siguientes campos:
    * - content_length
      - Tamaño del documento rastreado
    * - last_modified
-     - Fecha de última modificación del documento rastreado
+     - Fecha y hora de última modificación del documento rastreado
    * - mimetype
      - Tipo MIME del documento
 

--- a/es/15.3/user/search-sort.rst
+++ b/es/15.3/user/search-sort.rst
@@ -19,7 +19,7 @@ Por defecto, puede ordenar especificando los siguientes campos:
    * - content_length
      - Tamaño del documento rastreado
    * - last_modified
-     - Fecha de última modificación del documento rastreado
+     - Fecha y hora de última modificación del documento rastreado
    * - filename
      - Nombre del archivo
    * - score


### PR DESCRIPTION
…field descriptions

This commit fixes three instances where the Spanish translation incorrectly omitted the time component when describing datetime fields:

1. search-field.rst: Updated last_modified field description from "Fecha de última modificación" to "Fecha y hora de última modificación" to accurately reflect that this field contains both date and time information.

2. search-sort.rst: Updated last_modified field description with the same fix to maintain consistency with other datetime fields (created, timestamp) which already correctly included "y hora".

3. advanced-search.rst: Updated the Last Modified section description from "fecha de actualización" to "fecha y hora de actualización" to match the Japanese source documentation (日時 = date and time).

These changes align the Spanish documentation with the Japanese source and ensure consistency with similar fixes made to other language translations (e.g., Chinese in commit #225).