### PR TITLE
docs(config): add OpenSearch string length note for large documents

### DIFF
--- a/de/15.5/config/crawler-basic.rst
+++ b/de/15.5/config/crawler-basic.rst
@@ -344,6 +344,18 @@ Fügt Konfiguration für PDF-Dateien bis zu 5 MB hinzu.
 .. warning::
    Bei größeren Dateigrößen erhöhen Sie auch die Crawler-Speichereinstellungen.
 
+.. note::
+   Wenn die Dokumentgröße 50 MB überschreitet, müssen Sie auch die OpenSearch-Einstellungen ändern.
+   OpenSearch begrenzt die maximale Länge von Zeichenfolgenfeldern in JSON-Inhalten standardmäßig auf 50 MB.
+
+   Fügen Sie Folgendes zu ``opensearch.yml`` hinzu:
+
+   ::
+
+       opensearch.xcontent.string.length.max: 104857600
+
+   Das obige Beispiel setzt das Limit auf 100 MB. Weitere Details finden Sie in der `OpenSearch-Dokumentation <https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/#important-system-properties>`_.
+
 Längenbeschränkung für Wörter
 ==============
 

--- a/en/15.5/config/crawler-basic.rst
+++ b/en/15.5/config/crawler-basic.rst
@@ -344,6 +344,18 @@ This adds a configuration to process PDF files up to 5MB.
 .. warning::
    When increasing file sizes to handle, also increase crawler memory settings.
 
+.. note::
+   If the document size exceeds 50MB, you also need to change the OpenSearch settings.
+   OpenSearch limits the maximum length of string fields in JSON content to 50MB by default.
+
+   Add the following to ``opensearch.yml``:
+
+   ::
+
+       opensearch.xcontent.string.length.max: 104857600
+
+   The above example sets the limit to 100MB. For details, see the `OpenSearch documentation <https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/#important-system-properties>`_.
+
 Word Length Restrictions
 =========================
 

--- a/es/15.5/config/crawler-basic.rst
+++ b/es/15.5/config/crawler-basic.rst
@@ -344,6 +344,18 @@ Se ha agregado una configuración para procesar archivos PDF hasta 5MB.
 .. warning::
    Si aumenta el tamaño de archivo a manejar, también aumente la configuración de memoria del rastreador.
 
+.. note::
+   Si el tamaño del documento supera los 50 MB, también debe cambiar la configuración de OpenSearch.
+   OpenSearch limita la longitud máxima de los campos de cadena en el contenido JSON a 50 MB de forma predeterminada.
+
+   Agregue lo siguiente a ``opensearch.yml``:
+
+   ::
+
+       opensearch.xcontent.string.length.max: 104857600
+
+   El ejemplo anterior establece el límite en 100 MB. Para más detalles, consulte la `documentación de OpenSearch <https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/#important-system-properties>`_.
+
 Limitación de Longitud de Palabras
 ===================================
 

--- a/fr/15.5/config/crawler-basic.rst
+++ b/fr/15.5/config/crawler-basic.rst
@@ -344,6 +344,18 @@ Cela ajoute une configuration pour traiter les fichiers PDF jusqu'à 5 Mo.
 .. warning::
    Lors de l'augmentation de la taille des fichiers traités, augmentez également les paramètres de mémoire du robot d'indexation.
 
+.. note::
+   Si la taille du document dépasse 50 Mo, vous devez également modifier les paramètres d'OpenSearch.
+   OpenSearch limite par défaut la longueur maximale des champs de chaîne dans le contenu JSON à 50 Mo.
+
+   Ajoutez ce qui suit dans ``opensearch.yml`` :
+
+   ::
+
+       opensearch.xcontent.string.length.max: 104857600
+
+   L'exemple ci-dessus définit la limite à 100 Mo. Pour plus de détails, consultez la `documentation OpenSearch <https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/#important-system-properties>`_.
+
 Limitation de la longueur des mots
 ==============
 

--- a/ja/15.5/config/crawler-basic.rst
+++ b/ja/15.5/config/crawler-basic.rst
@@ -344,6 +344,18 @@ PDFファイルを5MBまで処理する設定を追加しています。
 .. warning::
    扱うファイルサイズを増やす場合は、クローラーのメモリ設定も増やしてください。
 
+.. note::
+   ドキュメントサイズが50MBを超える場合は、OpenSearch側の設定も変更する必要があります。
+   OpenSearchではJSONコンテンツの文字列フィールドの最大長がデフォルトで50MBに制限されています。
+
+   ``opensearch.yml`` に以下を追加してください:
+
+   ::
+
+       opensearch.xcontent.string.length.max: 104857600
+
+   上記は100MBに設定する例です。詳細は `OpenSearchのドキュメント <https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/#important-system-properties>`_ を参照してください。
+
 単語の長さ制限
 ==============
 

--- a/ko/15.5/config/crawler-basic.rst
+++ b/ko/15.5/config/crawler-basic.rst
@@ -344,6 +344,18 @@ PDF 파일을 5MB까지 처리하는 설정을 추가했습니다.
 .. warning::
    처리할 파일 크기를 늘리는 경우 크롤러의 메모리 설정도 늘리십시오.
 
+.. note::
+   문서 크기가 50MB를 초과하는 경우 OpenSearch 측의 설정도 변경해야 합니다.
+   OpenSearch는 JSON 콘텐츠의 문자열 필드 최대 길이를 기본적으로 50MB로 제한하고 있습니다.
+
+   ``opensearch.yml`` 에 다음을 추가하십시오:
+
+   ::
+
+       opensearch.xcontent.string.length.max: 104857600
+
+   위의 예는 100MB로 설정하는 것입니다. 자세한 내용은 `OpenSearch 문서 <https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/#important-system-properties>`_ 를 참조하십시오.
+
 단어 길이 제한
 ==============
 

--- a/zh-cn/15.5/config/crawler-basic.rst
+++ b/zh-cn/15.5/config/crawler-basic.rst
@@ -344,6 +344,18 @@ URL模式限制
 .. warning::
    增加处理文件大小时,也需要增加爬虫的内存配置。
 
+.. note::
+   当文档大小超过50MB时,还需要更改OpenSearch端的设置。
+   OpenSearch默认将JSON内容中字符串字段的最大长度限制为50MB。
+
+   请在 ``opensearch.yml`` 中添加以下内容:
+
+   ::
+
+       opensearch.xcontent.string.length.max: 104857600
+
+   以上是设置为100MB的示例。详细信息请参阅 `OpenSearch文档 <https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/#important-system-properties>`_ 。
+
 单词长度限制
 ==============
 


### PR DESCRIPTION
## Summary

Add a documentation note to `crawler-basic.rst` across all supported languages, explaining that OpenSearch requires additional configuration when processing documents larger than 50MB.

## Changes Made

- Added a `.. note::` directive to `{lang}/15.5/config/crawler-basic.rst` in all 7 languages (ja, en, de, es, fr, ko, zh-cn)
- The note explains that OpenSearch's default JSON string field limit is 50MB
- Provides the required `opensearch.xcontent.string.length.max` setting in `opensearch.yml`
- Includes a link to the official OpenSearch documentation for further reference

## Testing

- Documentation changes only; no functional code changes
- Verified RST formatting is consistent with the existing document style

## Breaking Changes

None

## Additional Notes

This note was placed immediately after the existing warning about crawler memory settings when increasing the max file size, which is the natural context where a user would need this information.