### PR TITLE
docs(config): update Gemini supported models for 15.5 across all languages

### DIFF
--- a/de/15.5/config/llm-gemini.rst
+++ b/de/15.5/config/llm-gemini.rst
@@ -23,10 +23,10 @@ Unterstützte Modelle
 
 Hauptsächlich verfügbare Modelle bei Gemini:
 
-- ``gemini-2.5-flash`` - Schnelles und effizientes Modell (empfohlen)
-- ``gemini-2.5-pro`` - Modell mit höherer Schlussfolgerungsfähigkeit
-- ``gemini-1.5-flash`` - Stabile Version des Flash-Modells
-- ``gemini-1.5-pro`` - Stabile Version des Pro-Modells
+- ``gemini-3-flash-preview`` - Neuestes schnelles Modell (empfohlen)
+- ``gemini-3.1-pro-preview`` - Neuestes Modell mit hoher Schlussfolgerungsfähigkeit
+- ``gemini-2.5-flash`` - Stabile Version des schnellen Modells
+- ``gemini-2.5-pro`` - Stabile Version des Schlussfolgerungsmodells
 
 .. note::
    Aktuelle Informationen zu verfügbaren Modellen finden Sie unter `Google AI for Developers <https://ai.google.dev/models/gemini>`__.
@@ -76,7 +76,7 @@ Minimalkonfiguration
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # Zu verwendendes Modell
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
 Empfohlene Konfiguration (Produktionsumgebung)
 ----------------------------------------------
@@ -93,7 +93,7 @@ Empfohlene Konfiguration (Produktionsumgebung)
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # Modelleinstellungen (schnelles Modell verwenden)
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
     # API-Endpunkt (normalerweise keine Änderung erforderlich)
     rag.llm.gemini.api.url=https://generativelanguage.googleapis.com/v1beta
@@ -118,7 +118,7 @@ Alle verfügbaren Einstellungselemente für den Gemini-Client.
      - (erforderlich)
    * - ``rag.llm.gemini.model``
      - Name des zu verwendenden Modells
-     - ``gemini-2.5-flash``
+     - ``gemini-3-flash-preview``
    * - ``rag.llm.gemini.api.url``
      - Basis-URL der API
      - ``https://generativelanguage.googleapis.com/v1beta``
@@ -150,7 +150,7 @@ docker-compose.yml
           - RAG_CHAT_ENABLED=true
           - RAG_LLM_TYPE=gemini
           - RAG_LLM_GEMINI_API_KEY=${GEMINI_API_KEY}
-          - RAG_LLM_GEMINI_MODEL=gemini-2.5-flash
+          - RAG_LLM_GEMINI_MODEL=gemini-3-flash-preview
 
 systemd-Umgebung
 ----------------
@@ -185,30 +185,30 @@ Richtlinien zur Modellauswahl je nach Verwendungszweck.
      - Geschwindigkeit
      - Qualität
      - Anwendungsfall
+   * - ``gemini-3-flash-preview``
+     - Schnell
+     - Sehr hoch
+     - Allgemeiner Einsatz (empfohlen)
+   * - ``gemini-3.1-pro-preview``
+     - Mittel
+     - Sehr hoch
+     - Komplexe Schlussfolgerungen
    * - ``gemini-2.5-flash``
      - Schnell
      - Hoch
-     - Allgemeiner Einsatz, ausgeglichen (empfohlen)
+     - Stabile Version, kostenorientiert
    * - ``gemini-2.5-pro``
      - Mittel
-     - Sehr hoch
-     - Komplexe Schlussfolgerungen, wenn hohe Qualität erforderlich
-   * - ``gemini-1.5-flash``
-     - Schnell
-     - Gut
-     - Kostenorientiert, Stabilitätsorientiert
-   * - ``gemini-1.5-pro``
-     - Mittel
      - Hoch
-     - Wenn langer Kontext erforderlich ist
+     - Stabile Version, langer Kontext
 
 Kontextfenster
 --------------
 
 Gemini-Modelle unterstützen sehr lange Kontextfenster:
 
-- **Gemini 1.5/2.5 Flash**: Bis zu 1 Million Token
-- **Gemini 1.5/2.5 Pro**: Bis zu 2 Millionen Token
+- **Gemini 3 Flash / 2.5 Flash**: Bis zu 1 Million Token
+- **Gemini 3.1 Pro / 2.5 Pro**: Bis zu 1 Million Token (3.1 Pro) / 2 Millionen Token (2.5 Pro)
 
 Diese Eigenschaft ermöglicht es, mehr Suchergebnisse in den Kontext einzubeziehen.
 
@@ -230,15 +230,18 @@ Die Google AI API wird nutzungsbasiert abgerechnet (mit Gratiskontingent).
    * - Modell
      - Eingabe (1M Zeichen)
      - Ausgabe (1M Zeichen)
-   * - Gemini 1.5 Flash
+   * - Gemini 3 Flash Preview
+     - $0.50
+     - $3.00
+   * - Gemini 3.1 Pro Preview
+     - $2.00
+     - $12.00
+   * - Gemini 2.5 Flash
      - $0.075
      - $0.30
-   * - Gemini 1.5 Pro
+   * - Gemini 2.5 Pro
      - $1.25
      - $5.00
-   * - Gemini 2.5 Flash
-     - Preise können variieren
-     - Preise können variieren
 
 .. note::
    Aktuelle Preise und Informationen zum Gratiskontingent finden Sie unter `Google AI Pricing <https://ai.google.dev/pricing>`__.

--- a/en/15.5/config/llm-gemini.rst
+++ b/en/15.5/config/llm-gemini.rst
@@ -23,10 +23,10 @@ Supported Models
 
 Main models available with Gemini:
 
-- ``gemini-2.5-flash`` - Fast and efficient model (recommended)
-- ``gemini-2.5-pro`` - Model with higher reasoning capabilities
-- ``gemini-1.5-flash`` - Stable Flash model
-- ``gemini-1.5-pro`` - Stable Pro model
+- ``gemini-3-flash-preview`` - Latest fast model (recommended)
+- ``gemini-3.1-pro-preview`` - Latest high reasoning model
+- ``gemini-2.5-flash`` - Stable fast model
+- ``gemini-2.5-pro`` - Stable high reasoning model
 
 .. note::
    For the latest information on available models, see `Google AI for Developers <https://ai.google.dev/models/gemini>`__.
@@ -76,7 +76,7 @@ Minimal Configuration
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # Model to use
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
 Recommended Configuration (Production)
 --------------------------------------
@@ -93,7 +93,7 @@ Recommended Configuration (Production)
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # Model setting (use fast model)
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
     # API endpoint (usually no change needed)
     rag.llm.gemini.api.url=https://generativelanguage.googleapis.com/v1beta
@@ -118,7 +118,7 @@ All configuration options available for the Gemini client.
      - (Required)
    * - ``rag.llm.gemini.model``
      - Model name to use
-     - ``gemini-2.5-flash``
+     - ``gemini-3-flash-preview``
    * - ``rag.llm.gemini.api.url``
      - API base URL
      - ``https://generativelanguage.googleapis.com/v1beta``
@@ -150,7 +150,7 @@ docker-compose.yml
           - RAG_CHAT_ENABLED=true
           - RAG_LLM_TYPE=gemini
           - RAG_LLM_GEMINI_API_KEY=${GEMINI_API_KEY}
-          - RAG_LLM_GEMINI_MODEL=gemini-2.5-flash
+          - RAG_LLM_GEMINI_MODEL=gemini-3-flash-preview
 
 systemd Environment
 -------------------
@@ -185,30 +185,30 @@ Guidelines for selecting models based on intended use.
      - Speed
      - Quality
      - Use Case
+   * - ``gemini-3-flash-preview``
+     - Fast
+     - Highest
+     - General use (recommended)
+   * - ``gemini-3.1-pro-preview``
+     - Medium
+     - Highest
+     - Complex reasoning
    * - ``gemini-2.5-flash``
      - Fast
      - High
-     - General use, balanced approach (recommended)
+     - Stable version, cost-focused
    * - ``gemini-2.5-pro``
      - Medium
-     - Highest
-     - Complex reasoning, when high quality is needed
-   * - ``gemini-1.5-flash``
-     - Fast
-     - Good
-     - Cost-focused, stability-focused
-   * - ``gemini-1.5-pro``
-     - Medium
      - High
-     - When long context is needed
+     - Stable version, long context
 
 Context Window
 --------------
 
 Gemini models support very long context windows:
 
-- **Gemini 1.5/2.5 Flash**: Up to 1 million tokens
-- **Gemini 1.5/2.5 Pro**: Up to 2 million tokens
+- **Gemini 3 Flash / 2.5 Flash**: Up to 1 million tokens
+- **Gemini 3.1 Pro / 2.5 Pro**: Up to 1 million tokens (3.1 Pro) / 2 million tokens (2.5 Pro)
 
 You can leverage this feature to include more search results in the context.
 
@@ -230,15 +230,18 @@ Google AI API is billed based on usage (free tier available).
    * - Model
      - Input (per 1M characters)
      - Output (per 1M characters)
-   * - Gemini 1.5 Flash
+   * - Gemini 3 Flash Preview
+     - $0.50
+     - $3.00
+   * - Gemini 3.1 Pro Preview
+     - $2.00
+     - $12.00
+   * - Gemini 2.5 Flash
      - $0.075
      - $0.30
-   * - Gemini 1.5 Pro
+   * - Gemini 2.5 Pro
      - $1.25
      - $5.00
-   * - Gemini 2.5 Flash
-     - Prices may vary
-     - Prices may vary
 
 .. note::
    For the latest pricing and free tier information, see `Google AI Pricing <https://ai.google.dev/pricing>`__.

--- a/es/15.5/config/llm-gemini.rst
+++ b/es/15.5/config/llm-gemini.rst
@@ -23,10 +23,10 @@ Modelos compatibles
 
 Principales modelos disponibles en Gemini:
 
-- ``gemini-2.5-flash`` - Modelo rapido y eficiente (recomendado)
-- ``gemini-2.5-pro`` - Modelo con mayor capacidad de razonamiento
-- ``gemini-1.5-flash`` - Modelo Flash version estable
-- ``gemini-1.5-pro`` - Modelo Pro version estable
+- ``gemini-3-flash-preview`` - Ultimo modelo rapido (recomendado)
+- ``gemini-3.1-pro-preview`` - Ultimo modelo de alto razonamiento
+- ``gemini-2.5-flash`` - Modelo rapido version estable
+- ``gemini-2.5-pro`` - Modelo de alto razonamiento version estable
 
 .. note::
    Para la informacion mas reciente sobre modelos disponibles, consulte `Google AI for Developers <https://ai.google.dev/models/gemini>`__.
@@ -76,7 +76,7 @@ Configuracion minima
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # Modelo a usar
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
 Configuracion recomendada (entorno de produccion)
 -------------------------------------------------
@@ -93,7 +93,7 @@ Configuracion recomendada (entorno de produccion)
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # Configuracion del modelo (usar modelo rapido)
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
     # Endpoint de API (normalmente no necesita cambios)
     rag.llm.gemini.api.url=https://generativelanguage.googleapis.com/v1beta
@@ -118,7 +118,7 @@ Todas las opciones de configuracion disponibles para el cliente de Gemini.
      - (requerido)
    * - ``rag.llm.gemini.model``
      - Nombre del modelo a usar
-     - ``gemini-2.5-flash``
+     - ``gemini-3-flash-preview``
    * - ``rag.llm.gemini.api.url``
      - URL base de la API
      - ``https://generativelanguage.googleapis.com/v1beta``
@@ -150,7 +150,7 @@ docker-compose.yml
           - RAG_CHAT_ENABLED=true
           - RAG_LLM_TYPE=gemini
           - RAG_LLM_GEMINI_API_KEY=${GEMINI_API_KEY}
-          - RAG_LLM_GEMINI_MODEL=gemini-2.5-flash
+          - RAG_LLM_GEMINI_MODEL=gemini-3-flash-preview
 
 Entorno systemd
 ---------------
@@ -185,30 +185,30 @@ Guia para la seleccion de modelos segun el proposito de uso.
      - Velocidad
      - Calidad
      - Uso
+   * - ``gemini-3-flash-preview``
+     - Rapido
+     - Maxima
+     - Uso general (recomendado)
+   * - ``gemini-3.1-pro-preview``
+     - Medio
+     - Maxima
+     - Razonamiento complejo
    * - ``gemini-2.5-flash``
      - Rapido
      - Alta
-     - Uso general, enfasis en equilibrio (recomendado)
+     - Version estable, enfasis en costos
    * - ``gemini-2.5-pro``
      - Medio
-     - Maxima
-     - Razonamiento complejo, cuando se requiere alta calidad
-   * - ``gemini-1.5-flash``
-     - Rapido
-     - Buena
-     - Enfasis en costos, enfasis en estabilidad
-   * - ``gemini-1.5-pro``
-     - Medio
      - Alta
-     - Cuando se requiere contexto largo
+     - Version estable, contexto largo
 
 Ventana de contexto
 -------------------
 
 Los modelos Gemini soportan ventanas de contexto muy largas:
 
-- **Gemini 1.5/2.5 Flash**: Hasta 1 millon de tokens
-- **Gemini 1.5/2.5 Pro**: Hasta 2 millones de tokens
+- **Gemini 3 Flash / 2.5 Flash**: Hasta 1 millon de tokens
+- **Gemini 3.1 Pro / 2.5 Pro**: Hasta 1 millon de tokens (3.1 Pro) / 2 millones de tokens (2.5 Pro)
 
 Aprovechando esta caracteristica, puede incluir mas resultados de busqueda en el contexto.
 
@@ -230,15 +230,18 @@ La API de Google AI cobra segun el uso (con cuota gratuita disponible).
    * - Modelo
      - Entrada (1M caracteres)
      - Salida (1M caracteres)
-   * - Gemini 1.5 Flash
+   * - Gemini 3 Flash Preview
+     - $0.50
+     - $3.00
+   * - Gemini 3.1 Pro Preview
+     - $2.00
+     - $12.00
+   * - Gemini 2.5 Flash
      - $0.075
      - $0.30
-   * - Gemini 1.5 Pro
+   * - Gemini 2.5 Pro
      - $1.25
      - $5.00
-   * - Gemini 2.5 Flash
-     - Los precios pueden variar
-     - Los precios pueden variar
 
 .. note::
    Para los precios mas recientes e informacion sobre la cuota gratuita, consulte `Google AI Pricing <https://ai.google.dev/pricing>`__.

--- a/fr/15.5/config/llm-gemini.rst
+++ b/fr/15.5/config/llm-gemini.rst
@@ -23,10 +23,10 @@ Modeles pris en charge
 
 Principaux modeles disponibles avec Gemini :
 
-- ``gemini-2.5-flash`` - Modele rapide et efficace (recommande)
-- ``gemini-2.5-pro`` - Modele avec capacites de raisonnement superieures
-- ``gemini-1.5-flash`` - Version stable du modele Flash
-- ``gemini-1.5-pro`` - Version stable du modele Pro
+- ``gemini-3-flash-preview`` - Dernier modele rapide (recommande)
+- ``gemini-3.1-pro-preview`` - Dernier modele de raisonnement avance
+- ``gemini-2.5-flash`` - Version stable du modele rapide
+- ``gemini-2.5-pro`` - Version stable du modele de raisonnement
 
 .. note::
    Pour les derniers modeles disponibles, consultez `Google AI for Developers <https://ai.google.dev/models/gemini>`__.
@@ -76,7 +76,7 @@ Configuration minimale
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # Modele a utiliser
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
 Configuration recommandee (environnement de production)
 --------------------
@@ -93,7 +93,7 @@ Configuration recommandee (environnement de production)
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # Configuration du modele (utiliser le modele rapide)
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
     # Point de terminaison API (generalement pas besoin de modifier)
     rag.llm.gemini.api.url=https://generativelanguage.googleapis.com/v1beta
@@ -118,7 +118,7 @@ Tous les elements de configuration disponibles pour le client Gemini.
      - (Requis)
    * - ``rag.llm.gemini.model``
      - Nom du modele a utiliser
-     - ``gemini-2.5-flash``
+     - ``gemini-3-flash-preview``
    * - ``rag.llm.gemini.api.url``
      - URL de base de l'API
      - ``https://generativelanguage.googleapis.com/v1beta``
@@ -150,7 +150,7 @@ docker-compose.yml
           - RAG_CHAT_ENABLED=true
           - RAG_LLM_TYPE=gemini
           - RAG_LLM_GEMINI_API_KEY=${GEMINI_API_KEY}
-          - RAG_LLM_GEMINI_MODEL=gemini-2.5-flash
+          - RAG_LLM_GEMINI_MODEL=gemini-3-flash-preview
 
 Environnement systemd
 -----------
@@ -185,30 +185,30 @@ Guide pour la selection du modele selon l'usage.
      - Vitesse
      - Qualite
      - Usage
+   * - ``gemini-3-flash-preview``
+     - Rapide
+     - Maximale
+     - Usage general (recommande)
+   * - ``gemini-3.1-pro-preview``
+     - Moyenne
+     - Maximale
+     - Raisonnement complexe
    * - ``gemini-2.5-flash``
      - Rapide
      - Elevee
-     - Usage general, equilibre (recommande)
+     - Version stable, priorite au cout
    * - ``gemini-2.5-pro``
      - Moyenne
-     - Maximale
-     - Raisonnement complexe, haute qualite requise
-   * - ``gemini-1.5-flash``
-     - Rapide
-     - Bonne
-     - Priorite au cout, stabilite
-   * - ``gemini-1.5-pro``
-     - Moyenne
      - Elevee
-     - Long contexte requis
+     - Version stable, long contexte
 
 Fenetre de contexte
 ----------------------
 
 Les modeles Gemini prennent en charge des fenetres de contexte tres longues :
 
-- **Gemini 1.5/2.5 Flash** : Maximum 1 million de tokens
-- **Gemini 1.5/2.5 Pro** : Maximum 2 millions de tokens
+- **Gemini 3 Flash / 2.5 Flash** : Maximum 1 million de tokens
+- **Gemini 3.1 Pro / 2.5 Pro** : Maximum 1 million de tokens (3.1 Pro) / 2 millions de tokens (2.5 Pro)
 
 Cette caracteristique permet d'inclure davantage de resultats de recherche dans le contexte.
 
@@ -230,15 +230,18 @@ L'API Google AI est facturee a l'usage (avec une offre gratuite).
    * - Modele
      - Entree (1M caracteres)
      - Sortie (1M caracteres)
-   * - Gemini 1.5 Flash
+   * - Gemini 3 Flash Preview
+     - $0.50
+     - $3.00
+   * - Gemini 3.1 Pro Preview
+     - $2.00
+     - $12.00
+   * - Gemini 2.5 Flash
      - $0.075
      - $0.30
-   * - Gemini 1.5 Pro
+   * - Gemini 2.5 Pro
      - $1.25
      - $5.00
-   * - Gemini 2.5 Flash
-     - Les prix peuvent varier
-     - Les prix peuvent varier
 
 .. note::
    Pour les derniers prix et informations sur l'offre gratuite, consultez `Google AI Pricing <https://ai.google.dev/pricing>`__.

--- a/ja/15.5/config/llm-gemini.rst
+++ b/ja/15.5/config/llm-gemini.rst
@@ -23,10 +23,10 @@ Geminiを使用することで、Googleの最新AI技術を活用した高品質
 
 Geminiで利用可能な主なモデル:
 
-- ``gemini-2.5-flash`` - 高速で効率的なモデル（推奨）
-- ``gemini-2.5-pro`` - より高い推論能力を持つモデル
-- ``gemini-1.5-flash`` - 安定版のFlashモデル
-- ``gemini-1.5-pro`` - 安定版のProモデル
+- ``gemini-3-flash-preview`` - 最新の高速モデル（推奨）
+- ``gemini-3.1-pro-preview`` - 最新の高推論モデル
+- ``gemini-2.5-flash`` - 安定版の高速モデル
+- ``gemini-2.5-pro`` - 安定版の高推論モデル
 
 .. note::
    利用可能なモデルの最新情報は `Google AI for Developers <https://ai.google.dev/models/gemini>`__ で確認できます。
@@ -76,7 +76,7 @@ APIキーの取得
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # 使用するモデル
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
 推奨構成（本番環境）
 --------------------
@@ -93,7 +93,7 @@ APIキーの取得
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # モデル設定（高速モデルを使用）
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
     # APIエンドポイント（通常は変更不要）
     rag.llm.gemini.api.url=https://generativelanguage.googleapis.com/v1beta
@@ -118,7 +118,7 @@ Geminiクライアントで使用可能なすべての設定項目です。
      - （必須）
    * - ``rag.llm.gemini.model``
      - 使用するモデル名
-     - ``gemini-2.5-flash``
+     - ``gemini-3-flash-preview``
    * - ``rag.llm.gemini.api.url``
      - APIのベースURL
      - ``https://generativelanguage.googleapis.com/v1beta``
@@ -150,7 +150,7 @@ docker-compose.yml
           - RAG_CHAT_ENABLED=true
           - RAG_LLM_TYPE=gemini
           - RAG_LLM_GEMINI_API_KEY=${GEMINI_API_KEY}
-          - RAG_LLM_GEMINI_MODEL=gemini-2.5-flash
+          - RAG_LLM_GEMINI_MODEL=gemini-3-flash-preview
 
 systemd環境
 -----------
@@ -185,30 +185,30 @@ Vertex AIを使用する場合は、APIエンドポイントと認証方法が�
      - 速度
      - 品質
      - 用途
+   * - ``gemini-3-flash-preview``
+     - 高速
+     - 最高
+     - 一般的な用途（推奨）
+   * - ``gemini-3.1-pro-preview``
+     - 中速
+     - 最高
+     - 複雑な推論
    * - ``gemini-2.5-flash``
      - 高速
      - 高
-     - 一般的な用途、バランス重視（推奨）
+     - 安定版、コスト重視
    * - ``gemini-2.5-pro``
      - 中速
-     - 最高
-     - 複雑な推論、高品質が必要な場合
-   * - ``gemini-1.5-flash``
-     - 高速
-     - 良好
-     - コスト重視、安定性重視
-   * - ``gemini-1.5-pro``
-     - 中速
      - 高
-     - 長いコンテキストが必要な場合
+     - 安定版、長いコンテキスト
 
 コンテキストウィンドウ
 ----------------------
 
 Geminiモデルは非常に長いコンテキストウィンドウをサポートしています:
 
-- **Gemini 1.5/2.5 Flash**: 最大100万トークン
-- **Gemini 1.5/2.5 Pro**: 最大200万トークン
+- **Gemini 3 Flash / 2.5 Flash**: 最大100万トークン
+- **Gemini 3.1 Pro / 2.5 Pro**: 最大100万トークン（3.1 Pro）/ 200万トークン（2.5 Pro）
 
 この特徴を活かして、より多くの検索結果をコンテキストに含めることができます。
 
@@ -230,15 +230,18 @@ Google AI APIは使用量に基づいて課金されます（無料枠あり）�
    * - モデル
      - 入力（100万文字）
      - 出力（100万文字）
-   * - Gemini 1.5 Flash
+   * - Gemini 3 Flash Preview
+     - $0.50
+     - $3.00
+   * - Gemini 3.1 Pro Preview
+     - $2.00
+     - $12.00
+   * - Gemini 2.5 Flash
      - $0.075
      - $0.30
-   * - Gemini 1.5 Pro
+   * - Gemini 2.5 Pro
      - $1.25
      - $5.00
-   * - Gemini 2.5 Flash
-     - 価格は変動する場合あり
-     - 価格は変動する場合あり
 
 .. note::
    最新の価格と無料枠の情報は `Google AI Pricing <https://ai.google.dev/pricing>`__ で確認してください。

--- a/ko/15.5/config/llm-gemini.rst
+++ b/ko/15.5/config/llm-gemini.rst
@@ -23,10 +23,10 @@ Gemini를 사용하면 Google의 최신 AI 기술을 활용한 고품질 응답 
 
 Gemini에서 이용 가능한 주요 모델:
 
-- ``gemini-2.5-flash`` - 빠르고 효율적인 모델(권장)
-- ``gemini-2.5-pro`` - 더 높은 추론 능력을 가진 모델
-- ``gemini-1.5-flash`` - 안정 버전의 Flash 모델
-- ``gemini-1.5-pro`` - 안정 버전의 Pro 모델
+- ``gemini-3-flash-preview`` - 최신 고속 모델(권장)
+- ``gemini-3.1-pro-preview`` - 최신 고추론 모델
+- ``gemini-2.5-flash`` - 안정 버전의 고속 모델
+- ``gemini-2.5-pro`` - 안정 버전의 고추론 모델
 
 .. note::
    이용 가능한 모델의 최신 정보는 `Google AI for Developers <https://ai.google.dev/models/gemini>`__에서 확인할 수 있습니다.
@@ -76,7 +76,7 @@ API 키 발급
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # 사용할 모델
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
 권장 구성(프로덕션 환경)
 --------------------
@@ -93,7 +93,7 @@ API 키 발급
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # 모델 설정(고속 모델 사용)
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
     # API 엔드포인트(일반적으로 변경 불필요)
     rag.llm.gemini.api.url=https://generativelanguage.googleapis.com/v1beta
@@ -118,7 +118,7 @@ Gemini 클라이언트에서 사용 가능한 모든 설정 항목입니다.
      - (필수)
    * - ``rag.llm.gemini.model``
      - 사용할 모델명
-     - ``gemini-2.5-flash``
+     - ``gemini-3-flash-preview``
    * - ``rag.llm.gemini.api.url``
      - API의 기본 URL
      - ``https://generativelanguage.googleapis.com/v1beta``
@@ -150,7 +150,7 @@ docker-compose.yml
           - RAG_CHAT_ENABLED=true
           - RAG_LLM_TYPE=gemini
           - RAG_LLM_GEMINI_API_KEY=${GEMINI_API_KEY}
-          - RAG_LLM_GEMINI_MODEL=gemini-2.5-flash
+          - RAG_LLM_GEMINI_MODEL=gemini-3-flash-preview
 
 systemd 환경
 -----------
@@ -185,30 +185,30 @@ Vertex AI를 사용하는 경우 API 엔드포인트와 인증 방법이 다릅�
      - 속도
      - 품질
      - 용도
+   * - ``gemini-3-flash-preview``
+     - 고속
+     - 최고
+     - 일반적인 용도(권장)
+   * - ``gemini-3.1-pro-preview``
+     - 중속
+     - 최고
+     - 복잡한 추론
    * - ``gemini-2.5-flash``
      - 고속
      - 높음
-     - 일반적인 용도, 균형 중시(권장)
+     - 안정 버전, 비용 중시
    * - ``gemini-2.5-pro``
      - 중속
-     - 최고
-     - 복잡한 추론, 고품질이 필요한 경우
-   * - ``gemini-1.5-flash``
-     - 고속
-     - 양호
-     - 비용 중시, 안정성 중시
-   * - ``gemini-1.5-pro``
-     - 중속
      - 높음
-     - 긴 컨텍스트가 필요한 경우
+     - 안정 버전, 긴 컨텍스트
 
 컨텍스트 윈도우
 ----------------------
 
 Gemini 모델은 매우 긴 컨텍스트 윈도우를 지원합니다:
 
-- **Gemini 1.5/2.5 Flash**: 최대 100만 토큰
-- **Gemini 1.5/2.5 Pro**: 최대 200만 토큰
+- **Gemini 3 Flash / 2.5 Flash**: 최대 100만 토큰
+- **Gemini 3.1 Pro / 2.5 Pro**: 최대 100만 토큰(3.1 Pro) / 200만 토큰(2.5 Pro)
 
 이 특징을 활용하여 더 많은 검색 결과를 컨텍스트에 포함할 수 있습니다.
 
@@ -230,15 +230,18 @@ Google AI API는 사용량에 따라 요금이 부과됩니다(무료 할당량 
    * - 모델
      - 입력(100만 문자)
      - 출력(100만 문자)
-   * - Gemini 1.5 Flash
+   * - Gemini 3 Flash Preview
+     - $0.50
+     - $3.00
+   * - Gemini 3.1 Pro Preview
+     - $2.00
+     - $12.00
+   * - Gemini 2.5 Flash
      - $0.075
      - $0.30
-   * - Gemini 1.5 Pro
+   * - Gemini 2.5 Pro
      - $1.25
      - $5.00
-   * - Gemini 2.5 Flash
-     - 가격 변동 가능
-     - 가격 변동 가능
 
 .. note::
    최신 가격 및 무료 할당량 정보는 `Google AI Pricing <https://ai.google.dev/pricing>`__에서 확인하세요.

--- a/zh-cn/15.5/config/llm-gemini.rst
+++ b/zh-cn/15.5/config/llm-gemini.rst
@@ -23,10 +23,10 @@ Google Gemini是Google公司提供的最先进的大型语言模型（LLM）。
 
 Gemini可用的主要模型:
 
-- ``gemini-2.5-flash`` - 高速高效的模型（推荐）
-- ``gemini-2.5-pro`` - 具有更高推理能力的模型
-- ``gemini-1.5-flash`` - 稳定版Flash模型
-- ``gemini-1.5-pro`` - 稳定版Pro模型
+- ``gemini-3-flash-preview`` - 最新高速模型（推荐）
+- ``gemini-3.1-pro-preview`` - 最新高推理模型
+- ``gemini-2.5-flash`` - 稳定版高速模型
+- ``gemini-2.5-pro`` - 稳定版高推理模型
 
 .. note::
    可用模型的最新信息请查阅 `Google AI for Developers <https://ai.google.dev/models/gemini>`__
@@ -76,7 +76,7 @@ Gemini可用的主要模型:
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # 使用的模型
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
 推荐配置（生产环境）
 --------------------
@@ -93,7 +93,7 @@ Gemini可用的主要模型:
     rag.llm.gemini.api.key=AIzaSyxxxxxxxxxxxxxxxxxxxxxxxxx
 
     # 模型设置（使用高速模型）
-    rag.llm.gemini.model=gemini-2.5-flash
+    rag.llm.gemini.model=gemini-3-flash-preview
 
     # API端点（通常无需更改）
     rag.llm.gemini.api.url=https://generativelanguage.googleapis.com/v1beta
@@ -118,7 +118,7 @@ Gemini客户端可用的所有配置项。
      - （必需）
    * - ``rag.llm.gemini.model``
      - 使用的模型名称
-     - ``gemini-2.5-flash``
+     - ``gemini-3-flash-preview``
    * - ``rag.llm.gemini.api.url``
      - API的基础URL
      - ``https://generativelanguage.googleapis.com/v1beta``
@@ -150,7 +150,7 @@ docker-compose.yml
           - RAG_CHAT_ENABLED=true
           - RAG_LLM_TYPE=gemini
           - RAG_LLM_GEMINI_API_KEY=${GEMINI_API_KEY}
-          - RAG_LLM_GEMINI_MODEL=gemini-2.5-flash
+          - RAG_LLM_GEMINI_MODEL=gemini-3-flash-preview
 
 systemd环境
 -----------
@@ -185,30 +185,30 @@ systemd环境
      - 速度
      - 质量
      - 用途
+   * - ``gemini-3-flash-preview``
+     - 高速
+     - 最高
+     - 一般用途（推荐）
+   * - ``gemini-3.1-pro-preview``
+     - 中速
+     - 最高
+     - 复杂推理
    * - ``gemini-2.5-flash``
      - 高速
      - 高
-     - 一般用途、平衡优先（推荐）
+     - 稳定版、成本优先
    * - ``gemini-2.5-pro``
      - 中速
-     - 最高
-     - 复杂推理、需要高质量
-   * - ``gemini-1.5-flash``
-     - 高速
-     - 良好
-     - 成本优先、稳定性优先
-   * - ``gemini-1.5-pro``
-     - 中速
      - 高
-     - 需要长上下文
+     - 稳定版、长上下文
 
 上下文窗口
 ----------
 
 Gemini模型支持非常长的上下文窗口:
 
-- **Gemini 1.5/2.5 Flash**: 最大100万令牌
-- **Gemini 1.5/2.5 Pro**: 最大200万令牌
+- **Gemini 3 Flash / 2.5 Flash**: 最大100万令牌
+- **Gemini 3.1 Pro / 2.5 Pro**: 最大100万令牌（3.1 Pro）/ 200万令牌（2.5 Pro）
 
 利用此特性，可以在上下文中包含更多搜索结果。
 
@@ -230,15 +230,18 @@ Google AI API按使用量计费（有免费额度）。
    * - 模型
      - 输入（100万字符）
      - 输出（100万字符）
-   * - Gemini 1.5 Flash
+   * - Gemini 3 Flash Preview
+     - $0.50
+     - $3.00
+   * - Gemini 3.1 Pro Preview
+     - $2.00
+     - $12.00
+   * - Gemini 2.5 Flash
      - $0.075
      - $0.30
-   * - Gemini 1.5 Pro
+   * - Gemini 2.5 Pro
      - $1.25
      - $5.00
-   * - Gemini 2.5 Flash
-     - 价格可能变动
-     - 价格可能变动
 
 .. note::
    最新价格和免费额度信息请查阅 `Google AI Pricing <https://ai.google.dev/pricing>`__


### PR DESCRIPTION
## Summary

Update the Gemini LLM configuration documentation for version 15.5 across all 7 supported languages (ja, en, de, es, fr, ko, zh-cn) to reflect the latest available models.

## Changes Made

- Added `gemini-3-flash-preview` as the new recommended fast model (replacing `gemini-2.5-flash` as default)
- Added `gemini-3.1-pro-preview` as the latest high-reasoning model
- Demoted `gemini-2.5-flash` and `gemini-2.5-pro` to "stable version" status in model listings
- Removed outdated `gemini-1.5-flash` and `gemini-1.5-pro` model references
- Updated default model in all configuration examples to `gemini-3-flash-preview`
- Added pricing rows for new models (Gemini 3 Flash Preview: $0.50/$3.00, Gemini 3.1 Pro Preview: $2.00/$12.00)
- Updated context window section to reflect Gemini 3 / 2.5 naming
- Updated model comparison table with revised quality ratings and use case descriptions

## Testing

Documentation-only change; no functional code modified. Visual review of RST formatting is recommended.

## Additional Notes

- Changes are consistent across all 7 language variants: `de`, `en`, `es`, `fr`, `ja`, `ko`, `zh-cn`
- All changes are in `{lang}/15.5/config/llm-gemini.rst`