### PR TITLE
Add proxy environment variables documentation for all languages

### DIFF
--- a/de/15.4/config/setup-port-network.rst
+++ b/de/15.4/config/setup-port-network.rst
@@ -157,6 +157,24 @@ Um einen HTTP-Proxy für die gesamte |Fess|-Anwendung zu verwenden, konfiguriere
 .. warning::
    Passwörter werden unverschlüsselt gespeichert. Setzen Sie entsprechende Dateiberechtigungen.
 
+Proxy-Konfiguration über Umgebungsvariablen
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Wenn Java-Bibliotheken wie SSO-Authentifizierung einen Proxy verwenden müssen, müssen Sie ihn über Umgebungsvariablen konfigurieren.
+Diese Umgebungsvariablen werden in Java-Systemeigenschaften (``http.proxyHost``, ``https.proxyHost`` usw.) umgewandelt.
+
+::
+
+    FESS_PROXY_HOST=proxy.example.com
+    FESS_PROXY_PORT=8080
+    FESS_NON_PROXY_HOSTS=localhost|*.local|192.168.*
+
+Für RPM-Pakete konfigurieren Sie in ``/etc/sysconfig/fess``. Für DEB-Pakete konfigurieren Sie in ``/etc/default/fess``.
+
+.. note::
+   Die ``http.proxy.*``-Einstellungen in ``fess_config.properties`` werden für HTTP-Kommunikation innerhalb von Fess verwendet.
+   Wenn externe Java-Bibliotheken wie SSO-Authentifizierung einen Proxy verwenden müssen, konfigurieren Sie auch die obigen Umgebungsvariablen.
+
 HTTP-Kommunikationseinstellungen
 ============
 

--- a/en/15.4/config/setup-port-network.rst
+++ b/en/15.4/config/setup-port-network.rst
@@ -158,6 +158,24 @@ To use an HTTP proxy for the entire |Fess| application, configure it in ``fess_c
 .. warning::
    Passwords are stored without encryption. Set appropriate file permissions.
 
+Proxy Configuration via Environment Variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When Java libraries such as SSO authentication need to use a proxy, you must configure it via environment variables.
+These environment variables are converted to Java system properties (``http.proxyHost``, ``https.proxyHost``, etc.).
+
+::
+
+    FESS_PROXY_HOST=proxy.example.com
+    FESS_PROXY_PORT=8080
+    FESS_NON_PROXY_HOSTS=localhost|*.local|192.168.*
+
+For RPM packages, configure in ``/etc/sysconfig/fess``. For DEB packages, configure in ``/etc/default/fess``.
+
+.. note::
+   The ``http.proxy.*`` settings in ``fess_config.properties`` are used for HTTP communications within Fess.
+   If external Java libraries such as SSO authentication need to use a proxy, also configure the environment variables above.
+
 HTTP Communication Settings
 ===========================
 

--- a/es/15.4/config/setup-port-network.rst
+++ b/es/15.4/config/setup-port-network.rst
@@ -158,6 +158,24 @@ Para usar el proxy HTTP en toda la aplicación |Fess|, configure en ``fess_confi
 .. warning::
    Las contraseñas se almacenan sin cifrar. Configure los permisos de archivo apropiados.
 
+Configuración de Proxy mediante Variables de Entorno
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Cuando las bibliotecas Java como la autenticación SSO necesitan usar un proxy, debe configurarlo mediante variables de entorno.
+Estas variables de entorno se convierten en propiedades del sistema Java (``http.proxyHost``, ``https.proxyHost``, etc.).
+
+::
+
+    FESS_PROXY_HOST=proxy.example.com
+    FESS_PROXY_PORT=8080
+    FESS_NON_PROXY_HOSTS=localhost|*.local|192.168.*
+
+Para paquetes RPM, configure en ``/etc/sysconfig/fess``. Para paquetes DEB, configure en ``/etc/default/fess``.
+
+.. note::
+   La configuración ``http.proxy.*`` en ``fess_config.properties`` se usa para las comunicaciones HTTP dentro de Fess.
+   Si las bibliotecas Java externas como la autenticación SSO necesitan usar un proxy, también configure las variables de entorno anteriores.
+
 Configuración de Comunicación HTTP
 ===================================
 

--- a/fr/15.4/config/setup-port-network.rst
+++ b/fr/15.4/config/setup-port-network.rst
@@ -158,6 +158,24 @@ Pour utiliser un proxy HTTP pour l'ensemble de l'application |Fess|, configurez 
 .. warning::
    Les mots de passe sont stockés sans chiffrement. Configurez les permissions de fichier appropriées.
 
+Configuration du proxy via les variables d'environnement
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Lorsque les bibliothèques Java telles que l'authentification SSO doivent utiliser un proxy, vous devez le configurer via des variables d'environnement.
+Ces variables d'environnement sont converties en propriétés système Java (``http.proxyHost``, ``https.proxyHost``, etc.).
+
+::
+
+    FESS_PROXY_HOST=proxy.example.com
+    FESS_PROXY_PORT=8080
+    FESS_NON_PROXY_HOSTS=localhost|*.local|192.168.*
+
+Pour les packages RPM, configurez dans ``/etc/sysconfig/fess``. Pour les packages DEB, configurez dans ``/etc/default/fess``.
+
+.. note::
+   Les paramètres ``http.proxy.*`` dans ``fess_config.properties`` sont utilisés pour les communications HTTP au sein de Fess.
+   Si des bibliothèques Java externes telles que l'authentification SSO doivent utiliser un proxy, configurez également les variables d'environnement ci-dessus.
+
 Configuration de la communication HTTP
 ============
 

--- a/ja/15.4/config/setup-port-network.rst
+++ b/ja/15.4/config/setup-port-network.rst
@@ -158,6 +158,24 @@ Windows 環境でサービス登録して使用する場合は、``bin\service.b
 .. warning::
    パスワードは暗号化されずに保存されます。適切なファイルパーミッションを設定してください。
 
+環境変数によるプロキシ設定
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SSO認証などのJavaライブラリがプロキシを使用する場合は、環境変数で設定する必要があります。
+これらの環境変数はJavaシステムプロパティ（``http.proxyHost``、``https.proxyHost`` 等）に変換されます。
+
+::
+
+    FESS_PROXY_HOST=proxy.example.com
+    FESS_PROXY_PORT=8080
+    FESS_NON_PROXY_HOSTS=localhost|*.local|192.168.*
+
+RPMパッケージでは ``/etc/sysconfig/fess``、DEBパッケージでは ``/etc/default/fess`` に設定します。
+
+.. note::
+   ``fess_config.properties`` の ``http.proxy.*`` 設定は Fess 内部のHTTP通信で使用されます。
+   SSO認証などの外部Javaライブラリがプロキシを使用する場合は、上記の環境変数も設定してください。
+
 HTTP通信設定
 ============
 

--- a/ko/15.4/config/setup-port-network.rst
+++ b/ko/15.4/config/setup-port-network.rst
@@ -158,6 +158,24 @@ Windows 환경에서 서비스 등록하여 사용하는 경우 ``bin\service.ba
 .. warning::
    비밀번호는 암호화되지 않고 저장됩니다. 적절한 파일 권한을 설정하십시오.
 
+환경 변수를 통한 프록시 설정
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SSO 인증과 같은 Java 라이브러리가 프록시를 사용해야 하는 경우 환경 변수를 통해 구성해야 합니다.
+이러한 환경 변수는 Java 시스템 속성(``http.proxyHost``, ``https.proxyHost`` 등)으로 변환됩니다.
+
+::
+
+    FESS_PROXY_HOST=proxy.example.com
+    FESS_PROXY_PORT=8080
+    FESS_NON_PROXY_HOSTS=localhost|*.local|192.168.*
+
+RPM 패키지의 경우 ``/etc/sysconfig/fess`` 에서 구성합니다. DEB 패키지의 경우 ``/etc/default/fess`` 에서 구성합니다.
+
+.. note::
+   ``fess_config.properties`` 의 ``http.proxy.*`` 설정은 Fess 내부의 HTTP 통신에 사용됩니다.
+   SSO 인증과 같은 외부 Java 라이브러리가 프록시를 사용해야 하는 경우 위의 환경 변수도 구성하십시오.
+
 HTTP 통신 설정
 ============
 

--- a/zh-cn/15.4/config/setup-port-network.rst
+++ b/zh-cn/15.4/config/setup-port-network.rst
@@ -158,6 +158,24 @@ Windows 环境配置
 .. warning::
    密码将以未加密形式保存。请设置适当的文件权限。
 
+通过环境变量配置代理
+~~~~~~~~~~~~~~~~~~~~
+
+当 Java 库(如 SSO 认证)需要使用代理时,必须通过环境变量进行配置。
+这些环境变量会被转换为 Java 系统属性(``http.proxyHost``、``https.proxyHost`` 等)。
+
+::
+
+    FESS_PROXY_HOST=proxy.example.com
+    FESS_PROXY_PORT=8080
+    FESS_NON_PROXY_HOSTS=localhost|*.local|192.168.*
+
+对于 RPM 包,在 ``/etc/sysconfig/fess`` 中配置。对于 DEB 包,在 ``/etc/default/fess`` 中配置。
+
+.. note::
+   ``fess_config.properties`` 中的 ``http.proxy.*`` 设置用于 Fess 内部的 HTTP 通信。
+   如果外部 Java 库(如 SSO 认证)需要使用代理,还需要配置上述环境变量。
+
 HTTP 通信配置
 ============
 


### PR DESCRIPTION
## Summary
- Add documentation for proxy configuration via environment variables (`FESS_PROXY_HOST`, `FESS_PROXY_PORT`, `FESS_NON_PROXY_HOSTS`)
- Document how these settings differ from `fess_config.properties` proxy settings
- Cover configuration locations for RPM and DEB packages

## Test plan
- [ ] Verify documentation renders correctly in all 7 languages (ja, en, de, fr, es, ko, zh-cn)
- [ ] Confirm RST syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)