### PR TITLE
Update Windows install docs to use FESS_JAVA_OPTS for configuration

### DIFF
--- a/de/15.3/install/install-windows.rst
+++ b/de/15.3/install/install-windows.rst
@@ -153,12 +153,12 @@ Konfiguration von Fess
 
 ::
 
-    set SEARCH_ENGINE_HTTP_URL=http://localhost:9200
-    set FESS_DICTIONARY_PATH=C:/opensearch-3.3.2/data/config/
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=C:/opensearch-3.3.2/data/config/
 
 .. note::
 
-   - Wenn OpenSearch auf einem anderen Host ausgeführt wird, ändern Sie ``SEARCH_ENGINE_HTTP_URL`` auf den entsprechenden Hostnamen oder die IP-Adresse.
+   - Wenn OpenSearch auf einem anderen Host ausgeführt wird, ändern Sie ``fess.search_engine.http_address`` auf den entsprechenden Hostnamen oder die IP-Adresse.
    - Verwenden Sie ``/`` als Pfadtrennzeichen.
 
 Überprüfung der Installation
@@ -168,8 +168,8 @@ Konfiguration von Fess
 
 In der Eingabeaufforderung::
 
-    C:\> findstr "SEARCH_ENGINE_HTTP_URL" C:\fess-15.3.2\bin\fess.in.bat
-    C:\> findstr "FESS_DICTIONARY_PATH" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.search_engine.http_address" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.dictionary.path" C:\fess-15.3.2\bin\fess.in.bat
 
 Schritt 3: Start
 ================

--- a/en/15.3/install/install-windows.rst
+++ b/en/15.3/install/install-windows.rst
@@ -153,12 +153,12 @@ Open ``bin\fess.in.bat`` with a text editor and add or modify the following sett
 
 ::
 
-    set SEARCH_ENGINE_HTTP_URL=http://localhost:9200
-    set FESS_DICTIONARY_PATH=C:/opensearch-3.3.2/data/config/
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=C:/opensearch-3.3.2/data/config/
 
 .. note::
 
-   - If OpenSearch is running on a different host, change ``SEARCH_ENGINE_HTTP_URL`` to the appropriate hostname or IP address.
+   - If OpenSearch is running on a different host, change ``fess.search_engine.http_address`` to the appropriate hostname or IP address.
    - Use ``/`` for path separators.
 
 Verify Installation
@@ -168,8 +168,8 @@ Verify that the configuration files have been edited correctly.
 
 In Command Prompt::
 
-    C:\> findstr "SEARCH_ENGINE_HTTP_URL" C:\fess-15.3.2\bin\fess.in.bat
-    C:\> findstr "FESS_DICTIONARY_PATH" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.search_engine.http_address" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.dictionary.path" C:\fess-15.3.2\bin\fess.in.bat
 
 Step 3: Startup
 ===============

--- a/es/15.3/install/install-windows.rst
+++ b/es/15.3/install/install-windows.rst
@@ -153,12 +153,12 @@ Abra ``bin\fess.in.bat`` con un editor de texto y agregue o modifique la siguien
 
 ::
 
-    set SEARCH_ENGINE_HTTP_URL=http://localhost:9200
-    set FESS_DICTIONARY_PATH=C:/opensearch-3.3.2/data/config/
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=C:/opensearch-3.3.2/data/config/
 
 .. note::
 
-   - Si está ejecutando OpenSearch en otro host, cambie ``SEARCH_ENGINE_HTTP_URL`` al nombre de host o dirección IP apropiados.
+   - Si está ejecutando OpenSearch en otro host, cambie ``fess.search_engine.http_address`` al nombre de host o dirección IP apropiados.
    - Use ``/`` como separador de ruta.
 
 Verificación de la Instalación
@@ -168,8 +168,8 @@ Verifique que los archivos de configuración se hayan editado correctamente.
 
 En el Símbolo del sistema::
 
-    C:\> findstr "SEARCH_ENGINE_HTTP_URL" C:\fess-15.3.2\bin\fess.in.bat
-    C:\> findstr "FESS_DICTIONARY_PATH" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.search_engine.http_address" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.dictionary.path" C:\fess-15.3.2\bin\fess.in.bat
 
 Paso 3: Inicio
 ==============

--- a/fr/15.3/install/install-windows.rst
+++ b/fr/15.3/install/install-windows.rst
@@ -153,12 +153,12 @@ Ouvrez ``bin\fess.in.bat`` avec un éditeur de texte et ajoutez ou modifiez les 
 
 ::
 
-    set SEARCH_ENGINE_HTTP_URL=http://localhost:9200
-    set FESS_DICTIONARY_PATH=C:/opensearch-3.3.2/data/config/
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=C:/opensearch-3.3.2/data/config/
 
 .. note::
 
-   - Si vous exécutez OpenSearch sur un autre hôte, modifiez ``SEARCH_ENGINE_HTTP_URL`` avec le nom d'hôte ou l'adresse IP appropriés.
+   - Si vous exécutez OpenSearch sur un autre hôte, modifiez ``fess.search_engine.http_address`` avec le nom d'hôte ou l'adresse IP appropriés.
    - Utilisez ``/`` comme séparateur de chemin.
 
 Vérification de l'installation
@@ -168,8 +168,8 @@ Vérifiez que les fichiers de configuration ont été correctement modifiés.
 
 Invite de commandes ::
 
-    C:\> findstr "SEARCH_ENGINE_HTTP_URL" C:\fess-15.3.2\bin\fess.in.bat
-    C:\> findstr "FESS_DICTIONARY_PATH" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.search_engine.http_address" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.dictionary.path" C:\fess-15.3.2\bin\fess.in.bat
 
 Étape 3 : Démarrage
 ====================

--- a/ja/15.3/install/install-windows.rst
+++ b/ja/15.3/install/install-windows.rst
@@ -153,12 +153,12 @@ Fess の設定
 
 ::
 
-    set SEARCH_ENGINE_HTTP_URL=http://localhost:9200
-    set FESS_DICTIONARY_PATH=C:/opensearch-3.3.2/data/config/
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=C:/opensearch-3.3.2/data/config/
 
 .. note::
 
-   - OpenSearch を別のホストで実行している場合は、``SEARCH_ENGINE_HTTP_URL`` を適切なホスト名または IP アドレスに変更してください。
+   - OpenSearch を別のホストで実行している場合は、``fess.search_engine.http_address`` を適切なホスト名または IP アドレスに変更してください。
    - パスの区切り文字は ``/`` を使用してください。
 
 インストールの確認
@@ -168,8 +168,8 @@ Fess の設定
 
 コマンドプロンプトで::
 
-    C:\> findstr "SEARCH_ENGINE_HTTP_URL" C:\fess-15.3.2\bin\fess.in.bat
-    C:\> findstr "FESS_DICTIONARY_PATH" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.search_engine.http_address" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.dictionary.path" C:\fess-15.3.2\bin\fess.in.bat
 
 ステップ 3: 起動
 ==============

--- a/ko/15.3/install/install-windows.rst
+++ b/ko/15.3/install/install-windows.rst
@@ -153,12 +153,12 @@ Fess 설정
 
 ::
 
-    set SEARCH_ENGINE_HTTP_URL=http://localhost:9200
-    set FESS_DICTIONARY_PATH=C:/opensearch-3.3.2/data/config/
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=C:/opensearch-3.3.2/data/config/
 
 .. note::
 
-   - OpenSearch를 다른 호스트에서 실행하는 경우 ``SEARCH_ENGINE_HTTP_URL`` 을 적절한 호스트 이름 또는 IP 주소로 변경하십시오.
+   - OpenSearch를 다른 호스트에서 실행하는 경우 ``fess.search_engine.http_address`` 를 적절한 호스트 이름 또는 IP 주소로 변경하십시오.
    - 경로 구분 문자는 ``/`` 를 사용하십시오.
 
 설치 확인
@@ -168,8 +168,8 @@ Fess 설정
 
 명령 프롬프트에서::
 
-    C:\> findstr "SEARCH_ENGINE_HTTP_URL" C:\fess-15.3.2\bin\fess.in.bat
-    C:\> findstr "FESS_DICTIONARY_PATH" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.search_engine.http_address" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.dictionary.path" C:\fess-15.3.2\bin\fess.in.bat
 
 단계 3: 시작
 ==============

--- a/zh-cn/15.3/install/install-windows.rst
+++ b/zh-cn/15.3/install/install-windows.rst
@@ -153,12 +153,12 @@ PowerShell 的情况::
 
 ::
 
-    set SEARCH_ENGINE_HTTP_URL=http://localhost:9200
-    set FESS_DICTIONARY_PATH=C:/opensearch-3.3.2/data/config/
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=C:/opensearch-3.3.2/data/config/
 
 .. note::
 
-   - 如果 OpenSearch 在其他主机上运行，请将 ``SEARCH_ENGINE_HTTP_URL`` 更改为适当的主机名或 IP 地址。
+   - 如果 OpenSearch 在其他主机上运行，请将 ``fess.search_engine.http_address`` 更改为适当的主机名或 IP 地址。
    - 路径分隔符请使用 ``/``。
 
 确认安装
@@ -168,8 +168,8 @@ PowerShell 的情况::
 
 在命令提示符中::
 
-    C:\> findstr "SEARCH_ENGINE_HTTP_URL" C:\fess-15.3.2\bin\fess.in.bat
-    C:\> findstr "FESS_DICTIONARY_PATH" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.search_engine.http_address" C:\fess-15.3.2\bin\fess.in.bat
+    C:\> findstr "fess.dictionary.path" C:\fess-15.3.2\bin\fess.in.bat
 
 步骤 3: 启动
 ==============


### PR DESCRIPTION
## Summary
- Update configuration format in Windows installation documentation from legacy environment variables to Java system properties via FESS_JAVA_OPTS
- Change `SEARCH_ENGINE_HTTP_URL` to `-Dfess.search_engine.http_address`
- Change `FESS_DICTIONARY_PATH` to `-Dfess.dictionary.path`
- Updated across all 7 languages: de, en, es, fr, ja, ko, zh-cn

## Test plan
- [ ] Verify the documentation renders correctly
- [ ] Confirm the new configuration format works with Fess 15.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)