### PR TITLE
docs(config): correct 15.7 datastore overview against implementation

### DIFF
--- a/de/15.7/config/datastore/ds-overview.rst
+++ b/de/15.7/config/datastore/ds-overview.rst
@@ -38,7 +38,7 @@ Cloud-Speicher
      - Crawlt Dateien und Ordner von Dropbox
    * - :doc:`ds-gsuite`
      - fess-ds-gsuite
-     - Crawlt Google Drive, Gmail usw.
+     - Crawlt Google Drive
    * - :doc:`ds-microsoft365`
      - fess-ds-microsoft365
      - Crawlt OneDrive, SharePoint usw.
@@ -111,11 +111,12 @@ Datenspeicher-Konnektor-Plugins können über die Administrationsoberfläche ins
 Über die Administrationsoberfläche
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Melden Sie sich bei der Administrationsoberfläche an
-2. Navigieren Sie zu "System" -> "Plugins"
-3. Suchen Sie auf der Registerkarte "Available" nach dem gewünschten Plugin
-4. Klicken Sie auf "Installieren"
-5. Starten Sie |Fess| neu
+1. Bei der Administrationsoberfläche anmelden
+2. Zu "System" → "Plugin" navigieren
+3. Auf die Schaltfläche "Installieren" klicken
+4. Das Plugin im Tab "Remote" auswählen (oder im Tab "Lokal" eine JAR-Datei hochladen)
+5. Auf "Installieren" klicken
+6. |Fess| neu starten
 
 
 Grundlagen der Datenspeicher-Konfiguration
@@ -137,7 +138,7 @@ Einstellungen, die allen Datenspeicher-Konnektoren gemeinsam sind:
    * - Name
      - Identifikationsname der Konfiguration
    * - Handler-Name
-     - Name des zu verwendenden Konnektor-Handlers (z.B. ``BoxDataStore``)
+     - Name des zu verwendenden Konnektor-Handlers (z.B. ``CsvDataStore``)
    * - Parameter
      - Konnektor-spezifische Konfigurationsparameter (Schlüssel=Wert-Format)
    * - Skript
@@ -169,31 +170,29 @@ Parameter werden im Format ``Schlüssel=Wert`` mit Zeilenumbrüchen als Trennzei
 Skript-Einstellungen
 --------------------
 
-Im Skript werden die abgerufenen Daten auf die Index-Felder von |Fess| abgebildet:
+Im Skript werden die abgerufenen Daten auf die Index-Felder von |Fess| abgebildet.
+Die linke Seite jeder Zeile ist das |Fess|-Indexfeld, die rechte Seite das vom Konnektor gelieferte Feld.
+
+Das folgende Beispiel gilt für den CSV-Konnektor mit den Spaltenüberschriften ``link``, ``subject`` und ``body``:
 
 ::
 
-    url=data.url
-    title=data.name
-    content=data.content
-    mimetype=data.mimetype
-    filetype=data.filetype
-    filename=data.filename
-    created=data.created
-    lastModified=data.lastModified
-    contentLength=data.contentLength
+    url=link
+    title=subject
+    content=body
 
 .. note::
 
-   Das Präfix ``data.*`` wird hier als Beispiel gezeigt und gilt für CSV- und JSON-Konnektoren.
-   Jeder Konnektor verwendet sein eigenes Präfix für die abgerufenen Daten, z.B.:
+   Die im Skript referenzierbaren Feldnamen unterscheiden sich je nach Konnektor.
+   Box/Dropbox/Google Drive/OneDrive referenzieren das abgerufene Objekt über das Präfix ``file.*``;
+   Slack verwendet ``message.*``; Jira verwendet ``issue.*``.
+   CSV-, JSON- und Datenbank-Konnektoren verwenden kein Präfix — die Felder werden direkt referenziert:
 
-   - ``file.*`` -- Box, Dropbox, Google Drive, OneDrive
-   - ``message.*`` -- Slack
-   - ``issue.*`` -- Jira
-   - ``page.*`` -- Confluence
+   - CSV: Spaltenüberschriften (bei ``has_header_line=true``), oder ``cell1``, ``cell2``, ... (1-basierter Spaltenindex); zusätzlich stehen ``csvfile`` und ``csvfilename`` zur Verfügung.
+   - JSON: Feldnamen des JSON-Objekts.
+   - Datenbank: Spaltennamen (Aliasse) aus dem SELECT-Ergebnis.
 
-   Weitere Informationen finden Sie in der Dokumentation des jeweiligen Konnektors.
+   Weitere Details finden Sie in der Dokumentation des jeweiligen Konnektors.
 
 Authentifizierung
 =================
@@ -209,7 +208,7 @@ Der folgende Parameter wird von ``AbstractDataStore`` vererbt und steht in allen
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - Parameter
      - Standardwert
@@ -217,6 +216,9 @@ Der folgende Parameter wird von ``AbstractDataStore`` vererbt und steht in allen
    * - ``readInterval``
      - ``0``
      - Wartezeit in Millisekunden zwischen der Verarbeitung einzelner Datensätze. Kann verwendet werden, um die Last auf die Datenquelle zu begrenzen.
+   * - ``script_type``
+     - ``groovy``
+     - Typ der Skript-Engine für das Mapping der Indexfelder. Standardmäßig ist nur ``groovy`` verfügbar.
 
 Fehlerbehebung
 ==============
@@ -247,9 +249,10 @@ Keine Daten abrufbar
 Debug-Einstellungen
 -------------------
 
-Bei der Untersuchung von Problemen passen Sie das Log-Level an:
+Bei der Untersuchung von Problemen passen Sie das Log-Level an.
+Das Crawlen von Datenspeichern läuft im Crawler-Prozess, daher muss die Log-Konfigurationsdatei des Crawlers bearbeitet werden:
 
-``app/WEB-INF/classes/log4j2.xml``:
+``app/WEB-INF/env/crawler/resources/log4j2.xml``:
 
 ::
 

--- a/en/15.7/config/datastore/ds-overview.rst
+++ b/en/15.7/config/datastore/ds-overview.rst
@@ -39,7 +39,7 @@ Cloud Storage
      - Crawl files and folders from Dropbox
    * - :doc:`ds-gsuite`
      - fess-ds-gsuite
-     - Crawl Google Drive, Gmail, etc.
+     - Crawl Google Drive
    * - :doc:`ds-microsoft365`
      - fess-ds-microsoft365
      - Crawl OneDrive, SharePoint, etc.
@@ -110,10 +110,11 @@ Installing Plugins
 Data Store Connector plugins can be installed from the admin UI.
 
 1. Log in to the admin console
-2. Navigate to "System" -> "Plugins"
-3. Search for the target plugin in the "Available" tab
-4. Click "Install"
-5. Restart |Fess|
+2. Go to "System" -> "Plugin"
+3. Click the "Install" button
+4. Select the plugin from the "Remote" tab (or upload a JAR file from the "Local" tab)
+5. Click "Install"
+6. Restart |Fess|
 
 Data Store Configuration Basics
 ===============================
@@ -134,7 +135,7 @@ Configuration items common to all Data Store Connectors:
    * - Name
      - Identifier name for the configuration
    * - Handler Name
-     - Handler name for the connector (e.g., ``BoxDataStore``)
+     - Handler name for the connector (e.g., ``CsvDataStore``)
    * - Description
      - A free-text description of the configuration
    * - Parameters
@@ -167,22 +168,27 @@ Script Configuration
 --------------------
 
 Scripts map retrieved data to |Fess| index fields.
-The example below uses the ``data.*`` prefix, which is used by CSV and JSON connectors.
-Other connectors use their own prefix: ``file.*`` for Box/Dropbox/Google Drive/OneDrive,
-``message.*`` for Slack, ``issue.*`` for Jira, etc.
-See each connector's documentation for the available fields.
+The left side of each line is a |Fess| index field; the right side is the field obtained from the connector.
+
+The following example is for a CSV connector whose header columns are ``link``, ``subject``, and ``body``:
 
 ::
 
-    url=data.url
-    title=data.name
-    content=data.content
-    mimetype=data.mimetype
-    filetype=data.filetype
-    filename=data.filename
-    created=data.created
-    lastModified=data.lastModified
-    contentLength=data.contentLength
+    url=link
+    title=subject
+    content=body
+
+.. note::
+
+   Field names referenced in scripts differ per connector.
+   Box/Dropbox/Google Drive/OneDrive reference the fetched object with a prefix: ``file.*``; Slack uses ``message.*``; Jira uses ``issue.*``.
+   CSV, JSON, and Database connectors do NOT use a prefix; fields are referenced directly:
+
+   - CSV: header column names (when ``has_header_line=true``), or ``cell1``, ``cell2``, ... (1-based column index); plus ``csvfile`` and ``csvfilename``.
+   - JSON: JSON object field names.
+   - Database: column names (aliases) from the SELECT result.
+
+   Refer to each connector's individual documentation for details.
 
 Authentication Configuration
 ============================
@@ -198,7 +204,7 @@ The following parameter is inherited from ``AbstractDataStore`` and available in
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - Parameter
      - Default
@@ -207,6 +213,9 @@ The following parameter is inherited from ``AbstractDataStore`` and available in
      - ``0``
      - Delay in milliseconds between processing each record. Increase this value to
        reduce load on the external service.
+   * - ``script_type``
+     - ``groovy``
+     - Type of script engine used for index field mapping. Only ``groovy`` is available by default.
 
 Troubleshooting
 ===============
@@ -237,9 +246,9 @@ Cannot Retrieve Data
 Debug Configuration
 -------------------
 
-When investigating issues, adjust the log level:
+When investigating issues, adjust the log level. Datastore crawling runs in the crawler process, so you must edit the crawler's log configuration file:
 
-``app/WEB-INF/classes/log4j2.xml``:
+``app/WEB-INF/env/crawler/resources/log4j2.xml``:
 
 ::
 

--- a/es/15.7/config/datastore/ds-overview.rst
+++ b/es/15.7/config/datastore/ds-overview.rst
@@ -39,7 +39,7 @@ Almacenamiento en la Nube
      - Rastrea archivos y carpetas de Dropbox
    * - :doc:`ds-gsuite`
      - fess-ds-gsuite
-     - Rastrea Google Drive, Gmail, etc.
+     - Rastrea Google Drive
    * - :doc:`ds-microsoft365`
      - fess-ds-microsoft365
      - Rastrea OneDrive, SharePoint, etc.
@@ -113,10 +113,11 @@ Desde la Consola de Administracion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Inicie sesion en la consola de administracion
-2. Navegue a "Sistema" -> "Plugins"
-3. Busque el plugin deseado en la pestana "Disponible"
-4. Haga clic en "Instalar"
-5. Reinicie |Fess|
+2. Vaya a "Sistema" -> "Plugin"
+3. Haga clic en el boton "Instalar"
+4. Seleccione el plugin en la pestana "Remoto" (o suba un archivo JAR desde la pestana "Local")
+5. Haga clic en "Instalar"
+6. Reinicie |Fess|
 
 Conceptos Basicos de Configuracion del Almacen de Datos
 =======================================================
@@ -139,7 +140,7 @@ Elementos de configuracion comunes a todos los conectores de almacen de datos:
    * - Descripcion
      - Texto descriptivo de la configuracion
    * - Nombre del Manejador
-     - Nombre del manejador del conector a utilizar (ej., ``BoxDataStore``)
+     - Nombre del manejador del conector a utilizar (ej., ``CsvDataStore``)
    * - Parametros
      - Parametros de configuracion especificos del conector (formato key=value)
    * - Script
@@ -170,26 +171,26 @@ Configuracion de Script
 -----------------------
 
 Los scripts mapean los datos obtenidos a los campos del indice de |Fess|.
+El lado izquierdo de cada linea es el campo del indice de |Fess|; el lado derecho es el campo obtenido del conector.
 
-El siguiente es un ejemplo utilizando el prefijo ``data.*`` para conectores CSV/JSON:
+El siguiente es un ejemplo para el conector CSV con columnas de encabezado ``link``, ``subject`` y ``body``:
 
 ::
 
-    url=data.url
-    title=data.name
-    content=data.content
-    mimetype=data.mimetype
-    filetype=data.filetype
-    filename=data.filename
-    created=data.created
-    lastModified=data.lastModified
-    contentLength=data.contentLength
+    url=link
+    title=subject
+    content=body
 
 .. note::
 
-   El prefijo de los campos en el script varia segun el conector.
-   Por ejemplo, Box/Dropbox/Google Drive/OneDrive utilizan ``file.*``, Slack utiliza ``message.*``,
-   Jira utiliza ``issue.*``.
+   Los nombres de campo utilizables en los scripts difieren segun el conector.
+   Box/Dropbox/Google Drive/OneDrive referencian el objeto obtenido con el prefijo ``file.*``; Slack utiliza ``message.*``; Jira utiliza ``issue.*``.
+   Los conectores CSV, JSON y de base de datos NO utilizan prefijo; los campos se referencian directamente:
+
+   - CSV: nombres de columna del encabezado (si ``has_header_line=true``), o ``cell1``, ``cell2``, ... (indice basado en 1); ademas de ``csvfile`` y ``csvfilename``.
+   - JSON: nombres de campo del objeto JSON.
+   - Base de datos: nombres de columna (alias) del resultado del SELECT.
+
    Consulte la documentacion individual de cada conector para mas detalles.
 
 Configuracion de Autenticacion
@@ -207,7 +208,7 @@ Parametros comunes disponibles para todos los conectores de almacen de datos:
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - Parametro
      - Valor por defecto
@@ -215,6 +216,9 @@ Parametros comunes disponibles para todos los conectores de almacen de datos:
    * - ``readInterval``
      - ``0``
      - Tiempo de espera entre el procesamiento de cada registro (milisegundos). Se utiliza para reducir la carga del servidor al procesar grandes cantidades de datos.
+   * - ``script_type``
+     - ``groovy``
+     - Tipo de motor de scripts usado para el mapeo de campos del indice. De forma predeterminada solo esta disponible ``groovy``.
 
 Solucion de Problemas
 =====================
@@ -245,9 +249,9 @@ No Se Pueden Obtener Datos
 Configuracion de Depuracion
 ---------------------------
 
-Al investigar problemas, ajuste el nivel de log:
+Al investigar problemas, ajuste el nivel de log. El rastreo de almacenes de datos se ejecuta en el proceso del rastreador, por lo que debe editar el archivo de configuracion de log del rastreador:
 
-``app/WEB-INF/classes/log4j2.xml``:
+``app/WEB-INF/env/crawler/resources/log4j2.xml``:
 
 ::
 

--- a/fr/15.7/config/datastore/ds-overview.rst
+++ b/fr/15.7/config/datastore/ds-overview.rst
@@ -39,7 +39,7 @@ Stockage cloud
      - Exploration des fichiers et dossiers Dropbox
    * - :doc:`ds-gsuite`
      - fess-ds-gsuite
-     - Exploration de Google Drive, Gmail, etc.
+     - Exploration de Google Drive
    * - :doc:`ds-microsoft365`
      - fess-ds-microsoft365
      - Exploration de OneDrive, SharePoint, etc.
@@ -113,10 +113,11 @@ Depuis l'interface d'administration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Connectez-vous a l'interface d'administration
-2. Naviguez vers "Systeme" -> "Plugins"
-3. Dans l'onglet "Disponibles", recherchez le plugin souhaite
-4. Cliquez sur "Installer"
-5. Redemarrez |Fess|
+2. Naviguez vers "Systeme" -> "Plugin"
+3. Cliquez sur le bouton "Installer"
+4. Selectionnez le plugin dans l'onglet "Distant" (ou telechargez un fichier JAR depuis l'onglet "Local")
+5. Cliquez sur "Installer"
+6. Redemarrez |Fess|
 
 Configuration de base des DataStores
 ====================================
@@ -139,7 +140,7 @@ Elements de configuration communs a tous les connecteurs DataStore :
    * - Description
      - Description de la configuration
    * - Nom du handler
-     - Nom du handler du connecteur a utiliser (ex: ``BoxDataStore``)
+     - Nom du handler du connecteur a utiliser (ex: ``CsvDataStore``)
    * - Parametres
      - Parametres de configuration specifiques au connecteur (format key=value)
    * - Script
@@ -170,27 +171,27 @@ Configuration du script
 -----------------------
 
 Le script permet de mapper les donnees recuperees vers les champs d'index de |Fess|.
+Chaque ligne du script associe un champ d'index |Fess| (membre gauche) au champ fourni par le connecteur (membre droit).
 
-Voici un exemple utilisant le prefixe ``data.*`` pour les connecteurs CSV/JSON :
+Voici un exemple pour le connecteur CSV avec les colonnes d'en-tete ``link``, ``subject`` et ``body`` :
 
 ::
 
-    url=data.url
-    title=data.name
-    content=data.content
-    mimetype=data.mimetype
-    filetype=data.filetype
-    filename=data.filename
-    created=data.created
-    lastModified=data.lastModified
-    contentLength=data.contentLength
+    url=link
+    title=subject
+    content=body
 
 .. note::
 
-   Le prefixe des champs dans le script varie selon le connecteur.
-   Par exemple, Box/Dropbox/Google Drive/OneDrive utilisent ``file.*``, Slack utilise ``message.*``,
-   Jira utilise ``issue.*``.
-   Consultez la documentation de chaque connecteur pour plus de details.
+   Les noms de champs utilisables dans le script varient selon le connecteur.
+   Box/Dropbox/Google Drive/OneDrive referencent l'objet recupere avec le prefixe ``file.*`` ; Slack utilise ``message.*`` ; Jira utilise ``issue.*``.
+   En revanche, les connecteurs CSV, JSON et Base de donnees n'utilisent aucun prefixe ; les champs sont references directement :
+
+   - CSV : noms des colonnes d'en-tete (si ``has_header_line=true``), ou ``cell1``, ``cell2``, ... (index base 1) ; ainsi que ``csvfile`` et ``csvfilename``.
+   - JSON : noms des champs de l'objet JSON.
+   - Base de donnees : noms des colonnes (alias) du resultat SELECT.
+
+   Consultez la documentation individuelle de chaque connecteur pour plus de details.
 
 Configuration de l'authentification
 ===================================
@@ -207,7 +208,7 @@ Parametres communs a tous les connecteurs DataStore :
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - Parametre
      - Defaut
@@ -215,6 +216,9 @@ Parametres communs a tous les connecteurs DataStore :
    * - ``readInterval``
      - ``0``
      - Delai d'attente entre le traitement de chaque enregistrement (en millisecondes). Utilisez ce parametre pour reduire la charge du serveur lors du traitement de grandes quantites de donnees.
+   * - ``script_type``
+     - ``groovy``
+     - Type de moteur de script utilise pour le mappage des champs d'index. Par defaut, seul ``groovy`` est disponible.
 
 Depannage
 =========
@@ -245,9 +249,9 @@ Impossible de recuperer les donnees
 Configuration de debogage
 -------------------------
 
-Pour investiguer les problemes, ajustez le niveau de log :
+Pour investiguer les problemes, ajustez le niveau de log. Le crawling des datastores s'execute dans le processus crawler ; c'est donc le fichier de configuration des logs du crawler qu'il faut modifier :
 
-``app/WEB-INF/classes/log4j2.xml`` :
+``app/WEB-INF/env/crawler/resources/log4j2.xml`` :
 
 ::
 

--- a/ja/15.7/config/datastore/ds-overview.rst
+++ b/ja/15.7/config/datastore/ds-overview.rst
@@ -39,7 +39,7 @@
      - Dropboxのファイルとフォルダをクロール
    * - :doc:`ds-gsuite`
      - fess-ds-gsuite
-     - Google Drive、Gmailなどをクロール
+     - Google Driveをクロール
    * - :doc:`ds-microsoft365`
      - fess-ds-microsoft365
      - OneDrive、SharePointなどをクロール
@@ -133,9 +133,10 @@
 
 1. 管理画面にログイン
 2. 「システム」→「プラグイン」に移動
-3. 「Available」タブで対象のプラグインを検索
-4. 「インストール」をクリック
-5. |Fess| を再起動
+3. 「インストール」ボタンをクリック
+4. 「リモート」タブからインストールするプラグインを選択（または「ローカル」タブでJARファイルをアップロード）
+5. 「インストール」をクリック
+6. |Fess| を再起動
 
 
 データストア設定の基本
@@ -159,7 +160,7 @@
    * - 説明
      - 設定の説明文
    * - ハンドラ名
-     - 使用するコネクタのハンドラ名（例: ``BoxDataStore``）
+     - 使用するコネクタのハンドラ名（例: ``CsvDataStore``）
    * - パラメーター
      - コネクタ固有の設定パラメーター（key=value形式）
    * - スクリプト
@@ -190,26 +191,27 @@
 --------------
 
 スクリプトでは、取得したデータを |Fess| のインデックスフィールドにマッピングします。
+各行の左辺が |Fess| のインデックスフィールド、右辺がコネクタから取得したフィールドです。
 
-以下はCSV/JSONコネクタでの ``data.*`` プレフィックスを使用した例です:
+以下はCSVコネクタ（ヘッダー行に ``link`` 、 ``subject`` 、 ``body`` の列がある場合）の例です:
 
 ::
 
-    url=data.url
-    title=data.name
-    content=data.content
-    mimetype=data.mimetype
-    filetype=data.filetype
-    filename=data.filename
-    created=data.created
-    lastModified=data.lastModified
-    contentLength=data.contentLength
+    url=link
+    title=subject
+    content=body
 
 .. note::
 
-   スクリプトで使用するフィールドのプレフィックスはコネクタごとに異なります。
-   例えば、Box/Dropbox/Google Drive/OneDriveでは ``file.*`` 、Slackでは ``message.*`` 、
-   Jiraでは ``issue.*`` を使用します。
+   スクリプトで参照できるフィールド名はコネクタごとに異なります。
+   Box/Dropbox/Google Drive/OneDriveでは ``file.*`` 、Slackでは ``message.*`` 、
+   Jiraでは ``issue.*`` のように、取得したオブジェクトをプレフィックス付きで参照します。
+   一方、CSV・JSON・データベースの各コネクタはプレフィックスを使用せず、フィールド名を直接参照します:
+
+   - CSV: ヘッダー行の列名（ ``has_header_line=true`` の場合）、または ``cell1`` 、 ``cell2`` ...（1始まりの列インデックス）。加えて ``csvfile`` 、 ``csvfilename`` が利用できます。
+   - JSON: JSONオブジェクトのフィールド名
+   - データベース: SELECT結果の列名（エイリアス）
+
    各コネクタの詳細は個別のドキュメントを参照してください。
 
 認証設定
@@ -227,7 +229,7 @@
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - パラメーター
      - デフォルト
@@ -235,6 +237,9 @@
    * - ``readInterval``
      - ``0``
      - 各レコードの処理間の待機時間（ミリ秒）。大量データ処理時にサーバー負荷を軽減するために使用します。
+   * - ``script_type``
+     - ``groovy``
+     - インデックスフィールドのマッピングに使用するスクリプトエンジンの種類。標準では ``groovy`` のみ利用可能です。
 
 トラブルシューティング
 ======================
@@ -265,9 +270,10 @@
 デバッグ設定
 ------------
 
-問題を調査する際は、ログレベルを調整します:
+問題を調査する際は、ログレベルを調整します。データストアのクロールはクローラープロセスで
+実行されるため、クローラー用のログ設定ファイルを編集します:
 
-``app/WEB-INF/classes/log4j2.xml``:
+``app/WEB-INF/env/crawler/resources/log4j2.xml``:
 
 ::
 

--- a/ko/15.7/config/datastore/ds-overview.rst
+++ b/ko/15.7/config/datastore/ds-overview.rst
@@ -39,7 +39,7 @@
      - Dropbox의 파일 및 폴더를 크롤링
    * - :doc:`ds-gsuite`
      - fess-ds-gsuite
-     - Google Drive, Gmail 등을 크롤링
+     - Google Drive를 크롤링
    * - :doc:`ds-microsoft365`
      - fess-ds-microsoft365
      - OneDrive, SharePoint 등을 크롤링
@@ -111,9 +111,10 @@
 
 1. 관리 화면에 로그인
 2. "시스템" → "플러그인"으로 이동
-3. "Available" 탭에서 대상 플러그인 검색
-4. "설치"를 클릭
-5. |Fess| 재시작
+3. "설치" 버튼 클릭
+4. "원격" 탭에서 설치할 플러그인 선택 (또는 "로컬" 탭에서 JAR 파일 업로드)
+5. "설치" 클릭
+6. |Fess| 재시작
 
 데이터스토어 설정 기본
 ======================
@@ -134,7 +135,7 @@
    * - 이름
      - 설정의 식별명
    * - 핸들러 이름
-     - 사용할 커넥터의 핸들러 이름 (예: ``BoxDataStore``)
+     - 사용할 커넥터의 핸들러 이름 (예: ``CsvDataStore``)
    * - 설명
      - 이 데이터스토어 설정에 대한 메모
    * - 파라미터
@@ -166,30 +167,29 @@
 스크립트 설정
 --------------
 
-스크립트에서는 가져온 데이터를 |Fess| 의 인덱스 필드에 매핑합니다:
+스크립트에서는 가져온 데이터를 |Fess| 의 인덱스 필드에 매핑합니다.
+각 행의 왼쪽이 |Fess| 의 인덱스 필드, 오른쪽이 커넥터에서 가져온 필드입니다.
+
+이하는 CSV 커넥터 (헤더 행에 ``link``, ``subject``, ``body`` 열이 있는 경우)의 예입니다:
 
 ::
 
-    url=data.url
-    title=data.name
-    content=data.content
-    mimetype=data.mimetype
-    filetype=data.filetype
-    filename=data.filename
-    created=data.created
-    lastModified=data.lastModified
-    contentLength=data.contentLength
+    url=link
+    title=subject
+    content=body
 
 .. note::
 
-   위의 예에서 사용하는 ``data.*`` 프리픽스는 CSV/JSON 커넥터용입니다.
-   각 커넥터에는 고유의 프리픽스가 있습니다:
+   스크립트에서 참조할 수 있는 필드 이름은 커넥터마다 다릅니다.
+   Box/Dropbox/Google Drive/OneDrive에서는 ``file.*``, Slack에서는 ``message.*``,
+   Jira에서는 ``issue.*`` 와 같이 가져온 오브젝트를 프리픽스를 붙여 참조합니다.
+   한편, CSV·JSON·데이터베이스 커넥터는 프리픽스를 사용하지 않고 필드 이름을 직접 참조합니다:
 
-   - ``file.*`` — Box, Dropbox, Google Drive, OneDrive
-   - ``message.*`` — Slack
-   - ``issue.*`` — Jira
+   - CSV: 헤더 행의 열 이름 (``has_header_line=true`` 인 경우), 또는 ``cell1``, ``cell2`` ... (1 시작 열 인덱스). 추가로 ``csvfile``, ``csvfilename`` 을 사용할 수 있습니다.
+   - JSON: JSON 오브젝트의 필드 이름
+   - 데이터베이스: SELECT 결과의 열 이름 (별칭)
 
-   자세한 내용은 각 커넥터의 문서를 참조하십시오.
+   각 커넥터의 자세한 내용은 개별 문서를 참조하십시오.
 
 인증 설정
 ========
@@ -204,14 +204,17 @@
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - 파라미터
      - 기본값
      - 설명
    * - ``readInterval``
      - ``0``
-     - 레코드 처리 사이의 대기 시간 (밀리초). ``AbstractDataStore`` 에서 상속됩니다.
+     - 레코드 처리 사이의 대기 시간 (밀리초). 대량 데이터 처리 시 서버 부하를 줄이기 위해 사용합니다.
+   * - ``script_type``
+     - ``groovy``
+     - 인덱스 필드 매핑에 사용하는 스크립트 엔진 종류. 기본적으로 ``groovy`` 만 사용할 수 있습니다.
 
 문제 해결
 ======================
@@ -242,9 +245,10 @@
 디버그 설정
 ------------
 
-문제를 조사할 때는 로그 레벨을 조정합니다:
+문제를 조사할 때는 로그 레벨을 조정합니다. 데이터스토어 크롤링은 크롤러 프로세스에서
+실행되므로, 크롤러용 로그 설정 파일을 편집합니다:
 
-``app/WEB-INF/classes/log4j2.xml``:
+``app/WEB-INF/env/crawler/resources/log4j2.xml``:
 
 ::
 

--- a/zh-cn/15.7/config/datastore/ds-overview.rst
+++ b/zh-cn/15.7/config/datastore/ds-overview.rst
@@ -39,7 +39,7 @@
      - 抓取Dropbox的文件和文件夹
    * - :doc:`ds-gsuite`
      - fess-ds-gsuite
-     - 抓取Google Drive、Gmail等
+     - 爬取 Google Drive
    * - :doc:`ds-microsoft365`
      - fess-ds-microsoft365
      - 抓取OneDrive、SharePoint等
@@ -114,9 +114,10 @@
 
 1. 登录管理界面
 2. 进入"系统"→"插件"
-3. 在"Available"标签页搜索目标插件
-4. 点击"安装"
-5. 重启 |Fess|
+3. 点击"安装"按钮
+4. 在"远程"选项卡中选择要安装的插件（或在"本地"选项卡上传 JAR 文件）
+5. 点击"安装"
+6. 重启 |Fess|
 
 数据存储设置基础
 ======================
@@ -139,7 +140,7 @@
    * - 描述
      - 设置的说明文本
    * - 处理器名
-     - 使用的连接器处理器名（例如：``BoxDataStore``）
+     - 使用的连接器处理器名（例如：``CsvDataStore``）
    * - 参数
      - 连接器特定的设置参数（key=value格式）
    * - 脚本
@@ -170,26 +171,26 @@
 --------------
 
 脚本将获取的数据映射到 |Fess| 的索引字段。
+左侧为 |Fess| 的索引字段，右侧为从连接器获取的字段。
 
-以下是CSV/JSON连接器使用 ``data.*`` 前缀的示例：
+以下是 CSV 连接器（头部列名为 ``link`` 、 ``subject`` 、 ``body`` ）的示例：
 
 ::
 
-    url=data.url
-    title=data.name
-    content=data.content
-    mimetype=data.mimetype
-    filetype=data.filetype
-    filename=data.filename
-    created=data.created
-    lastModified=data.lastModified
-    contentLength=data.contentLength
+    url=link
+    title=subject
+    content=body
 
 .. note::
 
-   脚本中使用的字段前缀因连接器而异。
-   例如，Box/Dropbox/Google Drive/OneDrive使用 ``file.*`` ，Slack使用 ``message.*`` ，
-   Jira使用 ``issue.*`` 。
+   脚本中可引用的字段名因连接器而异。
+   Box/Dropbox/Google Drive/OneDrive 使用 ``file.*`` 前缀引用获取的对象；Slack 使用 ``message.*`` ；Jira 使用 ``issue.*`` 。
+   而 CSV、JSON 和数据库连接器不使用前缀，直接引用字段名：
+
+   - CSV：头部行的列名（ ``has_header_line=true`` 时），或 ``cell1`` 、 ``cell2`` ...（从 1 开始的列索引）；此外还可使用 ``csvfile`` 和 ``csvfilename`` 。
+   - JSON：JSON 对象的字段名。
+   - 数据库：SELECT 结果的列名（别名）。
+
    各连接器的详细信息请参阅各自的文档。
 
 认证设置
@@ -207,7 +208,7 @@
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - 参数
      - 默认值
@@ -215,6 +216,9 @@
    * - ``readInterval``
      - ``0``
      - 各记录处理间的等待时间（毫秒）。在处理大量数据时，用于减轻服务器负载。
+   * - ``script_type``
+     - ``groovy``
+     - 用于索引字段映射的脚本引擎类型。默认仅提供 ``groovy`` 。
 
 故障排除
 ======================
@@ -245,9 +249,9 @@
 调试设置
 ------------
 
-调查问题时，调整日志级别：
+调查问题时，调整日志级别。数据存储的抓取在爬虫进程中执行，因此需要编辑爬虫用的日志配置文件：
 
-``app/WEB-INF/classes/log4j2.xml``：
+``app/WEB-INF/env/crawler/resources/log4j2.xml``：
 
 ::
 


### PR DESCRIPTION
## Summary

Reviewed `15.7/config/datastore/ds-overview.rst` against the actual Fess source code (`repos/fess`) and the `fess-ds-*` plugin implementations, and corrected several technical inaccuracies. Changes are applied consistently across all seven languages (ja/en/de/es/fr/ko/zh-cn).

## Findings & fixes

| # | Issue | Correction | Evidence |
|---|-------|-----------|----------|
| 1 | G Suite connector described as crawling "Google Drive, Gmail, etc." | Crawls **Google Drive only** | `fess-ds-gsuite` has only `GoogleDriveDataStore` + `GSuiteClient` (Drive API); no Gmail code |
| 2 | Plugin install steps reference an "Available" tab | Tabs are **"Remote"** and **"Local"**; added the local JAR-upload option | `AdminPluginAction` / `admin_plugin_installplugin.jsp`; labels `plugin_remote_install`=リモート, `plugin_local_install`=ローカル |
| 3 | Handler-name example `BoxDataStore` | Changed to `CsvDataStore` | `BoxDataStore.getName()` returns the literal `"Box"`, so the example was misleading; handler name is the class simple name |
| 4 | Script example used a fabricated `data.*` prefix for CSV/JSON | Removed; documented real per-connector field access | The Groovy engine binds the result map at the root level — there is **no `data` binding**, so `data.url` raises `MissingPropertyException` (verified empirically). CSV exposes header column names / `cell1`,`cell2`,…, `csvfile`, `csvfilename`; JSON exposes JSON field names; Database exposes column names — all **without a prefix**. `file.*`/`message.*`/`issue.*` (Box/Dropbox/GDrive/OneDrive, Slack, Jira) are nested maps and remain correct. |
| 5 | Common parameters listed only `readInterval`; `list-table` `:widths:` had 2 values for 3 columns | Added inherited `script_type` (default `groovy`); fixed `:widths:` to `20 15 65` | `AbstractDataStore.getScriptType()` (default `Constants.DEFAULT_SCRIPT` = `groovy`) |
| 6 | Debug log path `app/WEB-INF/classes/log4j2.xml` | Corrected to `app/WEB-INF/env/crawler/resources/log4j2.xml` | Datastore crawling runs in the crawler process (`CrawlJob`); no `log4j2.xml` exists under `WEB-INF/classes` |

## Verification

- Source of truth: `repos/fess`, `repos/fess-ds-*` (handler XML, DataStore classes, `AbstractDataStore`, `GroovyEngine`).
- The `data.*` → no-prefix conclusion was confirmed by running the same `Binding`/`GroovyShell` evaluation the engine uses: bare keys resolve, `data.<x>` throws `MissingPropertyException`.
- Confirmed no residual `data.*`, `WEB-INF/classes/log4j2`, `BoxDataStore`, or malformed `:widths:` remain in any language file.

> Note: `ds-csv.rst` and `ds-json.rst` contain the same `data.*` prefix error and should be corrected in a follow-up PR.