### PR TITLE
docs(config): correct 15.7 logging guide against current implementation

### DIFF
--- a/de/15.7/config/admin-logging.rst
+++ b/de/15.7/config/admin-logging.rst
@@ -30,6 +30,8 @@ Hauptprotokolldateien, die |Fess| ausgibt:
      - Protokolle bei Crawler-Ausführung, Ziel-URLs, abgerufene Dokumentinformationen, Fehler
    * - ``fess-suggest.log``
      - Protokolle bei Vorschlags-Generierung, Index-Aktualisierungsinformationen
+   * - ``fess-thumbnail.log``
+     - Protokolle des Thumbnail-Generierungsprozesses
    * - ``fess-llm.log``
      - LLM/RAG-Chat-bezogene Protokolle
    * - ``searchlog.log``
@@ -130,6 +132,70 @@ Empfohlene Protokollebenen
    * - Bei Problemuntersuchung
      - ``DEBUG`` oder ``TRACE``
      - Temporär detaillierte Protokolle aktivieren
+
+Änderung über Konfigurationsdatei
+----------------------------------
+
+Für eine detailliertere Protokollkonfiguration bearbeiten Sie die Log4j2-Konfigurationsdatei.
+
+Speicherort der Konfigurationsdatei
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **ZIP-Installation**: ``app/WEB-INF/classes/log4j2.xml``
+- **RPM/DEB-Pakete**: ``/usr/share/fess/app/WEB-INF/classes/log4j2.xml``
+
+Grundlegende Konfigurationsbeispiele
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Standard-Protokollebene:**
+
+In der Standard-Datei ``log4j2.xml`` wird die Protokollebene über die Variable ``${log.level}`` angegeben.
+Diese Variable wird beim Start mit dem Wert von ``-Dfess.log.level`` (``FESS_LOG_LEVEL``, Standard: ``warn``) aufgelöst.
+
+::
+
+    <Logger name="org.codelibs" level="${log.level}"/>
+
+Sie können anstelle der Variable auch direkt eine Ebene angeben.
+
+**Beispiel: Auf DEBUG-Ebene ändern**
+
+::
+
+    <Logger name="org.codelibs" level="debug"/>
+
+**Beispiel: Protokollebene für bestimmtes Paket ändern**
+
+::
+
+    <Logger name="org.codelibs.fess.crawler" level="info"/>
+    <Logger name="org.codelibs.fess.ds" level="debug"/>
+    <Logger name="org.codelibs.fess.app.web" level="warn"/>
+
+.. warning::
+   Die Ebenen ``DEBUG`` und ``TRACE`` geben große Mengen an Protokollen aus.
+   Verwenden Sie diese nicht in Produktionsumgebungen, da sie Festplattenspeicher und Leistung beeinträchtigen.
+
+Konfiguration über Umgebungsvariablen
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Die Protokollebene kann auch beim Systemstart festgelegt werden.
+Setzen Sie ``FESS_LOG_LEVEL`` in ``fess.in.sh`` (Linux).
+
+::
+
+    FESS_LOG_LEVEL=debug
+
+Der Standardwert ist ``warn``.
+
+.. note::
+   Die Windows-Datei ``fess.in.bat`` liest die Umgebungsvariable ``FESS_LOG_LEVEL`` nicht aus.
+   Da der Wert dort direkt als ``-Dfess.log.level=warn`` eingetragen ist, muss diese Zeile in
+   ``fess.in.bat`` direkt bearbeitet werden, um die Protokollebene unter Windows zu ändern.
+
+   ::
+
+       set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.log.level=debug
 
 Protokollrotation
 ==================

--- a/en/15.7/config/admin-logging.rst
+++ b/en/15.7/config/admin-logging.rst
@@ -28,6 +28,8 @@ The main log files output by |Fess| are as follows:
      - Crawl execution logs, crawl target URLs, retrieved document information, errors
    * - ``fess-suggest.log``
      - Suggest (search suggestions) generation logs, index update information
+   * - ``fess-thumbnail.log``
+     - Log of the thumbnail generation process
    * - ``fess-llm.log``
      - LLM/RAG chat related logs
    * - ``searchlog.log``
@@ -161,18 +163,22 @@ Configuration File Location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **ZIP installation**: ``app/WEB-INF/classes/log4j2.xml``
-- **RPM/DEB packages**: ``/usr/share/fess/lib/classes/log4j2.xml``
+- **RPM/DEB packages**: ``/usr/share/fess/app/WEB-INF/classes/log4j2.xml``
 
 Basic Configuration Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Default log level:**
 
+In the default ``log4j2.xml``, the log level is specified by the variable ``${log.level}``. This variable resolves at startup to the value of ``-Dfess.log.level`` (``FESS_LOG_LEVEL``, default ``warn``).
+
 ::
 
-    <Logger name="org.codelibs" level="warn"/>
+    <Logger name="org.codelibs" level="${log.level}"/>
 
 **Example: Change to DEBUG level**
+
+You can also specify a level directly instead of using the variable.
 
 ::
 
@@ -193,14 +199,21 @@ Basic Configuration Examples
 Configuration via Environment Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can also specify log level at system startup.
-Set ``FESS_LOG_LEVEL`` in ``fess.in.sh`` (or ``fess.in.bat`` on Windows).
+You can also specify the log level at system startup.
+On Linux, set ``FESS_LOG_LEVEL`` in ``fess.in.sh``.
 
 ::
 
     FESS_LOG_LEVEL=debug
 
 The default value is ``warn``.
+
+.. note::
+   The Windows ``fess.in.bat`` does not read the ``FESS_LOG_LEVEL`` environment variable. Because the value is written directly as ``-Dfess.log.level=warn``, to change the log level on Windows, edit this line in ``fess.in.bat`` directly.
+
+   ::
+
+       set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.log.level=debug
 
 Crawler Log Configuration
 ==========================
@@ -552,7 +565,7 @@ Logs Not Being Output
    ::
 
        # Check configuration file syntax
-       xmllint --noout /usr/share/fess/lib/classes/log4j2.xml
+       xmllint --noout /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 4. **Check SELinux**
 
@@ -575,7 +588,7 @@ Log Files Become Too Large
    ::
 
        # Check log4j2.xml configuration
-       grep -A 5 "RollingFile" /usr/share/fess/lib/classes/log4j2.xml
+       grep -A 5 "RollingFile" /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 3. **Disable Unnecessary Log Output**
 
@@ -603,7 +616,7 @@ Cannot Find Specific Logs
 
    ::
 
-       grep "org.codelibs.fess" /usr/share/fess/lib/classes/log4j2.xml
+       grep "org.codelibs.fess" /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 2. **Check Log File Path**
 

--- a/es/15.7/config/admin-logging.rst
+++ b/es/15.7/config/admin-logging.rst
@@ -28,6 +28,8 @@ Los principales archivos de registro generados por |Fess| son los siguientes:
      - Registros de ejecución de rastreo, URLs rastreadas, información de documentos obtenidos y errores
    * - ``fess-suggest.log``
      - Registros de generación de sugerencias (candidatos de búsqueda) e información de actualización de índices
+   * - ``fess-thumbnail.log``
+     - Registro del proceso de generación de miniaturas
    * - ``fess-llm.log``
      - Registros relacionados con chat LLM/RAG
    * - ``searchlog.log``
@@ -161,7 +163,7 @@ Ubicación del Archivo de Configuración
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **Instalación ZIP**: ``app/WEB-INF/classes/log4j2.xml``
-- **Paquetes RPM/DEB**: ``/usr/share/fess/lib/classes/log4j2.xml``
+- **Paquetes RPM/DEB**: ``/usr/share/fess/app/WEB-INF/classes/log4j2.xml``
 
 Ejemplos de Configuración Básica
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -170,7 +172,12 @@ Ejemplos de Configuración Básica
 
 ::
 
-    <Logger name="org.codelibs" level="warn"/>
+    <Logger name="org.codelibs" level="${log.level}"/>
+
+En el ``log4j2.xml`` predeterminado, el nivel de registro se especifica mediante la variable ``${log.level}``.
+Esta variable se resuelve al inicio con el valor de ``-Dfess.log.level`` (``FESS_LOG_LEVEL``, por defecto ``warn``).
+
+También puede especificar un nivel directamente en lugar de usar la variable.
 
 **Ejemplo: Cambiar al nivel DEBUG**
 
@@ -194,13 +201,22 @@ Configuración mediante Variables de Entorno
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 También puede especificar el nivel de registro al iniciar el sistema.
-Configure ``FESS_LOG_LEVEL`` en ``fess.in.sh`` (o ``fess.in.bat`` en Windows).
+En Linux, configure ``FESS_LOG_LEVEL`` en ``fess.in.sh``.
 
 ::
 
     FESS_LOG_LEVEL=debug
 
 El valor predeterminado es ``warn``.
+
+.. note::
+   El archivo ``fess.in.bat`` de Windows no lee la variable de entorno ``FESS_LOG_LEVEL``.
+   Dado que el valor se escribe directamente como ``-Dfess.log.level=warn``, para cambiar el nivel
+   de registro en Windows edite esta línea en ``fess.in.bat`` directamente.
+
+   ::
+
+       set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.log.level=debug
 
 Configuración de Registros del Rastreador
 ==========================================
@@ -553,7 +569,7 @@ Los Registros no se Generan
    ::
 
        # Verificar sintaxis del archivo de configuración
-       xmllint --noout /usr/share/fess/lib/classes/log4j2.xml
+       xmllint --noout /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 4. **Verificación de SELinux**
 
@@ -576,7 +592,7 @@ Los Archivos de Registro se Hacen Demasiado Grandes
    ::
 
        # Verificar configuración de log4j2.xml
-       grep -A 5 "RollingFile" /usr/share/fess/lib/classes/log4j2.xml
+       grep -A 5 "RollingFile" /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 3. **Deshabilitar salida de registros innecesaria**
 
@@ -604,7 +620,7 @@ No se Encuentra un Registro Específico
 
    ::
 
-       grep "org.codelibs.fess" /usr/share/fess/lib/classes/log4j2.xml
+       grep "org.codelibs.fess" /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 2. **Verificar la ruta del archivo de registro**
 

--- a/fr/15.7/config/admin-logging.rst
+++ b/fr/15.7/config/admin-logging.rst
@@ -28,6 +28,8 @@ Les principaux fichiers journaux générés par |Fess| sont les suivants.
      - Journaux lors de l'exécution de l'exploration, URL explorées, informations sur les documents récupérés, erreurs
    * - ``fess-suggest.log``
      - Journaux lors de la génération de suggestions (candidats de recherche), informations de mise à jour d'index
+   * - ``fess-thumbnail.log``
+     - Journal du processus de génération des miniatures
    * - ``fess-llm.log``
      - Journaux liés au chat LLM/RAG
    * - ``searchlog.log``
@@ -161,7 +163,7 @@ Emplacement du fichier de configuration
 ~~~~~~~~~~~~~~~~~~
 
 - **Installation Zip** : ``app/WEB-INF/classes/log4j2.xml``
-- **Paquets RPM/DEB** : ``/usr/share/fess/lib/classes/log4j2.xml``
+- **Paquets RPM/DEB** : ``/usr/share/fess/app/WEB-INF/classes/log4j2.xml``
 
 Exemples de configuration de base
 ~~~~~~~~~~~~~~
@@ -170,7 +172,12 @@ Exemples de configuration de base
 
 ::
 
-    <Logger name="org.codelibs" level="warn"/>
+    <Logger name="org.codelibs" level="${log.level}"/>
+
+Dans le fichier ``log4j2.xml`` par défaut, le niveau de journalisation est spécifié par la variable ``${log.level}``.
+Cette variable est résolue au démarrage à partir de la valeur de ``-Dfess.log.level`` (``FESS_LOG_LEVEL``, valeur par défaut : ``warn``).
+
+Vous pouvez également spécifier un niveau directement au lieu d'utiliser la variable.
 
 **Exemple : Changement au niveau DEBUG**
 
@@ -194,13 +201,22 @@ Configuration via les variables d'environnement
 ~~~~~~~~~~~~~~~~~~
 
 Vous pouvez également spécifier le niveau de journalisation lors du démarrage du système.
-Configurez ``FESS_LOG_LEVEL`` dans ``fess.in.sh`` (ou ``fess.in.bat`` sous Windows).
+Sous Linux, configurez ``FESS_LOG_LEVEL`` dans ``fess.in.sh``.
 
 ::
 
     FESS_LOG_LEVEL=debug
 
 La valeur par défaut est ``warn``.
+
+.. note::
+   Le fichier ``fess.in.bat`` sous Windows ne lit pas la variable d'environnement ``FESS_LOG_LEVEL``.
+   La valeur étant inscrite directement sous la forme ``-Dfess.log.level=warn``, pour modifier le niveau de journalisation sous Windows,
+   éditez directement cette ligne dans ``fess.in.bat`` :
+
+   ::
+
+       set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.log.level=debug
 
 Configuration des journaux d'exploration
 ====================
@@ -553,7 +569,7 @@ Les journaux ne sont pas générés
    ::
 
        # Vérifier la syntaxe du fichier de configuration
-       xmllint --noout /usr/share/fess/lib/classes/log4j2.xml
+       xmllint --noout /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 4. **Vérifier SELinux**
 
@@ -576,7 +592,7 @@ Le fichier journal devient trop volumineux
    ::
 
        # Vérifier la configuration de log4j2.xml
-       grep -A 5 "RollingFile" /usr/share/fess/lib/classes/log4j2.xml
+       grep -A 5 "RollingFile" /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 3. **Désactiver les sorties de journaux inutiles**
 
@@ -604,7 +620,7 @@ Impossible de trouver un journal spécifique
 
    ::
 
-       grep "org.codelibs" /usr/share/fess/lib/classes/log4j2.xml
+       grep "org.codelibs" /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 2. **Vérifier le chemin du fichier journal**
 

--- a/ja/15.7/config/admin-logging.rst
+++ b/ja/15.7/config/admin-logging.rst
@@ -28,6 +28,8 @@
      - クロール実行時のログ、クロール対象URL、取得したドキュメント情報、エラー
    * - ``fess-suggest.log``
      - サジェスト(検索候補)生成時のログ、インデックス更新情報
+   * - ``fess-thumbnail.log``
+     - サムネイル生成プロセスのログ
    * - ``fess-llm.log``
      - LLM/RAGチャット関連のログ
    * - ``searchlog.log``
@@ -161,18 +163,23 @@
 ~~~~~~~~~~~~~~~~~~
 
 - **Zipインストール**: ``app/WEB-INF/classes/log4j2.xml``
-- **RPM/DEBパッケージ**: ``/usr/share/fess/lib/classes/log4j2.xml``
+- **RPM/DEBパッケージ**: ``/usr/share/fess/app/WEB-INF/classes/log4j2.xml``
 
 基本的な設定例
 ~~~~~~~~~~~~~~
 
 **デフォルトのログレベル:**
 
+デフォルトの ``log4j2.xml`` では、ログレベルは変数 ``${log.level}`` で指定されています。
+この変数は起動時に ``-Dfess.log.level`` （ ``FESS_LOG_LEVEL`` 、デフォルト ``warn`` ）の値に解決されます。
+
 ::
 
-    <Logger name="org.codelibs" level="warn"/>
+    <Logger name="org.codelibs" level="${log.level}"/>
 
 **例: DEBUGレベルに変更**
+
+変数を使わず、特定のレベルを直接指定することもできます。
 
 ::
 
@@ -194,13 +201,22 @@
 ~~~~~~~~~~~~~~~~~~
 
 システム起動時にログレベルを指定することもできます。
-``fess.in.sh`` （Windowsの場合は ``fess.in.bat`` ）で ``FESS_LOG_LEVEL`` を設定します。
+Linux環境では ``fess.in.sh`` で ``FESS_LOG_LEVEL`` を設定します。
 
 ::
 
     FESS_LOG_LEVEL=debug
 
 デフォルト値は ``warn`` です。
+
+.. note::
+   Windowsの ``fess.in.bat`` は ``FESS_LOG_LEVEL`` 環境変数を参照しません。
+   ``-Dfess.log.level=warn`` の値が直接記述されているため、Windowsでログレベルを変更するには
+   ``fess.in.bat`` 内のこの行を直接編集してください。
+
+   ::
+
+       set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.log.level=debug
 
 クローラーログの設定
 ====================
@@ -552,7 +568,7 @@ JSON形式でログ出力
    ::
 
        # 設定ファイルの構文チェック
-       xmllint --noout /usr/share/fess/lib/classes/log4j2.xml
+       xmllint --noout /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 4. **SELinuxの確認**
 
@@ -575,7 +591,7 @@ JSON形式でログ出力
    ::
 
        # log4j2.xmlの設定確認
-       grep -A 5 "RollingFile" /usr/share/fess/lib/classes/log4j2.xml
+       grep -A 5 "RollingFile" /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 3. **不要なログ出力の無効化**
 
@@ -603,7 +619,7 @@ JSON形式でログ出力
 
    ::
 
-       grep "org.codelibs.fess" /usr/share/fess/lib/classes/log4j2.xml
+       grep "org.codelibs.fess" /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 2. **ログファイルパスの確認**
 

--- a/ko/15.7/config/admin-logging.rst
+++ b/ko/15.7/config/admin-logging.rst
@@ -28,6 +28,8 @@
      - 크롤 실행 시의 로그, 크롤 대상 URL, 취득한 문서 정보, 오류
    * - ``fess-suggest.log``
      - 제안(검색 후보) 생성 시의 로그, 인덱스 업데이트 정보
+   * - ``fess-thumbnail.log``
+     - 썸네일 생성 프로세스의 로그
    * - ``fess-llm.log``
      - LLM/RAG 채팅 관련 로그
    * - ``searchlog.log``
@@ -161,7 +163,7 @@
 ~~~~~~~~~~~~~~~~~~
 
 - **Zip 설치**: ``app/WEB-INF/classes/log4j2.xml``
-- **RPM/DEB 패키지**: ``/usr/share/fess/lib/classes/log4j2.xml``
+- **RPM/DEB 패키지**: ``/usr/share/fess/app/WEB-INF/classes/log4j2.xml``
 
 기본 설정 예
 ~~~~~~~~~~~~~~
@@ -170,7 +172,12 @@
 
 ::
 
-    <Logger name="org.codelibs" level="warn"/>
+    <Logger name="org.codelibs" level="${log.level}"/>
+
+기본 log4j2.xml 에서는 로그 레벨을 변수 ``${log.level}`` 로 지정합니다.
+이 변수는 시작 시 ``-Dfess.log.level`` (``FESS_LOG_LEVEL``, 기본값: ``warn``) 의 값으로 해석됩니다.
+
+변수를 사용하는 대신 레벨을 직접 지정할 수도 있습니다.
 
 **예: DEBUG 레벨로 변경**
 
@@ -193,14 +200,22 @@
 환경 변수를 통한 설정
 ~~~~~~~~~~~~~~~~~~
 
-시스템 시작 시 로그 레벨을 지정할 수도 있습니다.
-``fess.in.sh`` (Windows의 경우 ``fess.in.bat``)에서 ``FESS_LOG_LEVEL`` 을 설정합니다.
+Linux 환경에서는 시스템 시작 시 ``fess.in.sh`` 의 ``FESS_LOG_LEVEL`` 을 설정하여 로그 레벨을 지정할 수 있습니다.
 
 ::
 
     FESS_LOG_LEVEL=debug
 
 기본값은 ``warn`` 입니다.
+
+.. note::
+   Windows 의 ``fess.in.bat`` 은 ``FESS_LOG_LEVEL`` 환경 변수를 읽지 않습니다.
+   로그 레벨이 ``-Dfess.log.level=warn`` 으로 직접 기재되어 있기 때문에,
+   Windows 에서 로그 레벨을 변경하려면 ``fess.in.bat`` 의 해당 줄을 직접 편집하십시오.
+
+   ::
+
+       set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.log.level=debug
 
 크롤러 로그 설정
 ====================
@@ -552,7 +567,7 @@ JSON 형식으로 로그 출력
    ::
 
        # 설정 파일 구문 검사
-       xmllint --noout /usr/share/fess/lib/classes/log4j2.xml
+       xmllint --noout /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 4. **SELinux 확인**
 
@@ -575,7 +590,7 @@ JSON 형식으로 로그 출력
    ::
 
        # log4j2.xml 설정 확인
-       grep -A 5 "RollingFile" /usr/share/fess/lib/classes/log4j2.xml
+       grep -A 5 "RollingFile" /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 3. **불필요한 로그 출력 비활성화**
 
@@ -603,7 +618,7 @@ JSON 형식으로 로그 출력
 
    ::
 
-       grep "org.codelibs" /usr/share/fess/lib/classes/log4j2.xml
+       grep "org.codelibs" /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 2. **로그 파일 경로 확인**
 

--- a/zh-cn/15.7/config/admin-logging.rst
+++ b/zh-cn/15.7/config/admin-logging.rst
@@ -28,6 +28,8 @@
      - 爬取执行时的日志、爬取目标URL、获取的文档信息、错误
    * - ``fess-suggest.log``
      - 建议(搜索候选)生成时的日志、索引更新信息
+   * - ``fess-thumbnail.log``
+     - 缩略图生成过程的日志
    * - ``fess-llm.log``
      - LLM/RAG聊天相关日志
    * - ``searchlog.log``
@@ -161,7 +163,7 @@
 ~~~~~~~~~~~~~~~~~~
 
 - **Zip安装**: ``app/WEB-INF/classes/log4j2.xml``
-- **RPM/DEB软件包**: ``/usr/share/fess/lib/classes/log4j2.xml``
+- **RPM/DEB软件包**: ``/usr/share/fess/app/WEB-INF/classes/log4j2.xml``
 
 基本配置示例
 ~~~~~~~~~~~~~~
@@ -170,7 +172,11 @@
 
 ::
 
-    <Logger name="org.codelibs" level="warn"/>
+    <Logger name="org.codelibs" level="${log.level}"/>
+
+在默认的 log4j2.xml 中,日志级别由变量 ``${log.level}`` 指定。该变量在启动时解析为 ``-Dfess.log.level`` 的值(``FESS_LOG_LEVEL``,默认为 ``warn``)。
+
+也可以不使用变量,而是直接指定级别。
 
 **示例: 更改为DEBUG级别**
 
@@ -194,13 +200,22 @@
 ~~~~~~~~~~~~~~~~~~
 
 系统启动时也可以指定日志级别。
-在 ``fess.in.sh`` (Windows下为 ``fess.in.bat``)中设置 ``FESS_LOG_LEVEL``。
+在 Linux 环境下,请在 ``fess.in.sh`` 中设置 ``FESS_LOG_LEVEL``。
 
 ::
 
     FESS_LOG_LEVEL=debug
 
 默认值为 ``warn``。
+
+.. note::
+   Windows 的 ``fess.in.bat`` 不读取 ``FESS_LOG_LEVEL`` 环境变量。
+   由于日志级别以 ``-Dfess.log.level=warn`` 的形式直接写入文件,
+   如需在 Windows 上更改日志级别,请直接编辑 ``fess.in.bat`` 中的该行。
+
+   ::
+
+       set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.log.level=debug
 
 爬虫日志配置
 ====================
@@ -553,7 +568,7 @@ JSON格式输出日志
    ::
 
        # 配置文件语法检查
-       xmllint --noout /usr/share/fess/lib/classes/log4j2.xml
+       xmllint --noout /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 4. **SELinux确认**
 
@@ -576,7 +591,7 @@ JSON格式输出日志
    ::
 
        # 确认log4j2.xml配置
-       grep -A 5 "RollingFile" /usr/share/fess/lib/classes/log4j2.xml
+       grep -A 5 "RollingFile" /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 3. **禁用不必要的日志输出**
 
@@ -604,7 +619,7 @@ JSON格式输出日志
 
    ::
 
-       grep "org.codelibs" /usr/share/fess/lib/classes/log4j2.xml
+       grep "org.codelibs" /usr/share/fess/app/WEB-INF/classes/log4j2.xml
 
 2. **确认日志文件路径**
 


### PR DESCRIPTION
## Summary

Reviewed `15.7/config/admin-logging.rst` against the actual Fess source code and corrected several inaccuracies. The Japanese source was verified first, then the same fixes were mirrored across all language versions (de/en/es/fr/ja/ko/zh-cn).

## Changes

- **Fix RPM/DEB `log4j2.xml` path.** The doc pointed to `/usr/share/fess/lib/classes/log4j2.xml`, but the exploded webapp (including `WEB-INF/classes/log4j2.xml`) is deployed under `/usr/share/fess/app`. Corrected to `/usr/share/fess/app/WEB-INF/classes/log4j2.xml` (config-file location section plus three troubleshooting command examples).
- **Add missing `fess-thumbnail.log`.** The log file list omitted the thumbnail generation process log produced by the thumbnail sub-process.
- **Default logger level uses a variable.** The default `log4j2.xml` defines `level="${log.level}"` (resolved at startup from `-Dfess.log.level` / `FESS_LOG_LEVEL`, default `warn`), not a literal `level="warn"`. Updated the example and added an explanation so the value can be found in the actual file.
- **Clarify Windows behavior.** `fess.in.bat` hardcodes `-Dfess.log.level=warn` and does not read the `FESS_LOG_LEVEL` environment variable. Added a note that Windows users must edit this line directly, instead of implying `FESS_LOG_LEVEL` works on Windows.

## Verification

Facts confirmed against source:

- `src/main/resources/log4j2.xml` and `webapp/WEB-INF/env/{crawler,suggest,thumbnail}/resources/log4j2.xml` (appenders, `${log.level}`/`${log.pattern}` properties, `backup.max.history=10`, `100 MB`)
- `job/ExecJob.java#getLogName()` (hyphenated `fess-crawler` / `fess-suggest` / `fess-thumbnail` naming)
- `assemblies/files/fess.in.sh` (`FESS_LOG_LEVEL` default `warn`) and `fess.in.bat` (hardcoded `-Dfess.log.level=warn`)
- `admin/general/AdminGeneralAction.java` + `SystemHelper.setLogLevel()` (runtime-only log level change — already documented correctly)
- `fess_config.scheduled_job/scheduled_job.bulk` (Default Crawler `.logLevel("info")`)
- `logging.properties` (`server_%g.log` via Tomcat juli — confirmed accurate)
- `pom.xml` / `common-bin.xml` packaging targets (deployment paths)

## Notes

The German (`de`) version is a pre-existing condensed translation of this page; the applicable corrections were made within its existing scope.