### PR TITLE
docs(guide): simplify article descriptions across all languages

### DIFF
--- a/de/guide.rst
+++ b/de/guide.rst
@@ -10,41 +10,41 @@ Diese 23-teilige Serie behandelt alles von der Fess-Einfuehrung bis zur KI-Integ
 
 **Grundlagen (Fuer Einsteiger)**
 
-- :doc:`articles/guide-01` - Teil 1: Warum Unternehmen eine Suchinfrastruktur brauchen -- Herausforderungen der Wissensnutzung im Zeitalter der Informationsflut
-- :doc:`articles/guide-02` - Teil 2: Sucherlebnis in 5 Minuten -- Erster Kontakt mit Fess ueber Docker Compose
-- :doc:`articles/guide-03` - Teil 3: Suche in ein internes Portal einbetten -- Suchfunktion zu bestehenden Websites hinzufuegen
-- :doc:`articles/guide-04` - Teil 4: Verstreute Dateien einheitlich durchsuchen -- Quellenuebergreifende Suche aufbauen
-- :doc:`articles/guide-05` - Teil 5: Suche an den Nutzer anpassen -- Abteilungs- und berechtigungsbasierte Suchergebnissteuerung
+- :doc:`articles/guide-01` - Warum Unternehmen Volltextsuche benoetigen und welche Herausforderungen bei verteilten Informationen bestehen
+- :doc:`articles/guide-02` - Schnellstart: Fess mit Docker Compose in wenigen Minuten starten und Suche erleben
+- :doc:`articles/guide-03` - Drei Muster fuer die Einbettung von Such-Widgets in bestehende Websites
+- :doc:`articles/guide-04` - Quellenuebergreifende Suche ueber Dateiserver und Cloud-Speicher aufbauen
+- :doc:`articles/guide-05` - Suchergebnisse nach Rolle, Label, Abteilung und Berechtigungen filtern
 
 **Praxisloesungen (Fuer Fortgeschrittene)**
 
-- :doc:`articles/guide-06` - Teil 6: Knowledge Hub fuer Entwicklungsteams -- Code, Wiki und Tickets einheitlich durchsuchen
-- :doc:`articles/guide-07` - Teil 7: Suchstrategie fuer Cloud-Speicher -- Google Drive, SharePoint und Box uebergreifend durchsuchen
-- :doc:`articles/guide-08` - Teil 8: Suchqualitaet verbessern -- Tuning-Zyklen basierend auf Nutzerverhaltensdaten
-- :doc:`articles/guide-09` - Teil 9: Suchinfrastruktur fuer mehrsprachige Organisationen -- Dokumente in mehreren Sprachen korrekt durchsuchen
-- :doc:`articles/guide-10` - Teil 10: Stabiler Betrieb eines Suchsystems -- Ueberwachung, Backup und Ausfallsicherheit
-- :doc:`articles/guide-11` - Teil 11: Bestehende Systeme mit der Such-API erweitern -- Integrationsmuster fuer CRM und interne Systeme
-- :doc:`articles/guide-12` - Teil 12: SaaS-Daten durchsuchbar machen -- Integrationsszenarien mit Salesforce und Datenbanken
+- :doc:`articles/guide-06` - Einheitliche Suche ueber Git-Repos, Wikis, Tickets und Chat fuer Entwicklungsteams
+- :doc:`articles/guide-07` - Konfiguration und Betrieb der uebergreifenden Suche fuer Google Drive, SharePoint und Box
+- :doc:`articles/guide-08` - Kontinuierliche Suchqualitaetsverbesserung durch Loganalyse und Tuning
+- :doc:`articles/guide-09` - Analyzer-Konfiguration fuer die korrekte Suche in japanischen, englischen und chinesischen Dokumenten
+- :doc:`articles/guide-10` - Best Practices fuer Monitoring, Backup und Ausfallsicherheit im Produktivbetrieb
+- :doc:`articles/guide-11` - REST-API-Integrationsmuster fuer CRM und interne Geschaeftssysteme
+- :doc:`articles/guide-12` - Daten aus Salesforce, Datenbanken und anderen SaaS-Plattformen indexieren
 
 **Architektur und Skalierung (Fuer Experten)**
 
-- :doc:`articles/guide-13` - Teil 13: Multi-Tenant-Suchplattform -- Eine Fess-Instanz fuer mehrere Organisationen
-- :doc:`articles/guide-14` - Teil 14: Skalierungsstrategie fuer Suchsysteme -- Schrittweise Erweiterung von klein zu gross
-- :doc:`articles/guide-15` - Teil 15: Sichere Suchinfrastruktur -- SSO-Integration und Zugriffssteuerung in Zero-Trust-Umgebungen
-- :doc:`articles/guide-16` - Teil 16: Automatisierung der Suchinfrastruktur -- Verwaltung mit CI/CD-Pipelines und Infrastructure as Code
-- :doc:`articles/guide-17` - Teil 17: Suche mit Plugins erweitern -- Eigene Datenquellen und Ingest-Pipelines implementieren
+- :doc:`articles/guide-13` - Multi-Tenant-Design: mehrere Organisationen mit einer Fess-Instanz bedienen
+- :doc:`articles/guide-14` - Schrittweise Skalierung vom Einzelserver zur Cluster-Architektur
+- :doc:`articles/guide-15` - SSO-Integration (OIDC/SAML) und Zugriffssteuerung in Zero-Trust-Umgebungen
+- :doc:`articles/guide-16` - Konfiguration als Code und automatisiertes Deployment ueber CI/CD-Pipelines
+- :doc:`articles/guide-17` - Eigene Datenquellen-Plugins und Ingest-Pipelines implementieren
 
 **KI und Next-Generation-Suche (Fuer Experten)**
 
-- :doc:`articles/guide-18` - Teil 18: Grundlagen der KI-Suche -- Von der Stichwortsuche zur semantischen Suche
-- :doc:`articles/guide-19` - Teil 19: Internen KI-Assistenten aufbauen -- RAG-basiertes Frage-Antwort-System
-- :doc:`articles/guide-20` - Teil 20: KI-Agenten und Suche verbinden -- Fess ueber MCP-Server in externe KI-Tools integrieren
-- :doc:`articles/guide-21` - Teil 21: Bilder und Text uebergreifend durchsuchen -- Multimodale Suche fuer Next-Generation-Wissensmanagement
-- :doc:`articles/guide-22` - Teil 22: Organisationswissen aus Suchdaten kartieren -- Analyse-Dashboard fuer die Informationsnutzung
+- :doc:`articles/guide-18` - Ueberblick ueber die Entwicklung von Stichwortsuche zu Vektor- und semantischer Suche
+- :doc:`articles/guide-19` - Internes Frage-Antwort-System mit RAG auf Basis von Unternehmensdokumenten aufbauen
+- :doc:`articles/guide-20` - Fess als MCP-Server mit Claude und anderen KI-Tools integrieren
+- :doc:`articles/guide-21` - Multimodale Suche ueber Text und Bilder mittels Vektor-Embeddings
+- :doc:`articles/guide-22` - Informationsnutzung mit OpenSearch-Dashboards-Analysen visualisieren
 
 **Zusammenfassung**
 
-- :doc:`articles/guide-23` - Teil 23: Bauplan fuer eine unternehmensweite Wissensplattform -- Gesamtarchitektur mit Fess als Kern
+- :doc:`articles/guide-23` - Referenzarchitektur fuer eine unternehmensweite Wissensplattform auf Fess-Basis
 
 Anwendungsfaelle und Beispiele
 ==============================

--- a/en/guide.rst
+++ b/en/guide.rst
@@ -10,41 +10,41 @@ This 23-part series covers everything from Fess deployment to AI integration, dr
 
 **Fundamentals (For Beginners)**
 
-- :doc:`articles/guide-01` - Part 1: Why Enterprises Need Search -- Knowledge Utilization in the Age of Information Overload
-- :doc:`articles/guide-02` - Part 2: 5-Minute Search Experience -- First Contact with Fess Using Docker Compose
-- :doc:`articles/guide-03` - Part 3: Embedding Search into an Internal Portal -- Adding Search to Existing Websites
-- :doc:`articles/guide-04` - Part 4: Unified Search Across Scattered Files -- Building Cross-Search for Multi-Source Environments
-- :doc:`articles/guide-05` - Part 5: Tailoring Search to Users -- Role-Based Search Result Control
+- :doc:`articles/guide-01` - Why enterprise search matters and the challenges of scattered information
+- :doc:`articles/guide-02` - Quick start: launch Fess with Docker Compose and experience search in minutes
+- :doc:`articles/guide-03` - Three patterns for embedding search widgets into existing websites
+- :doc:`articles/guide-04` - Build cross-source search across file servers and cloud storage
+- :doc:`articles/guide-05` - Filter search results by role, label, department, and permissions
 
 **Practical Solutions (For Intermediate Users)**
 
-- :doc:`articles/guide-06` - Part 6: A Knowledge Hub for Development Teams -- Unified Search Across Code, Wiki, and Tickets
-- :doc:`articles/guide-07` - Part 7: Search Strategy for the Cloud Storage Era -- Cross-Search Across Google Drive, SharePoint, and Box
-- :doc:`articles/guide-08` - Part 8: Growing Search Quality -- Search Tuning Cycles Based on User Behavior Data
-- :doc:`articles/guide-09` - Part 9: Search Infrastructure for Multilingual Organizations -- Building an Environment to Properly Search Documents in Multiple Languages
-- :doc:`articles/guide-10` - Part 10: Stable Operation of a Search System -- Monitoring, Backup, and Disaster Recovery in Practice
-- :doc:`articles/guide-11` - Part 11: Extending Existing Systems with the Search API -- Integration Patterns with CRM and Internal Systems
-- :doc:`articles/guide-12` - Part 12: Making SaaS Data Searchable -- Integration Scenarios with Salesforce and Databases
+- :doc:`articles/guide-06` - Unified search across Git repos, wikis, tickets, and chat for dev teams
+- :doc:`articles/guide-07` - Configure and operate cross-search for Google Drive, SharePoint, and Box
+- :doc:`articles/guide-08` - Continuous search quality improvement through log analysis and tuning
+- :doc:`articles/guide-09` - Analyzer configuration for correctly searching Japanese, English, and Chinese documents
+- :doc:`articles/guide-10` - Production best practices for monitoring, backup, and disaster recovery
+- :doc:`articles/guide-11` - REST API integration patterns for CRM and internal business systems
+- :doc:`articles/guide-12` - Index data from Salesforce, databases, and other SaaS platforms
 
 **Architecture & Scaling (For Advanced Users)**
 
-- :doc:`articles/guide-13` - Part 13: Multi-Tenant Search Platform -- Designing a Single Fess Instance to Serve Multiple Organizations
-- :doc:`articles/guide-14` - Part 14: Scaling Strategy for Search Systems -- Gradual Expansion from Small to Large Scale
-- :doc:`articles/guide-15` - Part 15: Secure Search Infrastructure -- SSO Integration and Search Access Control in Zero Trust Environments
-- :doc:`articles/guide-16` - Part 16: Automating Search Infrastructure -- Management with CI/CD Pipelines and Infrastructure as Code
-- :doc:`articles/guide-17` - Part 17: Extending Search with Plugins -- Implementing Custom Data Sources and Ingest Pipelines
+- :doc:`articles/guide-13` - Multi-tenant design to serve multiple organizations from a single Fess instance
+- :doc:`articles/guide-14` - Step-by-step scaling from single server to cluster architecture
+- :doc:`articles/guide-15` - SSO (OIDC/SAML) integration and access control in zero-trust environments
+- :doc:`articles/guide-16` - Configuration as code and automated deployment via CI/CD pipelines
+- :doc:`articles/guide-17` - Implement custom data source plugins and Ingest pipelines
 
 **AI & Next-Generation Search (For Advanced Users)**
 
-- :doc:`articles/guide-18` - Part 18: Foundations of AI Search -- Evolution from Keyword Search to Semantic Search
-- :doc:`articles/guide-19` - Part 19: Building an Internal AI Assistant -- RAG-Powered Question Answering System
-- :doc:`articles/guide-20` - Part 20: Connecting AI Agents and Search -- Integrating Fess into External AI Tools via MCP Server
-- :doc:`articles/guide-21` - Part 21: Cross-Search Across Images and Text -- Next-Generation Knowledge Management with Multimodal Search
-- :doc:`articles/guide-22` - Part 22: Mapping Organizational Knowledge from Search Data -- Analytics Dashboard for Information Utilization
+- :doc:`articles/guide-18` - Overview of the evolution from keyword search to vector and semantic search
+- :doc:`articles/guide-19` - Build an internal Q&A system using RAG over corporate documents
+- :doc:`articles/guide-20` - Integrate Fess as an MCP server with Claude and other AI tools
+- :doc:`articles/guide-21` - Multimodal search across text and images using vector embeddings
+- :doc:`articles/guide-22` - Visualize information utilization with OpenSearch Dashboards analytics
 
 **Conclusion**
 
-- :doc:`articles/guide-23` - Part 23: Blueprint for an Enterprise Knowledge Platform -- Grand Design of an Information Utilization Infrastructure with Fess at Its Core
+- :doc:`articles/guide-23` - Reference architecture for an enterprise-wide knowledge platform built on Fess
 
 Use Cases & Examples
 ====================

--- a/es/guide.rst
+++ b/es/guide.rst
@@ -10,41 +10,41 @@ Esta serie de 23 partes cubre desde la implementacion de Fess hasta la integraci
 
 **Fundamentos (Para principiantes)**
 
-- :doc:`articles/guide-01` - Parte 1: Por que las empresas necesitan busqueda -- Desafios del aprovechamiento del conocimiento en la era de la sobrecarga de informacion
-- :doc:`articles/guide-02` - Parte 2: Experiencia de busqueda en 5 minutos -- Primer contacto con Fess usando Docker Compose
-- :doc:`articles/guide-03` - Parte 3: Integrar busqueda en un portal interno -- Agregar funcionalidad de busqueda a sitios web existentes
-- :doc:`articles/guide-04` - Parte 4: Busqueda unificada de archivos dispersos -- Construccion de busqueda transversal en entornos multi-fuente
-- :doc:`articles/guide-05` - Parte 5: Adaptar la busqueda al usuario -- Control de resultados por departamento y permisos
+- :doc:`articles/guide-01` - Por que la busqueda empresarial es importante y los desafios de la informacion dispersa
+- :doc:`articles/guide-02` - Inicio rapido: lanzar Fess con Docker Compose y experimentar la busqueda en minutos
+- :doc:`articles/guide-03` - Tres patrones para integrar widgets de busqueda en sitios web existentes
+- :doc:`articles/guide-04` - Construir busqueda transversal entre servidores de archivos y almacenamiento en la nube
+- :doc:`articles/guide-05` - Filtrado de resultados de busqueda por rol, etiqueta, departamento y permisos
 
 **Soluciones practicas (Para nivel intermedio)**
 
-- :doc:`articles/guide-06` - Parte 6: Hub de conocimiento para equipos de desarrollo -- Busqueda integrada de codigo, wiki y tickets
-- :doc:`articles/guide-07` - Parte 7: Estrategia de busqueda para almacenamiento en la nube -- Busqueda transversal en Google Drive, SharePoint y Box
-- :doc:`articles/guide-08` - Parte 8: Mejorar la calidad de busqueda -- Ciclos de ajuste basados en datos de comportamiento del usuario
-- :doc:`articles/guide-09` - Parte 9: Infraestructura de busqueda para organizaciones multilingues -- Busqueda correcta de documentos en multiples idiomas
-- :doc:`articles/guide-10` - Parte 10: Operacion estable de un sistema de busqueda -- Monitoreo, respaldo y recuperacion ante desastres
-- :doc:`articles/guide-11` - Parte 11: Extender sistemas existentes con la API de busqueda -- Patrones de integracion con CRM y sistemas internos
-- :doc:`articles/guide-12` - Parte 12: Hacer buscables los datos SaaS -- Escenarios de integracion con Salesforce y bases de datos
+- :doc:`articles/guide-06` - Busqueda unificada de repositorios Git, wikis, tickets y chat para equipos de desarrollo
+- :doc:`articles/guide-07` - Configuracion y operacion de busqueda transversal en Google Drive, SharePoint y Box
+- :doc:`articles/guide-08` - Ciclo de mejora continua de calidad de busqueda mediante analisis de logs
+- :doc:`articles/guide-09` - Configuracion de analizadores para buscar correctamente documentos en japones, ingles y chino
+- :doc:`articles/guide-10` - Mejores practicas de monitoreo, respaldo y recuperacion ante desastres en produccion
+- :doc:`articles/guide-11` - Patrones de integracion API REST con CRM y sistemas internos de negocio
+- :doc:`articles/guide-12` - Indexacion de datos de Salesforce, bases de datos y otras plataformas SaaS
 
 **Arquitectura y escalamiento (Para nivel avanzado)**
 
-- :doc:`articles/guide-13` - Parte 13: Plataforma de busqueda multi-tenant -- Diseno de una instancia Fess para multiples organizaciones
-- :doc:`articles/guide-14` - Parte 14: Estrategia de escalamiento para sistemas de busqueda -- Expansion gradual de pequena a gran escala
-- :doc:`articles/guide-15` - Parte 15: Infraestructura de busqueda segura -- Integracion SSO y control de acceso en entornos Zero Trust
-- :doc:`articles/guide-16` - Parte 16: Automatizacion de la infraestructura de busqueda -- Gestion con pipelines CI/CD e Infrastructure as Code
-- :doc:`articles/guide-17` - Parte 17: Extender la busqueda con plugins -- Implementacion de fuentes de datos personalizadas y pipelines de ingesta
+- :doc:`articles/guide-13` - Diseno multi-tenant para servir multiples organizaciones desde una sola instancia Fess
+- :doc:`articles/guide-14` - Estrategia de escalamiento gradual de servidor unico a arquitectura de cluster
+- :doc:`articles/guide-15` - Integracion SSO (OIDC/SAML) y control de acceso en entornos Zero Trust
+- :doc:`articles/guide-16` - Gestion de configuracion como codigo y despliegue automatizado via pipelines CI/CD
+- :doc:`articles/guide-17` - Implementacion de plugins de fuentes de datos personalizadas y pipelines de ingesta
 
 **IA y busqueda de proxima generacion (Para nivel avanzado)**
 
-- :doc:`articles/guide-18` - Parte 18: Fundamentos de la busqueda con IA -- Evolucion de la busqueda por palabras clave a la busqueda semantica
-- :doc:`articles/guide-19` - Parte 19: Construccion de un asistente de IA interno -- Sistema de preguntas y respuestas basado en RAG
-- :doc:`articles/guide-20` - Parte 20: Conectar agentes de IA y busqueda -- Integrar Fess en herramientas de IA externas via servidor MCP
-- :doc:`articles/guide-21` - Parte 21: Busqueda transversal de imagenes y texto -- Gestion del conocimiento de proxima generacion con busqueda multimodal
-- :doc:`articles/guide-22` - Parte 22: Mapear el conocimiento organizacional desde datos de busqueda -- Dashboard de analisis de utilizacion de informacion
+- :doc:`articles/guide-18` - Panorama de la evolucion de busqueda por palabras clave a busqueda vectorial y semantica
+- :doc:`articles/guide-19` - Construir un sistema de preguntas y respuestas interno con RAG sobre documentos corporativos
+- :doc:`articles/guide-20` - Integrar Fess como servidor MCP con Claude y otras herramientas de IA
+- :doc:`articles/guide-21` - Busqueda multimodal de texto e imagenes mediante embeddings vectoriales
+- :doc:`articles/guide-22` - Visualizar el uso de informacion con analiticas de OpenSearch Dashboards
 
 **Conclusion**
 
-- :doc:`articles/guide-23` - Parte 23: Plano para una plataforma de conocimiento empresarial -- Gran diseno de infraestructura de informacion con Fess como nucleo
+- :doc:`articles/guide-23` - Arquitectura de referencia para una plataforma de conocimiento empresarial basada en Fess
 
 Casos de uso y ejemplos
 ========================

--- a/fr/guide.rst
+++ b/fr/guide.rst
@@ -10,41 +10,41 @@ Cette serie en 23 parties couvre tout, du deploiement de Fess a l'integration de
 
 **Fondamentaux (Pour debutants)**
 
-- :doc:`articles/guide-01` - Partie 1 : Pourquoi les entreprises ont besoin de la recherche -- Les defis de l'exploitation des connaissances a l'ere de la surcharge informationnelle
-- :doc:`articles/guide-02` - Partie 2 : Experience de recherche en 5 minutes -- Premier contact avec Fess via Docker Compose
-- :doc:`articles/guide-03` - Partie 3 : Integrer la recherche dans un portail interne -- Ajouter une fonction de recherche a un site web existant
-- :doc:`articles/guide-04` - Partie 4 : Recherche unifiee de fichiers disperses -- Construction d'une recherche transversale multi-sources
-- :doc:`articles/guide-05` - Partie 5 : Adapter la recherche aux utilisateurs -- Controle des resultats par departement et par permissions
+- :doc:`articles/guide-01` - Pourquoi la recherche est essentielle en entreprise et les defis de l'information dispersee
+- :doc:`articles/guide-02` - Demarrage rapide : lancer Fess avec Docker Compose et decouvrir la recherche en quelques minutes
+- :doc:`articles/guide-03` - Trois modeles d'integration de widgets de recherche dans des sites web existants
+- :doc:`articles/guide-04` - Construire une recherche transversale sur serveurs de fichiers et stockage cloud
+- :doc:`articles/guide-05` - Filtrage des resultats de recherche par role, label, departement et permissions
 
 **Solutions pratiques (Pour niveau intermediaire)**
 
-- :doc:`articles/guide-06` - Partie 6 : Hub de connaissances pour equipes de developpement -- Recherche integree du code, wiki et tickets
-- :doc:`articles/guide-07` - Partie 7 : Strategie de recherche pour le stockage cloud -- Recherche transversale Google Drive, SharePoint et Box
-- :doc:`articles/guide-08` - Partie 8 : Ameliorer la qualite de recherche -- Cycles d'optimisation bases sur les donnees comportementales
-- :doc:`articles/guide-09` - Partie 9 : Infrastructure de recherche pour organisations multilingues -- Recherche correcte de documents en plusieurs langues
-- :doc:`articles/guide-10` - Partie 10 : Exploitation stable d'un systeme de recherche -- Supervision, sauvegarde et reprise apres sinistre
-- :doc:`articles/guide-11` - Partie 11 : Etendre les systemes existants avec l'API de recherche -- Modeles d'integration avec CRM et systemes internes
-- :doc:`articles/guide-12` - Partie 12 : Rendre les donnees SaaS recherchables -- Scenarios d'integration avec Salesforce et bases de donnees
+- :doc:`articles/guide-06` - Recherche unifiee sur Git, wikis, tickets et chat pour les equipes de developpement
+- :doc:`articles/guide-07` - Configuration et exploitation de la recherche transversale Google Drive, SharePoint et Box
+- :doc:`articles/guide-08` - Cycle d'amelioration continue de la qualite de recherche par analyse des logs
+- :doc:`articles/guide-09` - Configuration des analyseurs pour rechercher correctement des documents en japonais, anglais et chinois
+- :doc:`articles/guide-10` - Bonnes pratiques de supervision, sauvegarde et reprise apres sinistre en production
+- :doc:`articles/guide-11` - Modeles d'integration API REST avec CRM et systemes metier internes
+- :doc:`articles/guide-12` - Indexation des donnees Salesforce, bases de donnees et autres plateformes SaaS
 
 **Architecture et mise a l'echelle (Pour niveau avance)**
 
-- :doc:`articles/guide-13` - Partie 13 : Plateforme de recherche multi-tenant -- Concevoir une instance Fess pour plusieurs organisations
-- :doc:`articles/guide-14` - Partie 14 : Strategie de mise a l'echelle des systemes de recherche -- Extension progressive de petite a grande echelle
-- :doc:`articles/guide-15` - Partie 15 : Infrastructure de recherche securisee -- Integration SSO et controle d'acces en environnement Zero Trust
-- :doc:`articles/guide-16` - Partie 16 : Automatisation de l'infrastructure de recherche -- Gestion avec pipelines CI/CD et Infrastructure as Code
-- :doc:`articles/guide-17` - Partie 17 : Etendre la recherche avec des plugins -- Implementation de sources de donnees personnalisees et pipelines d'ingestion
+- :doc:`articles/guide-13` - Conception multi-tenant : servir plusieurs organisations avec une seule instance Fess
+- :doc:`articles/guide-14` - Montee en charge progressive du serveur unique a l'architecture en cluster
+- :doc:`articles/guide-15` - Integration SSO (OIDC/SAML) et controle d'acces en environnement Zero Trust
+- :doc:`articles/guide-16` - Gestion de la configuration en tant que code et deploiement automatise via CI/CD
+- :doc:`articles/guide-17` - Implementation de plugins de sources de donnees personnalisees et pipelines d'ingestion
 
 **IA et recherche de nouvelle generation (Pour niveau avance)**
 
-- :doc:`articles/guide-18` - Partie 18 : Fondements de la recherche IA -- Evolution de la recherche par mots-cles vers la recherche semantique
-- :doc:`articles/guide-19` - Partie 19 : Construction d'un assistant IA interne -- Systeme de questions-reponses base sur RAG
-- :doc:`articles/guide-20` - Partie 20 : Connecter agents IA et recherche -- Integrer Fess dans les outils IA externes via serveur MCP
-- :doc:`articles/guide-21` - Partie 21 : Recherche transversale images et texte -- Gestion des connaissances de nouvelle generation avec recherche multimodale
-- :doc:`articles/guide-22` - Partie 22 : Cartographier les connaissances organisationnelles a partir des donnees de recherche -- Tableau de bord analytique
+- :doc:`articles/guide-18` - Panorama de l'evolution de la recherche par mots-cles vers la recherche vectorielle et semantique
+- :doc:`articles/guide-19` - Construire un systeme de questions-reponses interne base sur RAG et documents d'entreprise
+- :doc:`articles/guide-20` - Integrer Fess comme serveur MCP avec Claude et d'autres outils IA
+- :doc:`articles/guide-21` - Recherche multimodale sur texte et images via embeddings vectoriels
+- :doc:`articles/guide-22` - Visualiser l'utilisation de l'information avec les tableaux de bord OpenSearch Dashboards
 
 **Conclusion**
 
-- :doc:`articles/guide-23` - Partie 23 : Plan directeur d'une plateforme de connaissances d'entreprise -- Architecture globale avec Fess au coeur
+- :doc:`articles/guide-23` - Architecture de reference pour une plateforme de connaissances d'entreprise basee sur Fess
 
 Cas d'utilisation et exemples
 =============================

--- a/ja/guide.rst
+++ b/ja/guide.rst
@@ -10,41 +10,41 @@ Fess で実現するナレッジ活用戦略
 
 **基礎編（初心者向け）**
 
-- :doc:`articles/guide-01` - 【第1回】なぜ企業に検索が必要なのか -- 情報過多時代のナレッジ活用課題
-- :doc:`articles/guide-02` - 【第2回】5分でわかる検索体験 -- Docker Composeで始めるFessファーストコンタクト
-- :doc:`articles/guide-03` - 【第3回】社内ポータルに検索を埋め込む -- 既存Webサイトへの検索機能追加シナリオ
-- :doc:`articles/guide-04` - 【第4回】散在するファイルを一元検索 -- マルチソース環境での横断検索構築
-- :doc:`articles/guide-05` - 【第5回】情報を探す人に合わせる -- 部門別・権限別の検索結果制御
+- :doc:`articles/guide-01` - 企業における情報検索の必要性と散在する情報の活用課題を解説
+- :doc:`articles/guide-02` - Docker Composeで数分でFessを起動し検索を体験するクイックスタート
+- :doc:`articles/guide-03` - 既存Webサイトへの検索ウィジェット埋め込み3パターンを紹介
+- :doc:`articles/guide-04` - ファイルサーバーやクラウドストレージなど複数ソースの横断検索を構築
+- :doc:`articles/guide-05` - ロールやラベルを使った部門別・権限別の検索結果フィルタリング
 
 **実践ソリューション編（中級者向け）**
 
-- :doc:`articles/guide-06` - 【第6回】開発チームのナレッジハブ -- コード・Wiki・チケットの統合検索環境
-- :doc:`articles/guide-07` - 【第7回】クラウドストレージ時代の検索戦略 -- Google Drive・SharePoint・Boxの横断検索
-- :doc:`articles/guide-08` - 【第8回】検索品質を育てる -- ユーザー行動データに基づく検索チューニングサイクル
-- :doc:`articles/guide-09` - 【第9回】多言語組織の検索基盤 -- 日英中の文書を正しく検索する環境構築
-- :doc:`articles/guide-10` - 【第10回】検索システムの安定運用 -- 監視・バックアップ・障害対策の実践
-- :doc:`articles/guide-11` - 【第11回】検索APIで既存システムを拡張 -- CRM・社内システムとの連携パターン集
-- :doc:`articles/guide-12` - 【第12回】SaaSデータを検索可能にする -- Salesforce・データベースとの連携シナリオ
+- :doc:`articles/guide-06` - Git・Wiki・チケットなど開発系ナレッジを統合検索する環境を構築
+- :doc:`articles/guide-07` - Google Drive・SharePoint・Boxをまとめて検索する設定と運用
+- :doc:`articles/guide-08` - 検索ログ分析に基づくチューニングの改善サイクルを実践
+- :doc:`articles/guide-09` - 日本語・英語・中国語文書を正しく検索するアナライザー設定
+- :doc:`articles/guide-10` - 本番環境の監視・バックアップ・障害対策のベストプラクティス
+- :doc:`articles/guide-11` - REST APIを使ったCRM・社内システムとの連携パターン集
+- :doc:`articles/guide-12` - Salesforce・データベースなどSaaSデータのインデックス化手順
 
 **アーキテクチャ・スケーリング編（上級者向け）**
 
-- :doc:`articles/guide-13` - 【第13回】マルチテナント検索基盤 -- 一つのFessで複数組織をサービスする設計
-- :doc:`articles/guide-14` - 【第14回】検索システムのスケール戦略 -- 小規模から大規模への段階的拡張
-- :doc:`articles/guide-15` - 【第15回】セキュアな検索基盤 -- SSO連携とゼロトラスト環境での検索アクセス制御
-- :doc:`articles/guide-16` - 【第16回】検索インフラの自動化 -- CI/CDパイプラインとInfrastructure as Codeでの管理
-- :doc:`articles/guide-17` - 【第17回】プラグインで検索を拡張する -- カスタムデータソースとIngestパイプラインの実装
+- :doc:`articles/guide-13` - 1つのFessインスタンスで複数組織にサービスするテナント設計
+- :doc:`articles/guide-14` - シングルサーバーからクラスター構成への段階的スケーリング戦略
+- :doc:`articles/guide-15` - SSO（OIDC/SAML）連携とゼロトラスト環境でのアクセス制御設計
+- :doc:`articles/guide-16` - Fess設定のコード管理とCI/CDパイプラインによるデプロイ自動化
+- :doc:`articles/guide-17` - カスタムデータソースプラグインとIngestパイプラインの実装方法
 
 **AI・次世代検索編（上級者向け）**
 
-- :doc:`articles/guide-18` - 【第18回】AI検索の基礎 -- キーワード検索からセマンティック検索への進化
-- :doc:`articles/guide-19` - 【第19回】社内AIアシスタントの構築 -- RAGで実現する検索ベースの質問応答システム
-- :doc:`articles/guide-20` - 【第20回】AIエージェントと検索をつなぐ -- MCPサーバーでFessを外部AIツールに統合
-- :doc:`articles/guide-21` - 【第21回】画像もテキストも横断検索 -- マルチモーダル検索で実現する次世代ナレッジ管理
-- :doc:`articles/guide-22` - 【第22回】検索データから組織の知識地図を描く -- 分析ダッシュボードで見る情報活用の実態
+- :doc:`articles/guide-18` - キーワード検索からベクトル検索・セマンティック検索への進化を概説
+- :doc:`articles/guide-19` - RAGを活用した社内文書ベースの質問応答システムの構築手順
+- :doc:`articles/guide-20` - MCPサーバーとしてFessをClaude等の外部AIツールと統合
+- :doc:`articles/guide-21` - ベクトル埋め込みによるテキスト・画像の横断マルチモーダル検索
+- :doc:`articles/guide-22` - 検索ログをOpenSearch Dashboardsで可視化し情報活用を分析
 
 **総括**
 
-- :doc:`articles/guide-23` - 【第23回】全社ナレッジプラットフォームの設計図 -- Fessを中核とした情報活用基盤のグランドデザイン
+- :doc:`articles/guide-23` - 全23回の要素を統合した全社ナレッジ基盤のリファレンスアーキテクチャ
 
 ユースケース・活用事例
 ====================

--- a/ko/guide.rst
+++ b/ko/guide.rst
@@ -10,41 +10,41 @@ Fess로 실현하는 지식 활용 전략
 
 **기초편 (초보자용)**
 
-- :doc:`articles/guide-01` - 【제1회】기업에 검색이 필요한 이유 -- 정보 과잉 시대의 지식 활용 과제
-- :doc:`articles/guide-02` - 【제2회】5분으로 알 수 있는 검색 체험 -- Docker Compose로 시작하는 Fess 첫 만남
-- :doc:`articles/guide-03` - 【제3회】사내 포털에 검색을 삽입하기 -- 기존 웹 사이트에 검색 기능 추가 시나리오
-- :doc:`articles/guide-04` - 【제4회】분산된 파일을 통합 검색 -- 멀티소스 환경에서의 횡단 검색 구축
-- :doc:`articles/guide-05` - 【제5회】정보를 찾는 사람에 맞추다 -- 부서별·권한별 검색 결과 제어
+- :doc:`articles/guide-01` - 기업에서 정보 검색이 필요한 이유와 분산된 정보 활용의 과제를 해설
+- :doc:`articles/guide-02` - Docker Compose로 수분 만에 Fess를 기동하고 검색을 체험하는 퀵스타트
+- :doc:`articles/guide-03` - 기존 웹사이트에 검색 위젯을 임베딩하는 3가지 패턴 소개
+- :doc:`articles/guide-04` - 파일 서버와 클라우드 스토리지 등 복수 소스의 횡단 검색 구축
+- :doc:`articles/guide-05` - 역할과 라벨을 사용한 부서별·권한별 검색 결과 필터링
 
 **실전 솔루션편 (중급자용)**
 
-- :doc:`articles/guide-06` - 【제6회】개발팀의 지식 허브 -- 코드·Wiki·티켓의 통합 검색 환경
-- :doc:`articles/guide-07` - 【제7회】클라우드 스토리지 시대의 검색 전략 -- Google Drive·SharePoint·Box 횡단 검색
-- :doc:`articles/guide-08` - 【제8회】검색 품질을 키우다 -- 사용자 행동 데이터 기반 검색 튜닝 사이클
-- :doc:`articles/guide-09` - 【제9회】다국어 조직의 검색 인프라 -- 다국어 문서를 올바르게 검색하는 환경 구축
-- :doc:`articles/guide-10` - 【제10회】검색 시스템의 안정 운영 -- 모니터링·백업·장애 대책 실전
-- :doc:`articles/guide-11` - 【제11회】검색 API로 기존 시스템 확장 -- CRM·사내 시스템과의 연계 패턴
-- :doc:`articles/guide-12` - 【제12회】SaaS 데이터를 검색 가능하게 -- Salesforce·데이터베이스 연계 시나리오
+- :doc:`articles/guide-06` - Git·Wiki·티켓 등 개발 관련 지식을 통합 검색하는 환경 구축
+- :doc:`articles/guide-07` - Google Drive·SharePoint·Box를 통합 검색하는 설정과 운용
+- :doc:`articles/guide-08` - 검색 로그 분석에 기반한 튜닝 개선 사이클 실천
+- :doc:`articles/guide-09` - 일본어·영어·중국어 문서를 올바르게 검색하는 분석기 설정
+- :doc:`articles/guide-10` - 운영 환경의 모니터링·백업·장애 대책 모범 사례
+- :doc:`articles/guide-11` - REST API를 사용한 CRM·사내 시스템과의 연계 패턴집
+- :doc:`articles/guide-12` - Salesforce·데이터베이스 등 SaaS 데이터의 인덱싱 절차
 
 **아키텍처·스케일링편 (상급자용)**
 
-- :doc:`articles/guide-13` - 【제13회】멀티테넌트 검색 플랫폼 -- 하나의 Fess로 여러 조직을 서비스하는 설계
-- :doc:`articles/guide-14` - 【제14회】검색 시스템의 스케일 전략 -- 소규모에서 대규모로의 단계적 확장
-- :doc:`articles/guide-15` - 【제15회】안전한 검색 인프라 -- SSO 연계와 제로 트러스트 환경에서의 검색 접근 제어
-- :doc:`articles/guide-16` - 【제16회】검색 인프라의 자동화 -- CI/CD 파이프라인과 Infrastructure as Code 관리
-- :doc:`articles/guide-17` - 【제17회】플러그인으로 검색을 확장하다 -- 커스텀 데이터소스와 Ingest 파이프라인 구현
+- :doc:`articles/guide-13` - 하나의 Fess 인스턴스로 여러 조직에 서비스하는 테넌트 설계
+- :doc:`articles/guide-14` - 싱글 서버에서 클러스터 구성으로의 단계적 스케일링 전략
+- :doc:`articles/guide-15` - SSO(OIDC/SAML) 연계와 제로 트러스트 환경에서의 접근 제어 설계
+- :doc:`articles/guide-16` - Fess 설정의 코드 관리와 CI/CD 파이프라인에 의한 배포 자동화
+- :doc:`articles/guide-17` - 커스텀 데이터소스 플러그인과 Ingest 파이프라인의 구현 방법
 
 **AI·차세대 검색편 (상급자용)**
 
-- :doc:`articles/guide-18` - 【제18회】AI 검색의 기초 -- 키워드 검색에서 시맨틱 검색으로의 진화
-- :doc:`articles/guide-19` - 【제19회】사내 AI 어시스턴트 구축 -- RAG로 실현하는 검색 기반 질의응답 시스템
-- :doc:`articles/guide-20` - 【제20회】AI 에이전트와 검색을 잇다 -- MCP 서버로 Fess를 외부 AI 도구에 통합
-- :doc:`articles/guide-21` - 【제21회】이미지도 텍스트도 횡단 검색 -- 멀티모달 검색으로 실현하는 차세대 지식 관리
-- :doc:`articles/guide-22` - 【제22회】검색 데이터에서 조직의 지식 지도를 그리다 -- 분석 대시보드로 보는 정보 활용 실태
+- :doc:`articles/guide-18` - 키워드 검색에서 벡터 검색·시맨틱 검색으로의 진화를 개설
+- :doc:`articles/guide-19` - RAG를 활용한 사내 문서 기반 질의응답 시스템 구축 절차
+- :doc:`articles/guide-20` - MCP 서버로서 Fess를 Claude 등 외부 AI 도구와 통합
+- :doc:`articles/guide-21` - 벡터 임베딩을 통한 텍스트·이미지의 횡단 멀티모달 검색
+- :doc:`articles/guide-22` - 검색 로그를 OpenSearch Dashboards로 시각화하여 정보 활용을 분석
 
 **총괄**
 
-- :doc:`articles/guide-23` - 【제23회】전사 지식 플랫폼의 설계도 -- Fess를 중핵으로 한 정보 활용 기반의 그랜드 디자인
+- :doc:`articles/guide-23` - 전 23회의 요소를 통합한 전사 지식 기반의 레퍼런스 아키텍처
 
 활용 사례 및 비교
 ==================

--- a/zh-cn/guide.rst
+++ b/zh-cn/guide.rst
@@ -10,41 +10,41 @@
 
 **基础篇（面向初学者）**
 
-- :doc:`articles/guide-01` - 【第1回】企业为何需要搜索 -- 信息过载时代的知识活用课题
-- :doc:`articles/guide-02` - 【第2回】5分钟了解搜索体验 -- 用 Docker Compose 开始 Fess 初体验
-- :doc:`articles/guide-03` - 【第3回】在企业门户中嵌入搜索 -- 为现有网站添加搜索功能
-- :doc:`articles/guide-04` - 【第4回】统一检索分散的文件 -- 在多数据源环境中构建跨源检索
-- :doc:`articles/guide-05` - 【第5回】根据用户匹配信息 -- 按部门和权限控制搜索结果
+- :doc:`articles/guide-01` - 解析企业信息检索的必要性与分散信息的活用课题
+- :doc:`articles/guide-02` - 用 Docker Compose 几分钟内启动 Fess 并体验搜索的快速入门
+- :doc:`articles/guide-03` - 向现有网站嵌入搜索小部件的3种模式介绍
+- :doc:`articles/guide-04` - 构建跨文件服务器和云存储等多数据源的统一检索
+- :doc:`articles/guide-05` - 使用角色和标签实现按部门·权限的搜索结果过滤
 
 **实践解决方案篇（面向中级用户）**
 
-- :doc:`articles/guide-06` - 【第6回】开发团队的知识中心 -- 代码·Wiki·工单的统合搜索环境
-- :doc:`articles/guide-07` - 【第7回】云存储时代的搜索策略 -- Google Drive·SharePoint·Box 的跨源搜索
-- :doc:`articles/guide-08` - 【第8回】培养搜索质量 -- 基于用户行为数据的搜索调优循环
-- :doc:`articles/guide-09` - 【第9回】多语言组织的搜索基础设施 -- 构建正确搜索多语言文档的环境
-- :doc:`articles/guide-10` - 【第10回】搜索系统的稳定运维 -- 监控·备份·故障对策实践
-- :doc:`articles/guide-11` - 【第11回】通过搜索 API 扩展现有系统 -- CRM·内部系统的集成模式
-- :doc:`articles/guide-12` - 【第12回】使 SaaS 数据可搜索 -- Salesforce·数据库集成场景
+- :doc:`articles/guide-06` - 构建统一检索 Git·Wiki·工单等开发知识的环境
+- :doc:`articles/guide-07` - 配置和运维 Google Drive·SharePoint·Box 的统一搜索
+- :doc:`articles/guide-08` - 基于搜索日志分析的调优改进循环实践
+- :doc:`articles/guide-09` - 正确搜索日语·英语·中文文档的分析器配置
+- :doc:`articles/guide-10` - 生产环境的监控·备份·故障对策最佳实践
+- :doc:`articles/guide-11` - 使用 REST API 与 CRM·内部系统的集成模式集
+- :doc:`articles/guide-12` - Salesforce·数据库等 SaaS 数据的索引化步骤
 
 **架构与扩展篇（面向高级用户）**
 
-- :doc:`articles/guide-13` - 【第13回】多租户搜索平台 -- 用一个 Fess 服务多个组织的设计
-- :doc:`articles/guide-14` - 【第14回】搜索系统的扩展策略 -- 从小规模到大规模的分阶段扩展
-- :doc:`articles/guide-15` - 【第15回】安全的搜索基础设施 -- SSO 集成与零信任环境下的搜索访问控制
-- :doc:`articles/guide-16` - 【第16回】搜索基础设施的自动化 -- 用 CI/CD 流水线和 Infrastructure as Code 管理
-- :doc:`articles/guide-17` - 【第17回】用插件扩展搜索 -- 自定义数据源和 Ingest 流水线的实现
+- :doc:`articles/guide-13` - 用一个 Fess 实例为多个组织提供服务的租户设计
+- :doc:`articles/guide-14` - 从单服务器到集群架构的分阶段扩展策略
+- :doc:`articles/guide-15` - SSO（OIDC/SAML）集成与零信任环境下的访问控制设计
+- :doc:`articles/guide-16` - Fess 配置的代码管理与 CI/CD 流水线自动化部署
+- :doc:`articles/guide-17` - 自定义数据源插件和 Ingest 流水线的实现方法
 
 **AI·下一代搜索篇（面向高级用户）**
 
-- :doc:`articles/guide-18` - 【第18回】AI 搜索基础 -- 从关键词搜索到语义搜索的进化
-- :doc:`articles/guide-19` - 【第19回】构建企业内部 AI 助手 -- 用 RAG 实现基于搜索的问答系统
-- :doc:`articles/guide-20` - 【第20回】连接 AI 代理与搜索 -- 通过 MCP 服务器将 Fess 集成到外部 AI 工具
-- :doc:`articles/guide-21` - 【第21回】图像与文本的跨模态搜索 -- 用多模态搜索实现下一代知识管理
-- :doc:`articles/guide-22` - 【第22回】从搜索数据描绘组织知识地图 -- 用分析仪表板了解信息活用实态
+- :doc:`articles/guide-18` - 概述从关键词搜索到向量搜索·语义搜索的进化
+- :doc:`articles/guide-19` - 利用 RAG 构建基于企业文档的问答系统的步骤
+- :doc:`articles/guide-20` - 将 Fess 作为 MCP 服务器与 Claude 等外部 AI 工具集成
+- :doc:`articles/guide-21` - 通过向量嵌入实现文本·图像的跨模态搜索
+- :doc:`articles/guide-22` - 用 OpenSearch Dashboards 可视化搜索日志并分析信息活用
 
 **总结**
 
-- :doc:`articles/guide-23` - 【第23回】全公司知识平台的设计蓝图 -- 以 Fess 为核心的信息活用基础设施总体设计
+- :doc:`articles/guide-23` - 整合全23回要素的全公司知识基础设施参考架构
 
 用例与示例
 ==========


### PR DESCRIPTION
## Summary
- Simplify all 23 article descriptions in `guide.rst` across all 7 languages (ja, en, de, es, fr, ko, zh-cn)
- Remove "Part N:" prefixes and verbose subtitles, replacing with concise, action-oriented descriptions

## Changes Made
- Removed numbered part prefixes (e.g., "Part 1:", "Teil 1:", "パート1:") from all article listings
- Rewrote descriptions to be shorter and more scannable while preserving the core meaning
- Applied consistent style across all languages

## Testing
- Verified RST syntax is preserved (`:doc:` references unchanged)
- All 7 language files follow the same structural pattern

## Additional Notes
- No content changes to the articles themselves — only the guide index descriptions
- Each language's descriptions are natural and idiomatic, not mechanical translations