### PR TITLE
Improve thumbnail configuration documentation for all languages

### DIFF
--- a/de/15.4/config/crawler-thumbnail.rst
+++ b/de/15.4/config/crawler-thumbnail.rst
@@ -1,9 +1,9 @@
-===============
+===================================
 Konfiguration von Thumbnail-Bildern
-===============
+===================================
 
-Anzeige von Thumbnail-Bildern
-===============
+Übersicht
+=========
 
 |Fess| kann Thumbnail-Bilder in Suchergebnissen anzeigen.
 Thumbnail-Bilder werden basierend auf dem MIME-Typ der Suchergebnisse generiert.
@@ -12,49 +12,370 @@ Die Verarbeitung zur Generierung von Thumbnail-Bildern kann für jeden MIME-Typ 
 
 Um Thumbnail-Bilder anzuzeigen, melden Sie sich als Administrator an, aktivieren Sie die Thumbnail-Anzeige in den allgemeinen Einstellungen und speichern Sie.
 
-Thumbnail-Bilder für HTML-Dateien
-======================
+Unterstützte Dateiformate
+=========================
 
-Für HTML-Thumbnails werden im HTML angegebene oder enthaltene Bilder verwendet.
-Thumbnail-Bilder werden in folgender Reihenfolge gesucht und angezeigt, wenn angegeben:
+Bilddateien
+-----------
 
-- Der Wert des content-Attributs eines meta-Tags mit name-Attribut thumbnail
-- Der Wert des content-Attributs eines meta-Tags mit property-Attribut og:image
-- Bilder in geeigneter Größe für Thumbnails in img-Tags
+.. list-table::
+   :widths: 15 40 20
+   :header-rows: 1
 
+   * - Format
+     - MIME-Typ
+     - Beschreibung
+   * - JPEG
+     - ``image/jpeg``
+     - Fotos usw.
+   * - PNG
+     - ``image/png``
+     - Transparente Bilder usw.
+   * - GIF
+     - ``image/gif``
+     - Einschließlich animierter GIFs
+   * - BMP
+     - ``image/bmp``, ``image/x-windows-bmp``, ``image/x-ms-bmp``
+     - Bitmap-Bilder
+   * - TIFF
+     - ``image/tiff``
+     - Hochqualitative Bilder
+   * - SVG
+     - ``image/svg+xml``
+     - Vektorbilder
+   * - Photoshop
+     - ``image/vnd.adobe.photoshop``, ``image/photoshop``, ``application/x-photoshop``, ``application/photoshop``
+     - PSD-Dateien
 
-Thumbnail-Bilder für MS Office-Dateien
+Dokumentdateien
+---------------
+
+.. list-table::
+   :widths: 15 50 20
+   :header-rows: 1
+
+   * - Format
+     - MIME-Typ
+     - Beschreibung
+   * - PDF
+     - ``application/pdf``
+     - PDF-Dokumente
+   * - Word
+     - ``application/msword``, ``application/vnd.openxmlformats-officedocument.wordprocessingml.document``
+     - Word-Dokumente
+   * - Excel
+     - ``application/vnd.ms-excel``, ``application/vnd.openxmlformats-officedocument.spreadsheetml.sheet``
+     - Excel-Tabellen
+   * - PowerPoint
+     - ``application/vnd.ms-powerpoint``, ``application/vnd.openxmlformats-officedocument.presentationml.presentation``
+     - PowerPoint-Präsentationen
+   * - RTF
+     - ``application/rtf``
+     - Rich Text
+   * - PostScript
+     - ``application/postscript``
+     - PostScript-Dateien
+
+HTML-Inhalte
+------------
+
+.. list-table::
+   :widths: 15 30 40
+   :header-rows: 1
+
+   * - Format
+     - MIME-Typ
+     - Beschreibung
+   * - HTML
+     - ``text/html``
+     - Generiert Thumbnails aus eingebetteten Bildern in HTML-Seiten
+
+Erforderliche externe Tools
 ===========================
 
-Thumbnail-Bilder für MS Office-Dateien werden mit LibreOffice und ImageMagick generiert.
-Wenn die Befehle unoconv und convert installiert sind, werden Thumbnail-Bilder generiert.
+Die Thumbnail-Generierung erfordert die folgenden externen Tools. Installieren Sie diese entsprechend den Dateiformaten, die Sie unterstützen möchten.
 
-Installation von Paketen
-------------------
+Basis-Tools (erforderlich)
+--------------------------
 
-Bei Redhat-basierten Betriebssystemen installieren Sie folgende Pakete zur Bildgenerierung:
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Tool
+     - Zweck
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - ImageMagick
+     - Bildkonvertierung & Größenänderung
+     - ``apt install imagemagick``
+     - ``brew install imagemagick``
+
+.. note::
+
+   Sowohl ImageMagick 6 (``convert``-Befehl) als auch ImageMagick 7 (``magick``-Befehl) werden unterstützt.
+
+SVG-Unterstützung
+-----------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Tool
+     - Zweck
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - rsvg-convert
+     - SVG zu PNG Konvertierung
+     - ``apt install librsvg2-bin``
+     - ``brew install librsvg``
+
+PDF-Unterstützung
+-----------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Tool
+     - Zweck
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - pdftoppm
+     - PDF zu PNG Konvertierung
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+MS Office-Unterstützung
+-----------------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Tool
+     - Zweck
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - unoconv
+     - Office zu PDF Konvertierung
+     - ``apt install unoconv``
+     - ``brew install unoconv``
+   * - pdftoppm
+     - PDF zu PNG Konvertierung
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+Bei Redhat-basierten Betriebssystemen installieren Sie folgende Pakete:
 
 ::
 
-    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick
+    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick poppler-utils
 
-Generierungsskript
------------
+PostScript-Unterstützung
+------------------------
 
-Bei Installation über RPM/DEB-Paket wird das Thumbnail-Generierungsskript für MS Office unter /usr/share/fess/bin/generate-thumbnail installiert.
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
 
-Thumbnail-Bilder für PDF-Dateien
+   * - Tool
+     - Zweck
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - ps2pdf
+     - PS zu PDF Konvertierung
+     - ``apt install ghostscript``
+     - ``brew install ghostscript``
+   * - pdftoppm
+     - PDF zu PNG Konvertierung
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+Thumbnail-Bilder für HTML-Dateien
+=================================
+
+Für HTML-Thumbnails werden im HTML angegebene oder enthaltene Bilder verwendet.
+Thumbnail-Bilder werden in folgender Reihenfolge gesucht und angezeigt:
+
+1. Der Wert des content-Attributs eines meta-Tags mit name-Attribut "thumbnail"
+2. Der Wert des content-Attributs eines meta-Tags mit property-Attribut "og:image"
+3. Bilder in geeigneter Größe für Thumbnails in img-Tags
+
+Konfiguration
+=============
+
+Konfigurationsdatei
+-------------------
+
+Der Thumbnail-Generator wird in ``fess_thumbnail.xml`` konfiguriert.
+
+::
+
+    src/main/resources/fess_thumbnail.xml
+
+Hauptkonfigurationsoptionen (fess_config.properties)
+----------------------------------------------------
+
+Die folgenden Optionen können in ``app/WEB-INF/classes/fess_config.properties`` oder ``/etc/fess/fess_config.properties`` konfiguriert werden.
+
+::
+
+    # Mindestbreite für Thumbnail-Bilder (Pixel)
+    thumbnail.html.image.min.width=100
+
+    # Mindesthöhe für Thumbnail-Bilder (Pixel)
+    thumbnail.html.image.min.height=100
+
+    # Maximales Seitenverhältnis (Breite:Höhe oder Höhe:Breite)
+    thumbnail.html.image.max.aspect.ratio=3.0
+
+    # Generierte Thumbnail-Breite
+    thumbnail.html.image.thumbnail.width=100
+
+    # Generierte Thumbnail-Höhe
+    thumbnail.html.image.thumbnail.height=100
+
+    # Ausgabeformat
+    thumbnail.html.image.format=png
+
+    # XPath zum Extrahieren von Bildern aus HTML
+    thumbnail.html.image.xpath=//IMG
+
+    # Ausgeschlossene Erweiterungen
+    thumbnail.html.image.exclude.extensions=svg,html,css,js
+
+    # Thumbnail-Generierungsintervall (Millisekunden)
+    thumbnail.generator.interval=0
+
+    # Befehlsausführungs-Timeout (Millisekunden)
+    thumbnail.command.timeout=30000
+
+    # Prozessbeendigungs-Timeout (Millisekunden)
+    thumbnail.command.destroy.timeout=5000
+
+generate-thumbnail Skript
+=========================
+
+Übersicht
+---------
+
+``generate-thumbnail`` ist ein Shell-Skript, das die eigentliche Thumbnail-Generierung durchführt.
+Bei Installation über RPM/DEB-Paket wird es unter ``/usr/share/fess/bin/generate-thumbnail`` installiert.
+
+Verwendung
+----------
+
+::
+
+    generate-thumbnail <type> <url> <output_file> [mimetype]
+
+Argumente
+---------
+
+.. list-table::
+   :widths: 15 40 30
+   :header-rows: 1
+
+   * - Argument
+     - Beschreibung
+     - Beispiel
+   * - ``type``
+     - Dateityp
+     - ``image``, ``svg``, ``pdf``, ``msoffice``, ``ps``
+   * - ``url``
+     - Eingabedatei-URL
+     - ``file:/path/to/file.jpg``
+   * - ``output_file``
+     - Ausgabedateipfad
+     - ``/var/lib/fess/thumbnails/_0/_1/abc.png``
+   * - ``mimetype``
+     - MIME-Typ (optional)
+     - ``image/gif``
+
+Unterstützte Typen
+------------------
+
+.. list-table::
+   :widths: 15 30 40
+   :header-rows: 1
+
+   * - Typ
+     - Beschreibung
+     - Verwendete Tools
+   * - ``image``
+     - Bilddateien
+     - ImageMagick (convert/magick)
+   * - ``svg``
+     - SVG-Dateien
+     - rsvg-convert
+   * - ``pdf``
+     - PDF-Dateien
+     - pdftoppm + ImageMagick
+   * - ``msoffice``
+     - MS Office-Dateien
+     - unoconv + pdftoppm + ImageMagick
+   * - ``ps``
+     - PostScript-Dateien
+     - ps2pdf + pdftoppm + ImageMagick
+
+Beispiele
+---------
+
+::
+
+    # Thumbnail für Bilddatei generieren
+    ./generate-thumbnail image file:/path/to/image.jpg /tmp/thumbnail.png image/jpeg
+
+    # Thumbnail für SVG-Datei generieren
+    ./generate-thumbnail svg file:/path/to/image.svg /tmp/thumbnail.png
+
+    # Thumbnail für PDF-Datei generieren
+    ./generate-thumbnail pdf file:/path/to/document.pdf /tmp/thumbnail.png
+
+    # GIF-Datei (MIME-Typ angeben für Format-Hinweis)
+    ./generate-thumbnail image file:/path/to/image.gif /tmp/thumbnail.png image/gif
+
+Thumbnail-Speicherort
 =====================
 
-Thumbnail-Bilder für PDF werden mit ImageMagick generiert.
-Wenn der Befehl convert installiert ist, werden Thumbnail-Bilder generiert.
+Standardpfad
+------------
+
+::
+
+    ${FESS_VAR_PATH}/thumbnails/
+
+oder
+
+::
+
+    /var/lib/fess/thumbnails/
+
+Verzeichnisstruktur
+-------------------
+
+Thumbnails werden in einer hash-basierten Verzeichnisstruktur gespeichert.
+
+::
+
+    thumbnails/
+    ├── _0/
+    │   ├── _1/
+    │   │   ├── _2/
+    │   │   │   └── _3/
+    │   │   │       └── abcdef123456.png
+    │   │   └── ...
+    │   └── ...
+    └── ...
 
 Deaktivierung des Thumbnail-Jobs
-==================
+================================
 
 Um den Thumbnail-Job zu deaktivieren, konfigurieren Sie Folgendes:
 
-1. Entfernen Sie in der Verwaltungsoberfläche unter System > Allgemein das Häkchen bei „Thumbnail-Anzeige" und klicken Sie auf „Aktualisieren".
+1. Entfernen Sie in der Verwaltungsoberfläche unter System > Allgemein das Häkchen bei "Thumbnail-Anzeige" und klicken Sie auf "Aktualisieren".
 2. Setzen Sie ``thumbnail.crawler.enabled`` in ``app/WEB-INF/classes/fess_config.properties`` oder ``/etc/fess/fess_config.properties`` auf ``false``.
 
 ::
@@ -62,3 +383,99 @@ Um den Thumbnail-Job zu deaktivieren, konfigurieren Sie Folgendes:
     thumbnail.crawler.enabled=false
 
 3. Starten Sie den Fess-Dienst neu.
+
+Fehlerbehebung
+==============
+
+Thumbnails werden nicht generiert
+---------------------------------
+
+1. **Externe Tools überprüfen**
+
+::
+
+    # ImageMagick überprüfen
+    which convert || which magick
+
+    # rsvg-convert überprüfen (für SVG)
+    which rsvg-convert
+
+    # pdftoppm überprüfen (für PDF)
+    which pdftoppm
+
+2. **Logs überprüfen**
+
+::
+
+    ${FESS_LOG_PATH}/fess-thumbnail.log
+
+3. **Skript manuell ausführen**
+
+::
+
+    /usr/share/fess/bin/generate-thumbnail image file:/path/to/test.jpg /tmp/test_thumbnail.png image/jpeg
+
+Fehler bei GIF/TIFF-Dateien
+---------------------------
+
+Bei Verwendung von ImageMagick 6 geben Sie den MIME-Typ an, um Format-Hinweise zu aktivieren. Dies geschieht automatisch, wenn Fess korrekt konfiguriert ist.
+
+Fehlerbeispiel::
+
+    convert-im6.q16: corrupt image `/tmp/thumbnail_xxx' @ error/gif.c/DecodeImage/512
+
+Lösungen:
+
+- Auf ImageMagick 7 aktualisieren
+- Oder überprüfen, dass der MIME-Typ korrekt übergeben wird
+
+SVG-Thumbnails werden nicht generiert
+-------------------------------------
+
+1. Prüfen Sie, ob ``rsvg-convert`` installiert ist
+
+::
+
+    which rsvg-convert
+
+2. Konvertierung manuell testen
+
+::
+
+    rsvg-convert -w 100 -h 100 --keep-aspect-ratio input.svg -o output.png
+
+Berechtigungsfehler
+-------------------
+
+Überprüfen Sie die Berechtigungen des Thumbnail-Speicherverzeichnisses.
+
+::
+
+    ls -la /var/lib/fess/thumbnails/
+
+Korrigieren Sie die Berechtigungen bei Bedarf.
+
+::
+
+    chown -R fess:fess /var/lib/fess/thumbnails/
+    chmod -R 755 /var/lib/fess/thumbnails/
+
+Plattformunterstützung
+======================
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Plattform
+     - Unterstützungsstatus
+     - Hinweise
+   * - Linux
+     - Vollständig unterstützt
+     - \-
+   * - macOS
+     - Vollständig unterstützt
+     - Externe Tools über Homebrew installieren
+   * - Windows
+     - Nicht unterstützt
+     - Aufgrund der Bash-Skript-Abhängigkeit

--- a/en/15.4/config/crawler-thumbnail.rst
+++ b/en/15.4/config/crawler-thumbnail.rst
@@ -2,8 +2,8 @@
 Thumbnail Configuration
 ======================
 
-Displaying Thumbnail Images
-============================
+Overview
+========
 
 |Fess| can display thumbnail images in search results.
 Thumbnail images are generated based on the MIME Type of search results.
@@ -12,41 +12,363 @@ Thumbnail generation processes can be configured and added for each MIME Type.
 
 To enable thumbnail image display, log in as an administrator and enable thumbnail display in the General settings.
 
+Supported File Formats
+======================
+
+Image Files
+-----------
+
+.. list-table::
+   :widths: 15 40 20
+   :header-rows: 1
+
+   * - Format
+     - MIME Type
+     - Description
+   * - JPEG
+     - ``image/jpeg``
+     - Photos, etc.
+   * - PNG
+     - ``image/png``
+     - Transparent images, etc.
+   * - GIF
+     - ``image/gif``
+     - Including animated GIFs
+   * - BMP
+     - ``image/bmp``, ``image/x-windows-bmp``, ``image/x-ms-bmp``
+     - Bitmap images
+   * - TIFF
+     - ``image/tiff``
+     - High-quality images
+   * - SVG
+     - ``image/svg+xml``
+     - Vector images
+   * - Photoshop
+     - ``image/vnd.adobe.photoshop``, ``image/photoshop``, ``application/x-photoshop``, ``application/photoshop``
+     - PSD files
+
+Document Files
+--------------
+
+.. list-table::
+   :widths: 15 50 20
+   :header-rows: 1
+
+   * - Format
+     - MIME Type
+     - Description
+   * - PDF
+     - ``application/pdf``
+     - PDF documents
+   * - Word
+     - ``application/msword``, ``application/vnd.openxmlformats-officedocument.wordprocessingml.document``
+     - Word documents
+   * - Excel
+     - ``application/vnd.ms-excel``, ``application/vnd.openxmlformats-officedocument.spreadsheetml.sheet``
+     - Excel spreadsheets
+   * - PowerPoint
+     - ``application/vnd.ms-powerpoint``, ``application/vnd.openxmlformats-officedocument.presentationml.presentation``
+     - PowerPoint presentations
+   * - RTF
+     - ``application/rtf``
+     - Rich text
+   * - PostScript
+     - ``application/postscript``
+     - PostScript files
+
+HTML Content
+------------
+
+.. list-table::
+   :widths: 15 30 40
+   :header-rows: 1
+
+   * - Format
+     - MIME Type
+     - Description
+   * - HTML
+     - ``text/html``
+     - Generates thumbnails from embedded images in HTML pages
+
+Required External Tools
+=======================
+
+Thumbnail generation requires the following external tools. Install them according to the file formats you need to support.
+
+Basic Tools (Required)
+----------------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Tool
+     - Purpose
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - ImageMagick
+     - Image conversion & resize
+     - ``apt install imagemagick``
+     - ``brew install imagemagick``
+
+.. note::
+
+   Both ImageMagick 6 (``convert`` command) and ImageMagick 7 (``magick`` command) are supported.
+
+SVG Support
+-----------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Tool
+     - Purpose
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - rsvg-convert
+     - SVG to PNG conversion
+     - ``apt install librsvg2-bin``
+     - ``brew install librsvg``
+
+PDF Support
+-----------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Tool
+     - Purpose
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - pdftoppm
+     - PDF to PNG conversion
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+MS Office Support
+-----------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Tool
+     - Purpose
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - unoconv
+     - Office to PDF conversion
+     - ``apt install unoconv``
+     - ``brew install unoconv``
+   * - pdftoppm
+     - PDF to PNG conversion
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+For Red Hat-based OS, install the following packages:
+
+::
+
+    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick poppler-utils
+
+PostScript Support
+------------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Tool
+     - Purpose
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - ps2pdf
+     - PS to PDF conversion
+     - ``apt install ghostscript``
+     - ``brew install ghostscript``
+   * - pdftoppm
+     - PDF to PNG conversion
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
 HTML File Thumbnail Images
-===========================
+==========================
 
 HTML thumbnail images use images specified or included in the HTML.
 Thumbnails are searched and displayed in the following order:
 
-- The content value of a meta tag with name attribute "thumbnail"
-- The content value of a meta tag with property attribute "og:image"
-- An appropriately sized image from an img tag
+1. The content value of a meta tag with name attribute "thumbnail"
+2. The content value of a meta tag with property attribute "og:image"
+3. An appropriately sized image from an img tag
 
-MS Office File Thumbnail Images
-================================
+Configuration
+=============
 
-MS Office thumbnail images are generated using LibreOffice and ImageMagick.
-If the unoconv and convert commands are installed, thumbnail images will be generated.
+Configuration File
+------------------
 
-Package Installation
---------------------
-
-For Red Hat-based OS, install the following packages for image generation:
+The thumbnail generator is configured in ``fess_thumbnail.xml``.
 
 ::
 
-    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick
+    src/main/resources/fess_thumbnail.xml
 
-Generation Script
------------------
+Main Configuration Items (fess_config.properties)
+-------------------------------------------------
 
-When installed via RPM/Deb packages, the MS Office thumbnail generation script is installed at /usr/share/fess/bin/generate-thumbnail.
+The following items can be configured in ``app/WEB-INF/classes/fess_config.properties`` or ``/etc/fess/fess_config.properties``.
 
-PDF File Thumbnail Images
+::
+
+    # Minimum width for thumbnail images (pixels)
+    thumbnail.html.image.min.width=100
+
+    # Minimum height for thumbnail images (pixels)
+    thumbnail.html.image.min.height=100
+
+    # Maximum aspect ratio (width:height or height:width)
+    thumbnail.html.image.max.aspect.ratio=3.0
+
+    # Generated thumbnail width
+    thumbnail.html.image.thumbnail.width=100
+
+    # Generated thumbnail height
+    thumbnail.html.image.thumbnail.height=100
+
+    # Output format
+    thumbnail.html.image.format=png
+
+    # XPath to extract images from HTML
+    thumbnail.html.image.xpath=//IMG
+
+    # Excluded extensions
+    thumbnail.html.image.exclude.extensions=svg,html,css,js
+
+    # Thumbnail generation interval (milliseconds)
+    thumbnail.generator.interval=0
+
+    # Command execution timeout (milliseconds)
+    thumbnail.command.timeout=30000
+
+    # Process destroy timeout (milliseconds)
+    thumbnail.command.destroy.timeout=5000
+
+generate-thumbnail Script
+=========================
+
+Overview
+--------
+
+``generate-thumbnail`` is a shell script that performs actual thumbnail generation.
+When installed via RPM/Deb packages, it is installed at ``/usr/share/fess/bin/generate-thumbnail``.
+
+Usage
+-----
+
+::
+
+    generate-thumbnail <type> <url> <output_file> [mimetype]
+
+Arguments
+---------
+
+.. list-table::
+   :widths: 15 40 30
+   :header-rows: 1
+
+   * - Argument
+     - Description
+     - Example
+   * - ``type``
+     - File type
+     - ``image``, ``svg``, ``pdf``, ``msoffice``, ``ps``
+   * - ``url``
+     - Input file URL
+     - ``file:/path/to/file.jpg``
+   * - ``output_file``
+     - Output file path
+     - ``/var/lib/fess/thumbnails/_0/_1/abc.png``
+   * - ``mimetype``
+     - MIME type (optional)
+     - ``image/gif``
+
+Supported Types
+---------------
+
+.. list-table::
+   :widths: 15 30 40
+   :header-rows: 1
+
+   * - Type
+     - Description
+     - Tools Used
+   * - ``image``
+     - Image files
+     - ImageMagick (convert/magick)
+   * - ``svg``
+     - SVG files
+     - rsvg-convert
+   * - ``pdf``
+     - PDF files
+     - pdftoppm + ImageMagick
+   * - ``msoffice``
+     - MS Office files
+     - unoconv + pdftoppm + ImageMagick
+   * - ``ps``
+     - PostScript files
+     - ps2pdf + pdftoppm + ImageMagick
+
+Examples
+--------
+
+::
+
+    # Generate thumbnail for image file
+    ./generate-thumbnail image file:/path/to/image.jpg /tmp/thumbnail.png image/jpeg
+
+    # Generate thumbnail for SVG file
+    ./generate-thumbnail svg file:/path/to/image.svg /tmp/thumbnail.png
+
+    # Generate thumbnail for PDF file
+    ./generate-thumbnail pdf file:/path/to/document.pdf /tmp/thumbnail.png
+
+    # GIF file (specify MIME type to enable format hint)
+    ./generate-thumbnail image file:/path/to/image.gif /tmp/thumbnail.png image/gif
+
+Thumbnail Storage Location
 ==========================
 
-PDF thumbnail images are generated using ImageMagick.
-If the convert command is installed, thumbnail images will be generated.
+Default Path
+------------
+
+::
+
+    ${FESS_VAR_PATH}/thumbnails/
+
+or
+
+::
+
+    /var/lib/fess/thumbnails/
+
+Directory Structure
+-------------------
+
+Thumbnails are stored in a hash-based directory structure.
+
+::
+
+    thumbnails/
+    ├── _0/
+    │   ├── _1/
+    │   │   ├── _2/
+    │   │   │   └── _3/
+    │   │   │       └── abcdef123456.png
+    │   │   └── ...
+    │   └── ...
+    └── ...
 
 Disabling Thumbnail Job
 =======================
@@ -61,3 +383,99 @@ To disable the thumbnail job, configure the following:
     thumbnail.crawler.enabled=false
 
 3. Restart the Fess service.
+
+Troubleshooting
+===============
+
+Thumbnails Not Being Generated
+------------------------------
+
+1. **Check external tools**
+
+::
+
+    # Check ImageMagick
+    which convert || which magick
+
+    # Check rsvg-convert (for SVG)
+    which rsvg-convert
+
+    # Check pdftoppm (for PDF)
+    which pdftoppm
+
+2. **Check logs**
+
+::
+
+    ${FESS_LOG_PATH}/fess-thumbnail.log
+
+3. **Run script manually**
+
+::
+
+    /usr/share/fess/bin/generate-thumbnail image file:/path/to/test.jpg /tmp/test_thumbnail.png image/jpeg
+
+Errors with GIF/TIFF Files
+--------------------------
+
+When using ImageMagick 6, specify the MIME type to enable format hints. This is done automatically if Fess is configured correctly.
+
+Error example::
+
+    convert-im6.q16: corrupt image `/tmp/thumbnail_xxx' @ error/gif.c/DecodeImage/512
+
+Solutions:
+
+- Upgrade to ImageMagick 7
+- Or verify that MIME type is being passed correctly
+
+SVG Thumbnails Not Being Generated
+----------------------------------
+
+1. Check if ``rsvg-convert`` is installed
+
+::
+
+    which rsvg-convert
+
+2. Test conversion manually
+
+::
+
+    rsvg-convert -w 100 -h 100 --keep-aspect-ratio input.svg -o output.png
+
+Permission Errors
+-----------------
+
+Check permissions on the thumbnail storage directory.
+
+::
+
+    ls -la /var/lib/fess/thumbnails/
+
+Fix permissions if necessary.
+
+::
+
+    chown -R fess:fess /var/lib/fess/thumbnails/
+    chmod -R 755 /var/lib/fess/thumbnails/
+
+Platform Support
+================
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Platform
+     - Support Status
+     - Notes
+   * - Linux
+     - Fully supported
+     - \-
+   * - macOS
+     - Fully supported
+     - Install external tools via Homebrew
+   * - Windows
+     - Not supported
+     - Due to bash script dependency

--- a/es/15.4/config/crawler-thumbnail.rst
+++ b/es/15.4/config/crawler-thumbnail.rst
@@ -1,9 +1,9 @@
-===============================
-Configuración de Imágenes en Miniatura
-===============================
-
-Visualización de Imágenes en Miniatura
 =======================================
+Configuración de Imágenes en Miniatura
+=======================================
+
+Descripción General
+===================
 
 |Fess| puede mostrar imágenes en miniatura en los resultados de búsqueda.
 Las imágenes en miniatura se generan en base al tipo MIME de los resultados de búsqueda.
@@ -12,53 +12,470 @@ El proceso de generación de imágenes en miniatura se puede configurar y agrega
 
 Para habilitar la visualización de imágenes en miniatura, inicie sesión como administrador, active la visualización de miniaturas en la configuración general y guarde los cambios.
 
-Imágenes en Miniatura de Archivos HTML
-=======================================
+Formatos de Archivo Soportados
+==============================
 
-Las imágenes en miniatura de HTML utilizan las imágenes especificadas o incluidas dentro del HTML.
-Las imágenes en miniatura se buscan en el siguiente orden y se muestran si están especificadas.
+Archivos de Imagen
+------------------
 
-- Valor del atributo content de la etiqueta meta con el atributo name establecido en thumbnail
-- Valor del atributo content de la etiqueta meta con el atributo property establecido en og:image
-- Imágenes de tamaño adecuado para miniaturas en las etiquetas img
+.. list-table::
+   :widths: 15 40 20
+   :header-rows: 1
 
+   * - Formato
+     - Tipo MIME
+     - Descripción
+   * - JPEG
+     - ``image/jpeg``
+     - Fotos, etc.
+   * - PNG
+     - ``image/png``
+     - Imágenes transparentes, etc.
+   * - GIF
+     - ``image/gif``
+     - Incluyendo GIFs animados
+   * - BMP
+     - ``image/bmp``, ``image/x-windows-bmp``, ``image/x-ms-bmp``
+     - Imágenes de mapa de bits
+   * - TIFF
+     - ``image/tiff``
+     - Imágenes de alta calidad
+   * - SVG
+     - ``image/svg+xml``
+     - Imágenes vectoriales
+   * - Photoshop
+     - ``image/vnd.adobe.photoshop``, ``image/photoshop``, ``application/x-photoshop``, ``application/photoshop``
+     - Archivos PSD
 
-Imágenes en Miniatura de Archivos MS Office
-============================================
+Archivos de Documento
+---------------------
 
-Las imágenes en miniatura de archivos MS Office se generan utilizando LibreOffice e ImageMagick.
-Si están instalados los comandos unoconv y convert, se generarán las imágenes en miniatura.
+.. list-table::
+   :widths: 15 50 20
+   :header-rows: 1
 
-Instalación de Paquetes
-------------------------
+   * - Formato
+     - Tipo MIME
+     - Descripción
+   * - PDF
+     - ``application/pdf``
+     - Documentos PDF
+   * - Word
+     - ``application/msword``, ``application/vnd.openxmlformats-officedocument.wordprocessingml.document``
+     - Documentos Word
+   * - Excel
+     - ``application/vnd.ms-excel``, ``application/vnd.openxmlformats-officedocument.spreadsheetml.sheet``
+     - Hojas de cálculo Excel
+   * - PowerPoint
+     - ``application/vnd.ms-powerpoint``, ``application/vnd.openxmlformats-officedocument.presentationml.presentation``
+     - Presentaciones PowerPoint
+   * - RTF
+     - ``application/rtf``
+     - Texto enriquecido
+   * - PostScript
+     - ``application/postscript``
+     - Archivos PostScript
 
-Para sistemas operativos basados en Redhat, instale los siguientes paquetes para la creación de imágenes.
+Contenido HTML
+--------------
+
+.. list-table::
+   :widths: 15 30 40
+   :header-rows: 1
+
+   * - Formato
+     - Tipo MIME
+     - Descripción
+   * - HTML
+     - ``text/html``
+     - Genera miniaturas a partir de imágenes incrustadas en páginas HTML
+
+Herramientas Externas Requeridas
+================================
+
+La generación de miniaturas requiere las siguientes herramientas externas. Instálelas según los formatos de archivo que necesite soportar.
+
+Herramientas Básicas (Requeridas)
+---------------------------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Herramienta
+     - Propósito
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - ImageMagick
+     - Conversión y redimensionamiento de imágenes
+     - ``apt install imagemagick``
+     - ``brew install imagemagick``
+
+.. note::
+
+   Se soportan tanto ImageMagick 6 (comando ``convert``) como ImageMagick 7 (comando ``magick``).
+
+Soporte SVG
+-----------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Herramienta
+     - Propósito
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - rsvg-convert
+     - Conversión SVG a PNG
+     - ``apt install librsvg2-bin``
+     - ``brew install librsvg``
+
+Soporte PDF
+-----------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Herramienta
+     - Propósito
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - pdftoppm
+     - Conversión PDF a PNG
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+Soporte MS Office
+-----------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Herramienta
+     - Propósito
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - unoconv
+     - Conversión Office a PDF
+     - ``apt install unoconv``
+     - ``brew install unoconv``
+   * - pdftoppm
+     - Conversión PDF a PNG
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+Para sistemas operativos basados en Redhat, instale los siguientes paquetes:
 
 ::
 
-    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick
+    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick poppler-utils
 
-Script de Generación
----------------------
+Soporte PostScript
+------------------
 
-Al instalar mediante paquetes RPM/Deb, el script de generación de miniaturas para MS Office se instalará en /usr/share/fess/bin/generate-thumbnail.
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
 
-Imágenes en Miniatura de Archivos PDF
+   * - Herramienta
+     - Propósito
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - ps2pdf
+     - Conversión PS a PDF
+     - ``apt install ghostscript``
+     - ``brew install ghostscript``
+   * - pdftoppm
+     - Conversión PDF a PNG
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+Imágenes en Miniatura de Archivos HTML
 ======================================
 
-Las imágenes en miniatura de PDF se generan utilizando ImageMagick.
-Si está instalado el comando convert, se generarán las imágenes en miniatura.
+Las imágenes en miniatura de HTML utilizan las imágenes especificadas o incluidas dentro del HTML.
+Las imágenes en miniatura se buscan en el siguiente orden y se muestran si están especificadas:
+
+1. Valor del atributo content de la etiqueta meta con el atributo name establecido en "thumbnail"
+2. Valor del atributo content de la etiqueta meta con el atributo property establecido en "og:image"
+3. Imágenes de tamaño adecuado para miniaturas en las etiquetas img
+
+Configuración
+=============
+
+Archivo de Configuración
+------------------------
+
+El generador de miniaturas se configura en ``fess_thumbnail.xml``.
+
+::
+
+    src/main/resources/fess_thumbnail.xml
+
+Principales Opciones de Configuración (fess_config.properties)
+--------------------------------------------------------------
+
+Las siguientes opciones pueden configurarse en ``app/WEB-INF/classes/fess_config.properties`` o ``/etc/fess/fess_config.properties``.
+
+::
+
+    # Ancho mínimo para imágenes en miniatura (píxeles)
+    thumbnail.html.image.min.width=100
+
+    # Altura mínima para imágenes en miniatura (píxeles)
+    thumbnail.html.image.min.height=100
+
+    # Relación de aspecto máxima (ancho:altura o altura:ancho)
+    thumbnail.html.image.max.aspect.ratio=3.0
+
+    # Ancho de miniatura generada
+    thumbnail.html.image.thumbnail.width=100
+
+    # Altura de miniatura generada
+    thumbnail.html.image.thumbnail.height=100
+
+    # Formato de salida
+    thumbnail.html.image.format=png
+
+    # XPath para extraer imágenes del HTML
+    thumbnail.html.image.xpath=//IMG
+
+    # Extensiones excluidas
+    thumbnail.html.image.exclude.extensions=svg,html,css,js
+
+    # Intervalo de generación de miniaturas (milisegundos)
+    thumbnail.generator.interval=0
+
+    # Tiempo de espera de ejecución de comando (milisegundos)
+    thumbnail.command.timeout=30000
+
+    # Tiempo de espera de destrucción de proceso (milisegundos)
+    thumbnail.command.destroy.timeout=5000
+
+Script generate-thumbnail
+=========================
+
+Descripción General
+-------------------
+
+``generate-thumbnail`` es un script de shell que realiza la generación real de miniaturas.
+Al instalar mediante paquetes RPM/Deb, se instala en ``/usr/share/fess/bin/generate-thumbnail``.
+
+Uso
+---
+
+::
+
+    generate-thumbnail <type> <url> <output_file> [mimetype]
+
+Argumentos
+----------
+
+.. list-table::
+   :widths: 15 40 30
+   :header-rows: 1
+
+   * - Argumento
+     - Descripción
+     - Ejemplo
+   * - ``type``
+     - Tipo de archivo
+     - ``image``, ``svg``, ``pdf``, ``msoffice``, ``ps``
+   * - ``url``
+     - URL del archivo de entrada
+     - ``file:/path/to/file.jpg``
+   * - ``output_file``
+     - Ruta del archivo de salida
+     - ``/var/lib/fess/thumbnails/_0/_1/abc.png``
+   * - ``mimetype``
+     - Tipo MIME (opcional)
+     - ``image/gif``
+
+Tipos Soportados
+----------------
+
+.. list-table::
+   :widths: 15 30 40
+   :header-rows: 1
+
+   * - Tipo
+     - Descripción
+     - Herramientas Utilizadas
+   * - ``image``
+     - Archivos de imagen
+     - ImageMagick (convert/magick)
+   * - ``svg``
+     - Archivos SVG
+     - rsvg-convert
+   * - ``pdf``
+     - Archivos PDF
+     - pdftoppm + ImageMagick
+   * - ``msoffice``
+     - Archivos MS Office
+     - unoconv + pdftoppm + ImageMagick
+   * - ``ps``
+     - Archivos PostScript
+     - ps2pdf + pdftoppm + ImageMagick
+
+Ejemplos
+--------
+
+::
+
+    # Generar miniatura para archivo de imagen
+    ./generate-thumbnail image file:/path/to/image.jpg /tmp/thumbnail.png image/jpeg
+
+    # Generar miniatura para archivo SVG
+    ./generate-thumbnail svg file:/path/to/image.svg /tmp/thumbnail.png
+
+    # Generar miniatura para archivo PDF
+    ./generate-thumbnail pdf file:/path/to/document.pdf /tmp/thumbnail.png
+
+    # Archivo GIF (especificar tipo MIME para habilitar indicación de formato)
+    ./generate-thumbnail image file:/path/to/image.gif /tmp/thumbnail.png image/gif
+
+Ubicación de Almacenamiento de Miniaturas
+=========================================
+
+Ruta Predeterminada
+-------------------
+
+::
+
+    ${FESS_VAR_PATH}/thumbnails/
+
+o
+
+::
+
+    /var/lib/fess/thumbnails/
+
+Estructura de Directorios
+-------------------------
+
+Las miniaturas se almacenan en una estructura de directorios basada en hash.
+
+::
+
+    thumbnails/
+    ├── _0/
+    │   ├── _1/
+    │   │   ├── _2/
+    │   │   │   └── _3/
+    │   │   │       └── abcdef123456.png
+    │   │   └── ...
+    │   └── ...
+    └── ...
 
 Desactivación del Trabajo de Miniaturas
-========================================
+=======================================
 
 Para desactivar el trabajo de miniaturas, configure lo siguiente:
 
 1. En la pantalla de administración, vaya a Sistema > General, desmarque "Visualización de miniaturas" y haga clic en el botón "Actualizar".
-2. Establezca ``false`` en ``thumbnail.crawler.enabled`` en ``app/WEB-INF/classes/fess_config.properties`` o ``/etc/fess/fess_config.properties``.
+2. Establezca ``thumbnail.crawler.enabled`` en ``false`` en ``app/WEB-INF/classes/fess_config.properties`` o ``/etc/fess/fess_config.properties``.
 
 ::
 
     thumbnail.crawler.enabled=false
 
 3. Reinicie el servicio de Fess.
+
+Solución de Problemas
+=====================
+
+Las Miniaturas No Se Generan
+----------------------------
+
+1. **Verificar herramientas externas**
+
+::
+
+    # Verificar ImageMagick
+    which convert || which magick
+
+    # Verificar rsvg-convert (para SVG)
+    which rsvg-convert
+
+    # Verificar pdftoppm (para PDF)
+    which pdftoppm
+
+2. **Verificar logs**
+
+::
+
+    ${FESS_LOG_PATH}/fess-thumbnail.log
+
+3. **Ejecutar script manualmente**
+
+::
+
+    /usr/share/fess/bin/generate-thumbnail image file:/path/to/test.jpg /tmp/test_thumbnail.png image/jpeg
+
+Errores con Archivos GIF/TIFF
+-----------------------------
+
+Al usar ImageMagick 6, especifique el tipo MIME para habilitar las indicaciones de formato. Esto se hace automáticamente si Fess está configurado correctamente.
+
+Ejemplo de error::
+
+    convert-im6.q16: corrupt image `/tmp/thumbnail_xxx' @ error/gif.c/DecodeImage/512
+
+Soluciones:
+
+- Actualizar a ImageMagick 7
+- O verificar que el tipo MIME se está pasando correctamente
+
+Las Miniaturas SVG No Se Generan
+--------------------------------
+
+1. Verificar si ``rsvg-convert`` está instalado
+
+::
+
+    which rsvg-convert
+
+2. Probar conversión manualmente
+
+::
+
+    rsvg-convert -w 100 -h 100 --keep-aspect-ratio input.svg -o output.png
+
+Errores de Permisos
+-------------------
+
+Verifique los permisos del directorio de almacenamiento de miniaturas.
+
+::
+
+    ls -la /var/lib/fess/thumbnails/
+
+Corrija los permisos si es necesario.
+
+::
+
+    chown -R fess:fess /var/lib/fess/thumbnails/
+    chmod -R 755 /var/lib/fess/thumbnails/
+
+Soporte de Plataformas
+======================
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Plataforma
+     - Estado de Soporte
+     - Notas
+   * - Linux
+     - Totalmente soportado
+     - \-
+   * - macOS
+     - Totalmente soportado
+     - Instalar herramientas externas via Homebrew
+   * - Windows
+     - No soportado
+     - Debido a la dependencia del script bash

--- a/fr/15.4/config/crawler-thumbnail.rst
+++ b/fr/15.4/config/crawler-thumbnail.rst
@@ -1,9 +1,9 @@
-===============
+===========================
 Configuration des vignettes
-===============
+===========================
 
-Affichage des vignettes
-===============
+Présentation
+============
 
 |Fess| peut afficher des vignettes dans les résultats de recherche.
 Les vignettes sont générées en fonction du type MIME des résultats de recherche.
@@ -12,49 +12,370 @@ Le traitement de génération de vignettes peut être configuré et ajouté pour
 
 Pour afficher les vignettes, connectez-vous en tant qu'administrateur et activez l'affichage des vignettes dans les paramètres généraux, puis enregistrez.
 
-Vignettes des fichiers HTML
+Formats de fichiers pris en charge
+==================================
+
+Fichiers image
+--------------
+
+.. list-table::
+   :widths: 15 40 20
+   :header-rows: 1
+
+   * - Format
+     - Type MIME
+     - Description
+   * - JPEG
+     - ``image/jpeg``
+     - Photos, etc.
+   * - PNG
+     - ``image/png``
+     - Images transparentes, etc.
+   * - GIF
+     - ``image/gif``
+     - Y compris les GIF animés
+   * - BMP
+     - ``image/bmp``, ``image/x-windows-bmp``, ``image/x-ms-bmp``
+     - Images bitmap
+   * - TIFF
+     - ``image/tiff``
+     - Images haute qualité
+   * - SVG
+     - ``image/svg+xml``
+     - Images vectorielles
+   * - Photoshop
+     - ``image/vnd.adobe.photoshop``, ``image/photoshop``, ``application/x-photoshop``, ``application/photoshop``
+     - Fichiers PSD
+
+Fichiers document
+-----------------
+
+.. list-table::
+   :widths: 15 50 20
+   :header-rows: 1
+
+   * - Format
+     - Type MIME
+     - Description
+   * - PDF
+     - ``application/pdf``
+     - Documents PDF
+   * - Word
+     - ``application/msword``, ``application/vnd.openxmlformats-officedocument.wordprocessingml.document``
+     - Documents Word
+   * - Excel
+     - ``application/vnd.ms-excel``, ``application/vnd.openxmlformats-officedocument.spreadsheetml.sheet``
+     - Feuilles de calcul Excel
+   * - PowerPoint
+     - ``application/vnd.ms-powerpoint``, ``application/vnd.openxmlformats-officedocument.presentationml.presentation``
+     - Présentations PowerPoint
+   * - RTF
+     - ``application/rtf``
+     - Texte enrichi
+   * - PostScript
+     - ``application/postscript``
+     - Fichiers PostScript
+
+Contenu HTML
+------------
+
+.. list-table::
+   :widths: 15 30 40
+   :header-rows: 1
+
+   * - Format
+     - Type MIME
+     - Description
+   * - HTML
+     - ``text/html``
+     - Génère des vignettes à partir des images intégrées dans les pages HTML
+
+Outils externes requis
 ======================
 
-Les vignettes HTML utilisent les images spécifiées ou contenues dans le HTML.
-Les vignettes sont recherchées dans l'ordre suivant et affichées si elles sont spécifiées.
+La génération de vignettes nécessite les outils externes suivants. Installez-les en fonction des formats de fichiers que vous devez prendre en charge.
 
-- Valeur de l'attribut content d'une balise meta avec l'attribut name défini sur thumbnail
-- Valeur de l'attribut content d'une balise meta avec l'attribut property défini sur og:image
-- Image de taille appropriée pour une vignette dans une balise img
+Outils de base (requis)
+-----------------------
 
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
 
-Vignettes des fichiers MS Office
-===========================
+   * - Outil
+     - Utilisation
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - ImageMagick
+     - Conversion et redimensionnement d'images
+     - ``apt install imagemagick``
+     - ``brew install imagemagick``
 
-Les vignettes des fichiers MS Office sont générées à l'aide de LibreOffice et ImageMagick.
-Si les commandes unoconv et convert sont installées, les vignettes sont générées.
+.. note::
 
-Installation des paquets
-------------------
+   ImageMagick 6 (commande ``convert``) et ImageMagick 7 (commande ``magick``) sont tous deux pris en charge.
 
-Pour les systèmes d'exploitation de type Redhat, installez les paquets suivants pour créer des images.
+Support SVG
+-----------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Outil
+     - Utilisation
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - rsvg-convert
+     - Conversion SVG vers PNG
+     - ``apt install librsvg2-bin``
+     - ``brew install librsvg``
+
+Support PDF
+-----------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Outil
+     - Utilisation
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - pdftoppm
+     - Conversion PDF vers PNG
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+Support MS Office
+-----------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Outil
+     - Utilisation
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - unoconv
+     - Conversion Office vers PDF
+     - ``apt install unoconv``
+     - ``brew install unoconv``
+   * - pdftoppm
+     - Conversion PDF vers PNG
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+Pour les systèmes d'exploitation de type Redhat, installez les paquets suivants :
 
 ::
 
-    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick
+    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick poppler-utils
 
-Script de génération
+Support PostScript
+------------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - Outil
+     - Utilisation
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - ps2pdf
+     - Conversion PS vers PDF
+     - ``apt install ghostscript``
+     - ``brew install ghostscript``
+   * - pdftoppm
+     - Conversion PDF vers PNG
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+Vignettes des fichiers HTML
+===========================
+
+Les vignettes HTML utilisent les images spécifiées ou contenues dans le HTML.
+Les vignettes sont recherchées dans l'ordre suivant et affichées si elles sont spécifiées :
+
+1. Valeur de l'attribut content d'une balise meta avec l'attribut name défini sur "thumbnail"
+2. Valeur de l'attribut content d'une balise meta avec l'attribut property défini sur "og:image"
+3. Image de taille appropriée pour une vignette dans une balise img
+
+Configuration
+=============
+
+Fichier de configuration
+------------------------
+
+Le générateur de vignettes est configuré dans ``fess_thumbnail.xml``.
+
+::
+
+    src/main/resources/fess_thumbnail.xml
+
+Principales options de configuration (fess_config.properties)
+-------------------------------------------------------------
+
+Les options suivantes peuvent être configurées dans ``app/WEB-INF/classes/fess_config.properties`` ou ``/etc/fess/fess_config.properties``.
+
+::
+
+    # Largeur minimale pour les vignettes (pixels)
+    thumbnail.html.image.min.width=100
+
+    # Hauteur minimale pour les vignettes (pixels)
+    thumbnail.html.image.min.height=100
+
+    # Rapport d'aspect maximum (largeur:hauteur ou hauteur:largeur)
+    thumbnail.html.image.max.aspect.ratio=3.0
+
+    # Largeur des vignettes générées
+    thumbnail.html.image.thumbnail.width=100
+
+    # Hauteur des vignettes générées
+    thumbnail.html.image.thumbnail.height=100
+
+    # Format de sortie
+    thumbnail.html.image.format=png
+
+    # XPath pour extraire les images du HTML
+    thumbnail.html.image.xpath=//IMG
+
+    # Extensions exclues
+    thumbnail.html.image.exclude.extensions=svg,html,css,js
+
+    # Intervalle de génération des vignettes (millisecondes)
+    thumbnail.generator.interval=0
+
+    # Délai d'expiration de l'exécution de commande (millisecondes)
+    thumbnail.command.timeout=30000
+
+    # Délai de destruction du processus (millisecondes)
+    thumbnail.command.destroy.timeout=5000
+
+Script generate-thumbnail
+=========================
+
+Présentation
+------------
+
+``generate-thumbnail`` est un script shell qui effectue la génération réelle des vignettes.
+Lors de l'installation via le paquet RPM/Deb, il est installé dans ``/usr/share/fess/bin/generate-thumbnail``.
+
+Utilisation
 -----------
 
-Lors de l'installation via le paquet RPM/Deb, le script de génération de vignettes pour MS Office est installé dans /usr/share/fess/bin/generate-thumbnail.
+::
 
-Vignettes des fichiers PDF
-=====================
+    generate-thumbnail <type> <url> <output_file> [mimetype]
 
-Les vignettes PDF sont générées à l'aide d'ImageMagick.
-Si la commande convert est installée, les vignettes sont générées.
+Arguments
+---------
+
+.. list-table::
+   :widths: 15 40 30
+   :header-rows: 1
+
+   * - Argument
+     - Description
+     - Exemple
+   * - ``type``
+     - Type de fichier
+     - ``image``, ``svg``, ``pdf``, ``msoffice``, ``ps``
+   * - ``url``
+     - URL du fichier d'entrée
+     - ``file:/path/to/file.jpg``
+   * - ``output_file``
+     - Chemin du fichier de sortie
+     - ``/var/lib/fess/thumbnails/_0/_1/abc.png``
+   * - ``mimetype``
+     - Type MIME (optionnel)
+     - ``image/gif``
+
+Types pris en charge
+--------------------
+
+.. list-table::
+   :widths: 15 30 40
+   :header-rows: 1
+
+   * - Type
+     - Description
+     - Outils utilisés
+   * - ``image``
+     - Fichiers image
+     - ImageMagick (convert/magick)
+   * - ``svg``
+     - Fichiers SVG
+     - rsvg-convert
+   * - ``pdf``
+     - Fichiers PDF
+     - pdftoppm + ImageMagick
+   * - ``msoffice``
+     - Fichiers MS Office
+     - unoconv + pdftoppm + ImageMagick
+   * - ``ps``
+     - Fichiers PostScript
+     - ps2pdf + pdftoppm + ImageMagick
+
+Exemples
+--------
+
+::
+
+    # Générer une vignette pour un fichier image
+    ./generate-thumbnail image file:/path/to/image.jpg /tmp/thumbnail.png image/jpeg
+
+    # Générer une vignette pour un fichier SVG
+    ./generate-thumbnail svg file:/path/to/image.svg /tmp/thumbnail.png
+
+    # Générer une vignette pour un fichier PDF
+    ./generate-thumbnail pdf file:/path/to/document.pdf /tmp/thumbnail.png
+
+    # Fichier GIF (spécifier le type MIME pour activer l'indication de format)
+    ./generate-thumbnail image file:/path/to/image.gif /tmp/thumbnail.png image/gif
+
+Emplacement de stockage des vignettes
+=====================================
+
+Chemin par défaut
+-----------------
+
+::
+
+    ${FESS_VAR_PATH}/thumbnails/
+
+ou
+
+::
+
+    /var/lib/fess/thumbnails/
+
+Structure des répertoires
+-------------------------
+
+Les vignettes sont stockées dans une structure de répertoires basée sur le hachage.
+
+::
+
+    thumbnails/
+    ├── _0/
+    │   ├── _1/
+    │   │   ├── _2/
+    │   │   │   └── _3/
+    │   │   │       └── abcdef123456.png
+    │   │   └── ...
+    │   └── ...
+    └── ...
 
 Désactivation du travail de vignettes
-==================
+=====================================
 
-Pour désactiver le travail de vignettes, configurez ce qui suit.
+Pour désactiver le travail de vignettes, configurez ce qui suit :
 
-1. Dans l'interface d'administration, allez dans Système > Général, décochez « Affichage des vignettes », et cliquez sur le bouton « Mettre à jour ».
+1. Dans l'interface d'administration, allez dans Système > Général, décochez "Affichage des vignettes", et cliquez sur le bouton "Mettre à jour".
 2. Définissez ``thumbnail.crawler.enabled`` sur ``false`` dans ``app/WEB-INF/classes/fess_config.properties`` ou ``/etc/fess/fess_config.properties``.
 
 ::
@@ -62,3 +383,99 @@ Pour désactiver le travail de vignettes, configurez ce qui suit.
     thumbnail.crawler.enabled=false
 
 3. Redémarrez le service Fess.
+
+Dépannage
+=========
+
+Les vignettes ne sont pas générées
+----------------------------------
+
+1. **Vérifier les outils externes**
+
+::
+
+    # Vérifier ImageMagick
+    which convert || which magick
+
+    # Vérifier rsvg-convert (pour SVG)
+    which rsvg-convert
+
+    # Vérifier pdftoppm (pour PDF)
+    which pdftoppm
+
+2. **Vérifier les logs**
+
+::
+
+    ${FESS_LOG_PATH}/fess-thumbnail.log
+
+3. **Exécuter le script manuellement**
+
+::
+
+    /usr/share/fess/bin/generate-thumbnail image file:/path/to/test.jpg /tmp/test_thumbnail.png image/jpeg
+
+Erreurs avec les fichiers GIF/TIFF
+----------------------------------
+
+Lors de l'utilisation d'ImageMagick 6, spécifiez le type MIME pour activer les indications de format. Cela se fait automatiquement si Fess est correctement configuré.
+
+Exemple d'erreur::
+
+    convert-im6.q16: corrupt image `/tmp/thumbnail_xxx' @ error/gif.c/DecodeImage/512
+
+Solutions :
+
+- Mettre à niveau vers ImageMagick 7
+- Ou vérifier que le type MIME est correctement transmis
+
+Les vignettes SVG ne sont pas générées
+--------------------------------------
+
+1. Vérifier si ``rsvg-convert`` est installé
+
+::
+
+    which rsvg-convert
+
+2. Tester la conversion manuellement
+
+::
+
+    rsvg-convert -w 100 -h 100 --keep-aspect-ratio input.svg -o output.png
+
+Erreurs de permission
+---------------------
+
+Vérifiez les permissions du répertoire de stockage des vignettes.
+
+::
+
+    ls -la /var/lib/fess/thumbnails/
+
+Corrigez les permissions si nécessaire.
+
+::
+
+    chown -R fess:fess /var/lib/fess/thumbnails/
+    chmod -R 755 /var/lib/fess/thumbnails/
+
+Support des plateformes
+=======================
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - Plateforme
+     - Statut de support
+     - Remarques
+   * - Linux
+     - Entièrement pris en charge
+     - \-
+   * - macOS
+     - Entièrement pris en charge
+     - Installer les outils externes via Homebrew
+   * - Windows
+     - Non pris en charge
+     - En raison de la dépendance au script bash

--- a/ja/15.4/config/crawler-thumbnail.rst
+++ b/ja/15.4/config/crawler-thumbnail.rst
@@ -2,8 +2,8 @@
 サムネイル画像の設定
 ===============
 
-サムネイル画像の表示
-===============
+概要
+====
 
 |Fess| では検索結果のサムネイル画像を表示することができます。
 サムネイル画像は検索結果のMIME Typeを元に生成されます。
@@ -12,45 +12,366 @@
 
 サムネイル画像を表示するためには、管理者としてログインして、全般の設定でサムネイル表示を有効にして保存してください。
 
+サポートしているファイル形式
+========================
+
+画像ファイル
+----------
+
+.. list-table::
+   :widths: 15 40 20
+   :header-rows: 1
+
+   * - 形式
+     - MIMEタイプ
+     - 説明
+   * - JPEG
+     - ``image/jpeg``
+     - 写真など
+   * - PNG
+     - ``image/png``
+     - 透過画像など
+   * - GIF
+     - ``image/gif``
+     - アニメーションGIF含む
+   * - BMP
+     - ``image/bmp``, ``image/x-windows-bmp``, ``image/x-ms-bmp``
+     - ビットマップ画像
+   * - TIFF
+     - ``image/tiff``
+     - 高品質画像
+   * - SVG
+     - ``image/svg+xml``
+     - ベクター画像
+   * - Photoshop
+     - ``image/vnd.adobe.photoshop``, ``image/photoshop``, ``application/x-photoshop``, ``application/photoshop``
+     - PSDファイル
+
+ドキュメントファイル
+----------------
+
+.. list-table::
+   :widths: 15 50 20
+   :header-rows: 1
+
+   * - 形式
+     - MIMEタイプ
+     - 説明
+   * - PDF
+     - ``application/pdf``
+     - PDFドキュメント
+   * - Word
+     - ``application/msword``, ``application/vnd.openxmlformats-officedocument.wordprocessingml.document``
+     - Word文書
+   * - Excel
+     - ``application/vnd.ms-excel``, ``application/vnd.openxmlformats-officedocument.spreadsheetml.sheet``
+     - Excelスプレッドシート
+   * - PowerPoint
+     - ``application/vnd.ms-powerpoint``, ``application/vnd.openxmlformats-officedocument.presentationml.presentation``
+     - PowerPointプレゼンテーション
+   * - RTF
+     - ``application/rtf``
+     - リッチテキスト
+   * - PostScript
+     - ``application/postscript``
+     - PostScriptファイル
+
+HTMLコンテンツ
+------------
+
+.. list-table::
+   :widths: 15 30 40
+   :header-rows: 1
+
+   * - 形式
+     - MIMEタイプ
+     - 説明
+   * - HTML
+     - ``text/html``
+     - HTMLページ内の埋め込み画像からサムネイルを生成
+
+必要な外部ツール
+==============
+
+サムネイル生成には、以下の外部ツールが必要です。使用するファイル形式に応じてインストールしてください。
+
+基本ツール（必須）
+---------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - ツール
+     - 用途
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - ImageMagick
+     - 画像変換・リサイズ
+     - ``apt install imagemagick``
+     - ``brew install imagemagick``
+
+.. note::
+
+   ImageMagick 6（``convert`` コマンド）とImageMagick 7（``magick`` コマンド）の両方に対応しています。
+
+SVGサポート
+----------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - ツール
+     - 用途
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - rsvg-convert
+     - SVG→PNG変換
+     - ``apt install librsvg2-bin``
+     - ``brew install librsvg``
+
+PDFサポート
+----------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - ツール
+     - 用途
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - pdftoppm
+     - PDF→PNG変換
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+MS Officeサポート
+----------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - ツール
+     - 用途
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - unoconv
+     - Office→PDF変換
+     - ``apt install unoconv``
+     - ``brew install unoconv``
+   * - pdftoppm
+     - PDF→PNG変換
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+Redhat系OSの場合は以下のパッケージをインストールします。
+
+::
+
+    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick poppler-utils
+
+PostScriptサポート
+-----------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - ツール
+     - 用途
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - ps2pdf
+     - PS→PDF変換
+     - ``apt install ghostscript``
+     - ``brew install ghostscript``
+   * - pdftoppm
+     - PDF→PNG変換
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
 HTMLファイルのサムネイル画像
-======================
+========================
 
 HTMLのサムネイル画像はHTML内で指定された画像または含まれている画像を利用します。
 以下の順にサムネイル画像を探して指定されている場合に表示します。
 
-- name属性がthumbnailで指定されたmetaタグののcontentの値
-- property属性がog:imageで指定されたmetaタグののcontentの値
-- imgタグでサムネイルに適したサイズの画像
+1. name属性がthumbnailで指定されたmetaタグのcontentの値
+2. property属性がog:imageで指定されたmetaタグのcontentの値
+3. imgタグでサムネイルに適したサイズの画像
 
+設定
+====
 
-MS Officeファイルのサムネイル画像
-===========================
+設定ファイル
+----------
 
-MS Office系のサムネイル画像は LibreOffice および ImageMagick を用いて生成されます。
-unoconv と convert コマンドがインストールされている場合、サムネイル画像が生成されます。
-
-パッケージのインストール
-------------------
-
-Redhat系OSの場合、画像の作成用に以下のパッケージをインストールします。
+サムネイルジェネレータの設定は ``fess_thumbnail.xml`` で行います。
 
 ::
 
-    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick
+    src/main/resources/fess_thumbnail.xml
 
-生成スクリプト
------------
+主な設定項目（fess_config.properties）
+----------------------------------
 
-RPM/Debパッケージでインストールすると、MS Office用のサムネイル生成スクリプトは/usr/share/fess/bin/generate-thumbnailにインストールされます。
+``app/WEB-INF/classes/fess_config.properties`` または ``/etc/fess/fess_config.properties`` で以下の項目を設定できます。
 
-PDFファイルのサムネイル画像
-=====================
+::
 
-PDFのサムネイル画像はImageMagickを用いて生成されます。
-convert コマンドがインストールされている場合、サムネイル画像が生成されます。
+    # サムネイル画像の最小幅（ピクセル）
+    thumbnail.html.image.min.width=100
+
+    # サムネイル画像の最小高さ（ピクセル）
+    thumbnail.html.image.min.height=100
+
+    # 最大アスペクト比（幅:高さまたは高さ:幅）
+    thumbnail.html.image.max.aspect.ratio=3.0
+
+    # 生成されるサムネイルの幅
+    thumbnail.html.image.thumbnail.width=100
+
+    # 生成されるサムネイルの高さ
+    thumbnail.html.image.thumbnail.height=100
+
+    # 出力フォーマット
+    thumbnail.html.image.format=png
+
+    # HTML内の画像を抽出するXPath
+    thumbnail.html.image.xpath=//IMG
+
+    # 除外する拡張子
+    thumbnail.html.image.exclude.extensions=svg,html,css,js
+
+    # サムネイル生成の間隔（ミリ秒）
+    thumbnail.generator.interval=0
+
+    # コマンド実行タイムアウト（ミリ秒）
+    thumbnail.command.timeout=30000
+
+    # プロセス破棄タイムアウト（ミリ秒）
+    thumbnail.command.destroy.timeout=5000
+
+generate-thumbnail スクリプト
+============================
+
+概要
+----
+
+``generate-thumbnail`` は、実際のサムネイル生成を行うシェルスクリプトです。
+RPM/Debパッケージでインストールすると、 ``/usr/share/fess/bin/generate-thumbnail`` にインストールされます。
+
+使用方法
+-------
+
+::
+
+    generate-thumbnail <type> <url> <output_file> [mimetype]
+
+引数
+----
+
+.. list-table::
+   :widths: 15 40 30
+   :header-rows: 1
+
+   * - 引数
+     - 説明
+     - 例
+   * - ``type``
+     - ファイルタイプ
+     - ``image``, ``svg``, ``pdf``, ``msoffice``, ``ps``
+   * - ``url``
+     - 入力ファイルのURL
+     - ``file:/path/to/file.jpg``
+   * - ``output_file``
+     - 出力ファイルパス
+     - ``/var/lib/fess/thumbnails/_0/_1/abc.png``
+   * - ``mimetype``
+     - MIMEタイプ（オプション）
+     - ``image/gif``
+
+サポートするタイプ
+----------------
+
+.. list-table::
+   :widths: 15 30 40
+   :header-rows: 1
+
+   * - タイプ
+     - 説明
+     - 使用ツール
+   * - ``image``
+     - 画像ファイル
+     - ImageMagick (convert/magick)
+   * - ``svg``
+     - SVGファイル
+     - rsvg-convert
+   * - ``pdf``
+     - PDFファイル
+     - pdftoppm + ImageMagick
+   * - ``msoffice``
+     - MS Officeファイル
+     - unoconv + pdftoppm + ImageMagick
+   * - ``ps``
+     - PostScriptファイル
+     - ps2pdf + pdftoppm + ImageMagick
+
+使用例
+-----
+
+::
+
+    # 画像ファイルのサムネイル生成
+    ./generate-thumbnail image file:/path/to/image.jpg /tmp/thumbnail.png image/jpeg
+
+    # SVGファイルのサムネイル生成
+    ./generate-thumbnail svg file:/path/to/image.svg /tmp/thumbnail.png
+
+    # PDFファイルのサムネイル生成
+    ./generate-thumbnail pdf file:/path/to/document.pdf /tmp/thumbnail.png
+
+    # GIFファイル（MIMEタイプを指定してフォーマットヒントを有効化）
+    ./generate-thumbnail image file:/path/to/image.gif /tmp/thumbnail.png image/gif
+
+サムネイル保存先
+==============
+
+デフォルトパス
+------------
+
+::
+
+    ${FESS_VAR_PATH}/thumbnails/
+
+または
+
+::
+
+    /var/lib/fess/thumbnails/
+
+ディレクトリ構造
+--------------
+
+サムネイルはハッシュベースのディレクトリ構造で保存されます。
+
+::
+
+    thumbnails/
+    ├── _0/
+    │   ├── _1/
+    │   │   ├── _2/
+    │   │   │   └── _3/
+    │   │   │       └── abcdef123456.png
+    │   │   └── ...
+    │   └── ...
+    └── ...
 
 サムネイルジョブの無効化
-==================
+====================
 
 サムネイルジョブを無効化する場合は以下を設定します。
 
@@ -62,3 +383,99 @@ convert コマンドがインストールされている場合、サムネイル
     thumbnail.crawler.enabled=false
 
 3. Fessのサービスを再起動。
+
+トラブルシューティング
+==================
+
+サムネイルが生成されない
+---------------------
+
+1. **外部ツールの確認**
+
+::
+
+    # ImageMagickの確認
+    which convert || which magick
+
+    # rsvg-convertの確認（SVG用）
+    which rsvg-convert
+
+    # pdftoppmの確認（PDF用）
+    which pdftoppm
+
+2. **ログの確認**
+
+::
+
+    ${FESS_LOG_PATH}/fess-thumbnail.log
+
+3. **手動でスクリプトを実行**
+
+::
+
+    /usr/share/fess/bin/generate-thumbnail image file:/path/to/test.jpg /tmp/test_thumbnail.png image/jpeg
+
+GIF/TIFFでエラーが発生する
+------------------------
+
+ImageMagick 6を使用している場合、MIMEタイプを指定してフォーマットヒントを有効にしてください。Fessの設定が正しければ自動的に行われます。
+
+エラー例::
+
+    convert-im6.q16: corrupt image `/tmp/thumbnail_xxx' @ error/gif.c/DecodeImage/512
+
+対処法:
+
+- ImageMagick 7にアップグレード
+- または、MIMEタイプが正しく渡されていることを確認
+
+SVGのサムネイルが生成されない
+--------------------------
+
+1. ``rsvg-convert`` がインストールされているか確認
+
+::
+
+    which rsvg-convert
+
+2. 手動で変換をテスト
+
+::
+
+    rsvg-convert -w 100 -h 100 --keep-aspect-ratio input.svg -o output.png
+
+権限エラー
+---------
+
+サムネイル保存ディレクトリの権限を確認します。
+
+::
+
+    ls -la /var/lib/fess/thumbnails/
+
+必要に応じて権限を修正します。
+
+::
+
+    chown -R fess:fess /var/lib/fess/thumbnails/
+    chmod -R 755 /var/lib/fess/thumbnails/
+
+プラットフォーム対応
+=================
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - プラットフォーム
+     - 対応状況
+     - 備考
+   * - Linux
+     - 完全対応
+     - \-
+   * - macOS
+     - 完全対応
+     - Homebrewで外部ツールをインストール
+   * - Windows
+     - 非対応
+     - bashスクリプトのため

--- a/zh-cn/15.4/config/crawler-thumbnail.rst
+++ b/zh-cn/15.4/config/crawler-thumbnail.rst
@@ -2,8 +2,8 @@
 缩略图配置
 ===============
 
-缩略图显示
-===============
+概述
+====
 
 |Fess| 可以在搜索结果中显示缩略图。
 缩略图根据搜索结果的 MIME 类型生成。
@@ -12,47 +12,368 @@
 
 要显示缩略图,请以管理员身份登录,在常规设置中启用缩略图显示并保存。
 
-HTML 文件缩略图
-======================
+支持的文件格式
+==============
 
-HTML 的缩略图使用 HTML 中指定的图片或包含的图片。
-按以下顺序查找缩略图并在指定时显示。
+图片文件
+--------
 
-- name 属性为 thumbnail 的 meta 标签的 content 值
-- property 属性为 og:image 的 meta 标签的 content 值
-- img 标签中适合缩略图大小的图片
+.. list-table::
+   :widths: 15 40 20
+   :header-rows: 1
 
+   * - 格式
+     - MIME 类型
+     - 说明
+   * - JPEG
+     - ``image/jpeg``
+     - 照片等
+   * - PNG
+     - ``image/png``
+     - 透明图片等
+   * - GIF
+     - ``image/gif``
+     - 包括动画 GIF
+   * - BMP
+     - ``image/bmp``, ``image/x-windows-bmp``, ``image/x-ms-bmp``
+     - 位图图片
+   * - TIFF
+     - ``image/tiff``
+     - 高质量图片
+   * - SVG
+     - ``image/svg+xml``
+     - 矢量图片
+   * - Photoshop
+     - ``image/vnd.adobe.photoshop``, ``image/photoshop``, ``application/x-photoshop``, ``application/photoshop``
+     - PSD 文件
 
-MS Office 文件缩略图
-===========================
+文档文件
+--------
 
-MS Office 系列的缩略图使用 LibreOffice 和 ImageMagick 生成。
-当安装了 unoconv 和 convert 命令时,将生成缩略图。
+.. list-table::
+   :widths: 15 50 20
+   :header-rows: 1
 
-软件包安装
-------------------
+   * - 格式
+     - MIME 类型
+     - 说明
+   * - PDF
+     - ``application/pdf``
+     - PDF 文档
+   * - Word
+     - ``application/msword``, ``application/vnd.openxmlformats-officedocument.wordprocessingml.document``
+     - Word 文档
+   * - Excel
+     - ``application/vnd.ms-excel``, ``application/vnd.openxmlformats-officedocument.spreadsheetml.sheet``
+     - Excel 电子表格
+   * - PowerPoint
+     - ``application/vnd.ms-powerpoint``, ``application/vnd.openxmlformats-officedocument.presentationml.presentation``
+     - PowerPoint 演示文稿
+   * - RTF
+     - ``application/rtf``
+     - 富文本
+   * - PostScript
+     - ``application/postscript``
+     - PostScript 文件
 
-对于 Redhat 系列 OS,请安装以下软件包以创建图片。
+HTML 内容
+---------
+
+.. list-table::
+   :widths: 15 30 40
+   :header-rows: 1
+
+   * - 格式
+     - MIME 类型
+     - 说明
+   * - HTML
+     - ``text/html``
+     - 从 HTML 页面中嵌入的图片生成缩略图
+
+所需的外部工具
+==============
+
+缩略图生成需要以下外部工具。请根据需要支持的文件格式进行安装。
+
+基本工具（必需）
+----------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - 工具
+     - 用途
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - ImageMagick
+     - 图片转换和调整大小
+     - ``apt install imagemagick``
+     - ``brew install imagemagick``
+
+.. note::
+
+   同时支持 ImageMagick 6（``convert`` 命令）和 ImageMagick 7（``magick`` 命令）。
+
+SVG 支持
+--------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - 工具
+     - 用途
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - rsvg-convert
+     - SVG 转 PNG
+     - ``apt install librsvg2-bin``
+     - ``brew install librsvg``
+
+PDF 支持
+--------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - 工具
+     - 用途
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - pdftoppm
+     - PDF 转 PNG
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+MS Office 支持
+--------------
+
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
+
+   * - 工具
+     - 用途
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - unoconv
+     - Office 转 PDF
+     - ``apt install unoconv``
+     - ``brew install unoconv``
+   * - pdftoppm
+     - PDF 转 PNG
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
+
+对于 Redhat 系列 OS,请安装以下软件包:
 
 ::
 
-    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick
+    $ sudo yum install unoconv libreoffice-headless vlgothic-fonts ImageMagick poppler-utils
 
-生成脚本
------------
+PostScript 支持
+---------------
 
-使用 RPM/Deb 软件包安装时,MS Office 的缩略图生成脚本会安装在 /usr/share/fess/bin/generate-thumbnail 中。
+.. list-table::
+   :widths: 15 25 30 30
+   :header-rows: 1
 
-PDF 文件缩略图
-=====================
+   * - 工具
+     - 用途
+     - Linux (apt)
+     - Mac (Homebrew)
+   * - ps2pdf
+     - PS 转 PDF
+     - ``apt install ghostscript``
+     - ``brew install ghostscript``
+   * - pdftoppm
+     - PDF 转 PNG
+     - ``apt install poppler-utils``
+     - ``brew install poppler``
 
-PDF 的缩略图使用 ImageMagick 生成。
-当安装了 convert 命令时,将生成缩略图。
+HTML 文件缩略图
+===============
+
+HTML 的缩略图使用 HTML 中指定的图片或包含的图片。
+按以下顺序查找缩略图并在指定时显示:
+
+1. name 属性为 "thumbnail" 的 meta 标签的 content 值
+2. property 属性为 "og:image" 的 meta 标签的 content 值
+3. img 标签中适合缩略图大小的图片
+
+配置
+====
+
+配置文件
+--------
+
+缩略图生成器在 ``fess_thumbnail.xml`` 中配置。
+
+::
+
+    src/main/resources/fess_thumbnail.xml
+
+主要配置项（fess_config.properties）
+------------------------------------
+
+以下选项可以在 ``app/WEB-INF/classes/fess_config.properties`` 或 ``/etc/fess/fess_config.properties`` 中配置。
+
+::
+
+    # 缩略图的最小宽度（像素）
+    thumbnail.html.image.min.width=100
+
+    # 缩略图的最小高度（像素）
+    thumbnail.html.image.min.height=100
+
+    # 最大宽高比（宽:高或高:宽）
+    thumbnail.html.image.max.aspect.ratio=3.0
+
+    # 生成的缩略图宽度
+    thumbnail.html.image.thumbnail.width=100
+
+    # 生成的缩略图高度
+    thumbnail.html.image.thumbnail.height=100
+
+    # 输出格式
+    thumbnail.html.image.format=png
+
+    # 从 HTML 提取图片的 XPath
+    thumbnail.html.image.xpath=//IMG
+
+    # 排除的扩展名
+    thumbnail.html.image.exclude.extensions=svg,html,css,js
+
+    # 缩略图生成间隔（毫秒）
+    thumbnail.generator.interval=0
+
+    # 命令执行超时（毫秒）
+    thumbnail.command.timeout=30000
+
+    # 进程销毁超时（毫秒）
+    thumbnail.command.destroy.timeout=5000
+
+generate-thumbnail 脚本
+=======================
+
+概述
+----
+
+``generate-thumbnail`` 是执行实际缩略图生成的 shell 脚本。
+使用 RPM/Deb 软件包安装时,它会安装在 ``/usr/share/fess/bin/generate-thumbnail``。
+
+用法
+----
+
+::
+
+    generate-thumbnail <type> <url> <output_file> [mimetype]
+
+参数
+----
+
+.. list-table::
+   :widths: 15 40 30
+   :header-rows: 1
+
+   * - 参数
+     - 说明
+     - 示例
+   * - ``type``
+     - 文件类型
+     - ``image``, ``svg``, ``pdf``, ``msoffice``, ``ps``
+   * - ``url``
+     - 输入文件 URL
+     - ``file:/path/to/file.jpg``
+   * - ``output_file``
+     - 输出文件路径
+     - ``/var/lib/fess/thumbnails/_0/_1/abc.png``
+   * - ``mimetype``
+     - MIME 类型（可选）
+     - ``image/gif``
+
+支持的类型
+----------
+
+.. list-table::
+   :widths: 15 30 40
+   :header-rows: 1
+
+   * - 类型
+     - 说明
+     - 使用的工具
+   * - ``image``
+     - 图片文件
+     - ImageMagick (convert/magick)
+   * - ``svg``
+     - SVG 文件
+     - rsvg-convert
+   * - ``pdf``
+     - PDF 文件
+     - pdftoppm + ImageMagick
+   * - ``msoffice``
+     - MS Office 文件
+     - unoconv + pdftoppm + ImageMagick
+   * - ``ps``
+     - PostScript 文件
+     - ps2pdf + pdftoppm + ImageMagick
+
+示例
+----
+
+::
+
+    # 为图片文件生成缩略图
+    ./generate-thumbnail image file:/path/to/image.jpg /tmp/thumbnail.png image/jpeg
+
+    # 为 SVG 文件生成缩略图
+    ./generate-thumbnail svg file:/path/to/image.svg /tmp/thumbnail.png
+
+    # 为 PDF 文件生成缩略图
+    ./generate-thumbnail pdf file:/path/to/document.pdf /tmp/thumbnail.png
+
+    # GIF 文件（指定 MIME 类型以启用格式提示）
+    ./generate-thumbnail image file:/path/to/image.gif /tmp/thumbnail.png image/gif
+
+缩略图存储位置
+==============
+
+默认路径
+--------
+
+::
+
+    ${FESS_VAR_PATH}/thumbnails/
+
+或
+
+::
+
+    /var/lib/fess/thumbnails/
+
+目录结构
+--------
+
+缩略图以基于哈希的目录结构存储。
+
+::
+
+    thumbnails/
+    ├── _0/
+    │   ├── _1/
+    │   │   ├── _2/
+    │   │   │   └── _3/
+    │   │   │       └── abcdef123456.png
+    │   │   └── ...
+    │   └── ...
+    └── ...
 
 禁用缩略图任务
-==================
+==============
 
-要禁用缩略图任务,请进行以下设置。
+要禁用缩略图任务,请进行以下设置:
 
 1. 在管理页面的"系统">"常规"中取消勾选"缩略图显示",然后点击"更新"按钮。
 2. 在 ``app/WEB-INF/classes/fess_config.properties`` 或 ``/etc/fess/fess_config.properties`` 的 ``thumbnail.crawler.enabled`` 中设置 ``false``。
@@ -62,3 +383,99 @@ PDF 的缩略图使用 ImageMagick 生成。
     thumbnail.crawler.enabled=false
 
 3. 重启 Fess 服务。
+
+故障排除
+========
+
+缩略图未生成
+------------
+
+1. **检查外部工具**
+
+::
+
+    # 检查 ImageMagick
+    which convert || which magick
+
+    # 检查 rsvg-convert（用于 SVG）
+    which rsvg-convert
+
+    # 检查 pdftoppm（用于 PDF）
+    which pdftoppm
+
+2. **检查日志**
+
+::
+
+    ${FESS_LOG_PATH}/fess-thumbnail.log
+
+3. **手动运行脚本**
+
+::
+
+    /usr/share/fess/bin/generate-thumbnail image file:/path/to/test.jpg /tmp/test_thumbnail.png image/jpeg
+
+GIF/TIFF 文件出错
+-----------------
+
+使用 ImageMagick 6 时,指定 MIME 类型以启用格式提示。如果 Fess 配置正确,这将自动完成。
+
+错误示例::
+
+    convert-im6.q16: corrupt image `/tmp/thumbnail_xxx' @ error/gif.c/DecodeImage/512
+
+解决方案:
+
+- 升级到 ImageMagick 7
+- 或验证 MIME 类型是否正确传递
+
+SVG 缩略图未生成
+----------------
+
+1. 检查 ``rsvg-convert`` 是否已安装
+
+::
+
+    which rsvg-convert
+
+2. 手动测试转换
+
+::
+
+    rsvg-convert -w 100 -h 100 --keep-aspect-ratio input.svg -o output.png
+
+权限错误
+--------
+
+检查缩略图存储目录的权限。
+
+::
+
+    ls -la /var/lib/fess/thumbnails/
+
+如有必要,修复权限。
+
+::
+
+    chown -R fess:fess /var/lib/fess/thumbnails/
+    chmod -R 755 /var/lib/fess/thumbnails/
+
+平台支持
+========
+
+.. list-table::
+   :widths: 20 20 60
+   :header-rows: 1
+
+   * - 平台
+     - 支持状态
+     - 备注
+   * - Linux
+     - 完全支持
+     - \-
+   * - macOS
+     - 完全支持
+     - 通过 Homebrew 安装外部工具
+   * - Windows
+     - 不支持
+     - 由于依赖 bash 脚本


### PR DESCRIPTION
## Summary
- Add comprehensive thumbnail configuration documentation covering supported file formats, required external tools, configuration options, and troubleshooting
- Include detailed installation instructions for ImageMagick, rsvg-convert, pdftoppm, unoconv, and ghostscript
- Document generate-thumbnail script usage with examples
- Add platform support information (Linux, macOS supported; Windows not supported)

## Test plan
- [ ] Verify RST syntax is valid by building documentation
- [ ] Review content accuracy for thumbnail generation workflow
- [ ] Check translations are consistent across all 6 languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)