### PR TITLE
docs(15.5): fix broken links and typos across multilingual docs (en, de, es, fr, ko, zh-cn)

### DIFF
--- a/de/15.5/api/admin/api-admin-overview.rst
+++ b/de/15.5/api/admin/api-admin-overview.rst
@@ -396,6 +396,8 @@ System
      - Systemstatistiken
    * - :doc:`api-admin-log`
      - Protokoll abrufen
+   * - :doc:`api-admin-searchlog`
+     - Suchprotokoll-Verwaltung
    * - :doc:`api-admin-storage`
      - Speicherverwaltung
    * - :doc:`api-admin-plugin`

--- a/de/15.5/config/datastore/ds-overview.rst
+++ b/de/15.5/config/datastore/ds-overview.rst
@@ -292,4 +292,4 @@ Weiterführende Informationen
 
 - :doc:`../../admin/dataconfig-guide` - Leitfaden zur Datenspeicher-Konfiguration
 - :doc:`../../admin/plugin-guide` - Leitfaden zur Plugin-Verwaltung
-- :doc:`../api/admin/api-admin-dataconfig` - Datenspeicher-Konfigurations-API
+- :doc:`../../api/admin/api-admin-dataconfig` - Datenspeicher-Konfigurations-API

--- a/de/15.5/config/search-scroll.rst
+++ b/de/15.5/config/search-scroll.rst
@@ -33,7 +33,7 @@ Aktivierung der Scroll-Suche
 ----------------------
 
 Standardmäßig ist Scroll-Suche aus Sicherheits- und Leistungsgründen deaktiviert.
-Zur Aktivierung ändern Sie in ``fess_config.properties`` oder ``/etc/fess/fess_config.properties``
+Zur Aktivierung ändern Sie in ``app/WEB-INF/classes/fess_config.properties`` oder ``/etc/fess/fess_config.properties``
 folgende Einstellung:
 
 ::

--- a/en/15.5/api/admin/api-admin-dict.rst
+++ b/en/15.5/api/admin/api-admin-dict.rst
@@ -321,5 +321,4 @@ Reference
 
 - :doc:`api-admin-overview` - Admin API Overview
 - :doc:`../../admin/dict-guide` - Dictionary Management Guide
-- :doc:`../../config/dict-config` - Dictionary Configuration Guide
 

--- a/en/15.5/api/admin/api-admin-overview.rst
+++ b/en/15.5/api/admin/api-admin-overview.rst
@@ -396,6 +396,8 @@ System
      - System statistics
    * - :doc:`api-admin-log`
      - Log retrieval
+   * - :doc:`api-admin-searchlog`
+     - Search Log Management
    * - :doc:`api-admin-storage`
      - Storage management
    * - :doc:`api-admin-plugin`

--- a/en/15.5/api/admin/api-admin-searchlog.rst
+++ b/en/15.5/api/admin/api-admin-searchlog.rst
@@ -429,5 +429,5 @@ Reference
 - :doc:`api-admin-overview` - Admin API Overview
 - :doc:`api-admin-stats` - System Stats API
 - :doc:`../../admin/searchlog-guide` - Search Log Management Guide
-- :doc:`../../config/search-analytics` - Search Analytics Configuration Guide
+- :doc:`../../config/admin-opensearch-dashboards` - Search Analytics Settings Guide
 

--- a/en/15.5/config/datastore/ds-overview.rst
+++ b/en/15.5/config/datastore/ds-overview.rst
@@ -293,4 +293,4 @@ Reference Information
 
 - :doc:`../../admin/dataconfig-guide` - Data Store Configuration Guide
 - :doc:`../../admin/plugin-guide` - Plugin Management Guide
-- :doc:`../api/admin/api-admin-dataconfig` - Data Store Configuration API
+- :doc:`../../api/admin/api-admin-dataconfig` - Data Store Configuration API

--- a/en/15.5/config/search-scroll.rst
+++ b/en/15.5/config/search-scroll.rst
@@ -33,7 +33,7 @@ Enabling Scroll Search
 ----------------------
 
 By default, scroll search is disabled from security and performance perspectives.
-To enable it, change the following setting in ``fess_config.properties`` or ``/etc/fess/fess_config.properties``.
+To enable it, change the following setting in ``app/WEB-INF/classes/fess_config.properties`` or ``/etc/fess/fess_config.properties``.
 
 ::
 

--- a/es/15.5/api/admin/api-admin-dict.rst
+++ b/es/15.5/api/admin/api-admin-dict.rst
@@ -321,4 +321,3 @@ Informacion de Referencia
 
 - :doc:`api-admin-overview` - Vision general de Admin API
 - :doc:`../../admin/dict-guide` - Guia de gestion de diccionarios
-- :doc:`../../config/dict-config` - Guia de configuracion de diccionarios

--- a/es/15.5/api/admin/api-admin-overview.rst
+++ b/es/15.5/api/admin/api-admin-overview.rst
@@ -396,6 +396,8 @@ Sistema
      - Estadisticas del sistema
    * - :doc:`api-admin-log`
      - Obtencion de registros
+   * - :doc:`api-admin-searchlog`
+     - Gestion de registros de busqueda
    * - :doc:`api-admin-storage`
      - Gestion de almacenamiento
    * - :doc:`api-admin-plugin`

--- a/es/15.5/api/admin/api-admin-searchlog.rst
+++ b/es/15.5/api/admin/api-admin-searchlog.rst
@@ -429,4 +429,4 @@ Informacion de Referencia
 - :doc:`api-admin-overview` - Vision general de Admin API
 - :doc:`api-admin-stats` - API de estadisticas del sistema
 - :doc:`../../admin/searchlog-guide` - Guia de gestion de registros de busqueda
-- :doc:`../../config/search-analytics` - Guia de configuracion de analisis de busqueda
+- :doc:`../../config/admin-opensearch-dashboards` - Guia de configuracion de analisis de busqueda

--- a/es/15.5/config/datastore/ds-overview.rst
+++ b/es/15.5/config/datastore/ds-overview.rst
@@ -293,4 +293,4 @@ Informacion de Referencia
 
 - :doc:`../../admin/dataconfig-guide` - Guia de Configuracion de Almacen de Datos
 - :doc:`../../admin/plugin-guide` - Guia de Administracion de Plugins
-- :doc:`../api/admin/api-admin-dataconfig` - API de Configuracion de Almacen de Datos
+- :doc:`../../api/admin/api-admin-dataconfig` - API de Configuracion de Almacen de Datos

--- a/es/15.5/config/search-scroll.rst
+++ b/es/15.5/config/search-scroll.rst
@@ -31,7 +31,7 @@ Habilitación de la Búsqueda Scroll
 ----------------------------------
 
 Por defecto, la búsqueda scroll está deshabilitada por motivos de seguridad y rendimiento.
-Para habilitarla, modifique la siguiente configuración en ``fess_config.properties`` o ``/etc/fess/fess_config.properties``.
+Para habilitarla, modifique la siguiente configuración en ``app/WEB-INF/classes/fess_config.properties`` o ``/etc/fess/fess_config.properties``.
 
 ::
 
@@ -379,6 +379,6 @@ La Respuesta Está Vacía
 Información de Referencia
 ==========================
 
-- :doc:`search` - Detalles de la función de búsqueda
-- :doc:`search-config` - Configuración relacionada con la búsqueda
+- :doc:`search-basic` - Detalles de la función de búsqueda
+- :doc:`search-scroll` - Configuración relacionada con la búsqueda
 - `OpenSearch Scroll API <https://opensearch.org/docs/latest/api-reference/scroll/>`_

--- a/fr/15.5/api/admin/api-admin-accesstoken.rst
+++ b/fr/15.5/api/admin/api-admin-accesstoken.rst
@@ -279,5 +279,5 @@ Informations complementaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
-- :doc:`../search-api` - API de recherche
+- :doc:`../api-search` - API de recherche
 - :doc:`../../admin/accesstoken-guide` - Guide de gestion des jetons d'acces

--- a/fr/15.5/api/admin/api-admin-dict.rst
+++ b/fr/15.5/api/admin/api-admin-dict.rst
@@ -321,4 +321,3 @@ Informations complementaires
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
 - :doc:`../../admin/dict-guide` - Guide de gestion des dictionnaires
-- :doc:`../../config/dict-config` - Guide de configuration des dictionnaires

--- a/fr/15.5/api/admin/api-admin-labeltype.rst
+++ b/fr/15.5/api/admin/api-admin-labeltype.rst
@@ -289,5 +289,5 @@ Informations complementaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
-- :doc:`../search-api` - API de recherche
+- :doc:`../api-search` - API de recherche
 - :doc:`../../admin/labeltype-guide` - Guide de gestion des types de labels

--- a/fr/15.5/api/admin/api-admin-overview.rst
+++ b/fr/15.5/api/admin/api-admin-overview.rst
@@ -396,6 +396,8 @@ Systeme
      - Statistiques systeme
    * - :doc:`api-admin-log`
      - Obtention des journaux
+   * - :doc:`api-admin-searchlog`
+     - Gestion des journaux de recherche
    * - :doc:`api-admin-storage`
      - Gestion du stockage
    * - :doc:`api-admin-plugin`

--- a/fr/15.5/api/admin/api-admin-searchlog.rst
+++ b/fr/15.5/api/admin/api-admin-searchlog.rst
@@ -429,4 +429,4 @@ Informations complementaires
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
 - :doc:`api-admin-stats` - API des statistiques systeme
 - :doc:`../../admin/searchlog-guide` - Guide de gestion des journaux de recherche
-- :doc:`../../config/search-analytics` - Guide de configuration de l'analyse de recherche
+- :doc:`../../config/admin-opensearch-dashboards` - Guide de configuration de l'analyse de recherche

--- a/fr/15.5/api/admin/api-admin-stats.rst
+++ b/fr/15.5/api/admin/api-admin-stats.rst
@@ -167,4 +167,4 @@ Informations complementaires
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
 - :doc:`api-admin-log` - API des journaux
 - :doc:`api-admin-systeminfo` - API des informations systeme
-- :doc:`../../admin/stats-guide` - Guide des statistiques
+- :doc:`../../admin/searchlog-guide` - Journaux de recherche

--- a/fr/15.5/config/datastore/ds-overview.rst
+++ b/fr/15.5/config/datastore/ds-overview.rst
@@ -293,4 +293,4 @@ Informations de reference
 
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration DataStore
 - :doc:`../../admin/plugin-guide` - Guide de gestion des plugins
-- :doc:`../api/admin/api-admin-dataconfig` - API de configuration DataStore
+- :doc:`../../api/admin/api-admin-dataconfig` - API de configuration DataStore

--- a/fr/15.5/config/search-scroll.rst
+++ b/fr/15.5/config/search-scroll.rst
@@ -33,7 +33,7 @@ Activation de la recherche par défilement
 ----------------------
 
 Par défaut, la recherche par défilement est désactivée pour des raisons de sécurité et de performances.
-Pour l'activer, modifiez le paramètre suivant dans ``fess_config.properties`` ou ``/etc/fess/fess_config.properties``.
+Pour l'activer, modifiez le paramètre suivant dans ``app/WEB-INF/classes/fess_config.properties`` ou ``/etc/fess/fess_config.properties``.
 
 ::
 
@@ -381,6 +381,6 @@ La réponse est vide
 Informations de référence
 ========
 
-- :doc:`search` - Détails de la fonction de recherche
-- :doc:`search-config` - Paramètres liés à la recherche
+- :doc:`search-basic` - Détails de la fonction de recherche
+- :doc:`search-scroll` - Paramètres liés à la recherche
 - `API Scroll d'OpenSearch <https://opensearch.org/docs/latest/api-reference/scroll/>`_

--- a/ko/15.5/api/admin/api-admin-dict.rst
+++ b/ko/15.5/api/admin/api-admin-dict.rst
@@ -321,4 +321,3 @@ Dict API는 |Fess| 의 사전 파일을 관리하기 위한 API입니다.
 
 - :doc:`api-admin-overview` - Admin API 개요
 - :doc:`../../admin/dict-guide` - 사전 관리 가이드
-- :doc:`../../config/dict-config` - 사전 설정 가이드

--- a/ko/15.5/api/admin/api-admin-overview.rst
+++ b/ko/15.5/api/admin/api-admin-overview.rst
@@ -396,6 +396,8 @@ HTTP 상태 코드
      - 시스템 통계
    * - :doc:`api-admin-log`
      - 로그 조회
+   * - :doc:`api-admin-searchlog`
+     - 검색 로그 관리
    * - :doc:`api-admin-storage`
      - 스토리지 관리
    * - :doc:`api-admin-plugin`

--- a/ko/15.5/api/admin/api-admin-searchlog.rst
+++ b/ko/15.5/api/admin/api-admin-searchlog.rst
@@ -429,4 +429,4 @@ SearchLog API는 |Fess| 의 검색 로그를 조회 및 관리하기 위한 API�
 - :doc:`api-admin-overview` - Admin API 개요
 - :doc:`api-admin-stats` - 시스템 통계 API
 - :doc:`../../admin/searchlog-guide` - 검색 로그 관리 가이드
-- :doc:`../../config/search-analytics` - 검색 분석 설정 가이드
+- :doc:`../../config/admin-opensearch-dashboards` - 검색 분석 설정 가이드

--- a/ko/15.5/api/admin/api-admin-stats.rst
+++ b/ko/15.5/api/admin/api-admin-stats.rst
@@ -265,4 +265,4 @@ Stats API는 |Fess| 의 통계 정보를 조회하기 위한 API입니다.
 - :doc:`api-admin-overview` - Admin API 개요
 - :doc:`api-admin-log` - 로그 API
 - :doc:`api-admin-systeminfo` - 시스템 정보 API
-- :doc:`../../admin/stats-guide` - 통계 관리 가이드
+- :doc:`../../admin/searchlog-guide` - 검색 로그

--- a/ko/15.5/config/datastore/ds-overview.rst
+++ b/ko/15.5/config/datastore/ds-overview.rst
@@ -293,4 +293,4 @@ API 키 인증
 
 - :doc:`../../admin/dataconfig-guide` - 데이터스토어 설정 가이드
 - :doc:`../../admin/plugin-guide` - 플러그인 관리 가이드
-- :doc:`../api/admin/api-admin-dataconfig` - 데이터스토어 설정 API
+- :doc:`../../api/admin/api-admin-dataconfig` - 데이터스토어 설정 API

--- a/ko/15.5/config/search-scroll.rst
+++ b/ko/15.5/config/search-scroll.rst
@@ -33,7 +33,7 @@
 ----------------------
 
 기본적으로 보안과 성능 관점에서 스크롤 검색은 비활성화되어 있습니다.
-활성화하려면 ``fess_config.properties`` 또는 ``/etc/fess/fess_config.properties`` 에서
+활성화하려면 ``app/WEB-INF/classes/fess_config.properties`` 또는 ``/etc/fess/fess_config.properties`` 에서
 다음 설정을 변경합니다.
 
 ::
@@ -382,6 +382,6 @@ jq 명령을 사용하여 CSV로 변환하는 예:
 참고 정보
 ========
 
-- :doc:`search` - 검색 기능 자세히 보기
-- :doc:`search-config` - 검색 관련 설정
+- :doc:`search-basic` - 검색 기능 자세히 보기
+- :doc:`search-scroll` - 검색 관련 설정
 - `OpenSearch Scroll API <https://opensearch.org/docs/latest/api-reference/scroll/>`_

--- a/zh-cn/15.5/api/admin/api-admin-accesstoken.rst
+++ b/zh-cn/15.5/api/admin/api-admin-accesstoken.rst
@@ -279,6 +279,6 @@ AccessToken API是用于管理 |Fess| API访问令牌的API。
 ========
 
 - :doc:`api-admin-overview` - Admin API概述
-- :doc:`../search-api` - 搜索API
+- :doc:`../api-search` - 搜索API
 - :doc:`../../admin/accesstoken-guide` - 访问令牌管理指南
 

--- a/zh-cn/15.5/api/admin/api-admin-dict.rst
+++ b/zh-cn/15.5/api/admin/api-admin-dict.rst
@@ -321,5 +321,4 @@ Dict API是用于管理 |Fess| 词典文件的API。
 
 - :doc:`api-admin-overview` - Admin API概述
 - :doc:`../../admin/dict-guide` - 词典管理指南
-- :doc:`../../config/dict-config` - 词典配置指南
 

--- a/zh-cn/15.5/api/admin/api-admin-labeltype.rst
+++ b/zh-cn/15.5/api/admin/api-admin-labeltype.rst
@@ -289,6 +289,6 @@ LabelType API是用于管理 |Fess| 标签类型的API。
 ========
 
 - :doc:`api-admin-overview` - Admin API概述
-- :doc:`../search-api` - 搜索API
+- :doc:`../api-search` - 搜索API
 - :doc:`../../admin/labeltype-guide` - 标签类型管理指南
 

--- a/zh-cn/15.5/api/admin/api-admin-overview.rst
+++ b/zh-cn/15.5/api/admin/api-admin-overview.rst
@@ -396,6 +396,8 @@ HTTP状态码
      - 系统统计
    * - :doc:`api-admin-log`
      - 日志获取
+   * - :doc:`api-admin-searchlog`
+     - 搜索日志管理
    * - :doc:`api-admin-storage`
      - 存储管理
    * - :doc:`api-admin-plugin`

--- a/zh-cn/15.5/api/admin/api-admin-searchlog.rst
+++ b/zh-cn/15.5/api/admin/api-admin-searchlog.rst
@@ -429,5 +429,5 @@ SearchLog API是用于获取和管理 |Fess| 搜索日志的API。
 - :doc:`api-admin-overview` - Admin API概述
 - :doc:`api-admin-stats` - 系统统计API
 - :doc:`../../admin/searchlog-guide` - 搜索日志管理指南
-- :doc:`../../config/search-analytics` - 搜索分析配置指南
+- :doc:`../../config/admin-opensearch-dashboards` - 搜索分析配置指南
 

--- a/zh-cn/15.5/api/admin/api-admin-stats.rst
+++ b/zh-cn/15.5/api/admin/api-admin-stats.rst
@@ -175,5 +175,5 @@ Stats API是用于获取 |Fess| 统计信息的API。
 - :doc:`api-admin-overview` - Admin API概述
 - :doc:`api-admin-log` - 日志API
 - :doc:`api-admin-systeminfo` - 系统信息API
-- :doc:`../../admin/stats-guide` - 统计管理指南
+- :doc:`../../admin/searchlog-guide` - 搜索日志
 

--- a/zh-cn/15.5/config/datastore/ds-overview.rst
+++ b/zh-cn/15.5/config/datastore/ds-overview.rst
@@ -293,4 +293,4 @@ API密钥认证
 
 - :doc:`../../admin/dataconfig-guide` - 数据存储设置指南
 - :doc:`../../admin/plugin-guide` - 插件管理指南
-- :doc:`../api/admin/api-admin-dataconfig` - 数据存储设置API
+- :doc:`../../api/admin/api-admin-dataconfig` - 数据存储设置API

--- a/zh-cn/15.5/config/search-scroll.rst
+++ b/zh-cn/15.5/config/search-scroll.rst
@@ -33,7 +33,7 @@
 ----------------------
 
 默认情况下,出于安全和性能考虑,滚动搜索被禁用。
-要启用,请在 ``fess_config.properties`` 或 ``/etc/fess/fess_config.properties`` 中
+要启用,请在 ``app/WEB-INF/classes/fess_config.properties`` 或 ``/etc/fess/fess_config.properties`` 中
 修改以下配置。
 
 ::
@@ -382,6 +382,6 @@ Python 处理示例
 参考信息
 ========
 
-- :doc:`search` - 搜索功能详情
-- :doc:`search-config` - 搜索相关配置
+- :doc:`search-basic` - 搜索功能详情
+- :doc:`search-scroll` - 搜索相关配置
 - `OpenSearch Scroll API <https://opensearch.org/docs/latest/api-reference/scroll/>`_


### PR DESCRIPTION
## Summary

Port documentation link fixes and typo corrections from the Japanese 15.5 docs (commit `8c42592`) to all other supported languages: en, de, es, fr, ko, zh-cn.

## Changes Made

- **Fix broken `search-api` links** (`../search-api` → `../api-search`) in `api-admin-accesstoken.rst` and `api-admin-labeltype.rst` (fr, zh-cn)
- **Remove invalid `dict-config` reference** — deleted lines pointing to the non-existent `../../config/dict-config` file in `api-admin-dict.rst` (en, es, fr, ko, zh-cn)
- **Add missing `api-admin-searchlog` table entry** to `api-admin-overview.rst` (all 6 languages)
- **Fix broken `search-analytics` link** (`../../config/search-analytics` → `../../config/admin-opensearch-dashboards`) in `api-admin-searchlog.rst` (en, es, fr, ko, zh-cn)
- **Fix broken `stats-guide` link** (`../../admin/stats-guide` → `../../admin/searchlog-guide`) in `api-admin-stats.rst` (fr, ko, zh-cn)
- **Fix incorrect relative path** in `ds-overview.rst` (`../api/admin/api-admin-dataconfig` → `../../api/admin/api-admin-dataconfig`) for all 6 languages
- **Fix config file path** in `search-scroll.rst` (`fess_config.properties` → `app/WEB-INF/classes/fess_config.properties`) for all 6 languages
- **Fix reference links** in `search-scroll.rst` (`search` → `search-basic`, `search-config` → `search-scroll`) for es, fr, ko, zh-cn

## Testing

All target files verified to exist on disk before linking. Changes mirror the already-merged Japanese fixes.

## Additional Notes

- German (`de`) had no `search-api` or `stats-guide` issues; only the overview entry, ds-overview path, and search-scroll config path were updated
- The `en` and `de` versions of `search-scroll.rst` already had the correct `search-basic` / `search-advanced` links; only the config file path was fixed