### PR TITLE
Pull OpenSearch Dashboards image from ECR Public registry in guide-22

### DIFF
--- a/de/articles/guide-22.rst
+++ b/de/articles/guide-22.rst
@@ -139,7 +139,7 @@ Fuegen Sie OpenSearch Dashboards zu Ihrer Docker-Compose-Konfiguration hinzu.
 
     services:
       opensearch-dashboards:
-        image: opensearchproject/opensearch-dashboards:3.6.0
+        image: public.ecr.aws/opensearchproject/opensearch-dashboards:3.6.0
         ports:
           - "5601:5601"
         environment:

--- a/en/articles/guide-22.rst
+++ b/en/articles/guide-22.rst
@@ -139,7 +139,7 @@ Add OpenSearch Dashboards to your Docker Compose configuration.
 
     services:
       opensearch-dashboards:
-        image: opensearchproject/opensearch-dashboards:3.6.0
+        image: public.ecr.aws/opensearchproject/opensearch-dashboards:3.6.0
         ports:
           - "5601:5601"
         environment:

--- a/es/articles/guide-22.rst
+++ b/es/articles/guide-22.rst
@@ -139,7 +139,7 @@ Agregue OpenSearch Dashboards a su configuracion de Docker Compose.
 
     services:
       opensearch-dashboards:
-        image: opensearchproject/opensearch-dashboards:3.6.0
+        image: public.ecr.aws/opensearchproject/opensearch-dashboards:3.6.0
         ports:
           - "5601:5601"
         environment:

--- a/fr/articles/guide-22.rst
+++ b/fr/articles/guide-22.rst
@@ -139,7 +139,7 @@ Ajoutez OpenSearch Dashboards a votre configuration Docker Compose.
 
     services:
       opensearch-dashboards:
-        image: opensearchproject/opensearch-dashboards:3.6.0
+        image: public.ecr.aws/opensearchproject/opensearch-dashboards:3.6.0
         ports:
           - "5601:5601"
         environment:

--- a/ja/articles/guide-22.rst
+++ b/ja/articles/guide-22.rst
@@ -139,7 +139,7 @@ Docker Compose 構成に OpenSearch Dashboards を追加します。
 
     services:
       opensearch-dashboards:
-        image: opensearchproject/opensearch-dashboards:3.6.0
+        image: public.ecr.aws/opensearchproject/opensearch-dashboards:3.6.0
         ports:
           - "5601:5601"
         environment:

--- a/ko/articles/guide-22.rst
+++ b/ko/articles/guide-22.rst
@@ -139,7 +139,7 @@ Docker Compose 구성에 OpenSearch Dashboards를 추가합니다.
 
     services:
       opensearch-dashboards:
-        image: opensearchproject/opensearch-dashboards:3.6.0
+        image: public.ecr.aws/opensearchproject/opensearch-dashboards:3.6.0
         ports:
           - "5601:5601"
         environment:

--- a/zh-cn/articles/guide-22.rst
+++ b/zh-cn/articles/guide-22.rst
@@ -139,7 +139,7 @@ OpenSearch Dashboards 的设置
 
     services:
       opensearch-dashboards:
-        image: opensearchproject/opensearch-dashboards:3.6.0
+        image: public.ecr.aws/opensearchproject/opensearch-dashboards:3.6.0
         ports:
           - "5601:5601"
         environment:


### PR DESCRIPTION
## Summary

Update the docker compose snippet in the `guide-22` article to pull the OpenSearch Dashboards image from the ECR Public registry instead of Docker Hub.

- `opensearchproject/opensearch-dashboards` → `public.ecr.aws/opensearchproject/opensearch-dashboards`

The version tag is unchanged; only the registry prefix is added.

## Why

Pulling from `public.ecr.aws` avoids Docker Hub anonymous pull rate limits and keeps the docs consistent with the docker-fess image source.

## Scope

`articles/guide-22.rst` across all language editions (de, en, es, fr, ja, ko, zh-cn).

Note: version-specific install/uninstall docs (15.3–15.7) are intentionally left unchanged.