### PR TITLE
docs(install): update Docker image source to GitHub Container Registry

### DIFF
--- a/de/15.3/install/install-docker.rst
+++ b/de/15.3/install/install-docker.rst
@@ -35,7 +35,7 @@ Das Docker-Image von |Fess| besteht aus folgenden Komponenten:
 - **Fess**: Volltext-Suchsystem
 - **OpenSearch**: Suchmaschine
 
-Das offizielle Docker-Image wird auf `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__ veröffentlicht.
+Das offizielle Docker-Image wird auf `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__ veröffentlicht.
 
 Schritt 1: Herunterladen der Docker Compose-Dateien
 ====================================================

--- a/de/15.4/install/install-docker.rst
+++ b/de/15.4/install/install-docker.rst
@@ -35,7 +35,7 @@ Das Docker-Image von |Fess| besteht aus folgenden Komponenten:
 - **Fess**: Volltext-Suchsystem
 - **OpenSearch**: Suchmaschine
 
-Das offizielle Docker-Image wird auf `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__ veröffentlicht.
+Das offizielle Docker-Image wird auf `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__ veröffentlicht.
 
 Schritt 1: Herunterladen der Docker Compose-Dateien
 ====================================================

--- a/de/15.5/install/install-docker.rst
+++ b/de/15.5/install/install-docker.rst
@@ -35,7 +35,7 @@ Das Docker-Image von |Fess| besteht aus folgenden Komponenten:
 - **Fess**: Volltext-Suchsystem
 - **OpenSearch**: Suchmaschine
 
-Das offizielle Docker-Image wird auf `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__ veröffentlicht.
+Das offizielle Docker-Image wird auf `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__ veröffentlicht.
 
 Schritt 1: Herunterladen der Docker Compose-Dateien
 ====================================================

--- a/de/15.6/install/install-docker.rst
+++ b/de/15.6/install/install-docker.rst
@@ -35,7 +35,7 @@ Das Docker-Image von |Fess| besteht aus folgenden Komponenten:
 - **Fess**: Volltext-Suchsystem
 - **OpenSearch**: Suchmaschine
 
-Das offizielle Docker-Image wird auf `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__ veröffentlicht.
+Das offizielle Docker-Image wird auf `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__ veröffentlicht.
 
 Schritt 1: Herunterladen der Docker Compose-Dateien
 ====================================================

--- a/en/15.3/install/install-docker.rst
+++ b/en/15.3/install/install-docker.rst
@@ -35,7 +35,7 @@ The |Fess| Docker image consists of the following components:
 - **Fess**: Full-text search system
 - **OpenSearch**: Search engine
 
-Official Docker images are published on `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__.
+Official Docker images are published on `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__.
 
 Step 1: Obtain Docker Compose Files
 ====================================

--- a/en/15.4/install/install-docker.rst
+++ b/en/15.4/install/install-docker.rst
@@ -35,7 +35,7 @@ The |Fess| Docker image consists of the following components:
 - **Fess**: Full-text search system
 - **OpenSearch**: Search engine
 
-Official Docker images are published on `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__.
+Official Docker images are published on `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__.
 
 Step 1: Obtain Docker Compose Files
 ====================================

--- a/en/15.5/install/install-docker.rst
+++ b/en/15.5/install/install-docker.rst
@@ -35,7 +35,7 @@ The |Fess| Docker image consists of the following components:
 - **Fess**: Full-text search system
 - **OpenSearch**: Search engine
 
-Official Docker images are published on `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__.
+Official Docker images are published on `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__.
 
 Step 1: Obtain Docker Compose Files
 ====================================

--- a/en/15.6/install/install-docker.rst
+++ b/en/15.6/install/install-docker.rst
@@ -35,7 +35,7 @@ The |Fess| Docker image consists of the following components:
 - **Fess**: Full-text search system
 - **OpenSearch**: Search engine
 
-Official Docker images are published on `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__.
+Official Docker images are published on `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__.
 
 Step 1: Obtain Docker Compose Files
 ====================================

--- a/es/15.3/install/install-docker.rst
+++ b/es/15.3/install/install-docker.rst
@@ -35,7 +35,7 @@ La imagen Docker de |Fess| está compuesta por los siguientes componentes:
 - **Fess**: Cuerpo del sistema de búsqueda de texto completo
 - **OpenSearch**: Motor de búsqueda
 
-La imagen Docker oficial está publicada en `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__.
+La imagen Docker oficial está publicada en `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__.
 
 Paso 1: Obtención del Archivo Docker Compose
 =============================================

--- a/es/15.4/install/install-docker.rst
+++ b/es/15.4/install/install-docker.rst
@@ -35,7 +35,7 @@ La imagen Docker de |Fess| está compuesta por los siguientes componentes:
 - **Fess**: Cuerpo del sistema de búsqueda de texto completo
 - **OpenSearch**: Motor de búsqueda
 
-La imagen Docker oficial está publicada en `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__.
+La imagen Docker oficial está publicada en `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__.
 
 Paso 1: Obtención del Archivo Docker Compose
 =============================================

--- a/es/15.5/install/install-docker.rst
+++ b/es/15.5/install/install-docker.rst
@@ -35,7 +35,7 @@ La imagen Docker de |Fess| está compuesta por los siguientes componentes:
 - **Fess**: Cuerpo del sistema de búsqueda de texto completo
 - **OpenSearch**: Motor de búsqueda
 
-La imagen Docker oficial está publicada en `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__.
+La imagen Docker oficial está publicada en `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__.
 
 Paso 1: Obtención del Archivo Docker Compose
 =============================================

--- a/es/15.6/install/install-docker.rst
+++ b/es/15.6/install/install-docker.rst
@@ -35,7 +35,7 @@ La imagen Docker de |Fess| está compuesta por los siguientes componentes:
 - **Fess**: Cuerpo del sistema de búsqueda de texto completo
 - **OpenSearch**: Motor de búsqueda
 
-La imagen Docker oficial está publicada en `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__.
+La imagen Docker oficial está publicada en `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__.
 
 Paso 1: Obtención del Archivo Docker Compose
 =============================================

--- a/fr/15.3/install/install-docker.rst
+++ b/fr/15.3/install/install-docker.rst
@@ -35,7 +35,7 @@ Les images Docker de |Fess| sont composées des composants suivants :
 - **Fess** : Système de recherche plein texte principal
 - **OpenSearch** : Moteur de recherche
 
-Les images Docker officielles sont publiées sur `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__.
+Les images Docker officielles sont publiées sur `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__.
 
 Étape 1 : Obtention des fichiers Docker Compose
 ================================================

--- a/fr/15.4/install/install-docker.rst
+++ b/fr/15.4/install/install-docker.rst
@@ -35,7 +35,7 @@ Les images Docker de |Fess| sont composées des composants suivants :
 - **Fess** : Système de recherche plein texte principal
 - **OpenSearch** : Moteur de recherche
 
-Les images Docker officielles sont publiées sur `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__.
+Les images Docker officielles sont publiées sur `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__.
 
 Étape 1 : Obtention des fichiers Docker Compose
 ================================================

--- a/fr/15.5/install/install-docker.rst
+++ b/fr/15.5/install/install-docker.rst
@@ -35,7 +35,7 @@ Les images Docker de |Fess| sont composées des composants suivants :
 - **Fess** : Système de recherche plein texte principal
 - **OpenSearch** : Moteur de recherche
 
-Les images Docker officielles sont publiées sur `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__.
+Les images Docker officielles sont publiées sur `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__.
 
 Étape 1 : Obtention des fichiers Docker Compose
 ================================================

--- a/fr/15.6/install/install-docker.rst
+++ b/fr/15.6/install/install-docker.rst
@@ -35,7 +35,7 @@ Les images Docker de |Fess| sont composées des composants suivants :
 - **Fess** : Système de recherche plein texte principal
 - **OpenSearch** : Moteur de recherche
 
-Les images Docker officielles sont publiées sur `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__.
+Les images Docker officielles sont publiées sur `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__.
 
 Étape 1 : Obtention des fichiers Docker Compose
 ================================================

--- a/ja/15.3/install/install-docker.rst
+++ b/ja/15.3/install/install-docker.rst
@@ -35,7 +35,7 @@ Docker イメージについて
 - **Fess**: 全文検索システム本体
 - **OpenSearch**: 検索エンジン
 
-公式 Docker イメージは `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__ で公開されています。
+公式 Docker イメージは `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__ で公開されています。
 
 ステップ 1: Docker Compose ファイルの取得
 =======================================

--- a/ja/15.4/install/install-docker.rst
+++ b/ja/15.4/install/install-docker.rst
@@ -35,7 +35,7 @@ Docker イメージについて
 - **Fess**: 全文検索システム本体
 - **OpenSearch**: 検索エンジン
 
-公式 Docker イメージは `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__ で公開されています。
+公式 Docker イメージは `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__ で公開されています。
 
 ステップ 1: Docker Compose ファイルの取得
 =======================================

--- a/ja/15.5/install/install-docker.rst
+++ b/ja/15.5/install/install-docker.rst
@@ -35,7 +35,7 @@ Docker イメージについて
 - **Fess**: 全文検索システム本体
 - **OpenSearch**: 検索エンジン
 
-公式 Docker イメージは `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__ で公開されています。
+公式 Docker イメージは `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__ で公開されています。
 
 ステップ 1: Docker Compose ファイルの取得
 =======================================

--- a/ja/15.6/install/install-docker.rst
+++ b/ja/15.6/install/install-docker.rst
@@ -35,7 +35,7 @@ Docker イメージについて
 - **Fess**: 全文検索システム本体
 - **OpenSearch**: 検索エンジン
 
-公式 Docker イメージは `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__ で公開されています。
+公式 Docker イメージは `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__ で公開されています。
 
 ステップ 1: Docker Compose ファイルの取得
 =======================================

--- a/ko/15.3/install/install-docker.rst
+++ b/ko/15.3/install/install-docker.rst
@@ -35,7 +35,7 @@ Docker 이미지 정보
 - **Fess**: 전문 검색 시스템 본체
 - **OpenSearch**: 검색 엔진
 
-공식 Docker 이미지는 `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__ 에서 공개되고 있습니다.
+공식 Docker 이미지는 `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__ 에서 공개되고 있습니다.
 
 단계 1: Docker Compose 파일 가져오기
 =======================================

--- a/ko/15.4/install/install-docker.rst
+++ b/ko/15.4/install/install-docker.rst
@@ -35,7 +35,7 @@ Docker 이미지 정보
 - **Fess**: 전문 검색 시스템 본체
 - **OpenSearch**: 검색 엔진
 
-공식 Docker 이미지는 `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__ 에서 공개되고 있습니다.
+공식 Docker 이미지는 `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__ 에서 공개되고 있습니다.
 
 단계 1: Docker Compose 파일 가져오기
 =======================================

--- a/ko/15.5/install/install-docker.rst
+++ b/ko/15.5/install/install-docker.rst
@@ -35,7 +35,7 @@ Docker 이미지 정보
 - **Fess**: 전문 검색 시스템 본체
 - **OpenSearch**: 검색 엔진
 
-공식 Docker 이미지는 `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__ 에서 공개되고 있습니다.
+공식 Docker 이미지는 `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__ 에서 공개되고 있습니다.
 
 단계 1: Docker Compose 파일 가져오기
 =======================================

--- a/ko/15.6/install/install-docker.rst
+++ b/ko/15.6/install/install-docker.rst
@@ -35,7 +35,7 @@ Docker 이미지 정보
 - **Fess**: 전문 검색 시스템 본체
 - **OpenSearch**: 검색 엔진
 
-공식 Docker 이미지는 `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__ 에서 공개되고 있습니다.
+공식 Docker 이미지는 `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__ 에서 공개되고 있습니다.
 
 단계 1: Docker Compose 파일 가져오기
 =======================================

--- a/zh-cn/15.3/install/install-docker.rst
+++ b/zh-cn/15.3/install/install-docker.rst
@@ -35,7 +35,7 @@
 - **Fess**: 全文搜索系统主体
 - **OpenSearch**: 搜索引擎
 
-官方 Docker 镜像发布在 `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__。
+官方 Docker 镜像发布在 `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__。
 
 步骤 1: 获取 Docker Compose 文件
 =======================================

--- a/zh-cn/15.4/install/install-docker.rst
+++ b/zh-cn/15.4/install/install-docker.rst
@@ -35,7 +35,7 @@
 - **Fess**: 全文搜索系统主体
 - **OpenSearch**: 搜索引擎
 
-官方 Docker 镜像发布在 `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__。
+官方 Docker 镜像发布在 `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__。
 
 步骤 1: 获取 Docker Compose 文件
 =======================================

--- a/zh-cn/15.5/install/install-docker.rst
+++ b/zh-cn/15.5/install/install-docker.rst
@@ -35,7 +35,7 @@
 - **Fess**: 全文搜索系统主体
 - **OpenSearch**: 搜索引擎
 
-官方 Docker 镜像发布在 `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__。
+官方 Docker 镜像发布在 `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__。
 
 步骤 1: 获取 Docker Compose 文件
 =======================================

--- a/zh-cn/15.6/install/install-docker.rst
+++ b/zh-cn/15.6/install/install-docker.rst
@@ -35,7 +35,7 @@
 - **Fess**: 全文搜索系统主体
 - **OpenSearch**: 搜索引擎
 
-官方 Docker 镜像发布在 `Docker Hub <https://hub.docker.com/r/codelibs/fess>`__。
+官方 Docker 镜像发布在 `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>`__。
 
 步骤 1: 获取 Docker Compose 文件
 =======================================


### PR DESCRIPTION
## Summary
Update the Docker image source reference in the installation guide from Docker Hub to GitHub Container Registry (GHCR), where the official Fess Docker images are now published.

## Changes Made
- Replace `Docker Hub <https://hub.docker.com/r/codelibs/fess>` with `GitHub Container Registry <https://github.com/codelibs/docker-fess/pkgs/container/fess>` in `install/install-docker.rst`
- Applied across all languages: `de`, `en`, `es`, `fr`, `ja`, `ko`, `zh-cn`
- Applied across all supported versions: `15.3`, `15.4`, `15.5`, `15.6`
- 28 files changed, 1 line each

## Testing
- Documentation-only change; no functional impact
- Reviewers can spot-check that the rendered links resolve to the GHCR package page

## Breaking Changes
- None

## Additional Notes
- This keeps the install guide aligned with the current distribution channel for Fess Docker images