### PR TITLE
Add MIME type detection override documentation for all languages

### DIFF
--- a/de/15.5/config/crawler-advanced.rst
+++ b/de/15.5/config/crawler-advanced.rst
@@ -598,6 +598,50 @@ Konfigurationsbeispiel
     # Temp-Ordner ausschließen
     crawler.document.file.default.exclude.index.patterns=.*/temp/.*
 
+MIME-Typ-Erkennung überschreiben
+----------------------------------
+
+Standardmäßig verwendet |Fess| Apache Tika für die inhaltsbasierte MIME-Typ-Erkennung.
+In einigen Fällen kann die inhaltsbasierte Erkennung falsche Ergebnisse liefern.
+Beispielsweise können Oracle-SQL-Dateien, die mit ``REM``-Kommentaren beginnen,
+fälschlicherweise als Batch-Dateien (``application/x-bat``) erkannt werden,
+da das Schlüsselwort ``REM`` dem Magic-Pattern von Batch-Dateien entspricht.
+
+Die Eigenschaft ``crawler.document.mimetype.extension.overrides`` ermöglicht es,
+die MIME-Typ-Erkennung basierend auf Dateierweiterungen zu überschreiben und
+die inhaltsbasierte Erkennung für bestimmte Dateitypen zu umgehen.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standard
+   * - ``crawler.document.mimetype.extension.overrides``
+     - Zuordnungen von Erweiterung zu MIME-Typ (eine pro Zeile, Format: ``.ext=mime/type``)
+     - (leer)
+
+Konfigurationsbeispiel
+~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    # MIME-Typ-Erkennung für SQL-Dateien überschreiben
+    crawler.document.mimetype.extension.overrides=\
+    .sql=text/x-sql\n\
+    .plsql=text/x-plsql\n\
+    .pls=text/x-plsql
+
+Jede Zeile enthält eine Zuordnung im Format ``.ext=mime/type``.
+Mehrere Zuordnungen werden durch ``\n`` (Zeilenumbruch) getrennt.
+Der Erweiterungsabgleich unterscheidet nicht zwischen Groß- und Kleinschreibung (``.SQL`` und ``.sql`` werden gleich behandelt).
+
+.. note::
+   Wenn eine Dateierweiterung einem Eintrag in dieser Zuordnung entspricht, wird der konfigurierte
+   MIME-Typ sofort zurückgegeben, ohne eine inhaltsbasierte Erkennung durchzuführen.
+   Dateien mit Erweiterungen, die nicht in der Zuordnung enthalten sind, verwenden weiterhin die normale Tika-Erkennung.
+
 Cache-Konfiguration
 ==============
 

--- a/en/15.5/config/crawler-advanced.rst
+++ b/en/15.5/config/crawler-advanced.rst
@@ -600,6 +600,50 @@ Configuration Example
     # Exclude temp folders
     crawler.document.file.default.exclude.index.patterns=.*/temp/.*
 
+MIME Type Detection Override
+----------------------------
+
+By default, |Fess| uses Apache Tika for content-based MIME type detection.
+In some cases, content-based detection can produce incorrect results.
+For example, Oracle SQL files starting with ``REM`` comments may be misdetected
+as batch files (``application/x-bat``) because the ``REM`` keyword matches
+the batch file magic pattern.
+
+The ``crawler.document.mimetype.extension.overrides`` property allows you to
+override MIME type detection based on file extensions, bypassing content-based detection
+for specific file types.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Property
+     - Description
+     - Default
+   * - ``crawler.document.mimetype.extension.overrides``
+     - Extension-to-MIME-type override mappings (one per line, format: ``.ext=mime/type``)
+     - (empty)
+
+Configuration Example
+~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    # Override MIME type detection for SQL files
+    crawler.document.mimetype.extension.overrides=\
+    .sql=text/x-sql\n\
+    .plsql=text/x-plsql\n\
+    .pls=text/x-plsql
+
+Each line contains a mapping in the format ``.ext=mime/type``.
+Multiple mappings are separated by ``\n`` (newline).
+The extension matching is case-insensitive (``.SQL`` and ``.sql`` are treated the same).
+
+.. note::
+   When a file extension matches an entry in this map, the configured MIME type
+   is returned immediately without performing content-based detection.
+   Files with extensions not in the map continue to use normal Tika detection.
+
 Cache Settings
 ==============
 

--- a/es/15.5/config/crawler-advanced.rst
+++ b/es/15.5/config/crawler-advanced.rst
@@ -600,6 +600,50 @@ Ejemplo de Configuración
     # Excluir carpetas temp
     crawler.document.file.default.exclude.index.patterns=.*/temp/.*
 
+Anulación de Detección de Tipo MIME
+-------------------------------------
+
+De forma predeterminada, |Fess| utiliza Apache Tika para la detección de tipo MIME basada en contenido.
+En algunos casos, la detección basada en contenido puede producir resultados incorrectos.
+Por ejemplo, los archivos SQL de Oracle que comienzan con comentarios ``REM`` pueden ser
+detectados erróneamente como archivos por lotes (``application/x-bat``) porque la palabra clave
+``REM`` coincide con el patrón mágico de los archivos por lotes.
+
+La propiedad ``crawler.document.mimetype.extension.overrides`` permite anular la detección
+de tipo MIME basándose en extensiones de archivo, omitiendo la detección basada en contenido
+para tipos de archivo específicos.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propiedad
+     - Descripción
+     - Predeterminado
+   * - ``crawler.document.mimetype.extension.overrides``
+     - Asignaciones de extensión a tipo MIME (una por línea, formato: ``.ext=mime/type``)
+     - (vacío)
+
+Ejemplo de Configuración
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    # Anular la detección de tipo MIME para archivos SQL
+    crawler.document.mimetype.extension.overrides=\
+    .sql=text/x-sql\n\
+    .plsql=text/x-plsql\n\
+    .pls=text/x-plsql
+
+Cada línea contiene una asignación en el formato ``.ext=mime/type``.
+Las asignaciones múltiples se separan con ``\n`` (nueva línea).
+La coincidencia de extensiones no distingue entre mayúsculas y minúsculas (``.SQL`` y ``.sql`` se tratan igual).
+
+.. note::
+   Cuando una extensión de archivo coincide con una entrada en este mapa, el tipo MIME configurado
+   se devuelve inmediatamente sin realizar la detección basada en contenido.
+   Los archivos con extensiones que no están en el mapa continúan usando la detección normal de Tika.
+
 Configuración de Caché
 ======================
 

--- a/fr/15.5/config/crawler-advanced.rst
+++ b/fr/15.5/config/crawler-advanced.rst
@@ -600,6 +600,50 @@ Exemple de configuration
     # Exclure le dossier temp
     crawler.document.file.default.exclude.index.patterns=.*/temp/.*
 
+Remplacement de la Détection du Type MIME
+-------------------------------------------
+
+Par défaut, |Fess| utilise Apache Tika pour la détection du type MIME basée sur le contenu.
+Dans certains cas, la détection basée sur le contenu peut produire des résultats incorrects.
+Par exemple, les fichiers SQL Oracle commençant par des commentaires ``REM`` peuvent être
+détectés à tort comme des fichiers batch (``application/x-bat``) car le mot-clé ``REM``
+correspond au motif magique des fichiers batch.
+
+La propriété ``crawler.document.mimetype.extension.overrides`` permet de remplacer la détection
+du type MIME en se basant sur les extensions de fichier, en contournant la détection basée sur
+le contenu pour des types de fichiers spécifiques.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Propriété
+     - Description
+     - Par défaut
+   * - ``crawler.document.mimetype.extension.overrides``
+     - Correspondances extension vers type MIME (une par ligne, format : ``.ext=mime/type``)
+     - (vide)
+
+Exemple de configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    # Remplacer la détection du type MIME pour les fichiers SQL
+    crawler.document.mimetype.extension.overrides=\
+    .sql=text/x-sql\n\
+    .plsql=text/x-plsql\n\
+    .pls=text/x-plsql
+
+Chaque ligne contient une correspondance au format ``.ext=mime/type``.
+Les correspondances multiples sont séparées par ``\n`` (saut de ligne).
+La correspondance des extensions est insensible à la casse (``.SQL`` et ``.sql`` sont traités de la même manière).
+
+.. note::
+   Lorsqu'une extension de fichier correspond à une entrée de cette table, le type MIME configuré
+   est renvoyé immédiatement sans effectuer de détection basée sur le contenu.
+   Les fichiers dont les extensions ne sont pas dans la table continuent d'utiliser la détection Tika normale.
+
 Configuration du cache
 ==============
 

--- a/ja/15.5/config/crawler-advanced.rst
+++ b/ja/15.5/config/crawler-advanced.rst
@@ -600,6 +600,50 @@ URLパターンフィルター
     # tempフォルダーを除外
     crawler.document.file.default.exclude.index.patterns=.*/temp/.*
 
+MIMEタイプ検出オーバーライド
+------------------------------
+
+|Fess| はデフォルトで Apache Tika を使用してコンテンツベースのMIMEタイプ検出を行います。
+しかし、一部のケースでコンテンツベースの検出が誤った結果を返すことがあります。
+たとえば、``REM`` コメントで始まるOracle SQLファイルは、``REM`` キーワードが
+バッチファイルのマジックパターンに一致するため、``application/x-bat`` として
+誤検出される場合があります。
+
+``crawler.document.mimetype.extension.overrides`` プロパティを使用すると、
+ファイル拡張子に基づいてMIMEタイプ検出をオーバーライドし、
+特定のファイルタイプに対するコンテンツベース検出をバイパスできます。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - プロパティ
+     - 説明
+     - デフォルト
+   * - ``crawler.document.mimetype.extension.overrides``
+     - 拡張子からMIMEタイプへのオーバーライドマッピング（1行に1つ、形式: ``.ext=mime/type``）
+     - (空)
+
+設定例
+~~~~~~
+
+::
+
+    # SQLファイルのMIMEタイプ検出をオーバーライド
+    crawler.document.mimetype.extension.overrides=\
+    .sql=text/x-sql\n\
+    .plsql=text/x-plsql\n\
+    .pls=text/x-plsql
+
+各行は ``.拡張子=MIMEタイプ`` の形式で記述します。
+複数のマッピングは ``\n``（改行）で区切ります。
+拡張子のマッチングは大文字小文字を区別しません（``.SQL`` と ``.sql`` は同じ扱い）。
+
+.. note::
+   ファイル拡張子がこのマップのエントリに一致する場合、設定されたMIMEタイプが
+   コンテンツベース検出を行わずに即座に返されます。
+   マップにない拡張子のファイルは、通常のTika検出が使用されます。
+
 キャッシュ設定
 ==============
 

--- a/ko/15.5/config/crawler-advanced.rst
+++ b/ko/15.5/config/crawler-advanced.rst
@@ -600,6 +600,50 @@ URL 패턴 필터
     # temp 폴더 제외
     crawler.document.file.default.exclude.index.patterns=.*/temp/.*
 
+MIME 타입 감지 오버라이드
+----------------------------
+
+기본적으로 |Fess| 는 Apache Tika를 사용하여 콘텐츠 기반 MIME 타입 감지를 수행합니다.
+일부 경우 콘텐츠 기반 감지가 잘못된 결과를 반환할 수 있습니다.
+예를 들어, ``REM`` 주석으로 시작하는 Oracle SQL 파일은 ``REM`` 키워드가
+배치 파일의 매직 패턴과 일치하기 때문에 ``application/x-bat`` 으로
+잘못 감지될 수 있습니다.
+
+``crawler.document.mimetype.extension.overrides`` 속성을 사용하면
+파일 확장자를 기반으로 MIME 타입 감지를 오버라이드하여
+특정 파일 유형에 대한 콘텐츠 기반 감지를 우회할 수 있습니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - 속성
+     - 설명
+     - 기본값
+   * - ``crawler.document.mimetype.extension.overrides``
+     - 확장자에서 MIME 타입으로의 오버라이드 매핑 (한 줄에 하나, 형식: ``.ext=mime/type``)
+     - (빈 값)
+
+설정 예
+~~~~~~~~
+
+::
+
+    # SQL 파일의 MIME 타입 감지 오버라이드
+    crawler.document.mimetype.extension.overrides=\
+    .sql=text/x-sql\n\
+    .plsql=text/x-plsql\n\
+    .pls=text/x-plsql
+
+각 줄은 ``.확장자=MIME타입`` 형식으로 작성합니다.
+여러 매핑은 ``\n`` (줄바꿈)으로 구분합니다.
+확장자 매칭은 대소문자를 구분하지 않습니다 (``.SQL`` 과 ``.sql`` 은 동일하게 처리).
+
+.. note::
+   파일 확장자가 이 맵의 항목과 일치하면 구성된 MIME 타입이
+   콘텐츠 기반 감지를 수행하지 않고 즉시 반환됩니다.
+   맵에 없는 확장자의 파일은 일반 Tika 감지가 계속 사용됩니다.
+
 캐시 설정
 ==============
 

--- a/zh-cn/15.5/config/crawler-advanced.rst
+++ b/zh-cn/15.5/config/crawler-advanced.rst
@@ -600,6 +600,49 @@ URL 模式过滤器
     # 排除 temp 文件夹
     crawler.document.file.default.exclude.index.patterns=.*/temp/.*
 
+MIME 类型检测覆盖
+--------------------
+
+默认情况下，|Fess| 使用 Apache Tika 进行基于内容的 MIME 类型检测。
+在某些情况下，基于内容的检测可能会产生错误的结果。
+例如，以 ``REM`` 注释开头的 Oracle SQL 文件可能会被错误地检测为
+批处理文件（``application/x-bat``），因为 ``REM`` 关键字
+与批处理文件的魔术模式匹配。
+
+``crawler.document.mimetype.extension.overrides`` 属性允许您
+基于文件扩展名覆盖 MIME 类型检测，从而绕过特定文件类型的基于内容的检测。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - 属性
+     - 说明
+     - 默认值
+   * - ``crawler.document.mimetype.extension.overrides``
+     - 扩展名到 MIME 类型的覆盖映射（每行一个，格式：``.ext=mime/type``）
+     - (空)
+
+配置示例
+~~~~~~~~~
+
+::
+
+    # 覆盖 SQL 文件的 MIME 类型检测
+    crawler.document.mimetype.extension.overrides=\
+    .sql=text/x-sql\n\
+    .plsql=text/x-plsql\n\
+    .pls=text/x-plsql
+
+每行包含一个 ``.扩展名=MIME类型`` 格式的映射。
+多个映射使用 ``\n``（换行符）分隔。
+扩展名匹配不区分大小写（``.SQL`` 和 ``.sql`` 被视为相同）。
+
+.. note::
+   当文件扩展名与此映射中的条目匹配时，将立即返回配置的 MIME 类型，
+   而不执行基于内容的检测。
+   扩展名不在映射中的文件将继续使用正常的 Tika 检测。
+
 缓存配置
 ==============
 


### PR DESCRIPTION
## Summary

- Add documentation for `crawler.document.mimetype.extension.overrides` property across all 7 languages (ja, en, de, fr, es, ko, zh-cn)
- Documents how to override Apache Tika's content-based MIME type detection using file extensions
- Addresses use case where SQL files starting with `REM` comments are misdetected as batch files

## Changes Made

- Added new "MIME Type Detection Override" section to `crawler-advanced.rst` in all language directories
- Each section includes:
  - Explanation of the problem (content-based detection limitations)
  - Property reference table (`crawler.document.mimetype.extension.overrides`)
  - Configuration example with SQL file extensions
  - Notes on case-insensitive matching and behavior details

## Testing

- Verified RST formatting consistency across all language files
- Followed existing documentation patterns and structure

## Additional Notes

- Translations follow the same structure as the English source
- Section is placed between URL pattern filters and cache settings sections