### PR TITLE
docs: correct and expand Database connector (ds-database) for 15.7

### DIFF
--- a/de/15.7/config/datastore/ds-database.rst
+++ b/de/15.7/config/datastore/ds-database.rst
@@ -24,19 +24,43 @@ Alle JDBC-kompatiblen Datenbanken werden unterstützt. Wichtige Beispiele:
 Voraussetzungen
 ===============
 
-1. Ein JDBC-Treiber ist erforderlich
-2. Lesezugriff auf die Datenbank ist erforderlich
-3. Bei großen Datenmengen ist ein geeignetes Query-Design wichtig
+1. Das Plugin ``fess-ds-db`` muss installiert sein
+2. Ein JDBC-Treiber für die Zieldatenbank ist erforderlich
+3. Lesezugriff auf die Datenbank ist erforderlich
+4. Bei großen Datenmengen ist ein geeignetes Query-Design wichtig
 
-Installation des JDBC-Treibers
-------------------------------
+Plugin-Installation
+-------------------
 
-Platzieren Sie den JDBC-Treiber im ``lib/``-Verzeichnis:
+Methode 1: JAR-Datei direkt platzieren
+
+::
+
+    # Herunterladen von Maven Central
+    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-db/X.X.X/fess-ds-db-X.X.X.jar
+
+    # Platzieren
+    cp fess-ds-db-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
+    # oder
+    cp fess-ds-db-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
+
+Methode 2: Installation über die Administrationsoberfläche
+
+1. "System" -> "Plugins" öffnen
+2. JAR-Datei hochladen
+3. |Fess| neu starten
+
+JDBC-Treiber-Installation
+--------------------------
+
+Platzieren Sie den JDBC-Treiber für die Zieldatenbank im Classpath von |Fess| (Verzeichnis ``app/WEB-INF/lib/``):
 
 ::
 
     # Beispiel: MySQL-Treiber
-    cp mysql-connector-java-8.0.33.jar /path/to/fess/lib/
+    cp mysql-connector-j-8.x.x.jar $FESS_HOME/app/WEB-INF/lib/
+    # oder
+    cp mysql-connector-j-8.x.x.jar /usr/share/fess/app/WEB-INF/lib/
 
 Starten Sie |Fess| neu, um den Treiber zu laden.
 
@@ -89,32 +113,41 @@ Parameterliste
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - Parameter
      - Erforderlich
      - Beschreibung
    * - ``driver``
      - Ja
-     - Klassenname des JDBC-Treibers
+     - Klassenname des JDBC-Treibers (ohne Angabe wird eine ``DataStoreException`` ausgelöst)
    * - ``url``
      - Ja
-     - JDBC-Verbindungs-URL
+     - JDBC-Verbindungs-URL (erforderlich für die Verbindung)
+   * - ``sql``
+     - Ja
+     - SQL-Query zum Abrufen der Daten (ohne Angabe wird eine ``DataStoreException`` ausgelöst)
    * - ``username``
      - Nein
      - Datenbank-Benutzername
    * - ``password``
      - Nein
      - Datenbank-Passwort
-   * - ``sql``
-     - Ja
-     - SQL-Query zum Abrufen der Daten
    * - ``fetch_size``
      - Nein
-     - Fetch-Größe (Standard: 100). Für MySQL-Streaming kann der Wert ``MIN_VALUE`` als String angegeben werden.
-   * - ``column_label.*``
+     - JDBC-Fetch-Größe. Für MySQL-Streaming-Resultsets kann ``MIN_VALUE`` angegeben werden
+   * - ``default_mimetype``
      - Nein
-     - Spaltenbezeichnung-Zuordnung. Bei BLOB-Spalten wird der MIME-Typ über die Dateierweiterung ermittelt und für die Inhaltsextraktion verwendet.
+     - Standard-MIME-Typ für die Inhaltsextraktion aus BLOB- und Binärspalten
+   * - ``column_label.mimetype``
+     - Nein
+     - Gibt den Spaltennamen an, der den MIME-Typ für die Extraktion aus BLOB- und Binärspalten enthält (Beispiel: ``column_label.mimetype=content_type``)
+   * - ``column_label.filename``
+     - Nein
+     - Gibt den Spaltennamen an, der den Dateinamen für die Extraktion aus BLOB- und Binärspalten enthält (MIME-Typ wird aus der Dateiendung abgeleitet)
+   * - ``info.*``
+     - Nein
+     - Zusätzliche JDBC-Verbindungseigenschaften (Beispiel: ``info.ssl=true``). Der Schlüssel ohne ``info.`` wird an den JDBC-Treiber übergeben
    * - ``readInterval``
      - Nein
      - Verzögerung in Millisekunden zwischen der Verarbeitung jeder Zeile. Standard: 0
@@ -136,7 +169,34 @@ Ordnen Sie die SQL-Spaltennamen den Index-Feldern zu:
 
 Verfügbare Felder:
 
-- ``<column_name>`` - Ergebnisspalten der SQL-Query (direkt über den Spaltennamen zugänglich)
+- ``<column_name>`` - Ergebnisspalten der SQL-Query (direkt über den Spaltenbezeichner zugänglich, ohne Präfix wie ``data.``)
+
+.. note::
+   Die Spaltennamen müssen mit den Spaltenbezeichnern (Aliasnamen) in der ``SELECT``-Klausel übereinstimmen.
+   Bei Aggregatfunktionen oder Ausdrücken vergeben Sie mit ``AS`` einen expliziten Aliasnamen
+   (Beispiel: ``COUNT(*) AS total``).
+
+Laden von BLOB- und Binärdaten
+==============================
+
+Spalten vom Typ BLOB, CLOB, NCLOB, Byte-Array oder Binär-Stream werden automatisch
+einer Inhaltsextraktion unterzogen (derselbe Extraktor wie beim Datei-Crawling) und als
+Text indiziert. Spalten vom Array-Typ werden in leerzeichengetrennte Zeichenketten
+umgewandelt. NULL-Werte werden zu leeren Zeichenketten.
+
+Damit Text aus BLOB- und Binär-Streams korrekt extrahiert werden kann, muss der Datentyp
+(MIME-Typ) bestimmt werden. Die folgende Prioritätsreihenfolge wird verwendet:
+
+1. ``column_label.mimetype=<Spaltenname>`` - Der Wert der angegebenen Spalte wird als MIME-Typ verwendet
+2. ``column_label.filename=<Spaltenname>`` - Der Wert der angegebenen Spalte wird als Dateiname behandelt, der MIME-Typ wird aus der Dateiendung abgeleitet
+3. ``default_mimetype`` - Standard-MIME-Typ, der verwendet wird, wenn die obigen Methoden keinen Typ ergeben
+
+Beispiel (BLOB der Spalte ``file_data`` wird mit dem MIME-Typ aus Spalte ``content_type`` extrahiert):
+
+::
+
+    sql=SELECT id, title, file_data, content_type FROM documents
+    column_label.mimetype=content_type
 
 SQL-Query-Design
 ================
@@ -144,11 +204,11 @@ SQL-Query-Design
 Effiziente Queries
 ------------------
 
-Bei großen Datenmengen ist die Query-Performance wichtig:
+Bei großen Datenmengen ist die Query-Performance wichtig.
+SQL-Abfragen werden unverändert an die Datenbank gesendet (kein Parameter-Binding):
 
 ::
 
-    # Effiziente Query mit Index-Nutzung
     SELECT id, title, content, url, updated_at
     FROM articles
     WHERE updated_at >= '2024-01-01 00:00:00'
@@ -186,7 +246,7 @@ Die Dokument-URL wird im Skript generiert:
 Multibyte-Zeichenunterstützung
 ==============================
 
-Bei der Verarbeitung von Daten mit Multibyte-Zeichen wie Deutsch oder Japanisch:
+Bei der Verarbeitung von Daten mit Multibyte-Zeichen wie Japanisch:
 
 MySQL
 -----
@@ -208,7 +268,7 @@ Sicherheit
 ==========
 
 Schutz der Datenbank-Anmeldedaten
----------------------------------
+----------------------------------
 
 .. warning::
    Das direkte Speichern von Passwörtern in Konfigurationsdateien stellt ein Sicherheitsrisiko dar.
@@ -220,7 +280,7 @@ Empfohlene Methoden:
 3. Nur-Lese-Benutzer verwenden
 
 Prinzip der minimalen Rechte
-----------------------------
+-----------------------------
 
 Gewähren Sie dem Datenbankbenutzer nur die minimal erforderlichen Berechtigungen:
 
@@ -284,7 +344,7 @@ Fehlerbehebung
 ==============
 
 JDBC-Treiber nicht gefunden
----------------------------
+----------------------------
 
 **Symptom**: ``ClassNotFoundException`` oder ``No suitable driver``
 

--- a/en/15.7/config/datastore/ds-database.rst
+++ b/en/15.7/config/datastore/ds-database.rst
@@ -25,21 +25,45 @@ All JDBC-compatible databases are supported. Main examples:
 Prerequisites
 =============
 
-1. JDBC driver is required
-2. Read access to the database is required
-3. Proper query design is important when retrieving large amounts of data
+1. Installation of the ``fess-ds-db`` plugin is required
+2. A JDBC driver compatible with the target database is required
+3. Read access to the database is required
+4. Proper query design is important when retrieving large amounts of data
+
+Plugin Installation
+-------------------
+
+Method 1: Place the JAR file directly
+
+::
+
+    # Download from Maven Central
+    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-db/X.X.X/fess-ds-db-X.X.X.jar
+
+    # Place the file
+    cp fess-ds-db-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
+    # or
+    cp fess-ds-db-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
+
+Method 2: Install from the admin console
+
+1. Open "System" -> "Plugin"
+2. Upload the JAR file
+3. Restart |Fess|
 
 Installing JDBC Drivers
 -----------------------
 
-Place the JDBC driver in the ``lib/`` directory:
+Place the JDBC driver compatible with your target database in the |Fess| classpath (``app/WEB-INF/lib/`` directory):
 
 ::
 
     # Example: MySQL driver
-    cp mysql-connector-java-8.0.33.jar /path/to/fess/lib/
+    cp mysql-connector-j-8.x.x.jar $FESS_HOME/app/WEB-INF/lib/
+    # or
+    cp mysql-connector-j-8.x.x.jar /usr/share/fess/app/WEB-INF/lib/
 
-Restart |Fess| to load the driver.
+After placing the JDBC driver, restart |Fess| to load it.
 
 Configuration
 =============
@@ -90,38 +114,47 @@ Parameter List
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - Parameter
      - Required
      - Description
    * - ``driver``
      - Yes
-     - JDBC driver class name
+     - JDBC driver class name (if not specified, a ``DataStoreException`` is raised)
    * - ``url``
      - Yes
-     - JDBC connection URL
+     - JDBC connection URL (required for connection)
+   * - ``sql``
+     - Yes
+     - SQL query for data retrieval (if not specified, a ``DataStoreException`` is raised)
    * - ``username``
      - No
      - Database username
    * - ``password``
      - No
      - Database password
-   * - ``sql``
-     - Yes
-     - SQL query for data retrieval
    * - ``fetch_size``
      - No
-     - Fetch size (default: 100). For MySQL streaming result sets, set to ``MIN_VALUE``.
+     - JDBC fetch size. Set to ``MIN_VALUE`` for MySQL streaming result sets
+   * - ``default_mimetype``
+     - No
+     - Default MIME type used when extracting content from BLOB or binary columns
+   * - ``column_label.mimetype``
+     - No
+     - Column name that contains the MIME type used for extracting BLOB or binary columns (e.g., ``column_label.mimetype=content_type``)
+   * - ``column_label.filename``
+     - No
+     - Column name that contains the filename used for extracting BLOB or binary columns (MIME type is inferred from the file extension)
+   * - ``info.*``
+     - No
+     - Additional JDBC connection properties (e.g., ``info.ssl=true``). The key with ``info.`` removed is passed to the JDBC driver
    * - ``readInterval``
      - No
      - Delay in milliseconds between processing each row. Default: 0
    * - ``script_type``
      - No
      - Script engine type. Default: groovy
-   * - ``column_label.*``
-     - No
-     - BLOB extraction MIME type mapping (e.g., ``column_label.mimetype=content_type``)
 
 Script Configuration
 --------------------
@@ -137,7 +170,33 @@ Map SQL column names to index fields:
 
 Available fields:
 
-- ``<column_name>`` - SQL query result columns, accessed by their label name in the SELECT clause
+- ``<column_name>`` - SQL query result columns (accessed directly by the column label name; no prefix such as ``data.`` is used)
+
+.. note::
+   Column names must match the column labels (aliases) in the ``SELECT`` clause.
+   When using aggregate functions or expressions, assign an explicit alias with ``AS``
+   (e.g., ``COUNT(*) AS total``).
+
+Loading BLOB/Binary Data
+========================
+
+Columns of type BLOB, CLOB, NCLOB, byte array, or binary stream are automatically passed through the
+content extraction process (the same extractor used for file crawling) and ingested as text.
+Array-type columns are converted to space-separated strings. NULL values become empty strings.
+
+To correctly extract text from BLOB or binary streams, the data type (MIME type) must be determined.
+The following priority order is used:
+
+1. ``column_label.mimetype=<column name>`` - Use the value of the specified column as the MIME type
+2. ``column_label.filename=<column name>`` - Treat the value of the specified column as a filename and infer the MIME type from the file extension
+3. ``default_mimetype`` - Default MIME type used when the above methods cannot determine the type
+
+Example (extract BLOB in the ``file_data`` column using the MIME type from the ``content_type`` column):
+
+::
+
+    sql=SELECT id, title, file_data, content_type FROM documents
+    column_label.mimetype=content_type
 
 SQL Query Design
 ================
@@ -145,18 +204,15 @@ SQL Query Design
 Efficient Queries
 -----------------
 
-Query performance is important when handling large amounts of data:
+Query performance is important when handling large amounts of data.
+SQL is sent to the database as-is (parameter binding is not performed):
 
 ::
 
-    # Efficient query using indexes
     SELECT id, title, content, url, updated_at
     FROM articles
     WHERE updated_at >= '2024-01-01 00:00:00'
     ORDER BY id
-
-.. note::
-   SQL is sent to the database as-is. Parameter binding (e.g., named parameters) is not supported.
 
 Incremental Crawling
 --------------------
@@ -188,7 +244,7 @@ Generate document URLs in the script:
     url=url
 
 Multi-byte Character Support
-============================
+=============================
 
 When handling data with multi-byte characters such as Japanese:
 
@@ -212,7 +268,7 @@ Security
 ========
 
 Protecting Database Credentials
--------------------------------
+--------------------------------
 
 .. warning::
    Writing passwords directly in configuration files poses a security risk.
@@ -224,9 +280,9 @@ Recommended methods:
 3. Use read-only users
 
 Principle of Least Privilege
-----------------------------
+-----------------------------
 
-Grant only minimum necessary permissions to database users:
+Grant only the minimum necessary permissions to database users:
 
 ::
 
@@ -256,7 +312,7 @@ Script:
 
     url="https://shop.example.com/product/" + id
     title=name
-    content=description + " Category: " + category + " Price: $" + price
+    content=description + " Category: " + category + " Price: " + price
     lastModified=updated_at
 
 Knowledge Base Articles
@@ -294,8 +350,8 @@ JDBC Driver Not Found
 
 **Resolution**:
 
-1. Verify that JDBC driver is placed in ``lib/``
-2. Verify driver class name is correct
+1. Verify that the JDBC driver is placed in ``lib/``
+2. Verify that the driver class name is correct
 3. Restart |Fess|
 
 Connection Errors
@@ -318,8 +374,8 @@ Query Errors
 **Check**:
 
 1. Test the SQL query directly on the database
-2. Verify column names are correct
-3. Verify table names are correct
+2. Verify that column names are correct
+3. Verify that table names are correct
 
 Reference Information
 =====================

--- a/es/15.7/config/datastore/ds-database.rst
+++ b/es/15.7/config/datastore/ds-database.rst
@@ -25,21 +25,45 @@ Compatible con todas las bases de datos que soporten JDBC. Ejemplos principales:
 Requisitos Previos
 ==================
 
-1. Se requiere el controlador JDBC
-2. Se requiere acceso de lectura a la base de datos
-3. Para grandes volumenes de datos, es importante un diseno de consultas apropiado
+1. Se requiere instalar el plugin ``fess-ds-db``
+2. Se requiere el controlador JDBC correspondiente a la base de datos de destino
+3. Se requiere acceso de lectura a la base de datos
+4. Para grandes volumenes de datos, es importante un diseno de consultas apropiado
+
+Instalacion del Plugin
+----------------------
+
+Metodo 1: Colocar el archivo JAR directamente
+
+::
+
+    # Descargar desde Maven Central
+    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-db/X.X.X/fess-ds-db-X.X.X.jar
+
+    # Colocar el archivo
+    cp fess-ds-db-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
+    # o bien
+    cp fess-ds-db-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
+
+Metodo 2: Instalar desde la consola de administracion
+
+1. Abrir "Sistema" -> "Plugins"
+2. Subir el archivo JAR
+3. Reiniciar |Fess|
 
 Instalacion del Controlador JDBC
---------------------------------
+---------------------------------
 
-Coloque el controlador JDBC en el directorio ``lib/``:
+Coloque el controlador JDBC correspondiente a la base de datos de destino en el classpath de |Fess| (directorio ``app/WEB-INF/lib/``):
 
 ::
 
     # Ejemplo: Controlador MySQL
-    cp mysql-connector-java-8.0.33.jar /path/to/fess/lib/
+    cp mysql-connector-j-8.x.x.jar $FESS_HOME/app/WEB-INF/lib/
+    # o bien
+    cp mysql-connector-j-8.x.x.jar /usr/share/fess/app/WEB-INF/lib/
 
-Reinicie |Fess| para cargar el controlador.
+Despues de colocar el controlador JDBC, reinicie |Fess| para cargarlo.
 
 Metodo de Configuracion
 =======================
@@ -63,7 +87,7 @@ Configuracion Basica
      - Activado
 
 Configuracion de Parametros
----------------------------
+----------------------------
 
 Ejemplo MySQL/MariaDB:
 
@@ -90,41 +114,50 @@ Lista de Parametros
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - Parametro
      - Requerido
      - Descripcion
    * - ``driver``
      - Si
-     - Nombre de la clase del controlador JDBC
+     - Nombre de la clase del controlador JDBC (si no se especifica, se produce ``DataStoreException``)
    * - ``url``
      - Si
-     - URL de conexion JDBC
+     - URL de conexion JDBC (obligatorio para la conexion)
+   * - ``sql``
+     - Si
+     - Consulta SQL para obtener datos (si no se especifica, se produce ``DataStoreException``)
    * - ``username``
      - No
      - Nombre de usuario de la base de datos
    * - ``password``
      - No
      - Contrasena de la base de datos
-   * - ``sql``
-     - Si
-     - Consulta SQL para obtener datos
    * - ``fetch_size``
      - No
-     - Tamano de obtencion (predeterminado: 100). Para streaming en MySQL, especifique ``MIN_VALUE``.
-   * - ``column_label.*``
+     - Tamano de recuperacion JDBC. Para resultados en streaming con MySQL, especifique ``MIN_VALUE``
+   * - ``default_mimetype``
      - No
-     - Mapeo de tipo MIME para extraccion de datos BLOB (ej. ``column_label.content=application/pdf``).
+     - Tipo MIME predeterminado utilizado al extraer contenido de columnas BLOB o binarias
+   * - ``column_label.mimetype``
+     - No
+     - Nombre de la columna que contiene el tipo MIME utilizado para la extraccion de columnas BLOB o binarias (ej. ``column_label.mimetype=content_type``)
+   * - ``column_label.filename``
+     - No
+     - Nombre de la columna que contiene el nombre de archivo utilizado para la extraccion de columnas BLOB o binarias (el tipo MIME se infiere a partir de la extension)
+   * - ``info.*``
+     - No
+     - Propiedades adicionales de conexion JDBC (ej. ``info.ssl=true``). La clave sin el prefijo ``info.`` se pasa al controlador JDBC
    * - ``readInterval``
      - No
-     - Retardo en milisegundos entre la lectura de cada fila (predeterminado: 0).
+     - Retardo en milisegundos entre el procesamiento de cada fila. Predeterminado: 0
    * - ``script_type``
      - No
-     - Tipo de lenguaje de script (predeterminado: groovy).
+     - Tipo de motor de scripts. Predeterminado: groovy
 
 Configuracion de Script
------------------------
+------------------------
 
 Mapee los nombres de columnas SQL a campos del indice:
 
@@ -137,27 +170,54 @@ Mapee los nombres de columnas SQL a campos del indice:
 
 Campos disponibles:
 
-- ``<nombre_columna>`` - Columnas de resultado de la consulta SQL, accesibles directamente por el nombre de la columna
+- ``<nombre_columna>`` - Columnas de resultado de la consulta SQL (se accede directamente por el nombre de la etiqueta de columna; no se usa prefijo como ``data.``)
 
-Diseno de Consultas SQL
-=======================
+.. note::
+   Los nombres de columna deben coincidir con la etiqueta de columna (alias) de la clausula ``SELECT``.
+   Cuando se usen funciones de agregacion o expresiones, asigne un alias explicito con ``AS``
+   (ej. ``COUNT(*) AS total``).
 
-Consultas Eficientes
---------------------
+Carga de Datos BLOB o Binarios
+================================
 
-Al manejar grandes cantidades de datos, el rendimiento de la consulta es importante:
+Las columnas de tipo BLOB, CLOB, NCLOB, arrays de bytes y flujos binarios se procesan
+automaticamente mediante el extractor de contenido (el mismo que se usa en el rastreo de
+archivos) y se incorporan como texto. Las columnas de tipo array se convierten en cadenas
+separadas por espacios. Los valores NULL se convierten en cadenas vacias.
+
+Para extraer correctamente el texto de datos BLOB o flujos binarios, es necesario
+determinar el tipo de dato (tipo MIME). La determinacion sigue el siguiente orden de
+prioridad:
+
+1. ``column_label.mimetype=<nombre_columna>`` - Usa el valor de la columna indicada como tipo MIME
+2. ``column_label.filename=<nombre_columna>`` - Trata el valor de la columna indicada como nombre de archivo e infiere el tipo MIME a partir de la extension
+3. ``default_mimetype`` - Tipo MIME predeterminado usado cuando no se puede determinar con los metodos anteriores
+
+Ejemplo (extraccion del BLOB de la columna ``file_data`` usando el tipo MIME de la columna ``content_type``):
 
 ::
 
-    # Consulta eficiente usando indices
-    # Nota: La consulta SQL se envia tal cual a la base de datos.
+    sql=SELECT id, title, file_data, content_type FROM documents
+    column_label.mimetype=content_type
+
+Diseno de Consultas SQL
+========================
+
+Consultas Eficientes
+---------------------
+
+Al manejar grandes cantidades de datos, el rendimiento de la consulta es importante.
+La consulta SQL se envia tal cual a la base de datos (no se realiza enlace de parametros):
+
+::
+
     SELECT id, title, content, url, updated_at
     FROM articles
     WHERE updated_at >= '2024-01-01 00:00:00'
     ORDER BY id
 
 Rastreo Incremental
--------------------
+--------------------
 
 Metodo para obtener solo registros actualizados:
 
@@ -170,7 +230,7 @@ Metodo para obtener solo registros actualizados:
     sql=SELECT * FROM articles WHERE id > 10000
 
 Generacion de URLs
-------------------
+-------------------
 
 Las URLs de documentos se generan en el script:
 
@@ -186,9 +246,9 @@ Las URLs de documentos se generan en el script:
     url=url
 
 Soporte de Caracteres Multibyte
-===============================
+================================
 
-Al manejar datos con caracteres multibyte como espanol o japones:
+Al manejar datos con caracteres multibyte como japones u otros idiomas:
 
 MySQL
 -----
@@ -210,7 +270,7 @@ Seguridad
 =========
 
 Proteccion de Credenciales de Base de Datos
--------------------------------------------
+--------------------------------------------
 
 .. warning::
    Escribir contrasenas directamente en archivos de configuracion es un riesgo de seguridad.
@@ -222,7 +282,7 @@ Metodos recomendados:
 3. Usar usuarios de solo lectura
 
 Principio de Minimo Privilegio
-------------------------------
+--------------------------------
 
 Otorgue solo los permisos minimos necesarios al usuario de la base de datos:
 
@@ -236,7 +296,7 @@ Ejemplos de Uso
 ===============
 
 Busqueda de Catalogo de Productos
----------------------------------
+-----------------------------------
 
 Parametros:
 
@@ -258,7 +318,7 @@ Script:
     lastModified=updated_at
 
 Articulos de Base de Conocimientos
-----------------------------------
+-------------------------------------
 
 Parametros:
 
@@ -283,10 +343,10 @@ Script:
     lastModified=updated_at
 
 Solucion de Problemas
-=====================
+======================
 
 Controlador JDBC No Encontrado
-------------------------------
+--------------------------------
 
 **Sintoma**: ``ClassNotFoundException`` o ``No suitable driver``
 
@@ -297,7 +357,7 @@ Controlador JDBC No Encontrado
 3. Reinicie |Fess|
 
 Error de Conexion
------------------
+------------------
 
 **Sintoma**: ``Connection refused`` o error de autenticacion
 
@@ -309,7 +369,7 @@ Error de Conexion
 4. Configuracion del firewall
 
 Error de Consulta
------------------
+------------------
 
 **Sintoma**: ``SQLException`` o error de sintaxis SQL
 
@@ -320,7 +380,7 @@ Error de Consulta
 3. Verifique que los nombres de tabla sean correctos
 
 Informacion de Referencia
-=========================
+==========================
 
 - :doc:`ds-overview` - Descripcion General de Conectores de Almacen de Datos
 - :doc:`ds-csv` - Conector CSV

--- a/fr/15.7/config/datastore/ds-database.rst
+++ b/fr/15.7/config/datastore/ds-database.rst
@@ -1,19 +1,19 @@
-==================================
-Connecteur base de donnees
-==================================
+==============================
+Connecteur de base de données
+==============================
 
-Apercu
+Aperçu
 ======
 
-Le connecteur de base de donnees fournit une fonctionnalite pour recuperer des donnees depuis
-des bases de donnees relationnelles compatibles JDBC et les enregistrer dans l'index de |Fess|.
+Le connecteur de base de données fournit une fonctionnalité pour récupérer des données depuis
+des bases de données relationnelles compatibles JDBC et les enregistrer dans l'index de |Fess|.
 
-Cette fonctionnalite necessite le plugin ``fess-ds-db``.
+Cette fonctionnalité nécessite le plugin ``fess-ds-db``.
 
-Bases de donnees prises en charge
-=================================
+Bases de données prises en charge
+==================================
 
-Toutes les bases de donnees compatibles JDBC sont prises en charge. Exemples principaux :
+Toutes les bases de données compatibles JDBC sont prises en charge. Exemples principaux :
 
 - MySQL / MariaDB
 - PostgreSQL
@@ -22,29 +22,53 @@ Toutes les bases de donnees compatibles JDBC sont prises en charge. Exemples pri
 - SQLite
 - H2 Database
 
-Prerequis
+Prérequis
 =========
 
-1. Un pilote JDBC est necessaire
-2. Un acces en lecture a la base de donnees est requis
-3. Pour les grands volumes de donnees, une conception de requete appropriee est importante
+1. L'installation du plugin ``fess-ds-db`` est nécessaire
+2. Un pilote JDBC adapté à la base de données cible est requis
+3. Un accès en lecture à la base de données est requis
+4. Pour les grands volumes de données, une conception de requête appropriée est importante
+
+Installation du plugin
+----------------------
+
+Méthode 1 : Déposer le fichier JAR directement
+
+::
+
+    # Téléchargement depuis Maven Central
+    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-db/X.X.X/fess-ds-db-X.X.X.jar
+
+    # Déploiement
+    cp fess-ds-db-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
+    # ou
+    cp fess-ds-db-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
+
+Méthode 2 : Installer depuis l'interface d'administration
+
+1. Ouvrir « Système » → « Plugins »
+2. Téléverser le fichier JAR
+3. Redémarrer |Fess|
 
 Installation du pilote JDBC
----------------------------
+----------------------------
 
-Placez le pilote JDBC dans le repertoire ``lib/`` :
+Placez le pilote JDBC adapté à la base de données cible dans le répertoire ``app/WEB-INF/lib/`` du classpath de |Fess| :
 
 ::
 
     # Exemple : pilote MySQL
-    cp mysql-connector-java-8.0.33.jar /path/to/fess/lib/
+    cp mysql-connector-j-8.x.x.jar $FESS_HOME/app/WEB-INF/lib/
+    # ou
+    cp mysql-connector-j-8.x.x.jar /usr/share/fess/app/WEB-INF/lib/
 
-Redemarrez |Fess| pour charger le pilote.
+Une fois le pilote JDBC déposé, redémarrez |Fess| pour le charger.
 
-Methode de configuration
+Méthode de configuration
 ========================
 
-Configurez depuis l'interface d'administration : "Crawler" -> "DataStore" -> "Nouveau".
+Configurez depuis l'interface d'administration : « Crawler » → « DataStore » → « Nouveau ».
 
 Configuration de base
 ---------------------
@@ -53,7 +77,7 @@ Configuration de base
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
+   * - Élément
      - Exemple de configuration
    * - Nom
      - Products Database
@@ -62,8 +86,8 @@ Configuration de base
    * - Actif
      - Oui
 
-Configuration des parametres
-----------------------------
+Configuration des paramètres
+-----------------------------
 
 Exemple MySQL/MariaDB :
 
@@ -85,43 +109,52 @@ Exemple PostgreSQL :
     password=your_password
     sql=SELECT id, title, content, url, updated_at FROM articles WHERE deleted = false
 
-Liste des parametres
+Liste des paramètres
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``driver``
      - Oui
-     - Nom de classe du pilote JDBC
+     - Nom de classe du pilote JDBC (si absent, une ``DataStoreException`` est levée)
    * - ``url``
      - Oui
-     - URL de connexion JDBC
-   * - ``username``
-     - Non
-     - Nom d'utilisateur de la base de donnees
-   * - ``password``
-     - Non
-     - Mot de passe de la base de donnees
+     - URL de connexion JDBC (obligatoire pour la connexion)
    * - ``sql``
      - Oui
-     - Requete SQL pour la recuperation des donnees
+     - Requête SQL pour la récupération des données (si absente, une ``DataStoreException`` est levée)
+   * - ``username``
+     - Non
+     - Nom d'utilisateur de la base de données
+   * - ``password``
+     - Non
+     - Mot de passe de la base de données
    * - ``fetch_size``
      - Non
-     - Taille de fetch (defaut : 100). Pour le streaming MySQL, specifiez la chaine ``MIN_VALUE``.
+     - Taille de fetch JDBC. Pour le streaming de résultats MySQL, spécifiez ``MIN_VALUE``
+   * - ``default_mimetype``
+     - Non
+     - Type MIME par défaut utilisé lors de l'extraction du contenu des colonnes BLOB/binaires
+   * - ``column_label.mimetype``
+     - Non
+     - Nom de la colonne contenant le type MIME à utiliser pour l'extraction d'une colonne BLOB/binaire (ex. : ``column_label.mimetype=content_type``)
+   * - ``column_label.filename``
+     - Non
+     - Nom de la colonne contenant le nom de fichier à utiliser pour l'extraction d'une colonne BLOB/binaire (le type MIME est déduit de l'extension)
+   * - ``info.*``
+     - Non
+     - Propriétés de connexion JDBC supplémentaires (ex. : ``info.ssl=true``). La clé sans le préfixe ``info.`` est transmise au pilote JDBC
    * - ``readInterval``
      - Non
-     - Delai en millisecondes entre chaque lecture de ligne (defaut : 0)
+     - Délai en millisecondes entre le traitement de chaque ligne. Par défaut : 0
    * - ``script_type``
      - Non
-     - Type du moteur de script (defaut : groovy)
-   * - ``column_label.*``
-     - Non
-     - Mappage de type MIME pour l'extraction de colonnes BLOB (ex: ``column_label.content=application/pdf``)
+     - Type du moteur de script. Par défaut : groovy
 
 Configuration du script
 -----------------------
@@ -137,58 +170,84 @@ Mappez les noms de colonnes SQL vers les champs d'index :
 
 Champs disponibles :
 
-- ``<column_name>`` - Colonnes du resultat de la requete SQL, accessibles directement par le nom de colonne
+- ``<column_name>`` - Colonnes du résultat de la requête SQL (accès direct par le nom de colonne. Aucun préfixe tel que ``data.`` n'est ajouté)
 
-Conception des requetes SQL
-===========================
+.. note::
+   Le nom de colonne doit correspondre au libellé de colonne (alias) de la clause ``SELECT``.
+   Pour les fonctions d'agrégation ou les expressions, utilisez explicitement ``AS`` pour définir un alias
+   (ex. : ``COUNT(*) AS total``).
 
-Requetes efficaces
-------------------
+Chargement de données BLOB/binaires
+=====================================
 
-Pour les grands volumes de donnees, les performances de requete sont importantes :
+Les colonnes de type BLOB, CLOB, NCLOB, tableau d'octets ou flux binaire sont automatiquement
+soumises au traitement d'extraction de contenu (le même extracteur que pour le crawl de fichiers)
+et intégrées sous forme de texte. Les colonnes de type tableau sont converties en chaîne séparée
+par des espaces. Les valeurs NULL deviennent des chaînes vides.
+
+Pour extraire correctement du texte depuis des BLOB ou des flux binaires, il est nécessaire de
+déterminer le type de données (type MIME). La priorité de détermination est la suivante :
+
+1. ``column_label.mimetype=<nom_de_colonne>`` - Utilise la valeur de la colonne spécifiée comme type MIME
+2. ``column_label.filename=<nom_de_colonne>`` - Traite la valeur de la colonne spécifiée comme un nom de fichier et déduit le type MIME à partir de l'extension
+3. ``default_mimetype`` - Type MIME par défaut utilisé si aucune des méthodes ci-dessus ne permet de déterminer le type
+
+Exemple (extraction du BLOB de la colonne ``file_data`` en utilisant le type MIME de la colonne ``content_type``) :
 
 ::
 
-    # Requete efficace utilisant un index
-    # La requete SQL est envoyee telle quelle a la base de donnees
+    sql=SELECT id, title, file_data, content_type FROM documents
+    column_label.mimetype=content_type
+
+Conception des requêtes SQL
+============================
+
+Requêtes efficaces
+------------------
+
+Pour les grands volumes de données, les performances de requête sont importantes.
+La requête SQL est envoyée telle quelle à la base de données (aucune liaison de paramètres n'est effectuée) :
+
+::
+
     SELECT id, title, content, url, updated_at
     FROM articles
     WHERE updated_at >= '2024-01-01 00:00:00'
     ORDER BY id
 
-Exploration incrementale
+Exploration incrémentale
 ------------------------
 
-Methode pour recuperer uniquement les enregistrements mis a jour :
+Méthode pour récupérer uniquement les enregistrements mis à jour :
 
 ::
 
-    # Filtrage par date de mise a jour
+    # Filtrage par date de mise à jour
     sql=SELECT * FROM articles WHERE updated_at >= '2024-01-01 00:00:00'
 
-    # Specification de plage par ID
+    # Spécification de plage par ID
     sql=SELECT * FROM articles WHERE id > 10000
 
-Generation d'URL
+Génération d'URL
 ----------------
 
-L'URL du document est generee par le script :
+L'URL du document est générée par le script :
 
 ::
 
-    # Motif fixe
+    # Modèle fixe
     url="https://example.com/article/" + id
 
     # Combinaison de plusieurs champs
     url="https://example.com/" + category + "/" + slug
 
-    # Utilisation de l'URL stockee dans la base de donnees
+    # Utilisation de l'URL stockée dans la base de données
     url=url
 
-Prise en charge des caracteres multi-octets
-===========================================
+Prise en charge des caractères multi-octets
+============================================
 
-Pour traiter des donnees contenant des caracteres multi-octets comme le francais :
+Pour traiter des données contenant des caractères multi-octets tels que le japonais :
 
 MySQL
 -----
@@ -200,31 +259,31 @@ MySQL
 PostgreSQL
 ----------
 
-PostgreSQL utilise generalement UTF-8 par defaut. Si necessaire :
+PostgreSQL utilise généralement UTF-8 par défaut. Si nécessaire :
 
 ::
 
     url=jdbc:postgresql://localhost:5432/mydb?charSet=UTF-8
 
-Securite
+Sécurité
 ========
 
-Protection des identifiants de base de donnees
-----------------------------------------------
+Protection des identifiants de base de données
+-----------------------------------------------
 
 .. warning::
-   Ecrire les mots de passe directement dans les fichiers de configuration presente un risque de securite.
+   Écrire les mots de passe directement dans les fichiers de configuration présente un risque de sécurité.
 
-Methodes recommandees :
+Méthodes recommandées :
 
 1. Utiliser des variables d'environnement
-2. Utiliser la fonctionnalite de chiffrement de |Fess|
+2. Utiliser la fonctionnalité de chiffrement de |Fess|
 3. Utiliser un utilisateur en lecture seule
 
-Principe du moindre privilege
------------------------------
+Principe du moindre privilège
+------------------------------
 
-Accordez uniquement les privileges minimum necessaires a l'utilisateur de la base de donnees :
+Accordez uniquement les privilèges minimum nécessaires à l'utilisateur de la base de données :
 
 ::
 
@@ -233,12 +292,12 @@ Accordez uniquement les privileges minimum necessaires a l'utilisateur de la bas
     GRANT SELECT ON mydb.articles TO 'fess_user'@'localhost';
 
 Exemples d'utilisation
-======================
+=======================
 
 Recherche de catalogue de produits
-----------------------------------
+------------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -254,13 +313,13 @@ Script :
 
     url="https://shop.example.com/product/" + id
     title=name
-    content=description + " Categorie: " + category + " Prix: " + price + " EUR"
+    content=description + " Catégorie: " + category + " Prix: " + price + " EUR"
     lastModified=updated_at
 
 Articles de base de connaissances
----------------------------------
+-----------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -282,47 +341,47 @@ Script :
     created=created_at
     lastModified=updated_at
 
-Depannage
+Dépannage
 =========
 
 Pilote JDBC introuvable
 -----------------------
 
-**Symptome** : ``ClassNotFoundException`` ou ``No suitable driver``
+**Symptôme** : ``ClassNotFoundException`` ou ``No suitable driver``
 
 **Solution** :
 
-1. Verifiez que le pilote JDBC est place dans ``lib/``
-2. Verifiez que le nom de classe du pilote est correct
-3. Redemarrez |Fess|
+1. Vérifiez que le pilote JDBC est placé dans ``lib/``
+2. Vérifiez que le nom de classe du pilote est correct
+3. Redémarrez |Fess|
 
 Erreur de connexion
--------------------
+--------------------
 
-**Symptome** : ``Connection refused`` ou erreur d'authentification
+**Symptôme** : ``Connection refused`` ou erreur d'authentification
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. La base de donnees est-elle demarree ?
-2. Le nom d'hote et le numero de port sont-ils corrects ?
+1. La base de données est-elle démarrée ?
+2. Le nom d'hôte et le numéro de port sont-ils corrects ?
 3. Le nom d'utilisateur et le mot de passe sont-ils corrects ?
 4. Configuration du pare-feu
 
-Erreur de requete
+Erreur de requête
 -----------------
 
-**Symptome** : ``SQLException`` ou erreur de syntaxe SQL
+**Symptôme** : ``SQLException`` ou erreur de syntaxe SQL
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Testez la requete SQL directement sur la base de donnees
-2. Verifiez que les noms de colonnes sont corrects
-3. Verifiez que les noms de tables sont corrects
+1. Testez la requête SQL directement sur la base de données
+2. Vérifiez que les noms de colonnes sont corrects
+3. Vérifiez que les noms de tables sont corrects
 
-Informations de reference
-=========================
+Informations de référence
+==========================
 
-- :doc:`ds-overview` - Apercu des connecteurs DataStore
+- :doc:`ds-overview` - Aperçu des connecteurs DataStore
 - :doc:`ds-csv` - Connecteur CSV
 - :doc:`ds-json` - Connecteur JSON
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration DataStore

--- a/ja/15.7/config/datastore/ds-database.rst
+++ b/ja/15.7/config/datastore/ds-database.rst
@@ -25,21 +25,45 @@ JDBC対応のすべてのデータベースに対応しています。主な例:
 前提条件
 ========
 
-1. JDBCドライバーが必要です
-2. データベースへの読み取りアクセス権が必要です
-3. 大量のデータを取得する場合、適切なクエリ設計が重要です
+1. ``fess-ds-db`` プラグインのインストールが必要です
+2. 接続先データベースに対応したJDBCドライバーが必要です
+3. データベースへの読み取りアクセス権が必要です
+4. 大量のデータを取得する場合、適切なクエリ設計が重要です
+
+プラグインのインストール
+------------------------
+
+方法1: JARファイルを直接配置
+
+::
+
+    # Maven Centralからダウンロード
+    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-db/X.X.X/fess-ds-db-X.X.X.jar
+
+    # 配置
+    cp fess-ds-db-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
+    # または
+    cp fess-ds-db-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
+
+方法2: 管理画面からインストール
+
+1. 「システム」→「プラグイン」を開く
+2. JARファイルをアップロード
+3. |Fess| を再起動
 
 JDBCドライバーのインストール
 ----------------------------
 
-JDBCドライバーを ``lib/`` ディレクトリに配置します:
+接続先データベースに対応したJDBCドライバーを |Fess| のクラスパス（ ``app/WEB-INF/lib/`` ディレクトリ）に配置します:
 
 ::
 
     # 例: MySQLドライバー
-    cp mysql-connector-java-8.0.33.jar /path/to/fess/lib/
+    cp mysql-connector-j-8.x.x.jar $FESS_HOME/app/WEB-INF/lib/
+    # または
+    cp mysql-connector-j-8.x.x.jar /usr/share/fess/app/WEB-INF/lib/
 
-|Fess| を再起動してドライバーを読み込みます。
+JDBCドライバーを配置したら |Fess| を再起動して読み込みます。
 
 設定方法
 ========
@@ -90,41 +114,44 @@ PostgreSQLの例:
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - パラメーター
      - 必須
      - 説明
    * - ``driver``
      - はい
-     - JDBCドライバーのクラス名
-   * - ``fetch_size``
-     - いいえ
-     - JDBCフェッチサイズ。MySQLのストリーミング結果セットには ``MIN_VALUE`` を指定
+     - JDBCドライバーのクラス名（未指定の場合 ``DataStoreException`` が発生）
    * - ``url``
      - はい
-     - JDBC接続URL
+     - JDBC接続URL（接続に必須）
+   * - ``sql``
+     - はい
+     - データ取得用のSQLクエリ（未指定の場合 ``DataStoreException`` が発生）
    * - ``username``
      - いいえ
      - データベースユーザー名
    * - ``password``
      - いいえ
      - データベースパスワード
-   * - ``sql``
-     - はい
-     - データ取得用のSQLクエリ
+   * - ``fetch_size``
+     - いいえ
+     - JDBCフェッチサイズ。MySQLのストリーミング結果セットには ``MIN_VALUE`` を指定
    * - ``default_mimetype``
      - いいえ
-     - BLOB抽出時のデフォルトMIMEタイプ
+     - BLOB・バイナリ列のコンテンツ抽出時に使用するデフォルトMIMEタイプ
+   * - ``column_label.mimetype``
+     - いいえ
+     - BLOB・バイナリ列の抽出に使用するMIMEタイプを格納した列名を指定（例: ``column_label.mimetype=content_type``）
+   * - ``column_label.filename``
+     - いいえ
+     - BLOB・バイナリ列の抽出に使用するファイル名を格納した列名を指定（拡張子からMIMEタイプを推定）
    * - ``info.*``
      - いいえ
-     - 追加のJDBC接続プロパティ（例: ``info.ssl=true``）
-   * - ``column_label.*``
-     - いいえ
-     - BLOB抽出時のカラムメタデータマッピング（例: ``column_label.mimetype=content_type`` でMIMEタイプ列を指定）
+     - 追加のJDBC接続プロパティ（例: ``info.ssl=true``）。``info.`` を除いたキーがJDBCドライバーへ渡されます
    * - ``readInterval``
      - いいえ
-     - 行間の処理遅延（ミリ秒）。デフォルト: 0
+     - 各行の処理間の遅延（ミリ秒）。デフォルト: 0
    * - ``script_type``
      - いいえ
      - スクリプトエンジンの種類。デフォルト: groovy
@@ -143,7 +170,34 @@ SQLの列名をインデックスフィールドにマッピングします:
 
 利用可能なフィールド:
 
-- ``<column_name>`` - SQLクエリの結果列（カラムラベル名でアクセス）
+- ``<column_name>`` - SQLクエリの結果列（カラムラベル名で直接アクセスします。``data.`` のような接頭辞は付きません）
+
+.. note::
+   列名は ``SELECT`` 句のカラムラベル（別名）と一致させる必要があります。
+   集計関数や式を使用する場合は ``AS`` で明示的に別名を付けてください
+   （例: ``COUNT(*) AS total``）。
+
+BLOB・バイナリデータの取り込み
+==============================
+
+BLOB、CLOB、NCLOB、バイト配列、バイナリストリームなどの列は、自動的に
+コンテンツ抽出処理（ファイルクロールと同じ抽出器）にかけられ、テキストとして
+取り込まれます。配列型の列はスペース区切りの文字列に変換されます。NULL値は
+空文字列になります。
+
+BLOBやバイナリストリームから正しくテキストを抽出するには、データの種類（MIMEタイプ）を
+判定する必要があります。判定には次の優先順位が使われます:
+
+1. ``column_label.mimetype=<列名>`` - 指定した列の値をMIMEタイプとして使用
+2. ``column_label.filename=<列名>`` - 指定した列の値をファイル名として扱い、拡張子からMIMEタイプを推定
+3. ``default_mimetype`` - 上記で判定できない場合に使用するデフォルトMIMEタイプ
+
+例（``file_data`` 列のBLOBを、``content_type`` 列のMIMEタイプを使って抽出）:
+
+::
+
+    sql=SELECT id, title, file_data, content_type FROM documents
+    column_label.mimetype=content_type
 
 SQLクエリの設計
 ===============

--- a/ko/15.7/config/datastore/ds-database.rst
+++ b/ko/15.7/config/datastore/ds-database.rst
@@ -11,7 +11,7 @@
 이 기능에는 ``fess-ds-db`` 플러그인이 필요합니다.
 
 지원 데이터베이스
-================
+=================
 
 JDBC 호환 모든 데이터베이스를 지원합니다. 주요 예:
 
@@ -23,31 +23,55 @@ JDBC 호환 모든 데이터베이스를 지원합니다. 주요 예:
 - H2 Database
 
 전제 조건
-========
+=========
 
-1. JDBC 드라이버가 필요합니다
-2. 데이터베이스에 대한 읽기 액세스 권한이 필요합니다
-3. 대량의 데이터를 가져올 경우, 적절한 쿼리 설계가 중요합니다
+1. ``fess-ds-db`` 플러그인 설치가 필요합니다
+2. 연결 대상 데이터베이스에 맞는 JDBC 드라이버가 필요합니다
+3. 데이터베이스에 대한 읽기 액세스 권한이 필요합니다
+4. 대량의 데이터를 가져올 경우, 적절한 쿼리 설계가 중요합니다
+
+플러그인 설치
+-------------
+
+방법1: JAR 파일을 직접 배치
+
+::
+
+    # Maven Central에서 다운로드
+    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-db/X.X.X/fess-ds-db-X.X.X.jar
+
+    # 배치
+    cp fess-ds-db-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
+    # 또는
+    cp fess-ds-db-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
+
+방법2: 관리 화면에서 설치
+
+1. "시스템" → "플러그인"을 엽니다
+2. JAR 파일을 업로드
+3. |Fess| 를 재시작
 
 JDBC 드라이버 설치
-----------------------------
+------------------
 
-JDBC 드라이버를 ``lib/`` 디렉토리에 배치합니다:
+연결 대상 데이터베이스에 맞는 JDBC 드라이버를 |Fess| 의 클래스패스（ ``app/WEB-INF/lib/`` 디렉터리）에 배치합니다:
 
 ::
 
     # 예: MySQL 드라이버
-    cp mysql-connector-java-8.0.33.jar /path/to/fess/lib/
+    cp mysql-connector-j-8.x.x.jar $FESS_HOME/app/WEB-INF/lib/
+    # 또는
+    cp mysql-connector-j-8.x.x.jar /usr/share/fess/app/WEB-INF/lib/
 
-|Fess| 를 재시작하여 드라이버를 로드합니다.
+JDBC 드라이버를 배치한 후 |Fess| 를 재시작하여 로드합니다.
 
 설정 방법
-========
+=========
 
 관리 화면에서 "크롤러" → "데이터스토어" → "신규 작성"으로 설정합니다.
 
 기본 설정
---------
+---------
 
 .. list-table::
    :header-rows: 1
@@ -63,7 +87,7 @@ JDBC 드라이버를 ``lib/`` 디렉토리에 배치합니다:
      - 켜기
 
 파라미터 설정
-----------------
+-------------
 
 MySQL/MariaDB 예:
 
@@ -86,45 +110,54 @@ PostgreSQL 예:
     sql=SELECT id, title, content, url, updated_at FROM articles WHERE deleted = false
 
 파라미터 목록
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - 파라미터
      - 필수
      - 설명
    * - ``driver``
      - 예
-     - JDBC 드라이버의 클래스명
+     - JDBC 드라이버의 클래스명（미지정 시 ``DataStoreException`` 발생）
    * - ``url``
      - 예
-     - JDBC 연결 URL
+     - JDBC 연결 URL（연결에 필수）
+   * - ``sql``
+     - 예
+     - 데이터 취득용 SQL 쿼리（미지정 시 ``DataStoreException`` 발생）
    * - ``username``
      - 아니요
      - 데이터베이스 사용자명
    * - ``password``
      - 아니요
      - 데이터베이스 비밀번호
-   * - ``sql``
-     - 예
-     - 데이터 취득용 SQL 쿼리
    * - ``fetch_size``
      - 아니요
-     - 페치 크기 (기본값: 100). MySQL에서 스트리밍 결과를 사용하려면 ``MIN_VALUE`` 문자열을 지정합니다.
-   * - ``column_label.*``
+     - JDBC 페치 크기. MySQL의 스트리밍 결과 세트에는 ``MIN_VALUE`` 를 지정
+   * - ``default_mimetype``
      - 아니요
-     - 열 라벨 매핑. BLOB 데이터 추출 시 ``column_label.content=application/pdf`` 와 같이 MIME 타입을 지정할 수 있습니다.
+     - BLOB·바이너리 열의 콘텐츠 추출 시 사용할 기본 MIME 타입
+   * - ``column_label.mimetype``
+     - 아니요
+     - BLOB·바이너리 열 추출에 사용할 MIME 타입을 저장한 열 이름을 지정（예: ``column_label.mimetype=content_type``）
+   * - ``column_label.filename``
+     - 아니요
+     - BLOB·바이너리 열 추출에 사용할 파일명을 저장한 열 이름을 지정（확장자에서 MIME 타입을 추정）
+   * - ``info.*``
+     - 아니요
+     - 추가 JDBC 연결 프로퍼티（예: ``info.ssl=true``）. ``info.`` 를 제외한 키가 JDBC 드라이버에 전달됩니다
    * - ``readInterval``
      - 아니요
-     - 각 행 처리 사이의 지연 시간 (밀리초, 기본값: 0)
+     - 각 행 처리 사이의 지연 시간（밀리초）. 기본값: 0
    * - ``script_type``
      - 아니요
-     - 스크립트 언어 타입 (기본값: groovy)
+     - 스크립트 엔진의 종류. 기본값: groovy
 
 스크립트 설정
---------------
+-------------
 
 SQL 열 이름을 인덱스 필드에 매핑합니다:
 
@@ -137,26 +170,53 @@ SQL 열 이름을 인덱스 필드에 매핑합니다:
 
 사용 가능한 필드:
 
-- ``<column_name>`` - SQL 쿼리 결과의 열 라벨명으로 직접 접근
+- ``<column_name>`` - SQL 쿼리 결과의 열（컬럼 라벨명으로 직접 접근합니다. ``data.`` 와 같은 접두사는 붙지 않습니다）
 
-SQL 쿼리 설계
-===============
+.. note::
+   열 이름은 ``SELECT`` 절의 컬럼 라벨（별칭）과 일치시켜야 합니다.
+   집계 함수나 식을 사용하는 경우 ``AS`` 로 명시적으로 별칭을 붙여 주세요
+   （예: ``COUNT(*) AS total``）.
 
-효율적인 쿼리
---------------
+BLOB·바이너리 데이터 취득
+==========================
 
-대량의 데이터를 다룰 경우, 쿼리 성능이 중요합니다:
+BLOB, CLOB, NCLOB, 바이트 배열, 바이너리 스트림 등의 열은 자동으로
+콘텐츠 추출 처리（파일 크롤링과 동일한 추출기）에 적용되어 텍스트로
+취득됩니다. 배열형 열은 공백으로 구분된 문자열로 변환됩니다. NULL 값은
+빈 문자열이 됩니다.
+
+BLOB나 바이너리 스트림에서 올바르게 텍스트를 추출하려면 데이터의 종류（MIME 타입）를
+판별해야 합니다. 판별에는 다음 우선순위가 사용됩니다:
+
+1. ``column_label.mimetype=<열 이름>`` - 지정한 열의 값을 MIME 타입으로 사용
+2. ``column_label.filename=<열 이름>`` - 지정한 열의 값을 파일명으로 취급하여 확장자에서 MIME 타입을 추정
+3. ``default_mimetype`` - 위에서 판별할 수 없는 경우에 사용할 기본 MIME 타입
+
+예（ ``file_data`` 열의 BLOB를 ``content_type`` 열의 MIME 타입을 사용하여 추출）:
 
 ::
 
-    # 인덱스를 사용한 효율적인 쿼리 (SQL은 그대로 데이터베이스에 전송됩니다)
+    sql=SELECT id, title, file_data, content_type FROM documents
+    column_label.mimetype=content_type
+
+SQL 쿼리 설계
+=============
+
+효율적인 쿼리
+-------------
+
+대량의 데이터를 다룰 경우, 쿼리 성능이 중요합니다.
+SQL은 그대로 데이터베이스에 전송됩니다（파라미터 바인딩은 수행되지 않습니다）:
+
+::
+
     SELECT id, title, content, url, updated_at
     FROM articles
     WHERE updated_at >= '2024-01-01 00:00:00'
     ORDER BY id
 
 차분 크롤링
-------------
+-----------
 
 업데이트된 레코드만 가져오는 방법:
 
@@ -169,7 +229,7 @@ SQL 쿼리 설계
     sql=SELECT * FROM articles WHERE id > 10000
 
 URL 생성
----------
+--------
 
 문서의 URL은 스크립트로 생성합니다:
 
@@ -185,7 +245,7 @@ URL 생성
     url=url
 
 다국어 문자 지원
-====================
+================
 
 한국어 등 다국어 문자를 포함한 데이터를 다룰 경우:
 
@@ -206,10 +266,10 @@ PostgreSQL은 보통 UTF-8이 기본입니다. 필요한 경우:
     url=jdbc:postgresql://localhost:5432/mydb?charSet=UTF-8
 
 보안
-============
+====
 
 데이터베이스 인증 정보 보호
---------------------------
+---------------------------
 
 .. warning::
    비밀번호를 설정 파일에 직접 기술하는 것은 보안 위험이 있습니다.
@@ -232,7 +292,7 @@ PostgreSQL은 보통 UTF-8이 기본입니다. 필요한 경우:
     GRANT SELECT ON mydb.articles TO 'fess_user'@'localhost';
 
 사용 예
-======
+=======
 
 제품 카탈로그 검색
 ------------------
@@ -257,7 +317,7 @@ PostgreSQL은 보통 UTF-8이 기본입니다. 필요한 경우:
     lastModified=updated_at
 
 지식 베이스 문서
-------------------
+----------------
 
 파라미터:
 
@@ -282,10 +342,10 @@ PostgreSQL은 보통 UTF-8이 기본입니다. 필요한 경우:
     lastModified=updated_at
 
 문제 해결
-======================
+=========
 
 JDBC 드라이버를 찾을 수 없음
-----------------------------
+-----------------------------
 
 **증상**: ``ClassNotFoundException`` 또는 ``No suitable driver``
 
@@ -296,7 +356,7 @@ JDBC 드라이버를 찾을 수 없음
 3. |Fess| 재시작
 
 연결 오류
-----------
+---------
 
 **증상**: ``Connection refused`` 또는 인증 오류
 
@@ -308,7 +368,7 @@ JDBC 드라이버를 찾을 수 없음
 4. 방화벽 설정
 
 쿼리 오류
-------------
+---------
 
 **증상**: ``SQLException`` 또는 SQL 구문 오류
 
@@ -319,7 +379,7 @@ JDBC 드라이버를 찾을 수 없음
 3. 테이블 이름이 올바른지 확인
 
 참고 정보
-========
+=========
 
 - :doc:`ds-overview` - 데이터스토어 커넥터 개요
 - :doc:`ds-csv` - CSV 커넥터

--- a/zh-cn/15.7/config/datastore/ds-database.rst
+++ b/zh-cn/15.7/config/datastore/ds-database.rst
@@ -11,7 +11,7 @@
 此功能需要安装 ``fess-ds-db`` 插件。
 
 支持的数据库
-================
+============
 
 支持所有JDBC兼容的数据库。主要包括：
 
@@ -25,21 +25,45 @@
 前提条件
 ========
 
-1. 需要JDBC驱动程序
-2. 需要对数据库的读取访问权限
-3. 获取大量数据时，适当的查询设计很重要
+1. 需要安装 ``fess-ds-db`` 插件
+2. 需要对应连接数据库的JDBC驱动程序
+3. 需要对数据库的读取访问权限
+4. 获取大量数据时，适当的查询设计很重要
 
-JDBC驱动程序安装
-----------------------------
+插件安装
+--------
 
-将JDBC驱动程序放置在 ``lib/`` 目录中：
+方法1：直接放置JAR文件
 
 ::
 
-    # 例如：MySQL驱动程序
-    cp mysql-connector-java-8.0.33.jar /path/to/fess/lib/
+    # 从Maven Central下载
+    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-db/X.X.X/fess-ds-db-X.X.X.jar
 
-重启 |Fess| 以加载驱动程序。
+    # 放置
+    cp fess-ds-db-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
+    # 或
+    cp fess-ds-db-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
+
+方法2：从管理界面安装
+
+1. 打开"系统"→"插件"
+2. 上传JAR文件
+3. 重启 |Fess|
+
+JDBC驱动程序安装
+----------------
+
+将对应连接数据库的JDBC驱动程序放置在 |Fess| 的类路径（ ``app/WEB-INF/lib/`` 目录）中：
+
+::
+
+    # 示例：MySQL驱动程序
+    cp mysql-connector-j-8.x.x.jar $FESS_HOME/app/WEB-INF/lib/
+    # 或
+    cp mysql-connector-j-8.x.x.jar /usr/share/fess/app/WEB-INF/lib/
+
+放置JDBC驱动程序后，重启 |Fess| 以加载驱动程序。
 
 设置方法
 ========
@@ -63,7 +87,7 @@ JDBC驱动程序安装
      - 开
 
 参数设置
-----------------
+--------
 
 MySQL/MariaDB示例：
 
@@ -86,45 +110,54 @@ PostgreSQL示例：
     sql=SELECT id, title, content, url, updated_at FROM articles WHERE deleted = false
 
 参数列表
-~~~~~~~~~~~~~~~~
+~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - 参数
      - 必须
      - 说明
    * - ``driver``
      - 是
-     - JDBC驱动程序类名
+     - JDBC驱动程序类名（未指定时将抛出 ``DataStoreException``）
    * - ``url``
      - 是
-     - JDBC连接URL
+     - JDBC连接URL（连接必须项）
+   * - ``sql``
+     - 是
+     - 数据获取用SQL查询（未指定时将抛出 ``DataStoreException``）
    * - ``username``
      - 否
      - 数据库用户名
    * - ``password``
      - 否
      - 数据库密码
-   * - ``sql``
-     - 是
-     - 数据获取用SQL查询
    * - ``fetch_size``
      - 否
-     - 获取大小（默认：100）。对于MySQL，可设置为 ``MIN_VALUE`` 字符串以启用流式结果集读取，避免大数据量时的内存溢出。
-   * - ``column_label.*``
+     - JDBC获取大小。MySQL流式结果集请指定 ``MIN_VALUE``
+   * - ``default_mimetype``
      - 否
-     - 列标签映射设置。可用于BLOB列的MIME类型映射（例如 ``column_label.content_type=application/pdf``），指定BLOB数据提取时的MIME类型。
+     - 提取BLOB/二进制列内容时使用的默认MIME类型
+   * - ``column_label.mimetype``
+     - 否
+     - 指定存储BLOB/二进制列提取所用MIME类型的列名（例：``column_label.mimetype=content_type``）
+   * - ``column_label.filename``
+     - 否
+     - 指定存储BLOB/二进制列提取所用文件名的列名（从扩展名推断MIME类型）
+   * - ``info.*``
+     - 否
+     - 附加JDBC连接属性（例：``info.ssl=true``）。去掉 ``info.`` 前缀后的键将传递给JDBC驱动程序
    * - ``readInterval``
      - 否
-     - 每行读取之间的延迟时间（毫秒）。默认值为0（无延迟）。
+     - 每行处理之间的延迟（毫秒）。默认值：0
    * - ``script_type``
      - 否
-     - 脚本类型。默认值为 ``groovy``。
+     - 脚本引擎类型。默认值：groovy
 
 脚本设置
---------------
+--------
 
 将SQL列名映射到索引字段：
 
@@ -137,29 +170,53 @@ PostgreSQL示例：
 
 可用字段：
 
-- ``<column_name>`` - SQL查询的结果列（直接使用列标签名称访问）
+- ``<column_name>`` - SQL查询的结果列（直接使用列标签名称访问，不带 ``data.`` 等前缀）
 
-SQL查询设计
-===============
+.. note::
+   列名需与 ``SELECT`` 子句中的列标签（别名）一致。
+   使用聚合函数或表达式时，请用 ``AS`` 明确指定别名
+   （例：``COUNT(*) AS total``）。
 
-高效查询
---------------
+BLOB/二进制数据的导入
+=====================
 
-处理大量数据时，查询性能很重要：
+BLOB、CLOB、NCLOB、字节数组、二进制流等列将自动经过
+内容提取处理（与文件爬取使用相同的提取器），以文本形式
+导入。数组类型的列将转换为空格分隔的字符串。NULL值将
+变为空字符串。
+
+要从BLOB或二进制流中正确提取文本，需要判断数据类型（MIME类型）。
+判断时使用以下优先顺序：
+
+1. ``column_label.mimetype=<列名>`` - 将指定列的值作为MIME类型使用
+2. ``column_label.filename=<列名>`` - 将指定列的值作为文件名处理，从扩展名推断MIME类型
+3. ``default_mimetype`` - 上述方式无法判断时使用的默认MIME类型
+
+示例（使用 ``content_type`` 列的MIME类型提取 ``file_data`` 列的BLOB）：
 
 ::
 
-    # 使用索引的高效查询
+    sql=SELECT id, title, file_data, content_type FROM documents
+    column_label.mimetype=content_type
+
+SQL查询设计
+===========
+
+高效查询
+--------
+
+处理大量数据时，查询性能很重要。
+SQL将原样发送到数据库（不进行参数绑定）：
+
+::
+
     SELECT id, title, content, url, updated_at
     FROM articles
     WHERE updated_at >= '2024-01-01 00:00:00'
     ORDER BY id
 
-.. note::
-   SQL查询将原样发送到数据库，不支持参数绑定（如 ``:last_crawl_date``）。请直接在SQL中写入具体的日期值。
-
 增量抓取
-------------
+--------
 
 只获取更新记录的方法：
 
@@ -172,7 +229,7 @@ SQL查询设计
     sql=SELECT * FROM articles WHERE id > 10000
 
 URL生成
----------
+-------
 
 文档的URL在脚本中生成：
 
@@ -188,7 +245,7 @@ URL生成
     url=url
 
 多字节字符支持
-====================
+==============
 
 处理包含中文等多字节字符的数据时：
 
@@ -209,10 +266,10 @@ PostgreSQL通常默认使用UTF-8。如有需要：
     url=jdbc:postgresql://localhost:5432/mydb?charSet=UTF-8
 
 安全性
-============
+======
 
 数据库认证信息保护
---------------------------
+------------------
 
 .. warning::
    在配置文件中直接写入密码存在安全风险。
@@ -224,7 +281,7 @@ PostgreSQL通常默认使用UTF-8。如有需要：
 3. 使用只读用户
 
 最小权限原则
---------------
+------------
 
 只为数据库用户授予必要的最小权限：
 
@@ -235,10 +292,10 @@ PostgreSQL通常默认使用UTF-8。如有需要：
     GRANT SELECT ON mydb.articles TO 'fess_user'@'localhost';
 
 使用示例
-======
+========
 
 产品目录搜索
-------------------
+------------
 
 参数：
 
@@ -260,7 +317,7 @@ PostgreSQL通常默认使用UTF-8。如有需要：
     lastModified=updated_at
 
 知识库文章
-------------------
+----------
 
 参数：
 
@@ -285,10 +342,10 @@ PostgreSQL通常默认使用UTF-8。如有需要：
     lastModified=updated_at
 
 故障排除
-======================
+========
 
 找不到JDBC驱动程序
-----------------------------
+------------------
 
 **症状**：``ClassNotFoundException`` 或 ``No suitable driver``
 
@@ -299,7 +356,7 @@ PostgreSQL通常默认使用UTF-8。如有需要：
 3. 重启 |Fess|
 
 连接错误
-----------
+--------
 
 **症状**：``Connection refused`` 或认证错误
 
@@ -311,7 +368,7 @@ PostgreSQL通常默认使用UTF-8。如有需要：
 4. 防火墙设置
 
 查询错误
-------------
+--------
 
 **症状**：``SQLException`` 或SQL语法错误
 


### PR DESCRIPTION
## Summary

Reviewed `15.7/config/datastore/ds-database.rst` against the actual `fess-ds-db` implementation (`DatabaseDataStore` / `AbstractDataStore`) and corrected several inaccuracies and gaps. Changes are applied consistently across all languages (ja, en, de, es, fr, ko, zh-cn).

## Findings & fixes

**Incorrect**
- **JDBC driver / plugin path**: documented as `lib/`, but the connector and JDBC drivers must be on the Fess classpath at `app/WEB-INF/lib/` (consistent with every other `ds-*.rst`).
- **`list-table` widths**: the parameter table used `:widths: 25 15.70` (2 values for a 3-column table) — corrected to `20 10 70`.

**Missing**
- **Plugin Installation section**: added (direct JAR placement + admin-console upload), matching the other datastore connector docs. The previous page only said the plugin was required.
- **`column_label.mimetype` / `column_label.filename`**: the doc only mentioned a generic `column_label.*`. Both keys are now documented separately, with the actual MIME-type resolution order used by `getColumnValue()`: `column_label.mimetype` → `column_label.filename` → `default_mimetype`.
- **Loading BLOB/Binary Data section**: added — BLOB/CLOB/NCLOB/byte-array/binary-stream columns are automatically run through the content extractor; array columns become space-separated strings; NULL becomes an empty string.

**Clarified**
- `driver` / `url` / `sql` are required (`driver` and `sql` throw `DataStoreException` when blank); `username` / `password` are optional.
- `info.*` keys are passed to the JDBC driver with the `info.` prefix stripped.
- Script fields are accessed by column label directly (no `data.` prefix), with a note about using `AS` aliases.

## Verification
- All parameter names cross-checked against the `*_PARAM` constants in `DatabaseDataStore` and inherited params (`readInterval`, `script_type`) in `AbstractDataStore`.
- Confirmed plain `Statement` is used (no parameter binding) and `DriverManager` connection (no pooling) — no fabricated features.
- RST validity checked for all 7 files (section underline lengths and table column counts).