### PR TITLE
Add SSO OIDC documentation for all languages

### DIFF
--- a/de/15.4/config/index.rst
+++ b/de/15.4/config/index.rst
@@ -47,6 +47,7 @@ Ein umfassender Leitfaden zur Konfiguration von |Fess|. Jeder Abschnitt ist nach
    :caption: SSO-Konfiguration
 
    sso-saml
+   sso-oidc
 
 .. toctree::
    :maxdepth: 2

--- a/de/15.4/config/sso-oidc.rst
+++ b/de/15.4/config/sso-oidc.rst
@@ -1,0 +1,248 @@
+====================================
+SSO-Konfiguration mit OpenID Connect
+====================================
+
+Überblick
+=========
+
+|Fess| unterstützt Single Sign-On (SSO) Authentifizierung mit OpenID Connect (OIDC).
+OpenID Connect ist ein Authentifizierungsprotokoll, das auf OAuth 2.0 aufbaut und ID-Token (JWT) für die Benutzerauthentifizierung verwendet.
+Durch die Verwendung von OpenID Connect können Benutzerinformationen, die von einem OpenID Provider (OP) authentifiziert wurden, mit |Fess| integriert werden.
+
+Funktionsweise der OpenID Connect Authentifizierung
+----------------------------------------------------
+
+Bei der OpenID Connect Authentifizierung fungiert |Fess| als Relying Party (RP) und arbeitet mit einem externen OpenID Provider (OP) für die Authentifizierung zusammen.
+
+1. Benutzer greift auf den |Fess| SSO-Endpunkt (``/sso/``) zu
+2. |Fess| leitet zum Autorisierungsendpunkt des OP weiter
+3. Benutzer authentifiziert sich beim OP
+4. OP leitet den Autorisierungscode an |Fess| weiter
+5. |Fess| verwendet den Autorisierungscode, um ein ID-Token vom Token-Endpunkt zu erhalten
+6. |Fess| validiert das ID-Token (JWT) und meldet den Benutzer an
+
+Für die Integration mit rollenbasierter Suche siehe :doc:`security-role`.
+
+Voraussetzungen
+===============
+
+Bevor Sie die OpenID Connect Authentifizierung konfigurieren, überprüfen Sie die folgenden Voraussetzungen:
+
+- |Fess| 15.4 oder höher ist installiert
+- Ein OpenID Connect-kompatibler Provider (OP) ist verfügbar
+- |Fess| ist über HTTPS erreichbar (erforderlich für Produktionsumgebungen)
+- Sie haben die Berechtigung, |Fess| als Client (RP) auf der OP-Seite zu registrieren
+
+Beispiele für unterstützte Provider:
+
+- Microsoft Entra ID (Azure AD)
+- Google Workspace / Google Cloud Identity
+- Okta
+- Keycloak
+- Auth0
+- Andere OpenID Connect-kompatible Provider
+
+Grundkonfiguration
+==================
+
+SSO aktivieren
+--------------
+
+Um die OpenID Connect Authentifizierung zu aktivieren, fügen Sie die folgende Einstellung in ``app/WEB-INF/conf/system.properties`` hinzu:
+
+::
+
+    sso.type=oic
+
+Provider-Konfiguration
+----------------------
+
+Konfigurieren Sie die vom OP erhaltenen Informationen.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``oic.auth.server.url``
+     - Autorisierungsendpunkt-URL
+     - (Erforderlich)
+   * - ``oic.token.server.url``
+     - Token-Endpunkt-URL
+     - (Erforderlich)
+
+.. note::
+   Diese URLs können vom Discovery-Endpunkt des OP (``/.well-known/openid-configuration``) abgerufen werden.
+
+Client-Konfiguration
+--------------------
+
+Konfigurieren Sie die beim OP registrierten Client-Informationen.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``oic.client.id``
+     - Client-ID
+     - (Erforderlich)
+   * - ``oic.client.secret``
+     - Client-Secret
+     - (Erforderlich)
+   * - ``oic.scope``
+     - Angeforderte Scopes
+     - (Erforderlich)
+
+.. note::
+   Der Scope muss mindestens ``openid`` enthalten.
+   Um die E-Mail-Adresse des Benutzers abzurufen, geben Sie ``openid email`` an.
+
+Redirect-URL-Konfiguration
+--------------------------
+
+Konfigurieren Sie die Callback-URL nach der Authentifizierung.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``oic.redirect.url``
+     - Redirect-URL (Callback-URL)
+     - ``{oic.base.url}/sso/``
+   * - ``oic.base.url``
+     - |Fess| Basis-URL
+     - ``http://localhost:8080``
+
+.. note::
+   Wenn ``oic.redirect.url`` weggelassen wird, wird sie automatisch aus ``oic.base.url`` erstellt.
+   Für Produktionsumgebungen setzen Sie ``oic.base.url`` auf eine HTTPS-URL.
+
+OP-seitige Konfiguration
+========================
+
+Wenn Sie |Fess| als Client (RP) auf der OP-Seite registrieren, konfigurieren Sie die folgenden Informationen:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Einstellung
+     - Wert
+   * - Anwendungstyp
+     - Webanwendung
+   * - Redirect-URI / Callback-URL
+     - ``https://<Fess-Host>/sso/``
+   * - Erlaubte Scopes
+     - ``openid`` und erforderliche Scopes (``email``, ``profile`` usw.)
+
+Vom OP zu erhaltende Informationen
+----------------------------------
+
+Rufen Sie die folgenden Informationen vom Konfigurationsbildschirm oder Discovery-Endpunkt des OP für die |Fess| Konfiguration ab:
+
+- **Autorisierungsendpunkt (Authorization Endpoint)**: URL zum Starten der Benutzerauthentifizierung
+- **Token-Endpunkt (Token Endpoint)**: URL zum Abrufen von Token
+- **Client-ID**: Vom OP ausgestellte Client-Kennung
+- **Client-Secret**: Geheimer Schlüssel für die Client-Authentifizierung
+
+.. note::
+   Die meisten OPs ermöglichen es Ihnen, die Autorisierungs- und Token-Endpunkt-URLs vom
+   Discovery-Endpunkt (``https://<OP>/.well-known/openid-configuration``) zu überprüfen.
+
+Konfigurationsbeispiele
+=======================
+
+Minimalkonfiguration (für Tests)
+--------------------------------
+
+Das folgende Beispiel zeigt eine minimale Konfiguration zur Überprüfung in einer Testumgebung.
+
+::
+
+    # SSO aktivieren
+    sso.type=oic
+
+    # Provider-Konfiguration (vom OP erhaltene Werte eintragen)
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # Client-Konfiguration
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email
+
+    # Redirect-URL (Testumgebung)
+    oic.redirect.url=http://localhost:8080/sso/
+
+Empfohlene Konfiguration (für Produktion)
+-----------------------------------------
+
+Das folgende Beispiel zeigt eine empfohlene Konfiguration für Produktionsumgebungen.
+
+::
+
+    # SSO aktivieren
+    sso.type=oic
+
+    # Provider-Konfiguration
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # Client-Konfiguration
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email profile
+
+    # Basis-URL (HTTPS für Produktion verwenden)
+    oic.base.url=https://fess.example.com
+
+Fehlerbehebung
+==============
+
+Häufige Probleme und Lösungen
+-----------------------------
+
+Rückkehr zu Fess nach der Authentifizierung nicht möglich
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Überprüfen Sie, ob die Redirect-URI auf der OP-Seite korrekt konfiguriert ist
+- Stellen Sie sicher, dass der Wert von ``oic.redirect.url`` oder ``oic.base.url`` mit der OP-Konfiguration übereinstimmt
+- Überprüfen Sie, ob das Protokoll (HTTP/HTTPS) übereinstimmt
+
+Authentifizierungsfehler treten auf
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Überprüfen Sie, ob Client-ID und Client-Secret korrekt konfiguriert sind
+- Stellen Sie sicher, dass der Scope ``openid`` enthält
+- Überprüfen Sie, ob die Autorisierungsendpunkt-URL und Token-Endpunkt-URL korrekt sind
+
+Benutzerinformationen können nicht abgerufen werden
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Stellen Sie sicher, dass der Scope die erforderlichen Berechtigungen (``email``, ``profile`` usw.) enthält
+- Überprüfen Sie, ob die erforderlichen Scopes für den Client auf der OP-Seite erlaubt sind
+
+Debug-Einstellungen
+-------------------
+
+Um Probleme zu untersuchen, können Sie detaillierte OpenID Connect-bezogene Protokolle ausgeben, indem Sie die |Fess| Protokollebene anpassen.
+
+In ``app/WEB-INF/classes/log4j2.xml`` können Sie den folgenden Logger hinzufügen, um die Protokollebene zu ändern:
+
+::
+
+    <Logger name="org.codelibs.fess.sso.oic" level="DEBUG"/>
+
+Referenz
+========
+
+- :doc:`security-role` - Konfiguration der rollenbasierten Suche
+- :doc:`sso-saml` - SSO-Konfiguration mit SAML-Authentifizierung

--- a/en/15.4/config/index.rst
+++ b/en/15.4/config/index.rst
@@ -47,6 +47,7 @@ This is a comprehensive guide for configuring |Fess|. Each section is organized 
    :caption: SSO Settings
 
    sso-saml
+   sso-oidc
 
 .. toctree::
    :maxdepth: 2

--- a/en/15.4/config/sso-oidc.rst
+++ b/en/15.4/config/sso-oidc.rst
@@ -1,0 +1,248 @@
+=====================================
+SSO Configuration with OpenID Connect
+=====================================
+
+Overview
+========
+
+|Fess| supports Single Sign-On (SSO) authentication using OpenID Connect (OIDC).
+OpenID Connect is an authentication protocol built on top of OAuth 2.0 that uses ID Tokens (JWT) for user authentication.
+By using OpenID Connect authentication, user information authenticated by an OpenID Provider (OP) can be integrated with |Fess|.
+
+How OpenID Connect Authentication Works
+---------------------------------------
+
+In OpenID Connect authentication, |Fess| operates as a Relying Party (RP) and collaborates with an external OpenID Provider (OP) for authentication.
+
+1. User accesses the |Fess| SSO endpoint (``/sso/``)
+2. |Fess| redirects to the OP's authorization endpoint
+3. User authenticates at the OP
+4. OP redirects the authorization code to |Fess|
+5. |Fess| uses the authorization code to obtain an ID Token from the token endpoint
+6. |Fess| validates the ID Token (JWT) and logs in the user
+
+For integration with role-based search, see :doc:`security-role`.
+
+Prerequisites
+=============
+
+Before configuring OpenID Connect authentication, verify the following prerequisites:
+
+- |Fess| 15.4 or later is installed
+- An OpenID Connect-compatible provider (OP) is available
+- |Fess| is accessible via HTTPS (required for production environments)
+- You have permission to register |Fess| as a client (RP) on the OP side
+
+Examples of supported providers:
+
+- Microsoft Entra ID (Azure AD)
+- Google Workspace / Google Cloud Identity
+- Okta
+- Keycloak
+- Auth0
+- Other OpenID Connect-compatible providers
+
+Basic Configuration
+===================
+
+Enabling SSO
+------------
+
+To enable OpenID Connect authentication, add the following setting in ``app/WEB-INF/conf/system.properties``:
+
+::
+
+    sso.type=oic
+
+Provider Configuration
+----------------------
+
+Configure the information obtained from your OP.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Property
+     - Description
+     - Default
+   * - ``oic.auth.server.url``
+     - Authorization endpoint URL
+     - (Required)
+   * - ``oic.token.server.url``
+     - Token endpoint URL
+     - (Required)
+
+.. note::
+   These URLs can be obtained from the OP's Discovery endpoint (``/.well-known/openid-configuration``).
+
+Client Configuration
+--------------------
+
+Configure the client information registered with the OP.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Property
+     - Description
+     - Default
+   * - ``oic.client.id``
+     - Client ID
+     - (Required)
+   * - ``oic.client.secret``
+     - Client secret
+     - (Required)
+   * - ``oic.scope``
+     - Requested scopes
+     - (Required)
+
+.. note::
+   The scope must include at least ``openid``.
+   To retrieve the user's email address, specify ``openid email``.
+
+Redirect URL Configuration
+--------------------------
+
+Configure the callback URL after authentication.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Property
+     - Description
+     - Default
+   * - ``oic.redirect.url``
+     - Redirect URL (callback URL)
+     - ``{oic.base.url}/sso/``
+   * - ``oic.base.url``
+     - |Fess| base URL
+     - ``http://localhost:8080``
+
+.. note::
+   If ``oic.redirect.url`` is omitted, it is automatically constructed from ``oic.base.url``.
+   For production environments, set ``oic.base.url`` to an HTTPS URL.
+
+OP-Side Configuration
+=====================
+
+When registering |Fess| as a client (RP) on the OP side, configure the following information:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Setting
+     - Value
+   * - Application type
+     - Web application
+   * - Redirect URI / Callback URL
+     - ``https://<Fess host>/sso/``
+   * - Allowed scopes
+     - ``openid`` and required scopes (``email``, ``profile``, etc.)
+
+Information to Obtain from OP
+-----------------------------
+
+Obtain the following information from the OP's configuration screen or Discovery endpoint for use in |Fess| configuration:
+
+- **Authorization Endpoint**: URL to initiate user authentication
+- **Token Endpoint**: URL to obtain tokens
+- **Client ID**: Client identifier issued by the OP
+- **Client Secret**: Secret key used for client authentication
+
+.. note::
+   Most OPs allow you to check the authorization and token endpoint URLs from the
+   Discovery endpoint (``https://<OP>/.well-known/openid-configuration``).
+
+Configuration Examples
+======================
+
+Minimal Configuration (for Testing)
+-----------------------------------
+
+The following is a minimal configuration example for verification in a test environment.
+
+::
+
+    # Enable SSO
+    sso.type=oic
+
+    # Provider configuration (set values obtained from OP)
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # Client configuration
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email
+
+    # Redirect URL (test environment)
+    oic.redirect.url=http://localhost:8080/sso/
+
+Recommended Configuration (for Production)
+------------------------------------------
+
+The following is a recommended configuration example for production environments.
+
+::
+
+    # Enable SSO
+    sso.type=oic
+
+    # Provider configuration
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # Client configuration
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email profile
+
+    # Base URL (use HTTPS for production)
+    oic.base.url=https://fess.example.com
+
+Troubleshooting
+===============
+
+Common Problems and Solutions
+-----------------------------
+
+Cannot Return to Fess After Authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Verify that the redirect URI is correctly configured on the OP side
+- Ensure that the ``oic.redirect.url`` or ``oic.base.url`` value matches the OP configuration
+- Verify that the protocol (HTTP/HTTPS) matches
+
+Authentication Errors Occur
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Verify that the client ID and client secret are correctly configured
+- Ensure that the scope includes ``openid``
+- Verify that the authorization endpoint URL and token endpoint URL are correct
+
+Cannot Retrieve User Information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Ensure that the scope includes the required permissions (``email``, ``profile``, etc.)
+- Verify that the required scopes are allowed for the client on the OP side
+
+Debugging
+---------
+
+To investigate problems, you can output detailed OpenID Connect-related logs by adjusting the |Fess| log level.
+
+In ``app/WEB-INF/classes/log4j2.xml``, you can add the following logger to change the log level:
+
+::
+
+    <Logger name="org.codelibs.fess.sso.oic" level="DEBUG"/>
+
+Reference
+=========
+
+- :doc:`security-role` - Role-based search configuration
+- :doc:`sso-saml` - SSO configuration with SAML authentication

--- a/es/15.4/config/index.rst
+++ b/es/15.4/config/index.rst
@@ -47,6 +47,7 @@ Guía integral sobre la configuración de |Fess|. Cada sección está organizada
    :caption: Configuración SSO
 
    sso-saml
+   sso-oidc
 
 .. toctree::
    :maxdepth: 2

--- a/es/15.4/config/sso-oidc.rst
+++ b/es/15.4/config/sso-oidc.rst
@@ -1,0 +1,248 @@
+==========================================
+Configuración de SSO con OpenID Connect
+==========================================
+
+Descripción general
+===================
+
+|Fess| soporta autenticación Single Sign-On (SSO) utilizando OpenID Connect (OIDC).
+OpenID Connect es un protocolo de autenticación basado en OAuth 2.0 que utiliza ID Tokens (JWT) para la autenticación de usuarios.
+Al utilizar autenticación OpenID Connect, la información del usuario autenticada por un OpenID Provider (OP) puede integrarse con |Fess|.
+
+Cómo funciona la autenticación OpenID Connect
+----------------------------------------------
+
+En la autenticación OpenID Connect, |Fess| opera como Relying Party (RP) y colabora con un OpenID Provider (OP) externo para la autenticación.
+
+1. El usuario accede al endpoint SSO de |Fess| (``/sso/``)
+2. |Fess| redirige al endpoint de autorización del OP
+3. El usuario se autentica en el OP
+4. El OP redirige el código de autorización a |Fess|
+5. |Fess| utiliza el código de autorización para obtener un ID Token del endpoint de token
+6. |Fess| valida el ID Token (JWT) e inicia sesión del usuario
+
+Para la integración con búsqueda basada en roles, consulte :doc:`security-role`.
+
+Prerrequisitos
+==============
+
+Antes de configurar la autenticación OpenID Connect, verifique los siguientes prerrequisitos:
+
+- |Fess| 15.4 o superior está instalado
+- Un proveedor compatible con OpenID Connect (OP) está disponible
+- |Fess| es accesible a través de HTTPS (requerido para entornos de producción)
+- Tiene permiso para registrar |Fess| como cliente (RP) en el lado del OP
+
+Ejemplos de proveedores soportados:
+
+- Microsoft Entra ID (Azure AD)
+- Google Workspace / Google Cloud Identity
+- Okta
+- Keycloak
+- Auth0
+- Otros proveedores compatibles con OpenID Connect
+
+Configuración básica
+====================
+
+Habilitar SSO
+-------------
+
+Para habilitar la autenticación OpenID Connect, agregue la siguiente configuración en ``app/WEB-INF/conf/system.properties``:
+
+::
+
+    sso.type=oic
+
+Configuración del proveedor
+---------------------------
+
+Configure la información obtenida de su OP.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Propiedad
+     - Descripción
+     - Por defecto
+   * - ``oic.auth.server.url``
+     - URL del endpoint de autorización
+     - (Requerido)
+   * - ``oic.token.server.url``
+     - URL del endpoint de token
+     - (Requerido)
+
+.. note::
+   Estas URLs se pueden obtener del endpoint Discovery del OP (``/.well-known/openid-configuration``).
+
+Configuración del cliente
+-------------------------
+
+Configure la información del cliente registrada con el OP.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Propiedad
+     - Descripción
+     - Por defecto
+   * - ``oic.client.id``
+     - ID de cliente
+     - (Requerido)
+   * - ``oic.client.secret``
+     - Secreto del cliente
+     - (Requerido)
+   * - ``oic.scope``
+     - Scopes solicitados
+     - (Requerido)
+
+.. note::
+   El scope debe incluir al menos ``openid``.
+   Para recuperar la dirección de correo electrónico del usuario, especifique ``openid email``.
+
+Configuración de URL de redirección
+-----------------------------------
+
+Configure la URL de callback después de la autenticación.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Propiedad
+     - Descripción
+     - Por defecto
+   * - ``oic.redirect.url``
+     - URL de redirección (URL de callback)
+     - ``{oic.base.url}/sso/``
+   * - ``oic.base.url``
+     - URL base de |Fess|
+     - ``http://localhost:8080``
+
+.. note::
+   Si ``oic.redirect.url`` se omite, se construye automáticamente a partir de ``oic.base.url``.
+   Para entornos de producción, configure ``oic.base.url`` con una URL HTTPS.
+
+Configuración del lado del OP
+=============================
+
+Al registrar |Fess| como cliente (RP) en el lado del OP, configure la siguiente información:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Configuración
+     - Valor
+   * - Tipo de aplicación
+     - Aplicación web
+   * - URI de redirección / URL de callback
+     - ``https://<Host de Fess>/sso/``
+   * - Scopes permitidos
+     - ``openid`` y scopes requeridos (``email``, ``profile``, etc.)
+
+Información a obtener del OP
+----------------------------
+
+Obtenga la siguiente información de la pantalla de configuración o endpoint Discovery del OP para usar en la configuración de |Fess|:
+
+- **Endpoint de autorización (Authorization Endpoint)**: URL para iniciar la autenticación del usuario
+- **Endpoint de token (Token Endpoint)**: URL para obtener tokens
+- **ID de cliente**: Identificador de cliente emitido por el OP
+- **Secreto del cliente**: Clave secreta utilizada para la autenticación del cliente
+
+.. note::
+   La mayoría de los OP le permiten verificar las URLs de los endpoints de autorización y token desde el
+   endpoint Discovery (``https://<OP>/.well-known/openid-configuration``).
+
+Ejemplos de configuración
+=========================
+
+Configuración mínima (para pruebas)
+-----------------------------------
+
+El siguiente es un ejemplo de configuración mínima para verificación en un entorno de pruebas.
+
+::
+
+    # Habilitar SSO
+    sso.type=oic
+
+    # Configuración del proveedor (establecer valores obtenidos del OP)
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # Configuración del cliente
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email
+
+    # URL de redirección (entorno de pruebas)
+    oic.redirect.url=http://localhost:8080/sso/
+
+Configuración recomendada (para producción)
+-------------------------------------------
+
+El siguiente es un ejemplo de configuración recomendada para entornos de producción.
+
+::
+
+    # Habilitar SSO
+    sso.type=oic
+
+    # Configuración del proveedor
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # Configuración del cliente
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email profile
+
+    # URL base (usar HTTPS para producción)
+    oic.base.url=https://fess.example.com
+
+Solución de problemas
+=====================
+
+Problemas comunes y soluciones
+------------------------------
+
+No se puede regresar a Fess después de la autenticación
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Verifique que la URI de redirección esté configurada correctamente en el lado del OP
+- Asegúrese de que el valor de ``oic.redirect.url`` o ``oic.base.url`` coincida con la configuración del OP
+- Verifique que el protocolo (HTTP/HTTPS) coincida
+
+Ocurren errores de autenticación
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Verifique que el ID de cliente y el secreto del cliente estén configurados correctamente
+- Asegúrese de que el scope incluya ``openid``
+- Verifique que la URL del endpoint de autorización y la URL del endpoint de token sean correctas
+
+No se puede recuperar información del usuario
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Asegúrese de que el scope incluya los permisos requeridos (``email``, ``profile``, etc.)
+- Verifique que los scopes requeridos estén permitidos para el cliente en el lado del OP
+
+Configuración de depuración
+---------------------------
+
+Para investigar problemas, puede mostrar logs detallados relacionados con OpenID Connect ajustando el nivel de log de |Fess|.
+
+En ``app/WEB-INF/classes/log4j2.xml``, puede agregar el siguiente logger para cambiar el nivel de log:
+
+::
+
+    <Logger name="org.codelibs.fess.sso.oic" level="DEBUG"/>
+
+Referencia
+==========
+
+- :doc:`security-role` - Configuración de búsqueda basada en roles
+- :doc:`sso-saml` - Configuración de SSO con autenticación SAML

--- a/fr/15.4/config/index.rst
+++ b/fr/15.4/config/index.rst
@@ -47,6 +47,7 @@ Ce guide complet couvre la configuration de |Fess|. Chaque section est organisé
    :caption: Configuration SSO
 
    sso-saml
+   sso-oidc
 
 .. toctree::
    :maxdepth: 2

--- a/fr/15.4/config/sso-oidc.rst
+++ b/fr/15.4/config/sso-oidc.rst
@@ -1,0 +1,248 @@
+====================================
+Configuration SSO avec OpenID Connect
+====================================
+
+Vue d'ensemble
+==============
+
+|Fess| prend en charge l'authentification Single Sign-On (SSO) utilisant OpenID Connect (OIDC).
+OpenID Connect est un protocole d'authentification basé sur OAuth 2.0 qui utilise des ID Tokens (JWT) pour l'authentification des utilisateurs.
+En utilisant l'authentification OpenID Connect, les informations utilisateur authentifiées par un OpenID Provider (OP) peuvent être intégrées avec |Fess|.
+
+Fonctionnement de l'authentification OpenID Connect
+----------------------------------------------------
+
+Dans l'authentification OpenID Connect, |Fess| fonctionne comme une Relying Party (RP) et collabore avec un OpenID Provider (OP) externe pour l'authentification.
+
+1. L'utilisateur accède au endpoint SSO de |Fess| (``/sso/``)
+2. |Fess| redirige vers le endpoint d'autorisation de l'OP
+3. L'utilisateur s'authentifie auprès de l'OP
+4. L'OP redirige le code d'autorisation vers |Fess|
+5. |Fess| utilise le code d'autorisation pour obtenir un ID Token depuis le endpoint de token
+6. |Fess| valide l'ID Token (JWT) et connecte l'utilisateur
+
+Pour l'intégration avec la recherche basée sur les rôles, voir :doc:`security-role`.
+
+Prérequis
+=========
+
+Avant de configurer l'authentification OpenID Connect, vérifiez les prérequis suivants :
+
+- |Fess| 15.4 ou supérieur est installé
+- Un fournisseur compatible OpenID Connect (OP) est disponible
+- |Fess| est accessible via HTTPS (requis pour les environnements de production)
+- Vous avez la permission d'enregistrer |Fess| comme client (RP) côté OP
+
+Exemples de fournisseurs pris en charge :
+
+- Microsoft Entra ID (Azure AD)
+- Google Workspace / Google Cloud Identity
+- Okta
+- Keycloak
+- Auth0
+- Autres fournisseurs compatibles OpenID Connect
+
+Configuration de base
+=====================
+
+Activation du SSO
+-----------------
+
+Pour activer l'authentification OpenID Connect, ajoutez le paramètre suivant dans ``app/WEB-INF/conf/system.properties`` :
+
+::
+
+    sso.type=oic
+
+Configuration du fournisseur
+----------------------------
+
+Configurez les informations obtenues de votre OP.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``oic.auth.server.url``
+     - URL du endpoint d'autorisation
+     - (Requis)
+   * - ``oic.token.server.url``
+     - URL du endpoint de token
+     - (Requis)
+
+.. note::
+   Ces URLs peuvent être obtenues depuis le endpoint Discovery de l'OP (``/.well-known/openid-configuration``).
+
+Configuration du client
+-----------------------
+
+Configurez les informations client enregistrées auprès de l'OP.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``oic.client.id``
+     - ID client
+     - (Requis)
+   * - ``oic.client.secret``
+     - Secret client
+     - (Requis)
+   * - ``oic.scope``
+     - Scopes demandés
+     - (Requis)
+
+.. note::
+   Le scope doit inclure au moins ``openid``.
+   Pour récupérer l'adresse e-mail de l'utilisateur, spécifiez ``openid email``.
+
+Configuration de l'URL de redirection
+-------------------------------------
+
+Configurez l'URL de callback après l'authentification.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``oic.redirect.url``
+     - URL de redirection (URL de callback)
+     - ``{oic.base.url}/sso/``
+   * - ``oic.base.url``
+     - URL de base de |Fess|
+     - ``http://localhost:8080``
+
+.. note::
+   Si ``oic.redirect.url`` est omis, il est automatiquement construit à partir de ``oic.base.url``.
+   Pour les environnements de production, définissez ``oic.base.url`` sur une URL HTTPS.
+
+Configuration côté OP
+=====================
+
+Lors de l'enregistrement de |Fess| comme client (RP) côté OP, configurez les informations suivantes :
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Paramètre
+     - Valeur
+   * - Type d'application
+     - Application web
+   * - URI de redirection / URL de callback
+     - ``https://<Hôte Fess>/sso/``
+   * - Scopes autorisés
+     - ``openid`` et les scopes requis (``email``, ``profile``, etc.)
+
+Informations à obtenir de l'OP
+------------------------------
+
+Obtenez les informations suivantes depuis l'écran de configuration ou le endpoint Discovery de l'OP pour la configuration de |Fess| :
+
+- **Endpoint d'autorisation (Authorization Endpoint)** : URL pour initier l'authentification utilisateur
+- **Endpoint de token (Token Endpoint)** : URL pour obtenir les tokens
+- **ID client** : Identifiant client émis par l'OP
+- **Secret client** : Clé secrète utilisée pour l'authentification du client
+
+.. note::
+   La plupart des OP vous permettent de vérifier les URLs des endpoints d'autorisation et de token depuis le
+   endpoint Discovery (``https://<OP>/.well-known/openid-configuration``).
+
+Exemples de configuration
+=========================
+
+Configuration minimale (pour les tests)
+---------------------------------------
+
+Voici un exemple de configuration minimale pour la vérification dans un environnement de test.
+
+::
+
+    # Activer SSO
+    sso.type=oic
+
+    # Configuration du fournisseur (définir les valeurs obtenues de l'OP)
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # Configuration du client
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email
+
+    # URL de redirection (environnement de test)
+    oic.redirect.url=http://localhost:8080/sso/
+
+Configuration recommandée (pour la production)
+----------------------------------------------
+
+Voici un exemple de configuration recommandée pour les environnements de production.
+
+::
+
+    # Activer SSO
+    sso.type=oic
+
+    # Configuration du fournisseur
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # Configuration du client
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email profile
+
+    # URL de base (utiliser HTTPS pour la production)
+    oic.base.url=https://fess.example.com
+
+Dépannage
+=========
+
+Problèmes courants et solutions
+-------------------------------
+
+Impossible de retourner à Fess après l'authentification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Vérifiez que l'URI de redirection est correctement configurée côté OP
+- Assurez-vous que la valeur de ``oic.redirect.url`` ou ``oic.base.url`` correspond à la configuration de l'OP
+- Vérifiez que le protocole (HTTP/HTTPS) correspond
+
+Des erreurs d'authentification se produisent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Vérifiez que l'ID client et le secret client sont correctement configurés
+- Assurez-vous que le scope inclut ``openid``
+- Vérifiez que l'URL du endpoint d'autorisation et l'URL du endpoint de token sont correctes
+
+Impossible de récupérer les informations utilisateur
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Assurez-vous que le scope inclut les permissions requises (``email``, ``profile``, etc.)
+- Vérifiez que les scopes requis sont autorisés pour le client côté OP
+
+Configuration de débogage
+-------------------------
+
+Pour investiguer les problèmes, vous pouvez afficher des logs détaillés liés à OpenID Connect en ajustant le niveau de log de |Fess|.
+
+Dans ``app/WEB-INF/classes/log4j2.xml``, vous pouvez ajouter le logger suivant pour changer le niveau de log :
+
+::
+
+    <Logger name="org.codelibs.fess.sso.oic" level="DEBUG"/>
+
+Référence
+=========
+
+- :doc:`security-role` - Configuration de la recherche basée sur les rôles
+- :doc:`sso-saml` - Configuration SSO avec authentification SAML

--- a/ja/15.4/config/index.rst
+++ b/ja/15.4/config/index.rst
@@ -47,6 +47,7 @@
    :caption: SSO設定
 
    sso-saml
+   sso-oidc
 
 .. toctree::
    :maxdepth: 2

--- a/ja/15.4/config/sso-oidc.rst
+++ b/ja/15.4/config/sso-oidc.rst
@@ -1,0 +1,248 @@
+==============================
+OpenID ConnectによるSSO設定
+==============================
+
+概要
+====
+
+|Fess| では、OpenID Connect（OIDC）を使用したシングルサインオン（SSO）認証をサポートしています。
+OpenID ConnectはOAuth 2.0を基盤とした認証プロトコルで、ID Token（JWT）を使用してユーザー認証を行います。
+OpenID Connect認証を使用することで、OIDCプロバイダー（OP）で認証されたユーザー情報を |Fess| に連携できます。
+
+OpenID Connect認証の仕組み
+--------------------------
+
+OpenID Connect認証では、|Fess| がRelying Party（RP）として動作し、外部のOpenIDプロバイダー（OP）と連携して認証を行います。
+
+1. ユーザーが |Fess| のSSOエンドポイント（``/sso/``）にアクセス
+2. |Fess| がOPの認可エンドポイントにリダイレクト
+3. ユーザーがOPで認証を実行
+4. OPが認可コードを |Fess| にリダイレクト
+5. |Fess| が認可コードを使用してトークンエンドポイントからID Tokenを取得
+6. |Fess| がID Token（JWT）を検証し、ユーザーをログイン
+
+ロールベース検索との連携については、:doc:`security-role` を参照してください。
+
+前提条件
+========
+
+OpenID Connect認証を設定する前に、以下の前提条件を確認してください。
+
+- |Fess| 15.4 以降がインストールされていること
+- OpenID Connect対応のプロバイダー（OP）が利用可能であること
+- |Fess| がHTTPSでアクセス可能であること（本番環境では必須）
+- OP側で |Fess| をクライアント（RP）として登録できる権限があること
+
+対応するプロバイダーの例:
+
+- Microsoft Entra ID（Azure AD）
+- Google Workspace / Google Cloud Identity
+- Okta
+- Keycloak
+- Auth0
+- その他のOpenID Connect対応プロバイダー
+
+基本設定
+========
+
+SSO機能の有効化
+---------------
+
+OpenID Connect認証を有効にするには、``app/WEB-INF/conf/system.properties`` に以下の設定を追加します。
+
+::
+
+    sso.type=oic
+
+プロバイダー設定
+----------------
+
+OPから取得した情報を設定します。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - プロパティ
+     - 説明
+     - デフォルト
+   * - ``oic.auth.server.url``
+     - 認可エンドポイントURL
+     - （必須）
+   * - ``oic.token.server.url``
+     - トークンエンドポイントURL
+     - （必須）
+
+.. note::
+   これらのURLは、OPのDiscoveryエンドポイント（``/.well-known/openid-configuration``）から取得できます。
+
+クライアント設定
+----------------
+
+OP側で登録したクライアント情報を設定します。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - プロパティ
+     - 説明
+     - デフォルト
+   * - ``oic.client.id``
+     - クライアントID
+     - （必須）
+   * - ``oic.client.secret``
+     - クライアントシークレット
+     - （必須）
+   * - ``oic.scope``
+     - 要求するスコープ
+     - （必須）
+
+.. note::
+   スコープには少なくとも ``openid`` を含める必要があります。
+   ユーザーのメールアドレスを取得する場合は ``openid email`` を指定します。
+
+リダイレクトURL設定
+-------------------
+
+認証後のコールバックURLを設定します。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - プロパティ
+     - 説明
+     - デフォルト
+   * - ``oic.redirect.url``
+     - リダイレクトURL（コールバックURL）
+     - ``{oic.base.url}/sso/``
+   * - ``oic.base.url``
+     - |Fess| のベースURL
+     - ``http://localhost:8080``
+
+.. note::
+   ``oic.redirect.url`` を省略した場合、``oic.base.url`` から自動的に構成されます。
+   本番環境では、``oic.base.url`` にHTTPSのURLを設定してください。
+
+OP側での設定
+============
+
+OP側で |Fess| をクライアント（RP）として登録する際に、以下の情報を設定します。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 設定項目
+     - 設定値
+   * - アプリケーションの種類
+     - Webアプリケーション
+   * - リダイレクトURI / コールバックURL
+     - ``https://<Fessのホスト>/sso/``
+   * - 許可するスコープ
+     - ``openid`` および必要なスコープ（``email``, ``profile`` など）
+
+OPから取得する情報
+------------------
+
+OPの設定画面またはDiscoveryエンドポイントから以下の情報を取得し、|Fess| の設定に使用します。
+
+- **認可エンドポイント（Authorization Endpoint）**: ユーザー認証を開始するURL
+- **トークンエンドポイント（Token Endpoint）**: トークンを取得するURL
+- **クライアントID**: OPで発行されたクライアント識別子
+- **クライアントシークレット**: クライアント認証に使用する秘密鍵
+
+.. note::
+   多くのOPでは、Discoveryエンドポイント（``https://<OP>/.well-known/openid-configuration``）から
+   認可エンドポイントとトークンエンドポイントのURLを確認できます。
+
+設定例
+======
+
+最小構成（検証環境向け）
+------------------------
+
+以下は、検証環境で動作確認を行うための最小限の設定例です。
+
+::
+
+    # SSO有効化
+    sso.type=oic
+
+    # プロバイダー設定（OPから取得した値を設定）
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # クライアント設定
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email
+
+    # リダイレクトURL（検証環境）
+    oic.redirect.url=http://localhost:8080/sso/
+
+推奨構成（本番環境向け）
+------------------------
+
+以下は、本番環境で使用する際の推奨設定例です。
+
+::
+
+    # SSO有効化
+    sso.type=oic
+
+    # プロバイダー設定
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # クライアント設定
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email profile
+
+    # ベースURL（本番環境ではHTTPSを使用）
+    oic.base.url=https://fess.example.com
+
+トラブルシューティング
+======================
+
+よくある問題と解決方法
+----------------------
+
+認証後に |Fess| に戻れない
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- OP側のリダイレクトURIが正しく設定されているか確認してください
+- ``oic.redirect.url`` または ``oic.base.url`` の値がOP側の設定と一致しているか確認してください
+- プロトコル（HTTP/HTTPS）が一致しているか確認してください
+
+認証エラーが発生する
+~~~~~~~~~~~~~~~~~~~~
+
+- クライアントIDとクライアントシークレットが正しく設定されているか確認してください
+- スコープに ``openid`` が含まれているか確認してください
+- 認可エンドポイントURLとトークンエンドポイントURLが正しいか確認してください
+
+ユーザー情報が取得できない
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- スコープに必要な権限（``email``, ``profile`` など）が含まれているか確認してください
+- OP側でクライアントに必要なスコープが許可されているか確認してください
+
+デバッグ設定
+------------
+
+問題を調査する際は、|Fess| のログレベルを調整することで、OpenID Connect関連の詳細なログを出力できます。
+
+``app/WEB-INF/classes/log4j2.xml`` で、以下のロガーを追加してログレベルを変更できます。
+
+::
+
+    <Logger name="org.codelibs.fess.sso.oic" level="DEBUG"/>
+
+参考情報
+========
+
+- :doc:`security-role` - ロールベース検索の設定について
+- :doc:`sso-saml` - SAML認証によるSSO設定について

--- a/zh-cn/15.4/config/index.rst
+++ b/zh-cn/15.4/config/index.rst
@@ -47,6 +47,7 @@
    :caption: SSO配置
 
    sso-saml
+   sso-oidc
 
 .. toctree::
    :maxdepth: 2

--- a/zh-cn/15.4/config/sso-oidc.rst
+++ b/zh-cn/15.4/config/sso-oidc.rst
@@ -1,0 +1,248 @@
+===========================
+OpenID Connect SSO配置
+===========================
+
+概述
+====
+
+|Fess| 支持使用OpenID Connect（OIDC）进行单点登录（SSO）认证。
+OpenID Connect是基于OAuth 2.0的认证协议，使用ID Token（JWT）进行用户认证。
+通过使用OpenID Connect认证，由OpenID提供者（OP）认证的用户信息可以与|Fess|集成。
+
+OpenID Connect认证的工作原理
+----------------------------
+
+在OpenID Connect认证中，|Fess|作为依赖方（RP）运行，并与外部OpenID提供者（OP）协作进行认证。
+
+1. 用户访问|Fess|的SSO端点（``/sso/``）
+2. |Fess|将请求重定向到OP的授权端点
+3. 用户在OP进行认证
+4. OP将授权码重定向到|Fess|
+5. |Fess|使用授权码从令牌端点获取ID Token
+6. |Fess|验证ID Token（JWT）并登录用户
+
+有关基于角色的搜索集成，请参阅:doc:`security-role`。
+
+前提条件
+========
+
+在配置OpenID Connect认证之前，请验证以下前提条件：
+
+- 已安装|Fess| 15.4或更高版本
+- 有可用的OpenID Connect兼容提供者（OP）
+- |Fess|可通过HTTPS访问（生产环境必需）
+- 您有权在OP侧将|Fess|注册为客户端（RP）
+
+支持的提供者示例：
+
+- Microsoft Entra ID（Azure AD）
+- Google Workspace / Google Cloud Identity
+- Okta
+- Keycloak
+- Auth0
+- 其他OpenID Connect兼容提供者
+
+基本配置
+========
+
+启用SSO
+-------
+
+要启用OpenID Connect认证，请在``app/WEB-INF/conf/system.properties``中添加以下设置：
+
+::
+
+    sso.type=oic
+
+提供者配置
+----------
+
+配置从您的OP获取的信息。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 属性
+     - 描述
+     - 默认值
+   * - ``oic.auth.server.url``
+     - 授权端点URL
+     - （必需）
+   * - ``oic.token.server.url``
+     - 令牌端点URL
+     - （必需）
+
+.. note::
+   这些URL可以从OP的Discovery端点（``/.well-known/openid-configuration``）获取。
+
+客户端配置
+----------
+
+配置在OP注册的客户端信息。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 属性
+     - 描述
+     - 默认值
+   * - ``oic.client.id``
+     - 客户端ID
+     - （必需）
+   * - ``oic.client.secret``
+     - 客户端密钥
+     - （必需）
+   * - ``oic.scope``
+     - 请求的范围
+     - （必需）
+
+.. note::
+   范围必须至少包含``openid``。
+   要获取用户的电子邮件地址，请指定``openid email``。
+
+重定向URL配置
+-------------
+
+配置认证后的回调URL。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 属性
+     - 描述
+     - 默认值
+   * - ``oic.redirect.url``
+     - 重定向URL（回调URL）
+     - ``{oic.base.url}/sso/``
+   * - ``oic.base.url``
+     - |Fess|的基础URL
+     - ``http://localhost:8080``
+
+.. note::
+   如果省略``oic.redirect.url``，它将从``oic.base.url``自动构建。
+   对于生产环境，请将``oic.base.url``设置为HTTPS URL。
+
+OP侧配置
+========
+
+在OP侧将|Fess|注册为客户端（RP）时，配置以下信息：
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 设置
+     - 值
+   * - 应用程序类型
+     - Web应用程序
+   * - 重定向URI / 回调URL
+     - ``https://<Fess主机>/sso/``
+   * - 允许的范围
+     - ``openid``以及所需的范围（``email``、``profile``等）
+
+从OP获取的信息
+--------------
+
+从OP的配置界面或Discovery端点获取以下信息，用于|Fess|配置：
+
+- **授权端点（Authorization Endpoint）**：启动用户认证的URL
+- **令牌端点（Token Endpoint）**：获取令牌的URL
+- **客户端ID**：OP颁发的客户端标识符
+- **客户端密钥**：用于客户端认证的密钥
+
+.. note::
+   大多数OP允许您从Discovery端点（``https://<OP>/.well-known/openid-configuration``）
+   确认授权和令牌端点的URL。
+
+配置示例
+========
+
+最小配置（用于测试）
+--------------------
+
+以下是在测试环境中进行验证的最小配置示例。
+
+::
+
+    # 启用SSO
+    sso.type=oic
+
+    # 提供者配置（设置从OP获取的值）
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # 客户端配置
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email
+
+    # 重定向URL（测试环境）
+    oic.redirect.url=http://localhost:8080/sso/
+
+推荐配置（用于生产）
+--------------------
+
+以下是生产环境的推荐配置示例。
+
+::
+
+    # 启用SSO
+    sso.type=oic
+
+    # 提供者配置
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # 客户端配置
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email profile
+
+    # 基础URL（生产环境使用HTTPS）
+    oic.base.url=https://fess.example.com
+
+故障排除
+========
+
+常见问题和解决方案
+------------------
+
+认证后无法返回Fess
+~~~~~~~~~~~~~~~~~~
+
+- 验证重定向URI是否在OP侧正确配置
+- 确保``oic.redirect.url``或``oic.base.url``的值与OP配置匹配
+- 验证协议（HTTP/HTTPS）是否匹配
+
+发生认证错误
+~~~~~~~~~~~~
+
+- 验证客户端ID和客户端密钥是否正确配置
+- 确保范围包含``openid``
+- 验证授权端点URL和令牌端点URL是否正确
+
+无法获取用户信息
+~~~~~~~~~~~~~~~~
+
+- 确保范围包含所需的权限（``email``、``profile``等）
+- 验证OP侧是否为客户端允许了所需的范围
+
+调试设置
+--------
+
+要调查问题，您可以通过调整|Fess|的日志级别来输出详细的OpenID Connect相关日志。
+
+在``app/WEB-INF/classes/log4j2.xml``中，您可以添加以下日志记录器来更改日志级别：
+
+::
+
+    <Logger name="org.codelibs.fess.sso.oic" level="DEBUG"/>
+
+参考
+====
+
+- :doc:`security-role` - 基于角色的搜索配置
+- :doc:`sso-saml` - SAML认证SSO配置


### PR DESCRIPTION
## Summary
- Add SSO OIDC (OpenID Connect) documentation for all languages (ja, en, de, fr, es, zh-cn)
- Update config/index.rst to include the new sso-oidc document

## Test plan
- [ ] Verify documentation builds correctly for all languages
- [ ] Check that links in index.rst point to the correct document

🤖 Generated with [Claude Code](https://claude.com/claude-code)