### PR TITLE
docs: Add Fess 15.4.0 release information for all languages

### DIFF
--- a/de/documentation.rst
+++ b/de/documentation.rst
@@ -4,9 +4,9 @@ Dokumentation
 
 .. toctree::
 
-   Installation <15.3/install/index>
-   Suche <15.3/user/index>
-   Verwaltung <15.3/admin/index>
-   API <15.3/api/index>
-   Konfiguration <15.3/config/index>
+   Installation <15.4/install/index>
+   Suche <15.4/user/index>
+   Verwaltung <15.4/admin/index>
+   API <15.4/api/index>
+   Konfiguration <15.4/config/index>
 

--- a/de/downloads.rst
+++ b/de/downloads.rst
@@ -14,6 +14,7 @@ Stabile Releases
 
 Getestete stabile Releases.
 
+* `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
 * `Fess 15.1.0 <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.1.0 <https://opensearch.org/versions/opensearch-3-1-0.html>`_)
@@ -23,13 +24,12 @@ Getestete stabile Releases.
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
 * `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
 * `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
-* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
-
 Für Installationsinformationen siehe die Installationsanleitung.
 
 Ältere Releases (EOL)
 =====================
 
+* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)
 * `Fess 14.11.1 <https://github.com/codelibs/fess/releases/tag/fess-14.11.1>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.11.0 <https://opensearch.org/versions/opensearch-2-11-1.html>`_)

--- a/de/index.rst
+++ b/de/index.rst
@@ -46,7 +46,7 @@ Fess wird unter der Apache-Lizenz bereitgestellt und ist kostenlos (Freeware) nu
 Download
 ========
 
-- :doc:`Fess 15.3.0 <downloads>` (zip/rpm/deb-Pakete)
+- :doc:`Fess 15.4.0 <downloads>` (zip/rpm/deb-Pakete)
 
 Funktionen
 ==========
@@ -102,6 +102,9 @@ Funktionen
 Nachrichten
 ===========
 
+2025-12-25
+    `Fess 15.4.0 Release <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Fess 15.3.0 Release <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 
@@ -113,9 +116,6 @@ Nachrichten
 
 2025-06-22
     `Fess 15.0.0 Release <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
-
-2025-05-24
-    `Fess 14.19.2 Release <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`__
 
 Für ältere Nachrichten siehe :doc:`hier <news>`.
 

--- a/de/news.rst
+++ b/de/news.rst
@@ -5,6 +5,9 @@ Open Source Volltextsuchserver - Nachrichtenübersicht
 Nachrichtenübersicht
 ====================
 
+2025-12-25
+    `Fess 15.4.0 Release <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Fess 15.3.0 Release <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 

--- a/en/archives.rst
+++ b/en/archives.rst
@@ -2,6 +2,20 @@
 Archives
 ==========
 
+15.3
+~~~~
+
+.. toctree::
+
+   15.3/install/index
+   15.3/user/index
+   15.3/api/index
+   15.3/admin/index
+   15.3/config/index
+   JavaDocs <https://fess.codelibs.org/15.3/apidocs/index.html>
+   XRef <https://fess.codelibs.org/15.3/xref/index.html>
+   I/F Doc <https://fess.codelibs.org/15.3/lastadoc-fess.html>
+
 15.2
 ~~~~
 

--- a/en/documentation.rst
+++ b/en/documentation.rst
@@ -4,9 +4,9 @@ Documentation
 
 .. toctree::
 
-   Installation <15.3/install/index>
-   Search <15.3/user/index>
-   Administration <15.3/admin/index>
-   API <15.3/api/index>
-   Configuration <15.3/config/index>
+   Installation <15.4/install/index>
+   Search <15.4/user/index>
+   Administration <15.4/admin/index>
+   API <15.4/api/index>
+   Configuration <15.4/config/index>
 

--- a/en/downloads.rst
+++ b/en/downloads.rst
@@ -14,6 +14,7 @@ Stable Release
 
 Tested stable releases are available from:
 
+* `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
 * `Fess 15.1.0 <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.1.0 <https://opensearch.org/versions/opensearch-3-1-0.html>`_)
@@ -23,13 +24,12 @@ Tested stable releases are available from:
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
 * `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
 * `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
-* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
-
 For installation instructions, please refer to the Installation Guide.
 
 Past Releases (EOL)
 ===================
 
+* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)
 * `Fess 14.11.1 <https://github.com/codelibs/fess/releases/tag/fess-14.11.1>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.11.1 <https://opensearch.org/versions/opensearch-2-11-1.html>`_)

--- a/en/index.rst
+++ b/en/index.rst
@@ -46,7 +46,7 @@ Fess is provided under the Apache License and is free software available at no c
 Downloads
 ============
 
-- :doc:`Fess 15.3.0 <downloads>` (zip/rpm/deb packages)
+- :doc:`Fess 15.4.0 <downloads>` (zip/rpm/deb packages)
 
 Features
 ====
@@ -102,6 +102,9 @@ Features
 News
 ========
 
+2025-12-25
+    `Fess 15.4.0 Released <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Fess 15.3.0 Released <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 
@@ -113,9 +116,6 @@ News
 
 2025-06-22
     `Fess 15.0.0 Released <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
-
-2025-05-24
-    `Fess 14.19.2 Released <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`__
 
 For past news, please see :doc:`here <news>`.
 

--- a/en/news.rst
+++ b/en/news.rst
@@ -5,6 +5,9 @@ Open Source Full-Text Search Server - News
 News
 ====
 
+2025-12-25
+    `Fess 15.4.0 Released <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Fess 15.3.0 Released <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 

--- a/es/documentation.rst
+++ b/es/documentation.rst
@@ -4,9 +4,9 @@ Documentación
 
 .. toctree::
 
-   Instalación <15.3/install/index>
-   Búsqueda <15.3/user/index>
-   Administración <15.3/admin/index>
-   API <15.3/api/index>
-   Configuración <15.3/config/index>
+   Instalación <15.4/install/index>
+   Búsqueda <15.4/user/index>
+   Administración <15.4/admin/index>
+   API <15.4/api/index>
+   Configuración <15.4/config/index>
 

--- a/es/downloads.rst
+++ b/es/downloads.rst
@@ -14,6 +14,7 @@ Versiones Estables
 
 Versiones estables probadas y verificadas.
 
+* `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
 * `Fess 15.1.0 <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.1.0 <https://opensearch.org/versions/opensearch-3-1-0.html>`_)
@@ -23,13 +24,12 @@ Versiones estables probadas y verificadas.
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
 * `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
 * `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
-* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
-
 Para obtener información sobre el método de instalación, consulte la Guía de Instalación.
 
 Versiones Anteriores (EOL)
 ===================
 
+* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)
 * `Fess 14.11.1 <https://github.com/codelibs/fess/releases/tag/fess-14.11.1>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.11.0 <https://opensearch.org/versions/opensearch-2-11-1.html>`_)

--- a/es/index.rst
+++ b/es/index.rst
@@ -46,7 +46,7 @@ Fess se proporciona bajo la licencia Apache y está disponible de forma gratuita
 Descargas
 ============
 
-- :doc:`Fess 15.3.0 <downloads>` (paquetes zip/rpm/deb)
+- :doc:`Fess 15.4.0 <downloads>` (paquetes zip/rpm/deb)
 
 Características
 ====
@@ -102,6 +102,9 @@ Características
 Noticias
 ========
 
+2025-12-25
+    `Lanzamiento de Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Lanzamiento de Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 
@@ -113,9 +116,6 @@ Noticias
 
 2025-06-22
     `Lanzamiento de Fess 15.0.0 <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
-
-2025-05-24
-    `Lanzamiento de Fess 14.19.2 <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`__
 
 Para noticias anteriores, consulte :doc:`aquí <news>`.
 

--- a/es/news.rst
+++ b/es/news.rst
@@ -5,6 +5,9 @@ Servidor de Búsqueda de Texto Completo de Código Abierto - Lista de Noticias
 Lista de Noticias
 ============
 
+2025-12-25
+    `Lanzamiento de Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Lanzamiento de Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 

--- a/fr/documentation.rst
+++ b/fr/documentation.rst
@@ -4,9 +4,9 @@ Documentation
 
 .. toctree::
 
-   Installation <15.3/install/index>
-   Recherche <15.3/user/index>
-   Administration <15.3/admin/index>
-   API <15.3/api/index>
-   Configuration <15.3/config/index>
+   Installation <15.4/install/index>
+   Recherche <15.4/user/index>
+   Administration <15.4/admin/index>
+   API <15.4/api/index>
+   Configuration <15.4/config/index>
 

--- a/fr/downloads.rst
+++ b/fr/downloads.rst
@@ -14,6 +14,7 @@ Versions stables
 
 Versions stables testées et vérifiées.
 
+* `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
 * `Fess 15.1.0 <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.1.0 <https://opensearch.org/versions/opensearch-3-1-0.html>`_)
@@ -23,13 +24,12 @@ Versions stables testées et vérifiées.
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
 * `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
 * `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
-* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
-
 Veuillez consulter le guide d'installation pour les méthodes d'installation.
 
 Versions antérieures (EOL)
 ===================
 
+* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)
 * `Fess 14.11.1 <https://github.com/codelibs/fess/releases/tag/fess-14.11.1>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.11.0 <https://opensearch.org/versions/opensearch-2-11-1.html>`_)

--- a/fr/index.rst
+++ b/fr/index.rst
@@ -46,7 +46,7 @@ Fess est fourni sous licence Apache et peut être utilisé gratuitement (logicie
 Téléchargement
 ============
 
-- :doc:`Fess 15.3.0 <downloads>` (packages zip/rpm/deb)
+- :doc:`Fess 15.4.0 <downloads>` (packages zip/rpm/deb)
 
 Caractéristiques
 ====
@@ -102,6 +102,9 @@ Caractéristiques
 Actualités
 ========
 
+2025-12-25
+    `Version Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Version Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 
@@ -113,9 +116,6 @@ Actualités
 
 2025-06-22
     `Version Fess 15.0.0 <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
-
-2025-05-24
-    `Version Fess 14.19.2 <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`__
 
 Pour les anciennes actualités, veuillez consulter :doc:`ici <news>`.
 

--- a/fr/news.rst
+++ b/fr/news.rst
@@ -5,6 +5,9 @@ Serveur de recherche plein texte open source - Liste des actualités
 Liste des actualités
 ============
 
+2025-12-25
+    `Version Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Version Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 

--- a/ja/archives.rst
+++ b/ja/archives.rst
@@ -2,6 +2,20 @@
 アーカイブ
 ==========
 
+15.3
+~~~~
+
+.. toctree::
+
+   15.3/install/index
+   15.3/user/index
+   15.3/api/index
+   15.3/admin/index
+   15.3/config/index
+   JavaDocs <https://fess.codelibs.org/15.3/apidocs/index.html>
+   XRef <https://fess.codelibs.org/15.3/xref/index.html>
+   I/F Doc <https://fess.codelibs.org/15.3/lastadoc-fess.html>
+
 15.2
 ~~~~
 

--- a/ja/documentation.rst
+++ b/ja/documentation.rst
@@ -4,9 +4,9 @@
 
 .. toctree::
 
-   インストール <15.3/install/index>
-   検索 <15.3/user/index>
-   管理 <15.3/admin/index>
-   API <15.3/api/index>
-   設定 <15.3/config/index>
+   インストール <15.4/install/index>
+   検索 <15.4/user/index>
+   管理 <15.4/admin/index>
+   API <15.4/api/index>
+   設定 <15.4/config/index>
 

--- a/ja/downloads.rst
+++ b/ja/downloads.rst
@@ -14,6 +14,7 @@ Dockerイメージは以下を参照してください。
 
 動作確認済の安定版リリースです。
 
+* `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
 * `Fess 15.1.0 <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.1.0 <https://opensearch.org/versions/opensearch-3-1-0.html>`_)
@@ -23,13 +24,12 @@ Dockerイメージは以下を参照してください。
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
 * `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
 * `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
-* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
-
 インストール方法についてはインストールガイドを参照してください。
 
 過去のリリース(EOL)
 ===================
 
+* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)
 * `Fess 14.11.1 <https://github.com/codelibs/fess/releases/tag/fess-14.11.1>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.11.0 <https://opensearch.org/versions/opensearch-2-11-1.html>`_)

--- a/ja/index.rst
+++ b/ja/index.rst
@@ -46,7 +46,7 @@ Fess は Apache ライセンスで提供され、無料 (フリーソフト) で
 ダウンロード
 ============
 
-- :doc:`Fess 15.3.0 <downloads>` (zip/rpm/debパッケージ)
+- :doc:`Fess 15.4.0 <downloads>` (zip/rpm/debパッケージ)
 
 特徴
 ====
@@ -102,6 +102,9 @@ Fess は Apache ライセンスで提供され、無料 (フリーソフト) で
 ニュース
 ========
 
+2025-12-25
+    `Fess 15.4.0 リリース <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Fess 15.3.0 リリース <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 
@@ -113,9 +116,6 @@ Fess は Apache ライセンスで提供され、無料 (フリーソフト) で
 
 2025-06-22
     `Fess 15.0.0 リリース <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
-
-2025-05-24
-    `Fess 14.19.2 リリース <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`__
 
 過去のニュースは :doc:`こちら <news>` をご覧ください。
 

--- a/ja/news.rst
+++ b/ja/news.rst
@@ -5,6 +5,9 @@
 ニュース一覧
 ============
 
+2025-12-25
+    `Fess 15.4.0 リリース <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Fess 15.3.0 リリース <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 

--- a/ko/archives.rst
+++ b/ko/archives.rst
@@ -2,6 +2,20 @@
 아카이브
 ==========
 
+15.3
+~~~~
+
+.. toctree::
+
+   15.3/install/index
+   15.3/user/index
+   15.3/api/index
+   15.3/admin/index
+   15.3/config/index
+   JavaDocs <https://fess.codelibs.org/15.3/apidocs/index.html>
+   XRef <https://fess.codelibs.org/15.3/xref/index.html>
+   I/F Doc <https://fess.codelibs.org/15.3/lastadoc-fess.html>
+
 15.2
 ~~~~
 

--- a/ko/documentation.rst
+++ b/ko/documentation.rst
@@ -4,9 +4,9 @@
 
 .. toctree::
 
-   설치 <15.3/install/index>
-   검색 <15.3/user/index>
-   관리 <15.3/admin/index>
-   API <15.3/api/index>
-   설정 <15.3/config/index>
+   설치 <15.4/install/index>
+   검색 <15.4/user/index>
+   관리 <15.4/admin/index>
+   API <15.4/api/index>
+   설정 <15.4/config/index>
 

--- a/ko/downloads.rst
+++ b/ko/downloads.rst
@@ -14,6 +14,7 @@ Docker 이미지는 다음을 참조하세요.
 
 동작이 확인된 안정 버전 릴리스입니다.
 
+* `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
 * `Fess 15.1.0 <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.1.0 <https://opensearch.org/versions/opensearch-3-1-0.html>`_)
@@ -23,13 +24,12 @@ Docker 이미지는 다음을 참조하세요.
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
 * `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
 * `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
-* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
-
 설치 방법에 대해서는 설치 가이드를 참조하세요.
 
 과거 릴리스(EOL)
 ===================
 
+* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)
 * `Fess 14.11.1 <https://github.com/codelibs/fess/releases/tag/fess-14.11.1>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.11.0 <https://opensearch.org/versions/opensearch-2-11-1.html>`_)

--- a/ko/index.rst
+++ b/ko/index.rst
@@ -46,7 +46,7 @@ Fess는 Apache 라이센스로 제공되며, 무료(프리 소프트웨어)로 �
 다운로드
 ============
 
-- :doc:`Fess 15.3.0 <downloads>` (zip/rpm/deb 패키지)
+- :doc:`Fess 15.4.0 <downloads>` (zip/rpm/deb 패키지)
 
 특징
 ====
@@ -102,6 +102,9 @@ Fess는 Apache 라이센스로 제공되며, 무료(프리 소프트웨어)로 �
 뉴스
 ========
 
+2025-12-25
+    `Fess 15.4.0 릴리스 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Fess 15.3.0 릴리스 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 
@@ -113,9 +116,6 @@ Fess는 Apache 라이센스로 제공되며, 무료(프리 소프트웨어)로 �
 
 2025-06-22
     `Fess 15.0.0 릴리스 <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
-
-2025-05-24
-    `Fess 14.19.2 릴리스 <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`__
 
 과거 뉴스는 :doc:`여기 <news>` 를 참조하세요.
 

--- a/ko/news.rst
+++ b/ko/news.rst
@@ -5,6 +5,9 @@
 뉴스 목록
 ============
 
+2025-12-25
+    `Fess 15.4.0 릴리스 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Fess 15.3.0 릴리스 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 

--- a/zh-cn/documentation.rst
+++ b/zh-cn/documentation.rst
@@ -4,9 +4,9 @@
 
 .. toctree::
 
-   安装 <15.3/install/index>
-   搜索 <15.3/user/index>
-   管理 <15.3/admin/index>
-   API <15.3/api/index>
-   设置 <15.3/config/index>
+   安装 <15.4/install/index>
+   搜索 <15.4/user/index>
+   管理 <15.4/admin/index>
+   API <15.4/api/index>
+   设置 <15.4/config/index>
 

--- a/zh-cn/downloads.rst
+++ b/zh-cn/downloads.rst
@@ -14,6 +14,7 @@ Docker 镜像请参考以下内容。
 
 经过验证的稳定版发布。
 
+* `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
 * `Fess 15.1.0 <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.1.0 <https://opensearch.org/versions/opensearch-3-1-0.html>`_)
@@ -23,13 +24,12 @@ Docker 镜像请参考以下内容。
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
 * `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
 * `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
-* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
-
 关于安装方法,请参考安装指南。
 
 过去的发布(EOL)
 ===================
 
+* `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)
 * `Fess 14.11.1 <https://github.com/codelibs/fess/releases/tag/fess-14.11.1>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.11.0 <https://opensearch.org/versions/opensearch-2-11-1.html>`_)

--- a/zh-cn/index.rst
+++ b/zh-cn/index.rst
@@ -46,7 +46,7 @@ Fess 采用 Apache 许可证提供，可以免费使用（自由软件）。
 下载
 ============
 
-- :doc:`Fess 15.3.0 <downloads>` (zip/rpm/deb包)
+- :doc:`Fess 15.4.0 <downloads>` (zip/rpm/deb包)
 
 特点
 ====
@@ -102,6 +102,9 @@ Fess 采用 Apache 许可证提供，可以免费使用（自由软件）。
 新闻
 ========
 
+2025-12-25
+    `Fess 15.4.0 发布 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Fess 15.3.0 发布 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 
@@ -113,9 +116,6 @@ Fess 采用 Apache 许可证提供，可以免费使用（自由软件）。
 
 2025-06-22
     `Fess 15.0.0 发布 <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
-
-2025-05-24
-    `Fess 14.19.2 发布 <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`__
 
 过去的新闻请查看 :doc:`这里 <news>`。
 

--- a/zh-cn/news.rst
+++ b/zh-cn/news.rst
@@ -5,6 +5,9 @@
 新闻列表
 ============
 
+2025-12-25
+    `Fess 15.4.0 发布 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
+
 2025-10-25
     `Fess 15.3.0 发布 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`__
 


### PR DESCRIPTION
## Summary
Add Fess 15.4.0 release documentation updates across all supported languages (de, en, es, fr, ja, ko, zh-cn).

## Changes Made
- Update documentation links to point to version 15.4 instead of 15.3
- Add Fess 15.4.0 to the stable releases section with Java 21 and OpenSearch 3.4.0 requirements
- Add release news entry for 15.4.0 dated 2025-12-25
- Move Fess 14.14.0 from stable releases to Past Releases (EOL) section
- Archive 15.3 documentation in archives.rst for ja, en, and ko languages

## Testing
- Verify RST syntax is correct
- Build documentation locally to confirm no rendering issues

## Breaking Changes
None. This is a documentation update only.

## Additional Notes
All 7 supported languages have been updated consistently. The changes follow the existing documentation structure and formatting patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)