### PR TITLE
docs(config): fix orphaned pages - add missing toctree sections to en/de/fr/ko

### DIFF
--- a/de/15.5/config/index.rst
+++ b/de/15.5/config/index.rst
@@ -27,6 +27,12 @@ Ein umfassender Leitfaden zur Konfiguration von |Fess|. Jeder Abschnitt ist nach
 
 .. toctree::
    :maxdepth: 2
+   :caption: Data Store-Konnektoren
+
+   datastore/index
+
+.. toctree::
+   :maxdepth: 2
    :caption: Suchfunktionen-Konfiguration
 
    search-basic
@@ -42,6 +48,8 @@ Ein umfassender Leitfaden zur Konfiguration von |Fess|. Jeder Abschnitt ist nach
 
    security-role
    security-virtual-host
+   ldap-integration
+   multitenancy
 
 .. toctree::
    :maxdepth: 2
@@ -51,6 +59,23 @@ Ein umfassender Leitfaden zur Konfiguration von |Fess|. Jeder Abschnitt ist nach
    sso-oidc
    sso-entraid
    sso-spnego
+
+.. toctree::
+   :maxdepth: 2
+   :caption: LLM/KI-Chat-Konfiguration
+
+   llm-overview
+   llm-ollama
+   llm-openai
+   llm-gemini
+   rag-chat
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Scripting
+
+   scripting-overview
+   scripting-groovy
 
 .. toctree::
    :maxdepth: 2

--- a/en/15.5/config/index.rst
+++ b/en/15.5/config/index.rst
@@ -27,6 +27,12 @@ This is a comprehensive guide for configuring |Fess|. Each section is organized 
 
 .. toctree::
    :maxdepth: 2
+   :caption: Datastore Connectors
+
+   datastore/index
+
+.. toctree::
+   :maxdepth: 2
    :caption: Search Features
 
    search-basic
@@ -42,6 +48,8 @@ This is a comprehensive guide for configuring |Fess|. Each section is organized 
 
    security-role
    security-virtual-host
+   ldap-integration
+   multitenancy
 
 .. toctree::
    :maxdepth: 2
@@ -51,6 +59,23 @@ This is a comprehensive guide for configuring |Fess|. Each section is organized 
    sso-oidc
    sso-entraid
    sso-spnego
+
+.. toctree::
+   :maxdepth: 2
+   :caption: LLM/AI Chat Settings
+
+   llm-overview
+   llm-ollama
+   llm-openai
+   llm-gemini
+   rag-chat
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Scripting
+
+   scripting-overview
+   scripting-groovy
 
 .. toctree::
    :maxdepth: 2

--- a/fr/15.5/config/index.rst
+++ b/fr/15.5/config/index.rst
@@ -27,6 +27,12 @@ Ce guide complet couvre la configuration de |Fess|. Chaque section est organisé
 
 .. toctree::
    :maxdepth: 2
+   :caption: Connecteurs Data Store
+
+   datastore/index
+
+.. toctree::
+   :maxdepth: 2
    :caption: Configuration des fonctions de recherche
 
    search-basic
@@ -42,6 +48,8 @@ Ce guide complet couvre la configuration de |Fess|. Chaque section est organisé
 
    security-role
    security-virtual-host
+   ldap-integration
+   multitenancy
 
 .. toctree::
    :maxdepth: 2
@@ -51,6 +59,23 @@ Ce guide complet couvre la configuration de |Fess|. Chaque section est organisé
    sso-oidc
    sso-entraid
    sso-spnego
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Configuration LLM/Chat IA
+
+   llm-overview
+   llm-ollama
+   llm-openai
+   llm-gemini
+   rag-chat
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Scripting
+
+   scripting-overview
+   scripting-groovy
 
 .. toctree::
    :maxdepth: 2

--- a/ko/15.5/config/index.rst
+++ b/ko/15.5/config/index.rst
@@ -27,6 +27,12 @@
 
 .. toctree::
    :maxdepth: 2
+   :caption: 데이터 스토어 커넥터
+
+   datastore/index
+
+.. toctree::
+   :maxdepth: 2
    :caption: 검색 기능 설정
 
    search-basic
@@ -42,6 +48,34 @@
 
    security-role
    security-virtual-host
+   ldap-integration
+   multitenancy
+
+.. toctree::
+   :maxdepth: 2
+   :caption: SSO 설정
+
+   sso-saml
+   sso-oidc
+   sso-entraid
+   sso-spnego
+
+.. toctree::
+   :maxdepth: 2
+   :caption: LLM/AI 채팅 설정
+
+   llm-overview
+   llm-ollama
+   llm-openai
+   llm-gemini
+   rag-chat
+
+.. toctree::
+   :maxdepth: 2
+   :caption: 스크립팅
+
+   scripting-overview
+   scripting-groovy
 
 .. toctree::
    :maxdepth: 2

--- a/ko/15.5/config/sso-entraid.rst
+++ b/ko/15.5/config/sso-entraid.rst
@@ -1,0 +1,297 @@
+=====================================
+Microsoft Entra ID를 이용한 SSO 설정
+=====================================
+
+개요
+====
+
+|Fess| 에서는 Microsoft Entra ID（구 Azure AD）를 사용한 싱글 사인온（SSO）인증을 지원합니다.
+Entra ID 인증을 사용하면 Microsoft 365 환경의 사용자 정보 및 그룹 정보를 |Fess| 의 역할 기반 검색과 연동할 수 있습니다.
+
+Entra ID 인증의 동작 방식
+--------------------------
+
+Entra ID 인증에서는 |Fess| 가 OAuth 2.0/OpenID Connect의 클라이언트로 동작하여 Microsoft Entra ID와 연동하여 인증을 수행합니다.
+
+1. 사용자가 |Fess| 의 SSO 엔드포인트（``/sso/``）에 접근
+2. |Fess| 가 Entra ID의 인가 엔드포인트로 리다이렉트
+3. 사용자가 Entra ID에서 인증（Microsoft 로그인）
+4. Entra ID가 인가 코드를 |Fess| 로 리다이렉트
+5. |Fess| 가 인가 코드를 사용하여 액세스 토큰을 취득
+6. |Fess| 가 Microsoft Graph API를 사용하여 사용자의 그룹 및 역할 정보를 취득
+7. 사용자를 로그인하고 그룹 정보를 역할 기반 검색에 적용
+
+역할 기반 검색과의 연동에 대해서는 :doc:`security-role` 을 참조하십시오.
+
+전제조건
+========
+
+Entra ID 인증을 설정하기 전에 다음 전제조건을 확인하십시오.
+
+- |Fess| 15.5 이상이 설치되어 있을 것
+- Microsoft Entra ID（Azure AD）테넌트를 사용할 수 있을 것
+- |Fess| 가 HTTPS로 접근 가능할 것（본번 환경에서는 필수）
+- Entra ID 측에서 애플리케이션을 등록할 수 있는 권한이 있을 것
+
+기본 설정
+========
+
+SSO 기능 활성화
+---------------
+
+Entra ID 인증을 활성화하려면 ``app/WEB-INF/conf/system.properties`` 에 다음 설정을 추가합니다.
+
+::
+
+    sso.type=entraid
+
+필수 설정
+--------
+
+Entra ID에서 취득한 정보를 설정합니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``entraid.tenant``
+     - 테넌트 ID（예: ``xxx.onmicrosoft.com``）
+     - （필수）
+   * - ``entraid.client.id``
+     - 애플리케이션（클라이언트）ID
+     - （필수）
+   * - ``entraid.client.secret``
+     - 클라이언트 시크릿 값
+     - （필수）
+   * - ``entraid.reply.url``
+     - 리다이렉트 URI（콜백 URL）
+     - 요청 URL을 사용
+
+.. note::
+   ``entraid.*`` 프리픽스 대신 레거시 ``aad.*`` 프리픽스도 사용할 수 있습니다（하위 호환성）.
+
+옵션 설정
+--------------
+
+필요에 따라 다음 설정을 추가할 수 있습니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``entraid.authority``
+     - 인증 서버 URL
+     - ``https://login.microsoftonline.com/``
+   * - ``entraid.state.ttl``
+     - State 유효 기간（초）
+     - ``3600``
+   * - ``entraid.default.groups``
+     - 기본 그룹（쉼표 구분）
+     - （없음）
+   * - ``entraid.default.roles``
+     - 기본 역할（쉼표 구분）
+     - （없음）
+
+Entra ID 측 설정
+==================
+
+Azure Portal에서의 앱 등록
+--------------------------
+
+1. `Azure Portal <https://portal.azure.com/>`_ 에 로그인
+
+2. **Microsoft Entra ID** 를 선택
+
+3. 왼쪽 메뉴의 **관리** → **앱 등록** → **새 등록** 을 클릭
+
+4. 애플리케이션을 등록:
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 30 70
+
+      * - 설정 항목
+        - 설정값
+      * - 이름
+        - 임의의 이름（예: Fess SSO）
+      * - 지원되는 계정 유형
+        - 「이 조직 디렉터리의 계정만」
+      * - 플랫폼 선택
+        - Web
+      * - 리다이렉트 URI
+        - ``https://<Fess 호스트>/sso/``
+
+5. **등록** 을 클릭
+
+클라이언트 시크릿 생성
+------------------------------
+
+1. 앱 세부 정보 페이지에서 **인증서 및 비밀** 을 클릭
+
+2. **새 클라이언트 비밀** 을 클릭
+
+3. 설명과 만료 기간을 설정하고 **추가** 를 클릭
+
+4. 생성된 **값** 을 복사하여 저장（이 값은 다시 표시되지 않습니다）
+
+.. warning::
+   클라이언트 시크릿 값은 생성 직후에만 표시됩니다.
+   다른 화면으로 이동하기 전에 반드시 기록해 두십시오.
+
+API 접근 권한 설정
+---------------------
+
+1. 왼쪽 메뉴의 **API 권한** 을 클릭
+
+2. **권한 추가** 를 클릭
+
+3. **Microsoft Graph** 를 선택
+
+4. **위임된 권한** 을 선택
+
+5. 다음 접근 권한을 추가:
+
+   - ``Group.Read.All`` - 사용자의 그룹 정보를 취득하기 위해 필요
+
+6. **권한 추가** 를 클릭
+
+7. **「<테넌트 이름>에 관리자 동의 부여」** 를 클릭
+
+.. note::
+   관리자 동의는 테넌트 관리자 권한이 필요합니다.
+
+취득하는 정보
+------------
+
+다음 정보를 Fess 설정에 사용합니다.
+
+- **애플리케이션（클라이언트）ID**: 개요 페이지의 「애플리케이션 (클라이언트) ID」
+- **테넌트 ID**: 개요 페이지의 「디렉터리 (테넌트) ID」또는 ``xxx.onmicrosoft.com`` 형식
+- **클라이언트 시크릿 값**: 인증서 및 비밀에서 생성한 값
+
+그룹 및 역할 매핑
+==========================
+
+Entra ID 인증에서는 Microsoft Graph API를 사용하여 사용자가 소속된 그룹 및 역할을 자동으로 취득합니다.
+취득한 그룹 ID 및 그룹 이름은 |Fess| 의 역할 기반 검색에 사용할 수 있습니다.
+
+중첩 그룹
+--------------------
+
+|Fess| 는 사용자가 직접 소속된 그룹뿐만 아니라 해당 그룹이 소속된 상위 그룹（중첩 그룹）도 재귀적으로 취득합니다.
+이 처리는 로그인 후 비동기로 실행되므로 로그인 시간에 대한 영향을 최소화합니다.
+
+기본 그룹 설정
+------------------------
+
+모든 Entra ID 사용자에게 공통 그룹을 부여하는 경우:
+
+::
+
+    entraid.default.groups=authenticated_users,entra_users
+
+설정 예
+======
+
+최소 구성（검증 환경용）
+------------------------
+
+다음은 검증 환경에서 동작을 확인하기 위한 최소한의 설정 예입니다.
+
+::
+
+    # SSO 활성화
+    sso.type=entraid
+
+    # Entra ID 설정
+    entraid.tenant=yourcompany.onmicrosoft.com
+    entraid.client.id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    entraid.client.secret=your-client-secret-value
+    entraid.reply.url=http://localhost:8080/sso/
+
+권장 구성（본번 환경용）
+------------------------
+
+다음은 본번 환경에서 사용할 때의 권장 설정 예입니다.
+
+::
+
+    # SSO 활성화
+    sso.type=entraid
+
+    # Entra ID 설정
+    entraid.tenant=yourcompany.onmicrosoft.com
+    entraid.client.id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    entraid.client.secret=your-client-secret-value
+    entraid.reply.url=https://fess.example.com/sso/
+
+    # 기본 그룹（옵션）
+    entraid.default.groups=authenticated_users
+
+레거시 설정（하위 호환성）
+--------------------------
+
+이전 버전과의 호환성을 위해 ``aad.*`` 프리픽스도 사용할 수 있습니다.
+
+::
+
+    # SSO 활성화
+    sso.type=entraid
+
+    # 레거시 설정 키
+    aad.tenant=yourcompany.onmicrosoft.com
+    aad.client.id=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    aad.client.secret=your-client-secret-value
+    aad.reply.url=https://fess.example.com/sso/
+
+문제 해결
+======================
+
+자주 발생하는 문제와 해결 방법
+----------------------
+
+인증 후 Fess로 돌아올 수 없음
+~~~~~~~~~~~~~~~~~~~~~~
+
+- Azure Portal의 앱 등록에서 리다이렉트 URI가 올바르게 설정되어 있는지 확인하십시오
+- ``entraid.reply.url`` 의 값이 Azure Portal의 설정과 완전히 일치하는지 확인하십시오
+- 프로토콜（HTTP/HTTPS）이 일치하는지 확인하십시오
+- 리다이렉트 URI의 끝에 ``/`` 가 포함되어 있는지 확인하십시오
+
+인증 오류가 발생함
+~~~~~~~~~~~~~~~~~~~~
+
+- 테넌트 ID, 클라이언트 ID, 클라이언트 시크릿이 올바르게 설정되어 있는지 확인하십시오
+- 클라이언트 시크릿의 유효 기간이 만료되지 않았는지 확인하십시오
+- API 접근 권한에 관리자 동의가 부여되어 있는지 확인하십시오
+
+그룹 정보를 취득할 수 없음
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``Group.Read.All`` 의 접근 권한이 부여되어 있는지 확인하십시오
+- 관리자 동의가 부여되어 있는지 확인하십시오
+- 사용자가 Entra ID에서 그룹에 소속되어 있는지 확인하십시오
+
+디버그 설정
+------------
+
+문제를 조사할 때는 |Fess| 의 로그 레벨을 조정하면 Entra ID 관련 상세 로그를 출력할 수 있습니다.
+
+``app/WEB-INF/classes/log4j2.xml`` 에서 다음 로거를 추가하여 로그 레벨을 변경할 수 있습니다.
+
+::
+
+    <Logger name="org.codelibs.fess.sso.entraid" level="DEBUG"/>
+
+참고 정보
+========
+
+- :doc:`security-role` - 역할 기반 검색 설정에 대하여
+- :doc:`sso-saml` - SAML 인증을 이용한 SSO 설정에 대하여
+- :doc:`sso-oidc` - OpenID Connect 인증을 이용한 SSO 설정에 대하여

--- a/ko/15.5/config/sso-oidc.rst
+++ b/ko/15.5/config/sso-oidc.rst
@@ -1,0 +1,248 @@
+==============================
+OpenID Connect SSO 설정
+==============================
+
+개요
+====
+
+|Fess| 는 OpenID Connect（OIDC）를 이용한 싱글 사인온（SSO）인증을 지원합니다.
+OpenID Connect는 OAuth 2.0을 기반으로 한 인증 프로토콜로, ID Token（JWT）을 사용하여 사용자 인증을 수행합니다.
+OpenID Connect 인증을 사용하면 OIDC 프로바이더（OP）에서 인증된 사용자 정보를 |Fess| 에 연동할 수 있습니다.
+
+OpenID Connect 인증 동작 방식
+------------------------------
+
+OpenID Connect 인증에서는 |Fess| 가 Relying Party（RP）로 동작하며, 외부 OpenID 프로바이더（OP）와 연계하여 인증을 수행합니다.
+
+1. 사용자가 |Fess| 의 SSO 엔드포인트（``/sso/``）에 접근
+2. |Fess| 가 OP의 인가 엔드포인트로 리다이렉트
+3. 사용자가 OP에서 인증 수행
+4. OP가 인가 코드를 |Fess| 에 리다이렉트
+5. |Fess| 가 인가 코드를 사용하여 토큰 엔드포인트에서 ID Token 취득
+6. |Fess| 가 ID Token（JWT）을 검증하고 사용자를 로그인
+
+역할 기반 검색과의 연동에 대해서는 :doc:`security-role` 을 참조하십시오.
+
+전제조건
+========
+
+OpenID Connect 인증을 설정하기 전에 다음 전제조건을 확인하십시오.
+
+- |Fess| 15.5 이상이 설치되어 있을 것
+- OpenID Connect 대응 프로바이더（OP）가 사용 가능할 것
+- |Fess| 가 HTTPS로 접근 가능할 것（운영 환경에서는 필수）
+- OP 측에서 |Fess| 를 클라이언트（RP）로 등록할 수 있는 권한이 있을 것
+
+지원 프로바이더 예:
+
+- Microsoft Entra ID（Azure AD）
+- Google Workspace / Google Cloud Identity
+- Okta
+- Keycloak
+- Auth0
+- 기타 OpenID Connect 대응 프로바이더
+
+기본 설정
+========
+
+SSO 기능 활성화
+---------------
+
+OpenID Connect 인증을 활성화하려면 ``app/WEB-INF/conf/system.properties`` 에 다음 설정을 추가합니다.
+
+::
+
+    sso.type=oic
+
+프로바이더 설정
+----------------
+
+OP에서 취득한 정보를 설정합니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``oic.auth.server.url``
+     - 인가 엔드포인트 URL
+     - （필수）
+   * - ``oic.token.server.url``
+     - 토큰 엔드포인트 URL
+     - （필수）
+
+.. note::
+   이 URL들은 OP의 Discovery 엔드포인트（``/.well-known/openid-configuration``）에서 취득할 수 있습니다.
+
+클라이언트 설정
+----------------
+
+OP 측에서 등록한 클라이언트 정보를 설정합니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``oic.client.id``
+     - 클라이언트 ID
+     - （필수）
+   * - ``oic.client.secret``
+     - 클라이언트 시크릿
+     - （필수）
+   * - ``oic.scope``
+     - 요청할 스코프
+     - （필수）
+
+.. note::
+   스코프에는 최소한 ``openid`` 를 포함해야 합니다.
+   사용자의 이메일 주소를 취득하는 경우 ``openid email`` 을 지정합니다.
+
+리다이렉트 URL 설정
+-------------------
+
+인증 후 콜백 URL을 설정합니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``oic.redirect.url``
+     - 리다이렉트 URL（콜백 URL）
+     - ``{oic.base.url}/sso/``
+   * - ``oic.base.url``
+     - |Fess| 의 베이스 URL
+     - ``http://localhost:8080``
+
+.. note::
+   ``oic.redirect.url`` 을 생략한 경우 ``oic.base.url`` 에서 자동으로 구성됩니다.
+   운영 환경에서는 ``oic.base.url`` 에 HTTPS URL을 설정하십시오.
+
+OP 측 설정
+============
+
+OP 측에서 |Fess| 를 클라이언트（RP）로 등록할 때 다음 정보를 설정합니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 설정 항목
+     - 설정값
+   * - 애플리케이션 종류
+     - 웹 애플리케이션
+   * - 리다이렉트 URI / 콜백 URL
+     - ``https://<Fess 호스트>/sso/``
+   * - 허용 스코프
+     - ``openid`` 및 필요한 스코프（``email``, ``profile`` 등）
+
+OP에서 취득하는 정보
+------------------
+
+OP의 설정 화면 또는 Discovery 엔드포인트에서 다음 정보를 취득하여 |Fess| 설정에 사용합니다.
+
+- **인가 엔드포인트（Authorization Endpoint）**: 사용자 인증을 시작하는 URL
+- **토큰 엔드포인트（Token Endpoint）**: 토큰을 취득하는 URL
+- **클라이언트 ID**: OP에서 발급된 클라이언트 식별자
+- **클라이언트 시크릿**: 클라이언트 인증에 사용하는 비밀 키
+
+.. note::
+   많은 OP에서 Discovery 엔드포인트（``https://<OP>/.well-known/openid-configuration``）를 통해
+   인가 엔드포인트와 토큰 엔드포인트 URL을 확인할 수 있습니다.
+
+설정 예
+======
+
+최소 구성（검증 환경용）
+------------------------
+
+다음은 검증 환경에서 동작을 확인하기 위한 최소한의 설정 예입니다.
+
+::
+
+    # SSO 활성화
+    sso.type=oic
+
+    # 프로바이더 설정（OP에서 취득한 값을 설정）
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # 클라이언트 설정
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email
+
+    # 리다이렉트 URL（검증 환경）
+    oic.redirect.url=http://localhost:8080/sso/
+
+권장 구성（운영 환경용）
+------------------------
+
+다음은 운영 환경에서 사용할 때의 권장 설정 예입니다.
+
+::
+
+    # SSO 활성화
+    sso.type=oic
+
+    # 프로바이더 설정
+    oic.auth.server.url=https://op.example.com/authorize
+    oic.token.server.url=https://op.example.com/token
+
+    # 클라이언트 설정
+    oic.client.id=your-client-id
+    oic.client.secret=your-client-secret
+    oic.scope=openid email profile
+
+    # 베이스 URL（운영 환경에서는 HTTPS 사용）
+    oic.base.url=https://fess.example.com
+
+문제 해결
+======================
+
+자주 발생하는 문제와 해결 방법
+------------------------------
+
+인증 후 |Fess| 로 돌아올 수 없음
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- OP 측의 리다이렉트 URI가 올바르게 설정되어 있는지 확인하십시오
+- ``oic.redirect.url`` 또는 ``oic.base.url`` 의 값이 OP 측 설정과 일치하는지 확인하십시오
+- 프로토콜（HTTP/HTTPS）이 일치하는지 확인하십시오
+
+인증 오류가 발생함
+~~~~~~~~~~~~~~~~~~
+
+- 클라이언트 ID와 클라이언트 시크릿이 올바르게 설정되어 있는지 확인하십시오
+- 스코프에 ``openid`` 가 포함되어 있는지 확인하십시오
+- 인가 엔드포인트 URL과 토큰 엔드포인트 URL이 올바른지 확인하십시오
+
+사용자 정보를 취득할 수 없음
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- 스코프에 필요한 권한（``email``, ``profile`` 등）이 포함되어 있는지 확인하십시오
+- OP 측에서 클라이언트에 필요한 스코프가 허용되어 있는지 확인하십시오
+
+디버그 설정
+------------
+
+문제를 조사할 때 |Fess| 의 로그 레벨을 조정하면 OpenID Connect 관련 상세 로그를 출력할 수 있습니다.
+
+``app/WEB-INF/classes/log4j2.xml`` 에서 다음 로거를 추가하여 로그 레벨을 변경할 수 있습니다.
+
+::
+
+    <Logger name="org.codelibs.fess.sso.oic" level="DEBUG"/>
+
+참고 정보
+========
+
+- :doc:`security-role` - 역할 기반 검색 설정에 대하여
+- :doc:`sso-saml` - SAML 인증에 의한 SSO 설정에 대하여

--- a/ko/15.5/config/sso-saml.rst
+++ b/ko/15.5/config/sso-saml.rst
@@ -1,0 +1,390 @@
+============================
+SAML 인증을 통한 SSO 설정
+============================
+
+개요
+====
+
+|Fess| 에서는 SAML（Security Assertion Markup Language）2.0을 사용한 싱글 사인온（SSO）인증을 지원합니다.
+SAML 인증을 사용하면 IdP（Identity Provider）에서 인증된 사용자 정보를 |Fess| 에 연동하고, 역할 기반 검색과 결합하여 사용자의 권한에 따른 검색 결과 구분이 가능해집니다.
+
+SAML 인증의 구조
+----------------
+
+SAML 인증에서는 |Fess| 가 SP（Service Provider）로 동작하여 외부 IdP와 연동하여 인증을 수행합니다.
+
+1. 사용자가 |Fess| 의 SSO 엔드포인트（``/sso/``）에 접근
+2. |Fess| 가 IdP에 인증 요청을 리다이렉트
+3. 사용자가 IdP에서 인증 실행
+4. IdP가 SAML 어서션을 |Fess| 에 전송
+5. |Fess| 가 어서션을 검증하고 사용자를 로그인
+
+역할 기반 검색과의 연동에 대해서는 :doc:`security-role` 을 참조하십시오.
+
+전제 조건
+=========
+
+SAML 인증을 설정하기 전에 다음 전제 조건을 확인하십시오.
+
+- |Fess| 15.5 이상이 설치되어 있을 것
+- SAML 2.0 대응 IdP（Identity Provider）를 사용할 수 있을 것
+- |Fess| 가 HTTPS로 접근 가능할 것（운영 환경에서는 필수）
+- IdP 측에서 |Fess| 를 SP로 등록할 수 있는 권한이 있을 것
+
+지원 IdP의 예:
+
+- Microsoft Entra ID（Azure AD）
+- Okta
+- Google Workspace
+- Keycloak
+- OneLogin
+- 기타 SAML 2.0 대응 IdP
+
+기본 설정
+=========
+
+SSO 기능 활성화
+---------------
+
+SAML 인증을 활성화하려면 ``app/WEB-INF/conf/system.properties`` 에 다음 설정을 추가합니다.
+
+::
+
+    sso.type=saml
+
+SP（Service Provider）설정
+--------------------------
+
+|Fess| 를 SP로 설정하려면 SP Base URL을 지정합니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``saml.sp.base.url``
+     - SP의 베이스 URL
+     - （필수）
+
+이 설정에 의해 다음 엔드포인트가 자동으로 구성됩니다.
+
+- **Entity ID**: ``{base_url}/sso/metadata``
+- **ACS URL**: ``{base_url}/sso/``
+- **SLO URL**: ``{base_url}/sso/logout``
+
+설정 예::
+
+    saml.sp.base.url=https://fess.example.com
+
+개별 URL 설정
+~~~~~~~~~~~~~
+
+Base URL을 사용하지 않고 개별로 URL을 지정할 수도 있습니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``saml.sp.entityid``
+     - SP의 Entity ID
+     - （개별 설정 시 필수）
+   * - ``saml.sp.assertion_consumer_service.url``
+     - Assertion Consumer Service URL
+     - （개별 설정 시 필수）
+   * - ``saml.sp.single_logout_service.url``
+     - Single Logout Service URL
+     - （선택 사항）
+
+IdP（Identity Provider）설정
+----------------------------
+
+IdP에서 취득한 정보를 설정합니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``saml.idp.entityid``
+     - IdP의 Entity ID
+     - （필수）
+   * - ``saml.idp.single_sign_on_service.url``
+     - IdP의 SSO 서비스 URL
+     - （필수）
+   * - ``saml.idp.x509cert``
+     - IdP의 서명용 X.509 인증서（Base64 인코딩, 줄 바꿈 없음）
+     - （필수）
+   * - ``saml.idp.single_logout_service.url``
+     - IdP의 SLO 서비스 URL
+     - （선택 사항）
+
+.. note::
+   ``saml.idp.x509cert`` 에는 인증서의 Base64 인코딩된 내용을 줄 바꿈 없이 1행으로 지정합니다.
+   ``-----BEGIN CERTIFICATE-----`` 와 ``-----END CERTIFICATE-----`` 행은 포함하지 마십시오.
+
+SP 메타데이터 취득
+------------------
+
+|Fess| 를 시작하면 ``/sso/metadata`` 엔드포인트에서 SP 메타데이터를 XML 형식으로 취득할 수 있습니다.
+
+::
+
+    https://fess.example.com/sso/metadata
+
+이 메타데이터를 IdP에 임포트하거나, 메타데이터의 내용을 참고하여 IdP 측에서 SP를 수동으로 등록하십시오.
+
+.. note::
+   메타데이터를 취득하려면 먼저 기본적인 SAML 설정（``sso.type=saml`` 과 ``saml.sp.base.url``）을 완료하고 |Fess| 를 시작해 두어야 합니다.
+
+IdP 측 설정
+===========
+
+IdP 측에서 |Fess| 를 SP로 등록할 때 다음 정보를 설정합니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 설정 항목
+     - 설정값
+   * - ACS URL / Reply URL
+     - ``https://<Fess의 호스트>/sso/``
+   * - Entity ID / Audience URI
+     - ``https://<Fess의 호스트>/sso/metadata``
+   * - Name ID Format
+     - ``urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`` （권장）
+
+IdP에서 취득하는 정보
+---------------------
+
+IdP의 설정 화면 또는 메타데이터에서 다음 정보를 취득하여 |Fess| 의 설정에 사용합니다.
+
+- **IdP Entity ID**: IdP를 식별하기 위한 URI
+- **SSO URL（HTTP-Redirect）**: 싱글 사인온의 엔드포인트 URL
+- **X.509 인증서**: SAML 어서션의 서명 검증에 사용하는 공개 키 인증서
+
+사용자 속성 매핑
+================
+
+SAML 어서션에서 취득한 사용자 속성을 |Fess| 의 그룹이나 역할에 매핑할 수 있습니다.
+
+그룹 속성 설정
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``saml.attribute.group.name``
+     - 그룹 정보를 포함하는 속성명
+     - ``memberOf``
+   * - ``saml.default.groups``
+     - 기본 그룹（쉼표로 구분）
+     - （없음）
+
+설정 예::
+
+    saml.attribute.group.name=groups
+    saml.default.groups=user
+
+역할 속성 설정
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``saml.attribute.role.name``
+     - 역할 정보를 포함하는 속성명
+     - （없음）
+   * - ``saml.default.roles``
+     - 기본 역할（쉼표로 구분）
+     - （없음）
+
+설정 예::
+
+    saml.attribute.role.name=roles
+    saml.default.roles=viewer
+
+.. note::
+   IdP에서 속성을 취득할 수 없는 경우 기본값이 사용됩니다.
+   역할 기반 검색을 사용하는 경우 적절한 그룹 또는 역할을 설정하십시오.
+
+보안 설정
+=========
+
+운영 환경에서는 다음 보안 설정을 활성화하는 것을 권장합니다.
+
+서명 설정
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``saml.security.authnrequest_signed``
+     - 인증 요청에 서명한다
+     - ``false``
+   * - ``saml.security.want_messages_signed``
+     - 메시지의 서명을 요구한다
+     - ``false``
+   * - ``saml.security.want_assertions_signed``
+     - 어서션의 서명을 요구한다
+     - ``false``
+   * - ``saml.security.logoutrequest_signed``
+     - 로그아웃 요청에 서명한다
+     - ``false``
+   * - ``saml.security.logoutresponse_signed``
+     - 로그아웃 응답에 서명한다
+     - ``false``
+
+.. warning::
+   기본값에서는 보안 기능이 비활성화되어 있습니다.
+   운영 환경에서는 최소한 ``saml.security.want_assertions_signed=true`` 를 설정하도록 강력히 권장합니다.
+
+암호화 설정
+-----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``saml.security.want_assertions_encrypted``
+     - 어서션의 암호화를 요구한다
+     - ``false``
+   * - ``saml.security.want_nameid_encrypted``
+     - NameID의 암호화를 요구한다
+     - ``false``
+
+기타 보안 설정
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``saml.security.strict``
+     - 엄격 모드（검증을 엄격하게 수행）
+     - ``true``
+   * - ``saml.security.signature_algorithm``
+     - 서명 알고리즘
+     - ``http://www.w3.org/2000/09/xmldsig#rsa-sha1``
+   * - ``saml.sp.nameidformat``
+     - NameID 형식
+     - ``urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress``
+
+설정 예
+=======
+
+최소 구성（검증 환경용）
+------------------------
+
+다음은 검증 환경에서 동작을 확인하기 위한 최소한의 설정 예입니다.
+
+::
+
+    # SSO 활성화
+    sso.type=saml
+
+    # SP 설정
+    saml.sp.base.url=https://fess.example.com
+
+    # IdP 설정（IdP의 관리 화면에서 취득한 값을 설정）
+    saml.idp.entityid=https://idp.example.com/saml/metadata
+    saml.idp.single_sign_on_service.url=https://idp.example.com/saml/sso
+    saml.idp.x509cert=MIIDpDCCAoygAwIBAgI...（Base64 인코딩된 인증서）
+
+    # 기본 그룹
+    saml.default.groups=user
+
+권장 구성（운영 환경용）
+------------------------
+
+다음은 운영 환경에서 사용하기 위한 권장 설정 예입니다.
+
+::
+
+    # SSO 활성화
+    sso.type=saml
+
+    # SP 설정
+    saml.sp.base.url=https://fess.example.com
+
+    # IdP 설정
+    saml.idp.entityid=https://idp.example.com/saml/metadata
+    saml.idp.single_sign_on_service.url=https://idp.example.com/saml/sso
+    saml.idp.single_logout_service.url=https://idp.example.com/saml/logout
+    saml.idp.x509cert=MIIDpDCCAoygAwIBAgI...（Base64 인코딩된 인증서）
+
+    # 사용자 속성 매핑
+    saml.attribute.group.name=groups
+    saml.attribute.role.name=roles
+    saml.default.groups=user
+
+    # 보안 설정（운영 환경에서는 활성화 권장）
+    saml.security.want_assertions_signed=true
+    saml.security.want_messages_signed=true
+
+문제 해결
+=========
+
+자주 발생하는 문제와 해결 방법
+------------------------------
+
+인증 후 |Fess| 로 돌아올 수 없음
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- IdP 측의 ACS URL이 올바르게 설정되어 있는지 확인하십시오
+- ``saml.sp.base.url`` 의 값이 IdP 측의 설정과 일치하는지 확인하십시오
+
+서명 검증 오류
+~~~~~~~~~~~~~~
+
+- IdP의 인증서가 올바르게 설정되어 있는지 확인하십시오
+- 인증서의 유효 기간이 만료되지 않았는지 확인하십시오
+- 인증서는 Base64 인코딩된 내용만 줄 바꿈 없이 설정하십시오
+
+사용자의 그룹·역할이 반영되지 않음
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- IdP 측에서 속성（Attribute）이 올바르게 설정되어 있는지 확인하십시오
+- ``saml.attribute.group.name`` 의 값이 IdP에서 전송되는 속성명과 일치하는지 확인하십시오
+- SAML 어서션의 내용을 확인하려면 디버그 모드를 활성화하십시오
+
+디버그 설정
+-----------
+
+문제를 조사할 때는 다음 설정으로 디버그 모드를 활성화할 수 있습니다.
+
+::
+
+    saml.security.debug=true
+
+또한 |Fess| 의 로그 레벨을 조정하면 SAML 관련 상세 로그를 출력할 수 있습니다.
+
+참고 정보
+=========
+
+- :doc:`security-role` - 역할 기반 검색 설정에 대하여

--- a/ko/15.5/config/sso-spnego.rst
+++ b/ko/15.5/config/sso-spnego.rst
@@ -1,0 +1,372 @@
+==========================================
+Windows 통합 인증을 통한 SSO 설정
+==========================================
+
+개요
+====
+
+|Fess| 는 Windows 통합 인증(SPNEGO/Kerberos)을 사용한 싱글 사인온(SSO) 인증을 지원합니다.
+Windows 통합 인증을 사용하면 Active Directory 도메인에 가입한 Windows에 로그인한 사용자는 추가 로그인 조작 없이 |Fess| 에 접근할 수 있습니다.
+
+Windows 통합 인증의 동작 방식
+------------------------------
+
+Windows 통합 인증에서는 |Fess| 가 SPNEGO(Simple and Protected GSSAPI Negotiation Mechanism) 프로토콜을 사용하여 Kerberos 인증을 수행합니다.
+
+1. 사용자가 Windows 도메인에 로그인
+2. 사용자가 |Fess| 에 접근
+3. |Fess| 가 SPNEGO 챌린지를 송신
+4. 브라우저가 Kerberos 티켓을 취득하여 서버에 송신
+5. |Fess| 가 티켓을 검증하고 사용자명을 취득
+6. LDAP를 사용하여 사용자의 그룹 정보를 취득
+7. 사용자가 로그인 상태가 되고 그룹 정보가 역할 기반 검색에 적용됨
+
+역할 기반 검색과의 연계에 대해서는 :doc:`security-role` 을 참조하십시오.
+
+전제조건
+========
+
+Windows 통합 인증을 설정하기 전에 다음 전제조건을 확인하십시오:
+
+- |Fess| 15.5 이상이 설치되어 있을 것
+- Active Directory(AD) 서버가 사용 가능할 것
+- |Fess| 서버가 AD 도메인에서 접근 가능할 것
+- AD에서 서비스 프린시펄 이름(SPN)을 설정할 권한이 있을 것
+- LDAP로 사용자 정보를 취득하기 위한 계정이 있을 것
+
+Active Directory 측 설정
+=========================
+
+서비스 프린시펄 이름(SPN) 등록
+--------------------------------
+
+|Fess| 용 SPN을 Active Directory에 등록해야 합니다.
+AD 도메인에 가입한 Windows에서 명령 프롬프트를 열고 ``setspn`` 명령을 실행합니다.
+
+::
+
+    setspn -S HTTP/<Fess 서버의 호스트명> <AD 접속용 사용자>
+
+예:
+
+::
+
+    setspn -S HTTP/fess-server.example.local svc_fess
+
+등록을 확인하려면:
+
+::
+
+    setspn -L <AD 접속용 사용자>
+
+.. note::
+   SPN 등록 후 Fess 서버에서 실행한 경우에는 한 번 Windows에서 로그아웃하고 다시 로그인하십시오.
+
+기본 설정
+=========
+
+SSO 활성화
+-----------
+
+Windows 통합 인증을 활성화하려면 ``app/WEB-INF/conf/system.properties`` 에 다음 설정을 추가합니다:
+
+::
+
+    sso.type=spnego
+
+Kerberos 설정 파일
+-------------------
+
+``app/WEB-INF/classes/krb5.conf`` 를 생성하고 Kerberos 설정을 작성합니다.
+
+::
+
+    [libdefaults]
+        default_realm = EXAMPLE.LOCAL
+        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+
+    [realms]
+        EXAMPLE.LOCAL = {
+            kdc = AD-SERVER.EXAMPLE.LOCAL
+            default_domain = EXAMPLE.LOCAL
+        }
+
+    [domain_realm]
+        example.local = EXAMPLE.LOCAL
+        .example.local = EXAMPLE.LOCAL
+
+.. note::
+   ``EXAMPLE.LOCAL`` 은 사용 중인 AD 도메인 이름(대문자)으로, ``AD-SERVER.EXAMPLE.LOCAL`` 은 AD 서버의 호스트명으로 교체하십시오.
+
+로그인 설정 파일
+-----------------
+
+``app/WEB-INF/classes/auth_login.conf`` 를 생성하고 JAAS 로그인 설정을 작성합니다.
+
+::
+
+    spnego-client {
+        com.sun.security.auth.module.Krb5LoginModule required;
+    };
+
+    spnego-server {
+        com.sun.security.auth.module.Krb5LoginModule required
+        storeKey=true
+        isInitiator=false;
+    };
+
+필수 설정
+----------
+
+``app/WEB-INF/conf/system.properties`` 에 다음 설정을 추가합니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``spnego.preauth.username``
+     - AD 접속용 사용자명
+     - (필수)
+   * - ``spnego.preauth.password``
+     - AD 접속용 비밀번호
+     - (필수)
+   * - ``spnego.krb5.conf``
+     - Kerberos 설정 파일 경로
+     - ``krb5.conf``
+   * - ``spnego.login.conf``
+     - 로그인 설정 파일 경로
+     - ``auth_login.conf``
+
+옵션 설정
+----------
+
+필요에 따라 다음 설정을 추가할 수 있습니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``spnego.login.client.module``
+     - 클라이언트 모듈명
+     - ``spnego-client``
+   * - ``spnego.login.server.module``
+     - 서버 모듈명
+     - ``spnego-server``
+   * - ``spnego.allow.basic``
+     - Basic 인증 허용
+     - ``true``
+   * - ``spnego.allow.unsecure.basic``
+     - 비보안 Basic 인증 허용
+     - ``true``
+   * - ``spnego.prompt.ntlm``
+     - NTLM 프롬프트 표시
+     - ``true``
+   * - ``spnego.allow.localhost``
+     - localhost에서의 접근 허용
+     - ``true``
+   * - ``spnego.allow.delegation``
+     - 위임 허용
+     - ``false``
+   * - ``spnego.exclude.dirs``
+     - 인증 제외 디렉터리(쉼표 구분)
+     - (없음)
+   * - ``spnego.logger.level``
+     - 로그 레벨(0-7)
+     - (자동)
+
+.. warning::
+   ``spnego.allow.unsecure.basic=true`` 는 Base64로 인코딩된 인증 정보를 암호화되지 않은 연결로 송신할 가능성이 있습니다.
+   프로덕션 환경에서는 ``false`` 로 설정하고 HTTPS를 사용할 것을 강력히 권장합니다.
+
+LDAP 설정
+=========
+
+Windows 통합 인증으로 로그인한 사용자의 그룹 정보를 취득하기 위해 LDAP 설정이 필요합니다.
+|Fess| 관리 화면의 「시스템」→「일반」에서 LDAP 설정을 수행합니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 항목
+     - 설정 예
+   * - LDAP URL
+     - ``ldap://AD-SERVER.example.local:389``
+   * - Base DN
+     - ``dc=example,dc=local``
+   * - Bind DN
+     - ``svc_fess@example.local``
+   * - 비밀번호
+     - AD 접속용 사용자의 비밀번호
+   * - User DN
+     - ``%s@example.local``
+   * - 계정 필터
+     - ``(&(objectClass=user)(sAMAccountName=%s))``
+   * - memberOf 속성
+     - ``memberOf``
+
+브라우저 설정
+=============
+
+Windows 통합 인증을 사용하려면 클라이언트 측의 브라우저 설정이 필요합니다.
+
+Internet Explorer / Microsoft Edge
+------------------------------------
+
+1. 인터넷 옵션 열기
+2. 「보안」 탭 선택
+3. 「로컬 인트라넷」 영역의 「사이트」 클릭
+4. 「고급」을 클릭하고 Fess의 URL 추가
+5. 「로컬 인트라넷」 영역의 「사용자 지정 수준」 클릭
+6. 「사용자 인증」→「로그온」→「인트라넷 영역에서만 자동으로 로그온」 선택
+7. 「고급」 탭에서 「Windows 통합 인증 사용」 체크
+
+Google Chrome
+--------------
+
+Chrome은 일반적으로 Windows의 인터넷 옵션 설정을 사용합니다.
+추가 설정이 필요한 경우 그룹 정책 또는 레지스트리에서 ``AuthServerAllowlist`` 를 설정합니다.
+
+Mozilla Firefox
+----------------
+
+1. 주소창에 ``about:config`` 입력
+2. ``network.negotiate-auth.trusted-uris`` 검색
+3. Fess 서버의 URL 또는 도메인 설정(예: ``https://fess-server.example.local``)
+
+설정 예
+=======
+
+최소 구성(검증용)
+------------------
+
+다음은 검증 환경에서의 최소 구성 예입니다.
+
+``app/WEB-INF/conf/system.properties``:
+
+::
+
+    # SSO 활성화
+    sso.type=spnego
+
+    # SPNEGO 설정
+    spnego.preauth.username=svc_fess
+    spnego.preauth.password=your-password
+
+``app/WEB-INF/classes/krb5.conf``:
+
+::
+
+    [libdefaults]
+        default_realm = EXAMPLE.LOCAL
+        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+
+    [realms]
+        EXAMPLE.LOCAL = {
+            kdc = AD-SERVER.EXAMPLE.LOCAL
+            default_domain = EXAMPLE.LOCAL
+        }
+
+    [domain_realm]
+        example.local = EXAMPLE.LOCAL
+        .example.local = EXAMPLE.LOCAL
+
+``app/WEB-INF/classes/auth_login.conf``:
+
+::
+
+    spnego-client {
+        com.sun.security.auth.module.Krb5LoginModule required;
+    };
+
+    spnego-server {
+        com.sun.security.auth.module.Krb5LoginModule required
+        storeKey=true
+        isInitiator=false;
+    };
+
+권장 구성(프로덕션용)
+-----------------------
+
+다음은 프로덕션 환경에서의 권장 구성 예입니다.
+
+``app/WEB-INF/conf/system.properties``:
+
+::
+
+    # SSO 활성화
+    sso.type=spnego
+
+    # SPNEGO 설정
+    spnego.preauth.username=svc_fess
+    spnego.preauth.password=your-secure-password
+    spnego.krb5.conf=krb5.conf
+    spnego.login.conf=auth_login.conf
+
+    # 보안 설정(프로덕션 환경)
+    spnego.allow.basic=false
+    spnego.allow.unsecure.basic=false
+    spnego.allow.localhost=false
+
+문제 해결
+=========
+
+자주 발생하는 문제와 해결 방법
+--------------------------------
+
+인증 다이얼로그가 표시되는 경우
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- 브라우저 설정에서 Fess 서버가 인트라넷 영역에 추가되어 있는지 확인
+- 「Windows 통합 인증 사용」이 활성화되어 있는지 확인
+- SPN이 올바르게 등록되어 있는지 확인( ``setspn -L <사용자명>`` )
+
+인증 오류가 발생하는 경우
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``krb5.conf`` 의 도메인 이름(대문자)과 AD 서버명이 올바른지 확인
+- ``spnego.preauth.username`` 과 ``spnego.preauth.password`` 가 올바른지 확인
+- AD 서버로의 네트워크 연결 확인
+
+그룹 정보를 취득할 수 없는 경우
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- LDAP 설정이 올바른지 확인
+- Bind DN과 비밀번호가 올바른지 확인
+- 사용자가 AD에서 그룹에 속해 있는지 확인
+
+디버그 설정
+-----------
+
+문제를 조사하기 위해 |Fess| 의 로그 레벨을 조정하여 SPNEGO 관련 상세 로그를 출력할 수 있습니다.
+
+``app/WEB-INF/conf/system.properties`` 에 다음을 추가:
+
+::
+
+    spnego.logger.level=1
+
+또는 ``app/WEB-INF/classes/log4j2.xml`` 에 다음 로거를 추가:
+
+::
+
+    <Logger name="org.codelibs.fess.sso.spnego" level="DEBUG"/>
+    <Logger name="org.codelibs.spnego" level="DEBUG"/>
+
+참고 정보
+=========
+
+- :doc:`security-role` - 역할 기반 검색 설정
+- :doc:`sso-saml` - SAML 인증을 통한 SSO 설정
+- :doc:`sso-oidc` - OpenID Connect 인증을 통한 SSO 설정
+- :doc:`sso-entraid` - Microsoft Entra ID를 통한 SSO 설정


### PR DESCRIPTION
## Summary

Fixes a systematic navigation gap in the English, German, French, and Korean config documentation: several sections of pages existed as files but were never wired into `index.rst` toctrees, making them unreachable from the sidebar. Also adds 4 missing SSO pages for Korean that didn't exist at all.

After this PR all 7 languages have identical toctree structure (36 entries each).

## Changes Made

**`index.rst` updated for en, de, fr, ko (4 files):**
- Added **Datastore Connectors** section (`datastore/index`) after Crawler Configuration
- Added `ldap-integration` and `multitenancy` to the existing Security section
- Added **LLM/AI Chat Settings** section (`llm-overview`, `llm-ollama`, `llm-openai`, `llm-gemini`, `rag-chat`) after SSO
- Added **Scripting** section (`scripting-overview`, `scripting-groovy`) after LLM

Section caption translations used:
| Section | en | de | fr | ko |
|---------|----|----|----|----|
| Datastore | Datastore Connectors | Data Store-Konnektoren | Connecteurs Data Store | 데이터 스토어 커넥터 |
| LLM/AI Chat | LLM/AI Chat Settings | LLM/KI-Chat-Konfiguration | Configuration LLM/Chat IA | LLM/AI 채팅 설정 |
| Scripting | Scripting | Scripting | Scripting | 스크립팅 |

**New files created for ko (4 files):**
- `ko/15.5/config/sso-saml.rst` — SAML SSO 설정
- `ko/15.5/config/sso-oidc.rst` — OpenID Connect SSO 설정
- `ko/15.5/config/sso-entraid.rst` — Microsoft Entra ID SSO 설정
- `ko/15.5/config/sso-spnego.rst` — Windows 통합 인증 SSO 설정

All Korean SSO pages are full translations of the Japanese originals, following the existing Korean doc style (합니다/하십시오 polite form), with all property names, code blocks, and `:doc:` references preserved.

## Testing

- Verified all 7 languages have exactly 36 toctree entries after the change
- Verified no broken toctree references (all entries resolve to existing files)

## Breaking Changes

None.

## Additional Notes

- es and zh-cn were already complete — only en, de, fr, ko needed fixing
- ko was missing the SSO section entirely (no files + not in toctree); the other 3 languages had the files but they were just not linked from the toctree

🤖 Generated with [Claude Code](https://claude.com/claude-code)