### PR TITLE
docs: Update documentation for Fess 15.5.0 release

### DIFF
--- a/.claude/skills/fess-docs-release/SKILL.md
+++ b/.claude/skills/fess-docs-release/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: fess-docs-release
+description: Automate Fess documentation updates across all languages (ja, en, de, es, fr, ko, zh-cn) for a new release. Updates documentation.rst, downloads.rst, index.rst, news.rst, and archives.rst for each language.
+---
+
+# Fess Documentation Release Skill
+
+This skill automates documentation updates across all 7 languages when a new Fess version is released.
+
+## Step 1: Collect Parameters
+
+Ask the user for the following parameters:
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `VERSION` | New Fess version | `15.5.0` |
+| `RELEASE_DATE` | Release date (YYYY-MM-DD) | `2026-01-25` |
+| `JAVA_VERSION` | Java version | `21` |
+| `OPENSEARCH_VERSION` | OpenSearch version | `3.5.0` |
+
+## Step 2: Derive Values
+
+Calculate these automatically:
+
+- `DOC_VERSION` = Major.Minor from VERSION (e.g., `15.5.0` -> `15.5`)
+- `PREV_DOC_VERSION` = Read from `ja/documentation.rst` toctree entries (the version currently referenced, e.g., `15.4`)
+- `OPENSEARCH_URL_SLUG` = OPENSEARCH_VERSION with dots replaced by hyphens (e.g., `3.5.0` -> `3-5-0`)
+- Today's date = current date for EOL comparison
+
+## Step 3: Target Languages
+
+All 7 languages: `ja`, `en`, `de`, `es`, `fr`, `ko`, `zh-cn`
+
+## Step 4: Update Files
+
+For each language, update the following files in order.
+
+### 4.1: `{lang}/documentation.rst` - Update version references
+
+Replace all occurrences of `PREV_DOC_VERSION` with `DOC_VERSION` in the toctree entries.
+
+**Pattern (all languages have the same structure):**
+```rst
+.. toctree::
+
+   Label1 <PREV_DOC_VERSION/install/index>
+   Label2 <PREV_DOC_VERSION/user/index>
+   Label3 <PREV_DOC_VERSION/admin/index>
+   API <PREV_DOC_VERSION/api/index>
+   Label4 <PREV_DOC_VERSION/config/index>
+```
+
+Change `PREV_DOC_VERSION` -> `DOC_VERSION` in each line.
+
+### 4.2: `{lang}/downloads.rst` - Add new version and handle EOL
+
+#### 4.2a: Add new version to stable releases
+
+Add the new version as the **first entry** in the stable releases list. The entry format is:
+
+```
+* `Fess VERSION <https://github.com/codelibs/fess/releases/tag/fess-VERSION>`_ (`Java JAVA_VERSION <https://adoptium.net/temurin/releases?version=JAVA_VERSION>`_, `OpenSearch OPENSEARCH_VERSION <https://opensearch.org/versions/opensearch-OPENSEARCH_URL_SLUG.html>`_)
+```
+
+Find the first `* \`Fess` line after the stable release section header and insert the new entry before it.
+
+**Language-specific stable release section headers:**
+
+| Language | Section Header |
+|----------|---------------|
+| ja | `安定版リリース` |
+| en | `Stable Release` |
+| de | `Stabile Releases` |
+| es | `Versiones Estables` |
+| fr | `Versions stables` |
+| ko | `안정 버전 릴리스` |
+| zh-cn | `稳定版发布` |
+
+#### 4.2b: Move EOL versions to Past Releases section
+
+1. Read `ja/eol.rst` and find entries in the "現在サポート中のバージョン" table where the EOL date has passed (EOL date < today's date AND the status contains `サポート終了`).
+2. For each EOL version found:
+   - Find the corresponding entry line in the stable releases section of downloads.rst (match by version pattern like `Fess 14.17.0`)
+   - Remove that line from the stable releases section
+   - Add it as the **first entry** in the "Past Releases (EOL)" section
+
+**Language-specific Past Releases section headers:**
+
+| Language | Section Header |
+|----------|---------------|
+| ja | `過去のリリース(EOL)` |
+| en | `Past Releases (EOL)` |
+| de | `Vergangene Releases (EOL)` |
+| es | `Versiones Anteriores (EOL)` |
+| fr | `Versions antérieures (EOL)` |
+| ko | `과거 릴리스(EOL)` |
+| zh-cn | `过去的发布(EOL)` |
+
+### 4.3: `{lang}/index.rst` - Update download section and news
+
+#### 4.3a: Update download version
+
+Find the line with `:doc:\`Fess PREV_VERSION <downloads>\`` and update the version number to `VERSION`.
+
+**Pattern:**
+```rst
+- :doc:`Fess VERSION <downloads>` (package description)
+```
+
+The package description text varies by language but the `:doc:` reference pattern is the same.
+
+#### 4.3b: Add news entry and maintain 5 entries
+
+Add a new news entry at the **top** of the news section. The news section is identified by the language-specific header followed by entries in this format:
+
+```rst
+RELEASE_DATE
+    `NEWS_TEXT <https://github.com/codelibs/fess/releases/tag/fess-VERSION>`__
+```
+
+**Language-specific news section headers and news text:**
+
+| Language | News Section Header | News Text Format |
+|----------|-------------------|-----------------|
+| ja | `ニュース` | `Fess {VERSION} リリース` |
+| en | `News` | `Fess {VERSION} Released` |
+| de | `Nachrichten` | `Fess {VERSION} Release` |
+| es | `Noticias` | `Lanzamiento de Fess {VERSION}` |
+| fr | `Actualités` | `Version Fess {VERSION}` |
+| ko | `뉴스` | `Fess {VERSION} 릴리스` |
+| zh-cn | `新闻` | `Fess {VERSION} 发布` |
+
+After adding the new entry, ensure only **5 news entries** remain in index.rst. Remove the oldest (bottom) entry if there are more than 5. Each entry consists of 2 lines (date line + indented link line) plus a blank line separator.
+
+### 4.4: `{lang}/news.rst` - Add news entry
+
+Add the new news entry at the **top** of the news list in news.rst (after the section header underline). Use the same format as index.rst news entries:
+
+```rst
+RELEASE_DATE
+    `NEWS_TEXT <https://github.com/codelibs/fess/releases/tag/fess-VERSION>`__
+```
+
+The news list in news.rst is the section immediately after the title/header. Insert the new entry as the first item (before the existing first date entry).
+
+### 4.5: `{lang}/archives.rst` - Add previous version archive
+
+Add a new archive section for `PREV_DOC_VERSION` at the **top** of the archives list (after the title/header). The format is:
+
+```rst
+PREV_DOC_VERSION
+~~~~
+
+.. toctree::
+
+   PREV_DOC_VERSION/install/index
+   PREV_DOC_VERSION/user/index
+   PREV_DOC_VERSION/api/index
+   PREV_DOC_VERSION/admin/index
+   PREV_DOC_VERSION/config/index
+   JavaDocs <https://fess.codelibs.org/PREV_DOC_VERSION/apidocs/index.html>
+   XRef <https://fess.codelibs.org/PREV_DOC_VERSION/xref/index.html>
+   I/F Doc <https://fess.codelibs.org/PREV_DOC_VERSION/lastadoc-fess.html>
+```
+
+**Important:** The tilde underline (`~~~~`) must be at least as long as the version string. For versions like `15.4`, use `~~~~`. For versions like `13.16`, use `~~~~~` (5 tildes).
+
+**Skip this step** if the `PREV_DOC_VERSION` section already exists in the archives.rst file.
+
+## Step 5: Verification
+
+After all updates:
+
+1. Run `git diff` to review all changes
+2. Confirm the expected number of files were modified (up to 35 files: 7 languages x 5 file types)
+3. Check each file for correct RST formatting (proper indentation, blank lines between entries)
+4. Verify no duplicate entries were created
+
+## Important Notes
+
+- The `de` language may sometimes be ahead of other languages (check current state before updating)
+- The `ja/archives.rst` has the most entries (back to version 2.0); other languages vary in depth
+- Some languages (de, es, fr, zh-cn) may have fewer archive entries than ja/en/ko
+- The news entry in `news.rst` does NOT remove old entries (unlike `index.rst` which maintains exactly 5)
+- In `downloads.rst`, all languages share the same version entries and URLs; only section headers differ
+- The OpenSearch URL format is: `https://opensearch.org/versions/opensearch-X-Y-Z.html` (hyphens, not dots)
+- The Fess release URL format is: `https://github.com/codelibs/fess/releases/tag/fess-VERSION`
+- The Java download URL format is: `https://adoptium.net/temurin/releases?version=JAVA_VERSION`

--- a/de/archives.rst
+++ b/de/archives.rst
@@ -2,6 +2,21 @@
 Archiv
 ==========
 
+15.4
+~~~~
+
+.. toctree::
+
+   15.4/install/index
+   15.4/user/index
+   15.4/api/index
+   15.4/admin/index
+   15.4/config/index
+   JavaDocs <https://fess.codelibs.org/15.4/apidocs/index.html>
+   XRef <https://fess.codelibs.org/15.4/xref/index.html>
+   I/F Doc <https://fess.codelibs.org/15.4/lastadoc-fess.html>
+
+
 15.3
 ~~~~
 

--- a/de/documentation.rst
+++ b/de/documentation.rst
@@ -4,9 +4,9 @@ Dokumentation
 
 .. toctree::
 
-   Installation <15.4/install/index>
-   Suche <15.4/user/index>
-   Verwaltung <15.4/admin/index>
-   API <15.4/api/index>
-   Konfiguration <15.4/config/index>
+   Installation <15.5/install/index>
+   Suche <15.5/user/index>
+   Verwaltung <15.5/admin/index>
+   API <15.5/api/index>
+   Konfiguration <15.5/config/index>
 

--- a/de/index.rst
+++ b/de/index.rst
@@ -115,7 +115,7 @@ Funktionen
 Nachrichten
 ===========
 
-2026-01-25
+2026-02-14
     `Fess 15.5.0 Release <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
 
 2025-12-25

--- a/de/news.rst
+++ b/de/news.rst
@@ -5,6 +5,9 @@ Open Source Volltextsuchserver - Nachrichtenübersicht
 Nachrichtenübersicht
 ====================
 
+2026-02-14
+    `Fess 15.5.0 Release <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Fess 15.4.0 Release <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 

--- a/en/archives.rst
+++ b/en/archives.rst
@@ -2,6 +2,20 @@
 Archives
 ==========
 
+15.4
+~~~~
+
+.. toctree::
+
+   15.4/install/index
+   15.4/user/index
+   15.4/api/index
+   15.4/admin/index
+   15.4/config/index
+   JavaDocs <https://fess.codelibs.org/15.4/apidocs/index.html>
+   XRef <https://fess.codelibs.org/15.4/xref/index.html>
+   I/F Doc <https://fess.codelibs.org/15.4/lastadoc-fess.html>
+
 15.3
 ~~~~
 

--- a/en/documentation.rst
+++ b/en/documentation.rst
@@ -4,9 +4,9 @@ Documentation
 
 .. toctree::
 
-   Installation <15.4/install/index>
-   Search <15.4/user/index>
-   Administration <15.4/admin/index>
-   API <15.4/api/index>
-   Configuration <15.4/config/index>
+   Installation <15.5/install/index>
+   Search <15.5/user/index>
+   Administration <15.5/admin/index>
+   API <15.5/api/index>
+   Configuration <15.5/config/index>
 

--- a/en/downloads.rst
+++ b/en/downloads.rst
@@ -14,6 +14,7 @@ Stable Release
 
 Tested stable releases are available from:
 
+* `Fess 15.5.0 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.5.0 <https://opensearch.org/versions/opensearch-3-5-0.html>`_)
 * `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
@@ -22,13 +23,13 @@ Tested stable releases are available from:
 * `Fess 14.19.2 <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.19.1 <https://opensearch.org/versions/opensearch-2-19-1.html>`_)
 * `Fess 14.18.0 <https://github.com/codelibs/fess/releases/tag/fess-14.18.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.18.0 <https://opensearch.org/versions/opensearch-2-18-0.html>`_)
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
-* `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
-* `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
 For installation instructions, please refer to the Installation Guide.
 
 Past Releases (EOL)
 ===================
 
+* `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
+* `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
 * `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)

--- a/en/index.rst
+++ b/en/index.rst
@@ -46,7 +46,7 @@ Fess is provided under the Apache License and is free software available at no c
 Downloads
 ============
 
-- :doc:`Fess 15.4.0 <downloads>` (zip/rpm/deb packages)
+- :doc:`Fess 15.5.0 <downloads>` (zip/rpm/deb packages)
 
 Features
 ====
@@ -102,6 +102,9 @@ Features
 News
 ========
 
+2026-02-14
+    `Fess 15.5.0 Released <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Fess 15.4.0 Released <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 
@@ -113,9 +116,6 @@ News
 
 2025-07-20
     `Fess 15.1.0 Released <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`__
-
-2025-06-22
-    `Fess 15.0.0 Released <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
 
 For past news, please see :doc:`here <news>`.
 

--- a/en/news.rst
+++ b/en/news.rst
@@ -5,6 +5,9 @@ Open Source Full-Text Search Server - News
 News
 ====
 
+2026-02-14
+    `Fess 15.5.0 Released <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Fess 15.4.0 Released <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 

--- a/es/archives.rst
+++ b/es/archives.rst
@@ -2,6 +2,20 @@
 Archivos
 ==========
 
+15.4
+~~~~
+
+.. toctree::
+
+   15.4/install/index
+   15.4/user/index
+   15.4/api/index
+   15.4/admin/index
+   15.4/config/index
+   JavaDocs <https://fess.codelibs.org/15.4/apidocs/index.html>
+   XRef <https://fess.codelibs.org/15.4/xref/index.html>
+   I/F Doc <https://fess.codelibs.org/15.4/lastadoc-fess.html>
+
 15.3
 ~~~~
 

--- a/es/documentation.rst
+++ b/es/documentation.rst
@@ -4,9 +4,9 @@ Documentación
 
 .. toctree::
 
-   Instalación <15.4/install/index>
-   Búsqueda <15.4/user/index>
-   Administración <15.4/admin/index>
-   API <15.4/api/index>
-   Configuración <15.4/config/index>
+   Instalación <15.5/install/index>
+   Búsqueda <15.5/user/index>
+   Administración <15.5/admin/index>
+   API <15.5/api/index>
+   Configuración <15.5/config/index>
 

--- a/es/downloads.rst
+++ b/es/downloads.rst
@@ -14,6 +14,7 @@ Versiones Estables
 
 Versiones estables probadas y verificadas.
 
+* `Fess 15.5.0 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.5.0 <https://opensearch.org/versions/opensearch-3-5-0.html>`_)
 * `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
@@ -22,13 +23,13 @@ Versiones estables probadas y verificadas.
 * `Fess 14.19.2 <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.19.1 <https://opensearch.org/versions/opensearch-2-19-1.html>`_)
 * `Fess 14.18.0 <https://github.com/codelibs/fess/releases/tag/fess-14.18.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.18.0 <https://opensearch.org/versions/opensearch-2-18-0.html>`_)
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
-* `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
-* `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
 Para obtener información sobre el método de instalación, consulte la Guía de Instalación.
 
 Versiones Anteriores (EOL)
 ===================
 
+* `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
+* `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
 * `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)

--- a/es/index.rst
+++ b/es/index.rst
@@ -46,7 +46,7 @@ Fess se proporciona bajo la licencia Apache y está disponible de forma gratuita
 Descargas
 ============
 
-- :doc:`Fess 15.4.0 <downloads>` (paquetes zip/rpm/deb)
+- :doc:`Fess 15.5.0 <downloads>` (paquetes zip/rpm/deb)
 
 Características
 ====
@@ -102,6 +102,9 @@ Características
 Noticias
 ========
 
+2026-02-14
+    `Lanzamiento de Fess 15.5.0 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Lanzamiento de Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 
@@ -113,9 +116,6 @@ Noticias
 
 2025-07-20
     `Lanzamiento de Fess 15.1.0 <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`__
-
-2025-06-22
-    `Lanzamiento de Fess 15.0.0 <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
 
 Para noticias anteriores, consulte :doc:`aquí <news>`.
 

--- a/es/news.rst
+++ b/es/news.rst
@@ -5,6 +5,9 @@ Servidor de Búsqueda de Texto Completo de Código Abierto - Lista de Noticias
 Lista de Noticias
 ============
 
+2026-02-14
+    `Lanzamiento de Fess 15.5.0 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Lanzamiento de Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 

--- a/fr/archives.rst
+++ b/fr/archives.rst
@@ -2,6 +2,20 @@
 Archives
 ==========
 
+15.4
+~~~~
+
+.. toctree::
+
+   15.4/install/index
+   15.4/user/index
+   15.4/api/index
+   15.4/admin/index
+   15.4/config/index
+   JavaDocs <https://fess.codelibs.org/15.4/apidocs/index.html>
+   XRef <https://fess.codelibs.org/15.4/xref/index.html>
+   I/F Doc <https://fess.codelibs.org/15.4/lastadoc-fess.html>
+
 15.3
 ~~~~
 

--- a/fr/documentation.rst
+++ b/fr/documentation.rst
@@ -4,9 +4,9 @@ Documentation
 
 .. toctree::
 
-   Installation <15.4/install/index>
-   Recherche <15.4/user/index>
-   Administration <15.4/admin/index>
-   API <15.4/api/index>
-   Configuration <15.4/config/index>
+   Installation <15.5/install/index>
+   Recherche <15.5/user/index>
+   Administration <15.5/admin/index>
+   API <15.5/api/index>
+   Configuration <15.5/config/index>
 

--- a/fr/downloads.rst
+++ b/fr/downloads.rst
@@ -14,6 +14,7 @@ Versions stables
 
 Versions stables testées et vérifiées.
 
+* `Fess 15.5.0 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.5.0 <https://opensearch.org/versions/opensearch-3-5-0.html>`_)
 * `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
@@ -22,13 +23,13 @@ Versions stables testées et vérifiées.
 * `Fess 14.19.2 <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.19.1 <https://opensearch.org/versions/opensearch-2-19-1.html>`_)
 * `Fess 14.18.0 <https://github.com/codelibs/fess/releases/tag/fess-14.18.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.18.0 <https://opensearch.org/versions/opensearch-2-18-0.html>`_)
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
-* `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
-* `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
 Veuillez consulter le guide d'installation pour les méthodes d'installation.
 
 Versions antérieures (EOL)
 ===================
 
+* `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
+* `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
 * `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)

--- a/fr/index.rst
+++ b/fr/index.rst
@@ -46,7 +46,7 @@ Fess est fourni sous licence Apache et peut être utilisé gratuitement (logicie
 Téléchargement
 ============
 
-- :doc:`Fess 15.4.0 <downloads>` (packages zip/rpm/deb)
+- :doc:`Fess 15.5.0 <downloads>` (packages zip/rpm/deb)
 
 Caractéristiques
 ====
@@ -102,6 +102,9 @@ Caractéristiques
 Actualités
 ========
 
+2026-02-14
+    `Version Fess 15.5.0 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Version Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 
@@ -113,9 +116,6 @@ Actualités
 
 2025-07-20
     `Version Fess 15.1.0 <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`__
-
-2025-06-22
-    `Version Fess 15.0.0 <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
 
 Pour les anciennes actualités, veuillez consulter :doc:`ici <news>`.
 

--- a/fr/news.rst
+++ b/fr/news.rst
@@ -5,6 +5,9 @@ Serveur de recherche plein texte open source - Liste des actualités
 Liste des actualités
 ============
 
+2026-02-14
+    `Version Fess 15.5.0 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Version Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 

--- a/ja/archives.rst
+++ b/ja/archives.rst
@@ -2,6 +2,20 @@
 アーカイブ
 ==========
 
+15.4
+~~~~
+
+.. toctree::
+
+   15.4/install/index
+   15.4/user/index
+   15.4/api/index
+   15.4/admin/index
+   15.4/config/index
+   JavaDocs <https://fess.codelibs.org/15.4/apidocs/index.html>
+   XRef <https://fess.codelibs.org/15.4/xref/index.html>
+   I/F Doc <https://fess.codelibs.org/15.4/lastadoc-fess.html>
+
 15.3
 ~~~~
 

--- a/ja/documentation.rst
+++ b/ja/documentation.rst
@@ -4,9 +4,9 @@
 
 .. toctree::
 
-   インストール <15.4/install/index>
-   検索 <15.4/user/index>
-   管理 <15.4/admin/index>
-   API <15.4/api/index>
-   設定 <15.4/config/index>
+   インストール <15.5/install/index>
+   検索 <15.5/user/index>
+   管理 <15.5/admin/index>
+   API <15.5/api/index>
+   設定 <15.5/config/index>
 

--- a/ja/downloads.rst
+++ b/ja/downloads.rst
@@ -14,6 +14,7 @@ Dockerイメージは以下を参照してください。
 
 動作確認済の安定版リリースです。
 
+* `Fess 15.5.0 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.5.0 <https://opensearch.org/versions/opensearch-3-5-0.html>`_)
 * `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
@@ -22,13 +23,13 @@ Dockerイメージは以下を参照してください。
 * `Fess 14.19.2 <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.19.1 <https://opensearch.org/versions/opensearch-2-19-1.html>`_)
 * `Fess 14.18.0 <https://github.com/codelibs/fess/releases/tag/fess-14.18.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.18.0 <https://opensearch.org/versions/opensearch-2-18-0.html>`_)
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
-* `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
-* `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
 インストール方法についてはインストールガイドを参照してください。
 
 過去のリリース(EOL)
 ===================
 
+* `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
+* `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
 * `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)

--- a/ja/index.rst
+++ b/ja/index.rst
@@ -46,7 +46,7 @@ Fess は Apache ライセンスで提供され、無料 (フリーソフト) で
 ダウンロード
 ============
 
-- :doc:`Fess 15.4.0 <downloads>` (zip/rpm/debパッケージ)
+- :doc:`Fess 15.5.0 <downloads>` (zip/rpm/debパッケージ)
 
 特徴
 ====
@@ -102,6 +102,9 @@ Fess は Apache ライセンスで提供され、無料 (フリーソフト) で
 ニュース
 ========
 
+2026-02-14
+    `Fess 15.5.0 リリース <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Fess 15.4.0 リリース <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 
@@ -113,9 +116,6 @@ Fess は Apache ライセンスで提供され、無料 (フリーソフト) で
 
 2025-07-20
     `Fess 15.1.0 リリース <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`__
-
-2025-06-22
-    `Fess 15.0.0 リリース <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
 
 過去のニュースは :doc:`こちら <news>` をご覧ください。
 

--- a/ja/news.rst
+++ b/ja/news.rst
@@ -5,6 +5,9 @@
 ニュース一覧
 ============
 
+2026-02-14
+    `Fess 15.5.0 リリース <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Fess 15.4.0 リリース <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 

--- a/ko/archives.rst
+++ b/ko/archives.rst
@@ -2,6 +2,20 @@
 아카이브
 ==========
 
+15.4
+~~~~
+
+.. toctree::
+
+   15.4/install/index
+   15.4/user/index
+   15.4/api/index
+   15.4/admin/index
+   15.4/config/index
+   JavaDocs <https://fess.codelibs.org/15.4/apidocs/index.html>
+   XRef <https://fess.codelibs.org/15.4/xref/index.html>
+   I/F Doc <https://fess.codelibs.org/15.4/lastadoc-fess.html>
+
 15.3
 ~~~~
 

--- a/ko/documentation.rst
+++ b/ko/documentation.rst
@@ -4,9 +4,9 @@
 
 .. toctree::
 
-   설치 <15.4/install/index>
-   검색 <15.4/user/index>
-   관리 <15.4/admin/index>
-   API <15.4/api/index>
-   설정 <15.4/config/index>
+   설치 <15.5/install/index>
+   검색 <15.5/user/index>
+   관리 <15.5/admin/index>
+   API <15.5/api/index>
+   설정 <15.5/config/index>
 

--- a/ko/downloads.rst
+++ b/ko/downloads.rst
@@ -14,6 +14,7 @@ Docker 이미지는 다음을 참조하세요.
 
 동작이 확인된 안정 버전 릴리스입니다.
 
+* `Fess 15.5.0 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.5.0 <https://opensearch.org/versions/opensearch-3-5-0.html>`_)
 * `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
@@ -22,13 +23,13 @@ Docker 이미지는 다음을 참조하세요.
 * `Fess 14.19.2 <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.19.1 <https://opensearch.org/versions/opensearch-2-19-1.html>`_)
 * `Fess 14.18.0 <https://github.com/codelibs/fess/releases/tag/fess-14.18.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.18.0 <https://opensearch.org/versions/opensearch-2-18-0.html>`_)
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
-* `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
-* `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
 설치 방법에 대해서는 설치 가이드를 참조하세요.
 
 과거 릴리스(EOL)
 ===================
 
+* `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
+* `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
 * `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)

--- a/ko/index.rst
+++ b/ko/index.rst
@@ -46,7 +46,7 @@ Fess는 Apache 라이센스로 제공되며, 무료(프리 소프트웨어)로 �
 다운로드
 ============
 
-- :doc:`Fess 15.4.0 <downloads>` (zip/rpm/deb 패키지)
+- :doc:`Fess 15.5.0 <downloads>` (zip/rpm/deb 패키지)
 
 특징
 ====
@@ -102,6 +102,9 @@ Fess는 Apache 라이센스로 제공되며, 무료(프리 소프트웨어)로 �
 뉴스
 ========
 
+2026-02-14
+    `Fess 15.5.0 릴리스 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Fess 15.4.0 릴리스 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 
@@ -113,9 +116,6 @@ Fess는 Apache 라이센스로 제공되며, 무료(프리 소프트웨어)로 �
 
 2025-07-20
     `Fess 15.1.0 릴리스 <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`__
-
-2025-06-22
-    `Fess 15.0.0 릴리스 <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
 
 과거 뉴스는 :doc:`여기 <news>` 를 참조하세요.
 

--- a/ko/news.rst
+++ b/ko/news.rst
@@ -5,6 +5,9 @@
 뉴스 목록
 ============
 
+2026-02-14
+    `Fess 15.5.0 릴리스 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Fess 15.4.0 릴리스 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 

--- a/zh-cn/archives.rst
+++ b/zh-cn/archives.rst
@@ -2,6 +2,20 @@
 归档文档
 ==========
 
+15.4
+~~~~
+
+.. toctree::
+
+   15.4/install/index
+   15.4/user/index
+   15.4/api/index
+   15.4/admin/index
+   15.4/config/index
+   JavaDocs <https://fess.codelibs.org/15.4/apidocs/index.html>
+   XRef <https://fess.codelibs.org/15.4/xref/index.html>
+   I/F Doc <https://fess.codelibs.org/15.4/lastadoc-fess.html>
+
 15.3
 ~~~~
 

--- a/zh-cn/documentation.rst
+++ b/zh-cn/documentation.rst
@@ -4,9 +4,9 @@
 
 .. toctree::
 
-   安装 <15.4/install/index>
-   搜索 <15.4/user/index>
-   管理 <15.4/admin/index>
-   API <15.4/api/index>
-   设置 <15.4/config/index>
+   安装 <15.5/install/index>
+   搜索 <15.5/user/index>
+   管理 <15.5/admin/index>
+   API <15.5/api/index>
+   设置 <15.5/config/index>
 

--- a/zh-cn/downloads.rst
+++ b/zh-cn/downloads.rst
@@ -14,6 +14,7 @@ Docker 镜像请参考以下内容。
 
 经过验证的稳定版发布。
 
+* `Fess 15.5.0 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.5.0 <https://opensearch.org/versions/opensearch-3-5-0.html>`_)
 * `Fess 15.4.0 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.4.0 <https://opensearch.org/versions/opensearch-3-4-0.html>`_)
 * `Fess 15.3.0 <https://github.com/codelibs/fess/releases/tag/fess-15.3.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.3.0 <https://opensearch.org/versions/opensearch-3-3-0.html>`_)
 * `Fess 15.2.0 <https://github.com/codelibs/fess/releases/tag/fess-15.2.0>`_ (`Java 21 <https://adoptium.net/temurin/releases?version=21>`_, `OpenSearch 3.2.0 <https://opensearch.org/versions/opensearch-3-2-0.html>`_)
@@ -22,13 +23,13 @@ Docker 镜像请参考以下内容。
 * `Fess 14.19.2 <https://github.com/codelibs/fess/releases/tag/fess-14.19.2>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.19.1 <https://opensearch.org/versions/opensearch-2-19-1.html>`_)
 * `Fess 14.18.0 <https://github.com/codelibs/fess/releases/tag/fess-14.18.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.18.0 <https://opensearch.org/versions/opensearch-2-18-0.html>`_)
 * `Fess 14.17.0 <https://github.com/codelibs/fess/releases/tag/fess-14.17.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.17.0 <https://opensearch.org/versions/opensearch-2-17-0.html>`_)
-* `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
-* `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
 关于安装方法,请参考安装指南。
 
 过去的发布(EOL)
 ===================
 
+* `Fess 14.16.0 <https://github.com/codelibs/fess/releases/tag/fess-14.16.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.16.0 <https://opensearch.org/versions/opensearch-2-16-0.html>`_)
+* `Fess 14.15.0 <https://github.com/codelibs/fess/releases/tag/fess-14.15.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.15.0 <https://opensearch.org/versions/opensearch-2-15-0.html>`_)
 * `Fess 14.14.0 <https://github.com/codelibs/fess/releases/tag/fess-14.14.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.14.0 <https://opensearch.org/versions/opensearch-2-14-0.html>`_)
 * `Fess 14.13.0 <https://github.com/codelibs/fess/releases/tag/fess-14.13.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.13.0 <https://opensearch.org/versions/opensearch-2-13-0.html>`_)
 * `Fess 14.12.0 <https://github.com/codelibs/fess/releases/tag/fess-14.12.0>`_ (`Java 17 <https://adoptium.net/temurin/releases?version=17>`_, `OpenSearch 2.12.0 <https://opensearch.org/versions/opensearch-2-12-0.html>`_)

--- a/zh-cn/index.rst
+++ b/zh-cn/index.rst
@@ -46,7 +46,7 @@ Fess 采用 Apache 许可证提供，可以免费使用（自由软件）。
 下载
 ============
 
-- :doc:`Fess 15.4.0 <downloads>` (zip/rpm/deb包)
+- :doc:`Fess 15.5.0 <downloads>` (zip/rpm/deb包)
 
 特点
 ====
@@ -102,6 +102,9 @@ Fess 采用 Apache 许可证提供，可以免费使用（自由软件）。
 新闻
 ========
 
+2026-02-14
+    `Fess 15.5.0 发布 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Fess 15.4.0 发布 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 
@@ -113,9 +116,6 @@ Fess 采用 Apache 许可证提供，可以免费使用（自由软件）。
 
 2025-07-20
     `Fess 15.1.0 发布 <https://github.com/codelibs/fess/releases/tag/fess-15.1.0>`__
-
-2025-06-22
-    `Fess 15.0.0 发布 <https://github.com/codelibs/fess/releases/tag/fess-15.0.0>`__
 
 过去的新闻请查看 :doc:`这里 <news>`。
 

--- a/zh-cn/news.rst
+++ b/zh-cn/news.rst
@@ -5,6 +5,9 @@
 新闻列表
 ============
 
+2026-02-14
+    `Fess 15.5.0 发布 <https://github.com/codelibs/fess/releases/tag/fess-15.5.0>`__
+
 2025-12-25
     `Fess 15.4.0 发布 <https://github.com/codelibs/fess/releases/tag/fess-15.4.0>`__
 


### PR DESCRIPTION
## Summary
Update documentation across all 7 languages for the Fess 15.5.0 release.

## Changes Made
- **documentation.rst**: Updated toctree references from 15.4 to 15.5 for all languages (ja, en, de, es, fr, ko, zh-cn)
- **downloads.rst**: Added Fess 15.5.0 (Java 21, OpenSearch 3.5.0) as the latest stable release; moved Fess 14.15 and 14.16 to EOL section
- **index.rst**: Updated featured download version to 15.5.0; added 2026-02-14 release news entry; rotated oldest news entry out
- **news.rst**: Added Fess 15.5.0 release entry dated 2026-02-14
- **archives.rst**: Added Fess 15.4 documentation to the archive section
- **New skill**: Added `fess-docs-release` Claude skill to automate future release documentation updates

## Testing
- Verified consistent changes across all 7 languages
- Confirmed version numbers, URLs, and date formats are correct

## Additional Notes
- Release date: 2026-02-14
- Dependencies: Java 21, OpenSearch 3.5.0
- All languages follow the same update pattern