### PR TITLE
docs(dropbox): correct Dropbox connector documentation against implementation (15.7)

### DIFF
--- a/de/15.7/config/datastore/ds-dropbox.rst
+++ b/de/15.7/config/datastore/ds-dropbox.rst
@@ -5,7 +5,8 @@ Dropbox-Konnektor
 Übersicht
 =========
 
-Der Dropbox-Konnektor bietet die Funktionalität, Dateien aus dem Dropbox-Cloud-Speicher abzurufen und im |Fess|-Index zu registrieren.
+Der Dropbox-Konnektor bietet die Funktionalität, Dateien aus dem Dropbox-Cloud-Speicher abzurufen
+und im |Fess|-Index zu registrieren.
 
 Für diese Funktion ist das Plugin ``fess-ds-dropbox`` erforderlich.
 
@@ -31,7 +32,7 @@ Installieren Sie über die Administrationsoberfläche unter "System" -> "Plugins
 2. Laden Sie es über die Plugin-Verwaltungsoberfläche hoch und installieren Sie es
 3. Starten Sie |Fess| neu
 
-Oder weitere Details finden Sie unter :doc:`../../admin/plugin-guide`.
+Weitere Details finden Sie unter :doc:`../../admin/plugin-guide`.
 
 Konfiguration
 =============
@@ -67,7 +68,7 @@ Parameterliste
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - Parameter
      - Erforderlich
@@ -104,7 +105,10 @@ Parameterliste
      - Standardberechtigungen für indizierte Dokumente, kommagetrennt
    * - ``max_cached_content_size``
      - Nein
-     - Maximale im Speicher gecachte Inhaltsgröße in Bytes (Standard: ``1048576``)
+     - Maximale im Speicher gecachte Inhaltsgröße in Bytes. Inhalte, die diesen Wert überschreiten, werden in eine temporäre Datei geschrieben (Standard: ``1048576``)
+   * - ``readInterval``
+     - Nein
+     - Wartezeit in Millisekunden zwischen der Verarbeitung einzelner Datensätze (Standard: ``0``)
 
 Skript-Einstellungen
 --------------------
@@ -203,8 +207,32 @@ Verfügbare Felder:
 Dropbox-Authentifizierung konfigurieren
 =======================================
 
+Kontotyp und Zugriffstoken
+---------------------------
+
+Dieser Konnektor schaltet über den Parameter ``basic_plan`` zwischen zwei Betriebsmodi um.
+Da die Art der zu erstellenden App und des Zugriffstokens unterschiedlich ist, überprüfen Sie dies zuerst.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Modus
+     - ``basic_plan``
+     - Beschreibung
+   * - Teamkonto (Standard)
+     - ``false``
+     - Für Dropbox Business (Team)-Konten. Erfordert ein Zugriffstoken mit Teamadministrator-Rechten und crawlt kontoübergreifend Dateien von Teammitgliedern und Teamordnern.
+   * - Einzelkonto
+     - ``true``
+     - Für persönliche (Nicht-Team)-Konten. Verwendet ein reguläres Zugriffstoken mit Bereichseinschränkung und crawlt Dateien direkt aus diesem Konto.
+
+.. note::
+   Im Standardmodus (``basic_plan=false``) werden Team-Verwaltungs-APIs verwendet (Teammitglieder-Liste, dateizugriff pro Mitglied, Teamordner).
+   Daher sind ein Dropbox Business-Konto und ein Token mit Teamadministrator-Rechten zwingend erforderlich. Wenn Sie ein Einzelkonto verwenden, setzen Sie unbedingt ``basic_plan=true``.
+
 Schritte zum Abrufen des Zugriffstokens
----------------------------------------
+----------------------------------------
 
 1. App in der Dropbox App Console erstellen
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -213,26 +241,31 @@ Besuchen Sie https://www.dropbox.com/developers/apps:
 
 1. Klicken Sie auf "Create app"
 2. Wählen Sie als API-Typ "Scoped access"
-3. Wählen Sie als Zugriffstyp "Full Dropbox" oder "App folder"
+3. Wählen Sie den Zugriffstyp (bei kontoübergreifendem Crawling wird "Full Dropbox" empfohlen)
 4. Geben Sie den App-Namen ein und erstellen Sie sie
 
 2. Berechtigungen konfigurieren
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Wählen Sie im Tab "Permissions" die erforderlichen Berechtigungen aus:
 
-**Erforderliche Berechtigungen für das Crawlen von Dateien**:
+**Erforderliche Berechtigungen für das Crawlen von Dateien und Paper**:
 
 - ``files.metadata.read`` - Lesen von Datei-Metadaten
-- ``files.content.read`` - Lesen von Dateiinhalten
+- ``files.content.read`` - Lesen von Datei- und Paper-Dokumentinhalten
 - ``sharing.read`` - Lesen von Freigabeinformationen
 
-**Zusätzlich erforderliche Berechtigungen für das Crawlen von Paper**:
+**Zusätzlich erforderliche Berechtigungen für Teamkonten (``basic_plan=false``)**:
 
-- ``files.content.read`` - Lesen von Paper-Dokumenten
+- ``members.read`` - Lesen der Teammitgliederliste
+- Zugriffsberechtigungen für Teamdaten/Teamspaces (erforderlich für das Crawling von Dateien einzelner Mitglieder und Teamordnern)
+
+.. note::
+   Im Teamkontomodus erfolgt der Zugriff auf einzelne Mitglieder und Teamordner als Teamadministrator.
+   Aktivieren Sie die oben genannten teambezogenen Berechtigungen im Tab "Permissions" und generieren Sie ein Token mit Teamadministrator-Rechten.
 
 3. Zugriffstoken generieren
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Im Tab "Settings":
 
@@ -244,7 +277,7 @@ Im Tab "Settings":
    Bewahren Sie das Zugriffstoken sicher auf. Mit diesem Token kann auf das Dropbox-Konto zugegriffen werden.
 
 4. Token konfigurieren
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Setzen Sie das abgerufene Token in den Parametern:
 
@@ -296,7 +329,7 @@ Skript:
     last_modified=file.client_modified
 
 Dropbox Paper-Dokumente crawlen
--------------------------------
+--------------------------------
 
 Parameter:
 
@@ -351,21 +384,34 @@ Skript (Dropbox Paper):
     role=paper.roles
 
 Nur bestimmte Dateitypen crawlen
---------------------------------
+---------------------------------
 
-Filterung im Skript:
+Um nur bestimmte MIME-Typen zu indizieren, geben Sie im Parameter ``supported_mimetypes``
+die zulässigen MIME-Typen als kommagetrennte Regex-Ausdrücke an.
+
+.. note::
+   Skripte im Datenspeicher werden zeilenweise als eigenständige Ausdrücke der Form ``Feldname=Ausdruck`` ausgewertet.
+   Daher ist es nicht möglich, mit einem mehrzeiligen ``if``-Block mehrere Felder gemeinsam zuzuweisen.
+   Die Einschränkung nach MIME-Typ sollte über den Parameter ``supported_mimetypes`` und nicht über das Skript erfolgen.
+
+Parameter (nur PDF- und Word-Dateien):
 
 ::
 
-    # Nur PDF und Word-Dateien
-    if (file.mimetype == "application/pdf" || file.mimetype == "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
-        url=file.url
-        title=file.name
-        content=file.contents
-        mimetype=file.mimetype
-        filename=file.name
-        last_modified=file.client_modified
-    }
+    access_token=sl.your-dropbox-token-here
+    basic_plan=false
+    supported_mimetypes=application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document
+
+Skript:
+
+::
+
+    url=file.url
+    title=file.name
+    content=file.contents
+    mimetype=file.mimetype
+    filename=file.name
+    last_modified=file.client_modified
 
 Fehlerbehebung
 ==============
@@ -409,9 +455,12 @@ API-Ratenbegrenzungsfehler
 
 **Lösung**:
 
-1. Bei Basic-Plan ``basic_plan=true`` setzen
-2. Crawl-Intervall verlängern
-3. Mehrere Zugriffstokens zur Lastverteilung verwenden
+1. ``readInterval`` setzen, um die Verarbeitungspause zwischen Dateien zu verlängern
+2. ``number_of_threads`` verringern, um die Anzahl gleichzeitiger Anfragen zu reduzieren
+3. Datenspeicher in mehrere aufteilen (z.B. nach Ordner) und die Ausführungszeiten versetzt planen
+
+.. note::
+   ``basic_plan`` ist ein Parameter zur Auswahl des Kontotyps (Team/Einzelkonto) und hat keinen Einfluss auf die Ratenbegrenzung. Setzen Sie ihn entsprechend Ihrem Konto korrekt.
 
 Paper-Dokumente werden nicht abgerufen
 --------------------------------------
@@ -436,10 +485,10 @@ Bei großen Dateimengen
 3. Bei Basic-Plan auf API-Ratenbegrenzung achten
 
 Berechtigungen und Zugriffskontrolle
-====================================
+=====================================
 
 Dropbox-Freigabeberechtigungen abbilden
----------------------------------------
+-----------------------------------------
 
 Dropbox-Freigabeeinstellungen können auf Fess-Berechtigungen abgebildet werden:
 

--- a/en/15.7/config/datastore/ds-dropbox.rst
+++ b/en/15.7/config/datastore/ds-dropbox.rst
@@ -68,7 +68,7 @@ Parameter List
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - Parameter
      - Required
@@ -105,7 +105,10 @@ Parameter List
      - Default permissions for indexed documents, comma-separated
    * - ``max_cached_content_size``
      - No
-     - Maximum content size cached in memory in bytes (default: ``1048576``)
+     - Maximum content size to cache in memory in bytes. Content exceeding this size is written to a temporary file (default: ``1048576``)
+   * - ``readInterval``
+     - No
+     - Wait time in milliseconds inserted between processing each record (default: ``0``)
 
 Script Configuration
 --------------------
@@ -148,9 +151,9 @@ Available fields:
    * - ``file.size``
      - File size (bytes)
    * - ``file.client_modified``
-     - Last modified date on client side
+     - Last modified date on the client side
    * - ``file.server_modified``
-     - Last modified date on server side
+     - Last modified date on the server side
    * - ``file.roles``
      - File access permissions
    * - ``file.id``
@@ -202,10 +205,34 @@ Available fields:
      - Paper document revision
 
 Dropbox Authentication Setup
-============================
+=============================
+
+Account Type and Access Token
+------------------------------
+
+This connector switches between two operating modes via the ``basic_plan`` parameter.
+The type of app and access token you need to create differs between modes, so confirm this first.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Mode
+     - ``basic_plan``
+     - Description
+   * - Team account (default)
+     - ``false``
+     - For Dropbox Business (team) accounts. Requires an access token with team administrator privileges, and crawls files of team members and team folders across the organization.
+   * - Individual account
+     - ``true``
+     - For personal (non-team) accounts. Uses a standard scoped access token and crawls files directly within that account.
+
+.. note::
+   In the default mode (``basic_plan=false``), team administration APIs (team member listing, per-member file access, team folders) are used,
+   so a Dropbox Business account and a token with team administrator privileges are required. If you are using a personal account, make sure to set ``basic_plan=true``.
 
 Access Token Acquisition Steps
-------------------------------
+-------------------------------
 
 1. Create an App in Dropbox App Console
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -214,36 +241,41 @@ Access https://www.dropbox.com/developers/apps:
 
 1. Click "Create app"
 2. Select "Scoped access" for API type
-3. Select "Full Dropbox" or "App folder" for access type
+3. Select the access type (for crawling across team accounts, "Full Dropbox" is recommended)
 4. Enter app name and create
 
 2. Configure Permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-In the "Permissions" tab, select required permissions:
+In the "Permissions" tab, select the required permissions:
 
-**Required permissions for file crawling**:
+**Required permissions for crawling files and Paper**:
 
 - ``files.metadata.read`` - Read file metadata
-- ``files.content.read`` - Read file content
+- ``files.content.read`` - Read content of files and Paper documents
 - ``sharing.read`` - Read sharing information
 
-**Additional permissions for Paper crawling**:
+**Additional permissions required for team accounts (``basic_plan=false``)**:
 
-- ``files.content.read`` - Read Paper documents
+- ``members.read`` - Read team member listing
+- Access permissions for team data / team spaces (required for crawling per-member files and team folders)
+
+.. note::
+   In team account mode, files are accessed as a team administrator on behalf of each member and team folder.
+   Enable the team-related permissions above in the Permissions tab, and generate a token for a team administrator.
 
 3. Generate Access Token
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 In the "Settings" tab:
 
-1. Scroll to "Generated access token" section
-2. Click "Generate" button
+1. Scroll to the "Generated access token" section
+2. Click the "Generate" button
 3. Copy the generated token (this token is only displayed once)
 
 .. warning::
-   Keep your access token secure. Anyone with this token can access
-   your Dropbox account.
+   Keep your access token secure. Anyone with this token can
+   access your Dropbox account.
 
 4. Configure Token
 ~~~~~~~~~~~~~~~~~~
@@ -255,10 +287,10 @@ Set the obtained token in the parameters:
     access_token=sl.your-dropbox-token-here
 
 Individual Account Settings
-===========================
+============================
 
 Using Individual Accounts
--------------------------
+--------------------------
 
 For individual accounts (not team accounts),
 set the ``basic_plan`` parameter to ``true``:
@@ -298,7 +330,7 @@ Script:
     last_modified=file.client_modified
 
 Crawling Dropbox Paper Documents
---------------------------------
+---------------------------------
 
 Parameters:
 
@@ -355,19 +387,32 @@ Script (Dropbox Paper):
 Crawling Specific File Types Only
 ----------------------------------
 
-Filtering in script:
+To index only specific MIME types, specify regex patterns for the allowed MIME types
+in the ``supported_mimetypes`` parameter, separated by commas.
+
+.. note::
+   Each line of a data store script is evaluated as an independent expression in the form ``field=expression``.
+   Therefore, it is not possible to assign multiple fields together inside a multi-line ``if`` block.
+   Use the ``supported_mimetypes`` parameter — not the script — to filter by MIME type.
+
+Parameters (PDF and Word files only):
 
 ::
 
-    # PDF and Word files only
-    if (file.mimetype == "application/pdf" || file.mimetype == "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
-        url=file.url
-        title=file.name
-        content=file.contents
-        mimetype=file.mimetype
-        filename=file.name
-        last_modified=file.client_modified
-    }
+    access_token=sl.your-dropbox-token-here
+    basic_plan=false
+    supported_mimetypes=application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document
+
+Script:
+
+::
+
+    url=file.url
+    title=file.name
+    content=file.contents
+    mimetype=file.mimetype
+    filename=file.name
+    last_modified=file.client_modified
 
 Troubleshooting
 ===============
@@ -394,7 +439,7 @@ Cannot Retrieve Files
 1. Verify app's "Access type" is appropriate:
 
    - "Full Dropbox": Can access entire Dropbox
-   - "App folder": Can only access specific folder
+   - "App folder": Can only access a specific folder
 
 2. Verify required permissions are granted:
 
@@ -402,7 +447,7 @@ Cannot Retrieve Files
    - ``files.content.read``
    - ``sharing.read``
 
-3. Verify files exist in Dropbox account
+3. Verify files exist in the Dropbox account
 
 API Rate Limit Errors
 ---------------------
@@ -411,9 +456,13 @@ API Rate Limit Errors
 
 **Resolution**:
 
-1. For Basic plan, set ``basic_plan=true``
-2. Increase crawl interval
-3. Use multiple access tokens for load distribution
+1. Set ``readInterval`` to add a wait between processing each file
+2. Reduce ``number_of_threads`` to lower the number of concurrent requests
+3. Split the data store into multiple instances (e.g., by folder) and stagger the schedules
+
+.. note::
+   ``basic_plan`` is a parameter that switches the account type (team / individual) and does not affect
+   rate limit adjustment. Set it correctly according to your account type.
 
 Paper Documents Cannot Be Retrieved
 ------------------------------------
@@ -433,15 +482,15 @@ When There Are Many Files
 
 **Resolution**:
 
-1. Split data stores into multiple (e.g., by folder)
+1. Split data stores into multiple instances (e.g., by folder)
 2. Distribute load with schedule settings
-3. For Basic plan, note API rate limits
+3. For the Basic plan, pay attention to API rate limits
 
 Permissions and Access Control
-==============================
+===============================
 
 Reflecting Dropbox Sharing Permissions
---------------------------------------
+---------------------------------------
 
 Dropbox sharing settings can be reflected in Fess permissions:
 

--- a/es/15.7/config/datastore/ds-dropbox.rst
+++ b/es/15.7/config/datastore/ds-dropbox.rst
@@ -56,7 +56,7 @@ Configuracion Basica
      - Activado
 
 Configuracion de Parametros
----------------------------
+----------------------------
 
 ::
 
@@ -68,7 +68,7 @@ Lista de Parametros
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - Parametro
      - Requerido
@@ -87,10 +87,10 @@ Lista de Parametros
      - Numero de hilos para rastreo (predeterminado: ``1``)
    * - ``ignore_folder``
      - No
-     - Omitir metadatos de carpetas (predeterminado: ``true``)
+     - Indica si se omiten los metadatos de carpetas (predeterminado: ``true``)
    * - ``ignore_error``
      - No
-     - Ignorar errores durante la extraccion de contenido (predeterminado: ``true``)
+     - Indica si se ignoran los errores durante la extraccion de contenido (predeterminado: ``true``)
    * - ``supported_mimetypes``
      - No
      - Patrones regex para tipos MIME permitidos, separados por comas (predeterminado: ``.*``)
@@ -105,7 +105,10 @@ Lista de Parametros
      - Permisos predeterminados para documentos indexados, separados por comas
    * - ``max_cached_content_size``
      - No
-     - Tamano maximo de contenido en cache en memoria en bytes (predeterminado: ``1048576``)
+     - Tamano maximo de contenido almacenado en cache en memoria en bytes. El contenido que supere este limite se escribe en un archivo temporal (predeterminado: ``1048576``)
+   * - ``readInterval``
+     - No
+     - Tiempo de espera en milisegundos entre el procesamiento de cada registro (predeterminado: ``0``)
 
 Configuracion de Script
 -----------------------
@@ -202,35 +205,66 @@ Campos disponibles:
      - Revision del documento Paper
 
 Configuracion de Autenticacion de Dropbox
-=========================================
+==========================================
 
-Pasos para Obtener Token de Acceso
-----------------------------------
+Tipo de Cuenta y Token de Acceso
+---------------------------------
+
+Este conector alterna entre dos modos de operacion segun el parametro ``basic_plan``.
+Dado que el tipo de aplicacion y de token de acceso que se debe crear difiere, verifiquelo primero.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Modo
+     - ``basic_plan``
+     - Descripcion
+   * - Cuenta de equipo (predeterminado)
+     - ``false``
+     - Destinado a cuentas Dropbox Business (equipo). Requiere un token de acceso con permisos de administrador del equipo, y rastrea archivos de los miembros del equipo y carpetas de equipo de forma transversal.
+   * - Cuenta individual
+     - ``true``
+     - Destinado a cuentas individuales (no de equipo). Utiliza un token de acceso con alcance estandar y rastrea directamente los archivos dentro de esa cuenta.
+
+.. note::
+   Con la configuracion predeterminada (``basic_plan=false``), se utilizan las API de administracion de equipos
+   (lista de miembros, acceso a archivos por miembro, carpetas de equipo), por lo que es obligatorio
+   disponer de una cuenta Dropbox Business y un token con permisos de administrador del equipo.
+   Si utiliza una cuenta individual, asegurese de configurar ``basic_plan=true``.
+
+Pasos para Obtener el Token de Acceso
+--------------------------------------
 
 1. Crear una aplicacion en Dropbox App Console
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Acceda a https://www.dropbox.com/developers/apps:
 
 1. Haga clic en "Create app"
 2. Seleccione "Scoped access" para el tipo de API
-3. Seleccione "Full Dropbox" o "App folder" para el tipo de acceso
+3. Seleccione el tipo de acceso (se recomienda "Full Dropbox" para rastrear cuentas de equipo de forma transversal)
 4. Ingrese el nombre de la aplicacion y cree
 
 2. Configuracion de Permisos
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 En la pestana "Permissions", seleccione los permisos requeridos:
 
-**Permisos requeridos para rastreo de archivos**:
+**Permisos necesarios para el rastreo de archivos y Paper**:
 
 - ``files.metadata.read`` - Lectura de metadatos de archivos
-- ``files.content.read`` - Lectura de contenido de archivos
+- ``files.content.read`` - Lectura de contenido de archivos y documentos Paper
 - ``sharing.read`` - Lectura de informacion de uso compartido
 
-**Permisos adicionales requeridos para rastreo de Paper**:
+**Permisos adicionales requeridos para cuentas de equipo (``basic_plan=false``)**:
 
-- ``files.content.read`` - Lectura de documentos Paper
+- ``members.read`` - Lectura de la lista de miembros del equipo
+- Permisos de acceso a datos de equipo y espacios de equipo (necesarios para rastrear archivos por miembro y carpetas de equipo)
+
+.. note::
+   En el modo de cuenta de equipo, se accede a cada miembro y carpeta de equipo como administrador del equipo.
+   Habilite los permisos de equipo mencionados en la pestana Permissions y genere un token de administrador del equipo.
 
 3. Generar Token de Acceso
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -275,7 +309,7 @@ Ejemplos de Uso
 ===============
 
 Rastrear Todos los Archivos de Dropbox
---------------------------------------
+---------------------------------------
 
 Parametros:
 
@@ -298,7 +332,7 @@ Script:
     last_modified=file.client_modified
 
 Rastrear Documentos de Dropbox Paper
-------------------------------------
+--------------------------------------
 
 Parametros:
 
@@ -317,28 +351,76 @@ Script:
     mimetype=paper.mimetype
     filetype=paper.filetype
 
-Rastrear Solo Tipos de Archivo Especificos
-------------------------------------------
+Rastrear con Permisos
+----------------------
 
-Filtrado en el script:
+Parametros:
 
 ::
 
-    # Solo PDF y archivos Word
-    if (file.mimetype == "application/pdf" || file.mimetype == "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
-        url=file.url
-        title=file.name
-        content=file.contents
-        mimetype=file.mimetype
-        filename=file.name
-        last_modified=file.client_modified
-    }
+    access_token=sl.your-dropbox-token-here
+    basic_plan=false
+    default_permissions={role}admin
+
+Script (archivos de Dropbox):
+
+::
+
+    url=file.url
+    title=file.name
+    content=file.contents
+    mimetype=file.mimetype
+    filename=file.name
+    content_length=file.size
+    last_modified=file.client_modified
+    role=file.roles
+
+Script (Dropbox Paper):
+
+::
+
+    title=paper.title
+    content=paper.contents
+    url=paper.url
+    mimetype=paper.mimetype
+    filetype=paper.filetype
+    role=paper.roles
+
+Rastrear Solo Tipos de Archivo Especificos
+-------------------------------------------
+
+Para indexar unicamente tipos MIME especificos, especifique en el parametro ``supported_mimetypes``
+las expresiones regulares de los tipos MIME permitidos, separadas por comas.
+
+.. note::
+   Los scripts del almacen de datos evaluan cada linea como una expresion independiente con el formato ``campo=expresion``.
+   Por ello, no es posible asignar multiples campos en un bloque ``if`` de varias lineas.
+   El filtrado por tipo MIME debe realizarse mediante el parametro ``supported_mimetypes``, no con scripts.
+
+Parametros (solo PDF y archivos Word):
+
+::
+
+    access_token=sl.your-dropbox-token-here
+    basic_plan=false
+    supported_mimetypes=application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document
+
+Script:
+
+::
+
+    url=file.url
+    title=file.name
+    content=file.contents
+    mimetype=file.mimetype
+    filename=file.name
+    last_modified=file.client_modified
 
 Solucion de Problemas
-=====================
+======================
 
 Errores de Autenticacion
-------------------------
+-------------------------
 
 **Sintoma**: ``Invalid access token`` o ``401 Unauthorized``
 
@@ -350,7 +432,7 @@ Errores de Autenticacion
 4. Verifique que la aplicacion no este desactivada
 
 No Se Pueden Obtener Archivos
------------------------------
+------------------------------
 
 **Sintoma**: El rastreo tiene exito pero hay 0 archivos
 
@@ -370,18 +452,22 @@ No Se Pueden Obtener Archivos
 3. Verifique que existan archivos en la cuenta de Dropbox
 
 Errores de Limite de Tasa de API
---------------------------------
+----------------------------------
 
 **Sintoma**: Error ``429 Too Many Requests``
 
 **Solucion**:
 
-1. Para el plan Basic, configure ``basic_plan=true``
-2. Aumente el intervalo de rastreo
-3. Distribuya la carga usando multiples tokens de acceso
+1. Configure ``readInterval`` para aumentar el intervalo de procesamiento entre archivos
+2. Reduzca ``number_of_threads`` para disminuir el numero de solicitudes simultaneas
+3. Divida el almacen de datos en varios (por carpeta u otro criterio) y escalone los horarios de ejecucion
+
+.. note::
+   ``basic_plan`` es un parametro que alterna el tipo de cuenta (equipo/individual)
+   y no afecta al ajuste de los limites de tasa. Configurelo correctamente segun su cuenta.
 
 No Se Pueden Obtener Documentos Paper
--------------------------------------
+---------------------------------------
 
 **Sintoma**: Los documentos Paper no se rastrean
 
@@ -392,7 +478,7 @@ No Se Pueden Obtener Documentos Paper
 3. Verifique que realmente existan documentos Paper
 
 Cuando Hay un Gran Numero de Archivos
--------------------------------------
+---------------------------------------
 
 **Sintoma**: El rastreo toma mucho tiempo o se agota el tiempo
 
@@ -400,13 +486,13 @@ Cuando Hay un Gran Numero de Archivos
 
 1. Divida los almacenes de datos en multiples (por unidad de carpeta, etc.)
 2. Distribuya la carga con configuracion de programacion
-3. Para el plan Basic, tenga en cuenta los limites de tasa de API
+3. En el plan Basic, tenga en cuenta los limites de tasa de API
 
 Permisos y Control de Acceso
-============================
+==============================
 
 Reflejar Permisos de Uso Compartido de Dropbox
-----------------------------------------------
+------------------------------------------------
 
 Puede reflejar la configuracion de uso compartido de Dropbox en los permisos de Fess:
 
@@ -432,7 +518,7 @@ Script:
 ``file.roles`` o ``paper.roles`` contienen informacion de uso compartido de Dropbox.
 
 Informacion de Referencia
-=========================
+==========================
 
 - :doc:`ds-overview` - Descripcion General de Conectores de Almacen de Datos
 - :doc:`ds-box` - Conector de Box

--- a/fr/15.7/config/datastore/ds-dropbox.rst
+++ b/fr/15.7/config/datastore/ds-dropbox.rst
@@ -2,12 +2,13 @@
 Connecteur Dropbox
 ==================================
 
-Apercu
+Aperçu
 ======
 
-Le connecteur Dropbox fournit une fonctionnalite pour recuperer des fichiers depuis le stockage cloud Dropbox et les enregistrer dans l'index de |Fess|.
+Le connecteur Dropbox fournit une fonctionnalité pour récupérer des fichiers depuis le
+stockage cloud Dropbox et les enregistrer dans l'index de |Fess|.
 
-Cette fonctionnalite necessite le plugin ``fess-ds-dropbox``.
+Cette fonctionnalité nécessite le plugin ``fess-ds-dropbox``.
 
 Services pris en charge
 =======================
@@ -15,28 +16,28 @@ Services pris en charge
 - Dropbox (stockage de fichiers)
 - Dropbox Paper (documents)
 
-Prerequis
+Prérequis
 =========
 
 1. L'installation du plugin est requise
-2. Un compte developpeur Dropbox et la creation d'une application sont necessaires
-3. L'obtention d'un token d'acces est requise
+2. Un compte développeur Dropbox et la création d'une application sont nécessaires
+3. L'obtention d'un token d'accès est requise
 
 Installation du plugin
 ----------------------
 
-Installez depuis l'interface d'administration sous "Systeme" -> "Plugins" :
+Installez depuis l'interface d'administration sous « Système » → « Plugins » :
 
-1. Telechargez ``fess-ds-dropbox-X.X.X.jar`` depuis Maven Central
+1. Téléchargez ``fess-ds-dropbox-X.X.X.jar`` depuis Maven Central
 2. Uploadez et installez depuis l'interface de gestion des plugins
-3. Redemarrez |Fess|
+3. Redémarrez |Fess|
 
-Ou consultez :doc:`../../admin/plugin-guide` pour plus de details.
+Ou consultez :doc:`../../admin/plugin-guide` pour plus de détails.
 
-Methode de configuration
+Méthode de configuration
 ========================
 
-Configurez depuis l'interface d'administration : "Crawler" -> "DataStore" -> "Nouveau".
+Configurez depuis l'interface d'administration : « Crawler » → « DataStore » → « Nouveau ».
 
 Configuration de base
 ---------------------
@@ -45,7 +46,7 @@ Configuration de base
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
+   * - Élément
      - Exemple de configuration
    * - Nom
      - Company Dropbox
@@ -54,57 +55,60 @@ Configuration de base
    * - Actif
      - Oui
 
-Configuration des parametres
-----------------------------
+Configuration des paramètres
+-----------------------------
 
 ::
 
     access_token=sl.your-dropbox-token-here
     basic_plan=false
 
-Liste des parametres
+Liste des paramètres
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``access_token``
      - Oui
-     - Token d'acces Dropbox (genere dans App Console)
+     - Token d'accès Dropbox (généré dans App Console)
    * - ``basic_plan``
      - Non
-     - ``true`` pour les comptes individuels, ``false`` pour les comptes d'equipe (defaut : ``false``)
+     - ``true`` pour les comptes individuels, ``false`` pour les comptes d'équipe (défaut : ``false``)
    * - ``max_size``
      - Non
-     - Taille maximale des fichiers pour l'indexation en octets (defaut : ``10000000``)
+     - Taille maximale des fichiers pour l'indexation en octets (défaut : ``10000000``)
    * - ``number_of_threads``
      - Non
-     - Nombre de threads pour l'exploration (defaut : ``1``)
+     - Nombre de threads pour l'exploration (défaut : ``1``)
    * - ``ignore_folder``
      - Non
-     - Ignorer les metadonnees des dossiers (defaut : ``true``)
+     - Ignorer les métadonnées des dossiers (défaut : ``true``)
    * - ``ignore_error``
      - Non
-     - Ignorer les erreurs lors de l'extraction de contenu (defaut : ``true``)
+     - Ignorer les erreurs lors de l'extraction de contenu (défaut : ``true``)
    * - ``supported_mimetypes``
      - Non
-     - Motifs regex pour les types MIME autorises, separes par des virgules (defaut : ``.*``)
+     - Motifs regex pour les types MIME autorisés, séparés par des virgules (défaut : ``.*``)
    * - ``include_pattern``
      - Non
-     - Motif d'URL a inclure dans l'exploration
+     - Motif d'URL à inclure dans l'exploration
    * - ``exclude_pattern``
      - Non
-     - Motif d'URL a exclure de l'exploration
+     - Motif d'URL à exclure de l'exploration
    * - ``default_permissions``
      - Non
-     - Permissions par defaut pour les documents indexes, separees par des virgules
+     - Permissions par défaut pour les documents indexés, séparées par des virgules
    * - ``max_cached_content_size``
      - Non
-     - Taille maximale du contenu en cache en memoire en octets (defaut : ``1048576``)
+     - Taille maximale du contenu mis en cache en mémoire en octets. Le contenu dépassant cette taille est écrit dans un fichier temporaire (défaut : ``1048576``)
+   * - ``readInterval``
+     - Non
+     - Temps d'attente inséré entre le traitement de chaque enregistrement (en millisecondes) (défaut : ``0``)
 
 Configuration du script
 -----------------------
@@ -133,7 +137,7 @@ Champs disponibles :
    * - Champ
      - Description
    * - ``file.url``
-     - Lien de previsualisation du fichier
+     - Lien de prévisualisation du fichier
    * - ``file.contents``
      - Contenu texte du fichier
    * - ``file.mimetype``
@@ -147,21 +151,21 @@ Champs disponibles :
    * - ``file.size``
      - Taille du fichier (octets)
    * - ``file.client_modified``
-     - Date de derniere modification cote client
+     - Date de dernière modification côté client
    * - ``file.server_modified``
-     - Date de derniere modification cote serveur
+     - Date de dernière modification côté serveur
    * - ``file.roles``
-     - Autorisations d'acces au fichier
+     - Autorisations d'accès au fichier
    * - ``file.id``
      - Identifiant du fichier Dropbox
    * - ``file.path_lower``
      - Chemin du fichier en minuscules
    * - ``file.parent_shared_folder_id``
-     - ID du dossier partage parent
+     - ID du dossier partagé parent
    * - ``file.content_hash``
      - Hash du contenu
    * - ``file.rev``
-     - Revision du fichier
+     - Révision du fichier
 
 Pour Dropbox Paper
 ~~~~~~~~~~~~~~~~~~
@@ -184,7 +188,7 @@ Champs disponibles :
    * - Champ
      - Description
    * - ``paper.url``
-     - Lien de previsualisation du document Paper
+     - Lien de prévisualisation du document Paper
    * - ``paper.contents``
      - Contenu texte du document Paper
    * - ``paper.mimetype``
@@ -194,88 +198,117 @@ Champs disponibles :
    * - ``paper.title``
      - Titre du document Paper
    * - ``paper.owner``
-     - Proprietaire du document Paper
+     - Propriétaire du document Paper
    * - ``paper.roles``
-     - Autorisations d'acces au document
+     - Autorisations d'accès au document
    * - ``paper.revision``
-     - Revision du document Paper
+     - Révision du document Paper
 
 Configuration de l'authentification Dropbox
-===========================================
+============================================
 
-Procedure d'obtention du token d'acces
---------------------------------------
+Type de compte et token d'accès
+---------------------------------
 
-1. Creer une application dans Dropbox App Console
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ce connecteur bascule entre deux modes de fonctionnement via le paramètre ``basic_plan``.
+Le type d'application et de token d'accès à créer diffère selon le mode ; vérifiez ce point en premier.
 
-Accedez a https://www.dropbox.com/developers/apps :
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
 
-1. Cliquez sur "Create app"
-2. Selectionnez "Scoped access" pour le type d'API
-3. Selectionnez "Full Dropbox" ou "App folder" pour le type d'acces
-4. Entrez le nom de l'application et creez
+   * - Mode
+     - ``basic_plan``
+     - Description
+   * - Compte d'équipe (défaut)
+     - ``false``
+     - Pour les comptes Dropbox Business (équipe). Un token d'accès disposant des droits d'administrateur d'équipe est requis ; il explore les fichiers des membres de l'équipe et les dossiers d'équipe de manière transversale.
+   * - Compte individuel
+     - ``true``
+     - Pour les comptes personnels (hors équipe). Utilise un token d'accès étendu standard et explore directement les fichiers du compte.
+
+.. note::
+   Par défaut (``basic_plan=false``), le connecteur utilise les API de gestion d'équipe (liste des membres, accès aux fichiers par membre, dossiers d'équipe) ;
+   un compte Dropbox Business et un token disposant des droits d'administrateur d'équipe sont donc obligatoires. Si vous utilisez un compte individuel, définissez impérativement ``basic_plan=true``.
+
+Procédure d'obtention du token d'accès
+---------------------------------------
+
+1. Créer une application dans Dropbox App Console
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Accédez à https://www.dropbox.com/developers/apps :
+
+1. Cliquez sur « Create app »
+2. Sélectionnez « Scoped access » pour le type d'API
+3. Sélectionnez le type d'accès (« Full Dropbox » recommandé pour explorer l'intégralité d'un compte d'équipe)
+4. Saisissez le nom de l'application et créez-la
 
 2. Configuration des permissions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Dans l'onglet "Permissions", selectionnez les permissions necessaires :
+Dans l'onglet « Permissions », sélectionnez les permissions nécessaires :
 
-**Permissions requises pour l'exploration des fichiers** :
+**Permissions requises pour l'exploration des fichiers et de Paper** :
 
-- ``files.metadata.read`` - Lecture des metadonnees des fichiers
-- ``files.content.read`` - Lecture du contenu des fichiers
+- ``files.metadata.read`` - Lecture des métadonnées des fichiers
+- ``files.content.read`` - Lecture du contenu des fichiers et des documents Paper
 - ``sharing.read`` - Lecture des informations de partage
 
-**Permissions supplementaires requises pour l'exploration Paper** :
+**Permissions supplémentaires requises pour les comptes d'équipe (``basic_plan=false``)** :
 
-- ``files.content.read`` - Lecture des documents Paper
+- ``members.read`` - Lecture de la liste des membres de l'équipe
+- Permissions d'accès aux données d'équipe / espaces d'équipe (nécessaires pour explorer les fichiers par membre et les dossiers d'équipe)
 
-3. Generation du token d'acces
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. note::
+   En mode compte d'équipe, le connecteur accède à chaque membre et dossier d'équipe en tant qu'administrateur d'équipe.
+   Activez les permissions liées à l'équipe ci-dessus dans l'onglet Permissions, puis générez un token d'administrateur d'équipe.
 
-Dans l'onglet "Settings" :
+3. Génération du token d'accès
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Faites defiler jusqu'a la section "Generated access token"
-2. Cliquez sur le bouton "Generate"
-3. Copiez le token genere (ce token ne s'affiche qu'une seule fois)
+Dans l'onglet « Settings » :
+
+1. Faites défiler jusqu'à la section « Generated access token »
+2. Cliquez sur le bouton « Generate »
+3. Copiez le token généré (ce token ne s'affiche qu'une seule fois)
 
 .. warning::
-   Conservez le token d'acces en securite. Ce token permet d'acceder a votre compte Dropbox.
+   Conservez le token d'accès en sécurité. Ce token permet d'accéder à votre compte Dropbox.
 
 4. Configuration du token
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Configurez le token obtenu dans les parametres :
+Configurez le token obtenu dans les paramètres :
 
 ::
 
     access_token=sl.your-dropbox-token-here
 
 Configuration pour compte individuel
-=====================================
+======================================
 
 Utilisation avec un compte individuel
--------------------------------------
+---------------------------------------
 
-Pour les comptes individuels (pas les comptes d'equipe),
-definissez le parametre ``basic_plan`` sur ``true`` :
+Pour les comptes individuels (pas les comptes d'équipe),
+définissez le paramètre ``basic_plan`` sur ``true`` :
 
 ::
 
     access_token=sl.your-dropbox-token-here
     basic_plan=true
 
-Quand ``false`` (defaut), il fonctionne comme un compte d'equipe et explore les fichiers des membres et des dossiers d'equipe.
-Quand ``true``, il fonctionne comme un compte individuel et explore les fichiers directement depuis le compte.
+Quand ``false`` (défaut), le connecteur fonctionne comme un compte d'équipe et explore les fichiers des membres et des dossiers d'équipe.
+Quand ``true``, il fonctionne comme un compte individuel et explore directement les fichiers du compte.
 
 Exemples d'utilisation
-======================
+=======================
 
 Explorer l'ensemble des fichiers Dropbox
-----------------------------------------
+-----------------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -296,9 +329,9 @@ Script :
     last_modified=file.client_modified
 
 Explorer les documents Dropbox Paper
-------------------------------------
+--------------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -315,27 +348,10 @@ Script :
     mimetype=paper.mimetype
     filetype=paper.filetype
 
-Explorer uniquement certains types de fichiers
-----------------------------------------------
-
-Filtrage dans le script :
-
-::
-
-    # Uniquement PDF et fichiers Word
-    if (file.mimetype == "application/pdf" || file.mimetype == "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
-        url=file.url
-        title=file.name
-        content=file.contents
-        mimetype=file.mimetype
-        filename=file.name
-        last_modified=file.client_modified
-    }
-
 Exploration avec permissions
-----------------------------
+------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -367,83 +383,116 @@ Script (Dropbox Paper) :
     filetype=paper.filetype
     role=paper.roles
 
-Depannage
-=========
+Explorer uniquement certains types de fichiers
+-----------------------------------------------
+
+Pour n'indexer que certains types MIME, spécifiez dans le paramètre ``supported_mimetypes``
+les expressions régulières des types MIME autorisés, séparées par des virgules.
+
+.. note::
+   Les scripts de datastore évaluent chaque ligne comme une expression indépendante sous la forme ``champ=expression``.
+   Il n'est donc pas possible d'affecter plusieurs champs à l'intérieur d'un bloc ``if`` multiligne.
+   Le filtrage par type MIME doit être réalisé via le paramètre ``supported_mimetypes``, et non dans le script.
+
+Paramètres (PDF et fichiers Word uniquement) :
+
+::
+
+    access_token=sl.your-dropbox-token-here
+    basic_plan=false
+    supported_mimetypes=application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document
+
+Script :
+
+::
+
+    url=file.url
+    title=file.name
+    content=file.contents
+    mimetype=file.mimetype
+    filename=file.name
+    last_modified=file.client_modified
+
+Dépannage
+==========
 
 Erreur d'authentification
--------------------------
+--------------------------
 
-**Symptome** : ``Invalid access token`` ou ``401 Unauthorized``
+**Symptôme** : ``Invalid access token`` ou ``401 Unauthorized``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifiez que le token d'acces est correctement copie
-2. Verifiez que le token n'a pas expire (utilisez un token longue duree)
-3. Verifiez que les permissions necessaires sont accordees dans Dropbox App Console
-4. Verifiez que l'application n'est pas desactivee
+1. Vérifiez que le token d'accès est correctement copié
+2. Vérifiez que le token n'a pas expiré (utilisez un token longue durée)
+3. Vérifiez que les permissions nécessaires sont accordées dans Dropbox App Console
+4. Vérifiez que l'application n'est pas désactivée
 
-Impossible de recuperer les fichiers
-------------------------------------
+Impossible de récupérer les fichiers
+--------------------------------------
 
-**Symptome** : L'exploration reussit mais 0 fichier
+**Symptôme** : L'exploration réussit mais 0 fichier
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifiez le "Access type" de l'application :
+1. Vérifiez le « Access type » de l'application :
 
-   - "Full Dropbox" : Acces a l'ensemble de Dropbox
-   - "App folder" : Acces a un dossier specifique uniquement
+   - « Full Dropbox » : Accès à l'ensemble de Dropbox
+   - « App folder » : Accès à un dossier spécifique uniquement
 
-2. Verifiez que les permissions necessaires sont accordees :
+2. Vérifiez que les permissions nécessaires sont accordées :
 
    - ``files.metadata.read``
    - ``files.content.read``
    - ``sharing.read``
 
-3. Verifiez que des fichiers existent dans le compte Dropbox
+3. Vérifiez que des fichiers existent dans le compte Dropbox
 
-Erreur de limitation de debit API
----------------------------------
+Erreur de limitation de débit API
+-----------------------------------
 
-**Symptome** : Erreur ``429 Too Many Requests``
+**Symptôme** : Erreur ``429 Too Many Requests``
 
 **Solution** :
 
-1. Pour le plan Basic, configurez ``basic_plan=true``
-2. Augmentez l'intervalle d'exploration
-3. Utilisez plusieurs tokens d'acces pour repartir la charge
+1. Configurez ``readInterval`` pour espacer le traitement de chaque fichier
+2. Réduisez ``number_of_threads`` pour diminuer le nombre de requêtes simultanées
+3. Divisez le datastore en plusieurs parties (par dossier, etc.) et décalez les horaires d'exécution
 
-Impossible de recuperer les documents Paper
--------------------------------------------
+.. note::
+   ``basic_plan`` est un paramètre qui bascule entre le type de compte (équipe/individuel) et n'a pas d'effet sur la gestion des limites de débit. Configurez-le correctement selon votre compte.
 
-**Symptome** : Les documents Paper ne sont pas explores
+Impossible de récupérer les documents Paper
+--------------------------------------------
 
-**Points a verifier** :
+**Symptôme** : Les documents Paper ne sont pas explorés
 
-1. Verifiez que le nom du handler est ``DropboxPaperDataStore``
-2. Verifiez que ``files.content.read`` est inclus dans les permissions
-3. Verifiez que des documents Paper existent reellement
+**Points à vérifier** :
+
+1. Vérifiez que le nom du handler est ``DropboxPaperDataStore``
+2. Vérifiez que ``files.content.read`` est inclus dans les permissions
+3. Vérifiez que des documents Paper existent réellement
 
 En cas de grand nombre de fichiers
-----------------------------------
+------------------------------------
 
-**Symptome** : L'exploration prend du temps ou timeout
+**Symptôme** : L'exploration prend du temps ou expire
 
 **Solution** :
 
-1. Divisez les datastores en plusieurs (par dossier, etc.)
-2. Repartissez la charge avec les parametres de planification
-3. Pour le plan Basic, attention aux limites de debit API
+1. Divisez les datastores en plusieurs parties (par dossier, etc.)
+2. Répartissez la charge avec les paramètres de planification
+3. Pour le plan Basic, faites attention aux limites de débit API
 
-Permissions et controle d'acces
-===============================
+Permissions et contrôle d'accès
+=================================
 
 Reflet des permissions de partage Dropbox
------------------------------------------
+------------------------------------------
 
-Les parametres de partage Dropbox peuvent etre refletes dans les permissions Fess :
+Les paramètres de partage Dropbox peuvent être reflétés dans les permissions Fess :
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -464,10 +513,10 @@ Script :
 
 ``file.roles`` ou ``paper.roles`` contiennent les informations de partage Dropbox.
 
-Informations de reference
-=========================
+Informations de référence
+==========================
 
-- :doc:`ds-overview` - Apercu des connecteurs DataStore
+- :doc:`ds-overview` - Aperçu des connecteurs DataStore
 - :doc:`ds-box` - Connecteur Box
 - :doc:`ds-gsuite` - Connecteur Google Workspace
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration DataStore

--- a/ja/15.7/config/datastore/ds-dropbox.rst
+++ b/ja/15.7/config/datastore/ds-dropbox.rst
@@ -68,7 +68,7 @@ Dropboxコネクタは、Dropboxのクラウドストレージからファイル
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - パラメーター
      - 必須
@@ -105,7 +105,10 @@ Dropboxコネクタは、Dropboxのクラウドストレージからファイル
      - インデックスされたドキュメントのデフォルト権限（カンマ区切り）
    * - ``max_cached_content_size``
      - いいえ
-     - メモリにキャッシュするコンテンツの最大サイズ（バイト）（デフォルト: ``1048576``）
+     - メモリにキャッシュするコンテンツの最大サイズ（バイト）。これを超えるコンテンツは一時ファイルに書き出されます（デフォルト: ``1048576``）
+   * - ``readInterval``
+     - いいえ
+     - 各レコードを処理する間に挿入する待機時間（ミリ秒）（デフォルト: ``0``）
 
 スクリプト設定
 --------------
@@ -204,6 +207,30 @@ Dropbox Paperの場合
 Dropbox認証の設定
 =================
 
+アカウント種別とアクセストークン
+--------------------------------
+
+このコネクタは ``basic_plan`` パラメーターによって2つの動作モードを切り替えます。
+作成すべきアプリとアクセストークンの種類が異なるため、最初に確認してください。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - モード
+     - ``basic_plan``
+     - 説明
+   * - チームアカウント（デフォルト）
+     - ``false``
+     - Dropbox Business（チーム）アカウント向けです。チーム管理者の権限を持つアクセストークンが必要で、チームメンバーのファイルとチームフォルダを横断的にクロールします。
+   * - 個人アカウント
+     - ``true``
+     - 個人（非チーム）アカウント向けです。通常のスコープ付きアクセストークンを使用し、そのアカウント内のファイルを直接クロールします。
+
+.. note::
+   デフォルト（``basic_plan=false``）ではチーム管理用のAPI（チームメンバー一覧、メンバー単位のファイルアクセス、チームフォルダ）を使用するため、
+   Dropbox Businessアカウントとチーム管理者権限を持つトークンが必須です。個人アカウントを利用する場合は必ず ``basic_plan=true`` を設定してください。
+
 アクセストークンの取得手順
 --------------------------
 
@@ -214,7 +241,7 @@ https://www.dropbox.com/developers/apps にアクセス:
 
 1. 「Create app」をクリック
 2. APIタイプで「Scoped access」を選択
-3. アクセスタイプで「Full Dropbox」または「App folder」を選択
+3. アクセスタイプを選択（チームアカウントを横断的にクロールする場合は「Full Dropbox」を推奨）
 4. アプリ名を入力して作成
 
 2. 権限の設定
@@ -222,15 +249,20 @@ https://www.dropbox.com/developers/apps にアクセス:
 
 「Permissions」タブで必要な権限を選択:
 
-**ファイルのクロールに必要な権限**:
+**ファイル・Paperのクロールに必要な権限**:
 
 - ``files.metadata.read`` - ファイルのメタデータ読み取り
-- ``files.content.read`` - ファイルのコンテンツ読み取り
+- ``files.content.read`` - ファイルおよびPaperドキュメントのコンテンツ読み取り
 - ``sharing.read`` - 共有情報の読み取り
 
-**Paperのクロールに追加で必要な権限**:
+**チームアカウント（``basic_plan=false``）で追加で必要な権限**:
 
-- ``files.content.read`` - Paperドキュメントの読み取り
+- ``members.read`` - チームメンバー一覧の読み取り
+- チームデータ／チームスペースへのアクセス権限（メンバー単位のファイルおよびチームフォルダのクロールに必要）
+
+.. note::
+   チームアカウントモードでは、チーム管理者として各メンバーやチームフォルダにアクセスします。
+   Permissionsタブで上記のチーム関連権限を有効にし、チーム管理者のトークンを生成してください。
 
 3. アクセストークンの生成
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -355,19 +387,32 @@ Dropbox Paperドキュメントのクロール
 特定のファイルタイプのみクロール
 --------------------------------
 
-スクリプトでフィルタリング:
+特定のMIMEタイプのみをインデックス対象にするには、``supported_mimetypes`` パラメーターに
+許可するMIMEタイプの正規表現をカンマ区切りで指定します。
+
+.. note::
+   データストアのスクリプトは1行ごとに ``フィールド名=式`` の独立した式として評価されます。
+   そのため、複数行にまたがる ``if`` ブロックで複数のフィールドをまとめて代入することはできません。
+   MIMEタイプによる絞り込みは、スクリプトではなく ``supported_mimetypes`` パラメーターで行ってください。
+
+パラメーター（PDFとWordファイルのみ）:
 
 ::
 
-    # PDFとWordファイルのみ
-    if (file.mimetype == "application/pdf" || file.mimetype == "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
-        url=file.url
-        title=file.name
-        content=file.contents
-        mimetype=file.mimetype
-        filename=file.name
-        last_modified=file.client_modified
-    }
+    access_token=sl.your-dropbox-token-here
+    basic_plan=false
+    supported_mimetypes=application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document
+
+スクリプト:
+
+::
+
+    url=file.url
+    title=file.name
+    content=file.contents
+    mimetype=file.mimetype
+    filename=file.name
+    last_modified=file.client_modified
 
 トラブルシューティング
 ======================
@@ -411,9 +456,13 @@ APIレート制限エラー
 
 **解決方法**:
 
-1. Basicプランの場合、``basic_plan=true`` を設定
-2. クロール間隔を長くする
-3. 複数のアクセストークンを使用して負荷分散
+1. ``readInterval`` を設定して各ファイルの処理間隔を空ける
+2. ``number_of_threads`` を小さくして同時リクエスト数を減らす
+3. データストアをフォルダ単位などで複数に分割し、スケジュールをずらして実行する
+
+.. note::
+   ``basic_plan`` はアカウントの種別（チーム／個人）を切り替えるパラメーターであり、
+   レート制限の調整には影響しません。アカウントに合わせて正しく設定してください。
 
 Paperドキュメントが取得できない
 -------------------------------

--- a/ko/15.7/config/datastore/ds-dropbox.rst
+++ b/ko/15.7/config/datastore/ds-dropbox.rst
@@ -16,31 +16,31 @@ Dropbox 커넥터는 Dropbox 클라우드 스토리지에서 파일을 가져와
 - Dropbox (파일 스토리지)
 - Dropbox Paper (문서)
 
-전제조건
-========
+전제 조건
+=========
 
 1. 플러그인 설치가 필요합니다
 2. Dropbox 개발자 계정과 애플리케이션 생성이 필요합니다
 3. 액세스 토큰 취득이 필요합니다
 
 플러그인 설치
-------------------------
+-------------
 
 관리 화면의 "시스템" → "플러그인"에서 설치합니다:
 
-1. Maven Central에서 ``fess-ds-dropbox-X.X.X.jar``를 다운로드
+1. Maven Central에서 ``fess-ds-dropbox-X.X.X.jar`` 를 다운로드
 2. 플러그인 관리 화면에서 업로드하여 설치
-3. |Fess| 재시작
+3. |Fess| 를 재시작
 
 또는 자세한 내용은 :doc:`../../admin/plugin-guide` 를 참조하세요.
 
 설정 방법
-========
+=========
 
 관리 화면에서 "크롤러" → "데이터 스토어" → "새로 만들기"에서 설정합니다.
 
 기본 설정
---------
+---------
 
 .. list-table::
    :header-rows: 1
@@ -56,7 +56,7 @@ Dropbox 커넥터는 Dropbox 클라우드 스토리지에서 파일을 가져와
      - 켬
 
 파라미터 설정
-----------------
+-------------
 
 ::
 
@@ -64,11 +64,11 @@ Dropbox 커넥터는 Dropbox 클라우드 스토리지에서 파일을 가져와
     basic_plan=false
 
 파라미터 목록
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - 파라미터
      - 필수
@@ -81,7 +81,7 @@ Dropbox 커넥터는 Dropbox 클라우드 스토리지에서 파일을 가져와
      - 개인 계정인 경우 ``true``, 팀 계정인 경우 ``false`` (기본값: ``false``)
    * - ``max_size``
      - 아니오
-     - 인덱싱 대상 최대 파일 크기(바이트) (기본값: ``10000000``)
+     - 인덱싱 대상 최대 파일 크기 (바이트) (기본값: ``10000000``)
    * - ``number_of_threads``
      - 아니오
      - 크롤링에 사용할 스레드 수 (기본값: ``1``)
@@ -93,7 +93,7 @@ Dropbox 커넥터는 Dropbox 클라우드 스토리지에서 파일을 가져와
      - 콘텐츠 추출 중 오류를 무시할지 여부 (기본값: ``true``)
    * - ``supported_mimetypes``
      - 아니오
-     - 허용할 MIME 타입의 정규식 패턴(쉼표 구분) (기본값: ``.*``)
+     - 허용할 MIME 타입의 정규식 패턴 (쉼표 구분) (기본값: ``.*``)
    * - ``include_pattern``
      - 아니오
      - 크롤링에 포함할 URL 패턴
@@ -102,16 +102,19 @@ Dropbox 커넥터는 Dropbox 클라우드 스토리지에서 파일을 가져와
      - 크롤링에서 제외할 URL 패턴
    * - ``default_permissions``
      - 아니오
-     - 인덱싱된 문서의 기본 권한(쉼표 구분)
+     - 인덱싱된 문서의 기본 권한 (쉼표 구분)
    * - ``max_cached_content_size``
      - 아니오
-     - 메모리에 캐시할 콘텐츠 최대 크기(바이트) (기본값: ``1048576``)
+     - 메모리에 캐시할 콘텐츠 최대 크기 (바이트). 이 크기를 초과하는 콘텐츠는 임시 파일에 기록됩니다 (기본값: ``1048576``)
+   * - ``readInterval``
+     - 아니오
+     - 각 레코드를 처리하는 사이에 삽입할 대기 시간 (밀리초) (기본값: ``0``)
 
 스크립트 설정
---------------
+-------------
 
 Dropbox 파일의 경우
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 ::
 
@@ -165,7 +168,7 @@ Dropbox 파일의 경우
      - 파일 리비전
 
 Dropbox Paper의 경우
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 ::
 
@@ -204,49 +207,78 @@ Dropbox Paper의 경우
 Dropbox 인증 설정
 =================
 
+계정 종류와 액세스 토큰
+-----------------------
+
+이 커넥터는 ``basic_plan`` 파라미터에 따라 두 가지 동작 모드로 전환됩니다.
+생성해야 할 앱과 액세스 토큰의 종류가 다르므로 먼저 확인하세요.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - 모드
+     - ``basic_plan``
+     - 설명
+   * - 팀 계정 (기본값)
+     - ``false``
+     - Dropbox Business (팀) 계정용입니다. 팀 관리자 권한을 가진 액세스 토큰이 필요하며, 팀 멤버의 파일과 팀 폴더를 横断적으로 크롤링합니다.
+   * - 개인 계정
+     - ``true``
+     - 개인 (비팀) 계정용입니다. 일반 범위 지정 액세스 토큰을 사용하여 해당 계정 내 파일을 직접 크롤링합니다.
+
+.. note::
+   기본값 (``basic_plan=false``) 에서는 팀 관리용 API (팀 멤버 목록, 멤버 단위 파일 액세스, 팀 폴더) 를 사용하므로
+   Dropbox Business 계정과 팀 관리자 권한을 가진 토큰이 필수입니다. 개인 계정을 사용하는 경우 반드시 ``basic_plan=true`` 를 설정하세요.
+
 액세스 토큰 취득 절차
---------------------------
+---------------------
 
 1. Dropbox App Console에서 앱 생성
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 https://www.dropbox.com/developers/apps 에 접속:
 
 1. "Create app"을 클릭
 2. API 타입에서 "Scoped access"를 선택
-3. 액세스 타입에서 "Full Dropbox" 또는 "App folder"를 선택
+3. 액세스 타입을 선택 (팀 계정을 横断적으로 크롤링하는 경우 "Full Dropbox" 권장)
 4. 앱 이름을 입력하고 생성
 
 2. 권한 설정
-~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 "Permissions" 탭에서 필요한 권한을 선택:
 
-**파일 크롤링에 필요한 권한**:
+**파일 및 Paper 크롤링에 필요한 권한**:
 
 - ``files.metadata.read`` - 파일 메타데이터 읽기
-- ``files.content.read`` - 파일 콘텐츠 읽기
+- ``files.content.read`` - 파일 및 Paper 문서 콘텐츠 읽기
 - ``sharing.read`` - 공유 정보 읽기
 
-**Paper 크롤링에 추가로 필요한 권한**:
+**팀 계정 (``basic_plan=false``) 에서 추가로 필요한 권한**:
 
-- ``files.content.read`` - Paper 문서 읽기
+- ``members.read`` - 팀 멤버 목록 읽기
+- 팀 데이터/팀 스페이스 액세스 권한 (멤버 단위 파일 및 팀 폴더 크롤링에 필요)
+
+.. note::
+   팀 계정 모드에서는 팀 관리자로서 각 멤버와 팀 폴더에 액세스합니다.
+   Permissions 탭에서 위의 팀 관련 권한을 활성화하고 팀 관리자 토큰을 생성하세요.
 
 3. 액세스 토큰 생성
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 "Settings" 탭에서:
 
 1. "Generated access token" 섹션까지 스크롤
-2. "Generate" 버튼 클릭
-3. 생성된 토큰 복사 (이 토큰은 한 번만 표시됩니다)
+2. "Generate" 버튼을 클릭
+3. 생성된 토큰을 복사 (이 토큰은 한 번만 표시됩니다)
 
 .. warning::
    액세스 토큰은 안전하게 보관하세요. 이 토큰이 있으면
    Dropbox 계정에 액세스할 수 있습니다.
 
 4. 토큰 설정
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 취득한 토큰을 파라미터에 설정:
 
@@ -255,27 +287,27 @@ https://www.dropbox.com/developers/apps 에 접속:
     access_token=sl.your-dropbox-token-here
 
 개인 계정 설정
-=================
+==============
 
 개인 계정 사용
--------------------------
+--------------
 
-개인 계정(팀 계정이 아닌 경우)에서는
-``basic_plan`` 파라미터를 ``true``로 설정하세요:
+개인 계정 (팀 계정이 아닌 경우) 에서는
+``basic_plan`` 파라미터를 ``true`` 로 설정하세요:
 
 ::
 
     access_token=sl.your-dropbox-token-here
     basic_plan=true
 
-``false``(기본값)인 경우 팀 계정으로 동작하여 팀 멤버와 팀 폴더의 파일을 크롤링합니다.
-``true``인 경우 개인 계정으로 동작하여 계정 내 파일을 직접 크롤링합니다.
+``false`` (기본값) 인 경우 팀 계정으로 동작하여 팀 멤버와 팀 폴더의 파일을 크롤링합니다.
+``true`` 인 경우 개인 계정으로 동작하여 계정 내 파일을 직접 크롤링합니다.
 
 사용 예
-======
+=======
 
 Dropbox 파일 전체 크롤링
-------------------------------
+------------------------
 
 파라미터:
 
@@ -298,7 +330,7 @@ Dropbox 파일 전체 크롤링
     last_modified=file.client_modified
 
 Dropbox Paper 문서 크롤링
------------------------------------
+-------------------------
 
 파라미터:
 
@@ -353,27 +385,40 @@ Dropbox Paper 문서 크롤링
     role=paper.roles
 
 특정 파일 타입만 크롤링
---------------------------------
+-----------------------
 
-스크립트로 필터링:
+특정 MIME 타입만을 인덱싱 대상으로 하려면 ``supported_mimetypes`` 파라미터에
+허용할 MIME 타입의 정규식을 쉼표로 구분하여 지정합니다.
+
+.. note::
+   데이터 스토어 스크립트는 한 줄씩 ``필드명=식`` 의 독립된 식으로 평가됩니다.
+   따라서 여러 줄에 걸친 ``if`` 블록으로 여러 필드를 한꺼번에 대입할 수 없습니다.
+   MIME 타입에 따른 필터링은 스크립트가 아닌 ``supported_mimetypes`` 파라미터로 수행하세요.
+
+파라미터 (PDF 및 Word 파일만):
 
 ::
 
-    # PDF와 Word 파일만
-    if (file.mimetype == "application/pdf" || file.mimetype == "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
-        url=file.url
-        title=file.name
-        content=file.contents
-        mimetype=file.mimetype
-        filename=file.name
-        last_modified=file.client_modified
-    }
+    access_token=sl.your-dropbox-token-here
+    basic_plan=false
+    supported_mimetypes=application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document
+
+스크립트:
+
+::
+
+    url=file.url
+    title=file.name
+    content=file.contents
+    mimetype=file.mimetype
+    filename=file.name
+    last_modified=file.client_modified
 
 문제 해결
-======================
+=========
 
 인증 오류
-----------
+---------
 
 **증상**: ``Invalid access token`` 또는 ``401 Unauthorized``
 
@@ -385,9 +430,9 @@ Dropbox Paper 문서 크롤링
 4. 앱이 비활성화되지 않았는지 확인
 
 파일을 가져올 수 없음
-----------------------
+---------------------
 
-**증상**: 크롤링은 성공하지만 파일이 0개
+**증상**: 크롤링은 성공하지만 파일이 0건
 
 **확인 사항**:
 
@@ -405,29 +450,33 @@ Dropbox Paper 문서 크롤링
 3. Dropbox 계정에 파일이 존재하는지 확인
 
 API 속도 제한 오류
--------------------
+------------------
 
 **증상**: ``429 Too Many Requests`` 오류
 
 **해결 방법**:
 
-1. Basic 플랜인 경우 ``basic_plan=true`` 설정
-2. 크롤링 간격을 늘림
-3. 여러 액세스 토큰을 사용하여 부하 분산
+1. ``readInterval`` 을 설정하여 각 파일 처리 간격을 벌림
+2. ``number_of_threads`` 를 줄여 동시 요청 수를 감소
+3. 데이터 스토어를 폴더 단위 등으로 여러 개로 분할하고 스케줄을 분산하여 실행
+
+.. note::
+   ``basic_plan`` 은 계정 종류 (팀/개인) 를 전환하는 파라미터이며
+   속도 제한 조정에는 영향을 미치지 않습니다. 계정에 맞게 올바르게 설정하세요.
 
 Paper 문서를 가져올 수 없음
--------------------------------
+---------------------------
 
 **증상**: Paper 문서가 크롤링되지 않음
 
 **확인 사항**:
 
-1. 핸들러 이름이 ``DropboxPaperDataStore``인지 확인
-2. 권한에 ``files.content.read``가 포함되어 있는지 확인
+1. 핸들러 이름이 ``DropboxPaperDataStore`` 인지 확인
+2. 권한에 ``files.content.read`` 가 포함되어 있는지 확인
 3. Paper 문서가 실제로 존재하는지 확인
 
 대량의 파일이 있는 경우
-------------------------
+-----------------------
 
 **증상**: 크롤링에 시간이 오래 걸리거나 타임아웃됨
 
@@ -441,7 +490,7 @@ Paper 문서를 가져올 수 없음
 ==================
 
 Dropbox 공유 권한 반영
------------------------
+----------------------
 
 Dropbox 공유 설정을 Fess 권한에 반영할 수 있습니다:
 
@@ -464,10 +513,10 @@ Dropbox 공유 설정을 Fess 권한에 반영할 수 있습니다:
     filename=file.name
     last_modified=file.client_modified
 
-``file.roles`` 또는 ``paper.roles``에 Dropbox 공유 정보가 포함됩니다.
+``file.roles`` 또는 ``paper.roles`` 에 Dropbox 공유 정보가 포함됩니다.
 
 참고 정보
-========
+=========
 
 - :doc:`ds-overview` - 데이터 스토어 커넥터 개요
 - :doc:`ds-box` - Box 커넥터

--- a/zh-cn/15.7/config/datastore/ds-dropbox.rst
+++ b/zh-cn/15.7/config/datastore/ds-dropbox.rst
@@ -11,7 +11,7 @@ Dropbox连接器提供从Dropbox云存储获取文件并
 此功能需要 ``fess-ds-dropbox`` 插件。
 
 支持的服务
-============
+==========
 
 - Dropbox（文件存储）
 - Dropbox Paper（文档）
@@ -24,7 +24,7 @@ Dropbox连接器提供从Dropbox云存储获取文件并
 3. 需要获取访问令牌
 
 插件安装
-------------------------
+--------
 
 从管理界面的"系统"→"插件"安装：
 
@@ -56,7 +56,7 @@ Dropbox连接器提供从Dropbox云存储获取文件并
      - 开
 
 参数设置
-----------------
+--------
 
 ::
 
@@ -64,11 +64,11 @@ Dropbox连接器提供从Dropbox云存储获取文件并
     basic_plan=false
 
 参数列表
-~~~~~~~~~~~~~~~~
+~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - 参数
      - 必须
@@ -105,13 +105,16 @@ Dropbox连接器提供从Dropbox云存储获取文件并
      - 索引文档的默认权限（逗号分隔）
    * - ``max_cached_content_size``
      - 否
-     - 内存中缓存的最大内容大小（字节）（默认：``1048576``）
+     - 内存中缓存的最大内容大小（字节）。超出此大小的内容将写入临时文件（默认：``1048576``）
+   * - ``readInterval``
+     - 否
+     - 处理每条记录之间插入的等待时间（毫秒）（默认：``0``）
 
 脚本设置
---------------
+--------
 
 Dropbox文件的情况
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 ::
 
@@ -148,9 +151,9 @@ Dropbox文件的情况
    * - ``file.size``
      - 文件大小（字节）
    * - ``file.client_modified``
-     - 客户端最后更新日期
+     - 客户端最后更新日期时间
    * - ``file.server_modified``
-     - 服务器端最后更新日期
+     - 服务器端最后更新日期时间
    * - ``file.roles``
      - 文件访问权限
    * - ``file.id``
@@ -202,38 +205,67 @@ Dropbox Paper的情况
      - Paper文档修订版本
 
 Dropbox认证设置
-=================
+===============
+
+账户类型与访问令牌
+------------------
+
+此连接器通过 ``basic_plan`` 参数切换两种运行模式。
+由于需要创建的应用和访问令牌类型不同，请先确认以下内容。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - 模式
+     - ``basic_plan``
+     - 说明
+   * - 团队账户（默认）
+     - ``false``
+     - 适用于Dropbox Business（团队）账户。需要具有团队管理员权限的访问令牌，可跨团队成员文件和团队文件夹进行抓取。
+   * - 个人账户
+     - ``true``
+     - 适用于个人（非团队）账户。使用普通的带范围访问令牌，直接抓取该账户内的文件。
+
+.. note::
+   默认模式（``basic_plan=false``）使用团队管理API（团队成员列表、按成员访问文件、团队文件夹），
+   因此必须使用Dropbox Business账户和具有团队管理员权限的令牌。如果使用个人账户，请务必设置 ``basic_plan=true``。
 
 访问令牌获取步骤
---------------------------
+----------------
 
 1. 在Dropbox App Console创建应用
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 访问 https://www.dropbox.com/developers/apps：
 
 1. 点击"Create app"
 2. 在API类型中选择"Scoped access"
-3. 在访问类型中选择"Full Dropbox"或"App folder"
+3. 选择访问类型（跨团队账户抓取时推荐选择"Full Dropbox"）
 4. 输入应用名称并创建
 
 2. 权限设置
-~~~~~~~~~~~~~
+~~~~~~~~~~~
 
 在"Permissions"标签页选择所需权限：
 
-**抓取文件所需的权限**：
+**抓取文件和Paper所需的权限**：
 
 - ``files.metadata.read`` - 读取文件元数据
-- ``files.content.read`` - 读取文件内容
+- ``files.content.read`` - 读取文件及Paper文档的内容
 - ``sharing.read`` - 读取共享信息
 
-**抓取Paper额外所需的权限**：
+**团队账户（``basic_plan=false``）额外所需的权限**：
 
-- ``files.content.read`` - 读取Paper文档
+- ``members.read`` - 读取团队成员列表
+- 团队数据/团队空间的访问权限（按成员抓取文件和团队文件夹所需）
+
+.. note::
+   在团队账户模式下，将以团队管理员身份访问各成员和团队文件夹。
+   请在Permissions标签页启用上述团队相关权限，并生成团队管理员令牌。
 
 3. 生成访问令牌
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 在"Settings"标签页：
 
@@ -242,10 +274,11 @@ Dropbox认证设置
 3. 复制生成的令牌（此令牌只显示一次）
 
 .. warning::
-   请安全保管访问令牌。有了此令牌就可以访问Dropbox账户。
+   请安全保管访问令牌。有了此令牌就可以访问
+   Dropbox账户。
 
 4. 设置令牌
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~
 
 将获取的令牌设置到参数中：
 
@@ -254,10 +287,10 @@ Dropbox认证设置
     access_token=sl.your-dropbox-token-here
 
 个人账户设置
-=================
+============
 
 个人账户的使用
--------------------------
+--------------
 
 对于个人账户（非团队账户），
 请将 ``basic_plan`` 参数设置为 ``true``：
@@ -271,10 +304,10 @@ Dropbox认证设置
 ``true`` 时作为个人账户运行，直接抓取账户中的文件。
 
 使用示例
-======
+========
 
 抓取整个Dropbox文件
-------------------------------
+-------------------
 
 参数：
 
@@ -297,7 +330,7 @@ Dropbox认证设置
     last_modified=file.client_modified
 
 抓取Dropbox Paper文档
------------------------------------
+---------------------
 
 参数：
 
@@ -317,7 +350,7 @@ Dropbox认证设置
     filetype=paper.filetype
 
 带权限抓取
-----------------
+----------
 
 参数：
 
@@ -352,27 +385,40 @@ Dropbox认证设置
     role=paper.roles
 
 仅抓取特定文件类型
---------------------------------
+------------------
 
-脚本中进行过滤：
+若要仅对特定MIME类型建立索引，请在 ``supported_mimetypes`` 参数中
+以逗号分隔指定允许的MIME类型正则表达式。
+
+.. note::
+   数据存储脚本中每一行均作为 ``字段名=表达式`` 的独立表达式进行求值。
+   因此，无法在跨多行的 ``if`` 块中同时赋值多个字段。
+   按MIME类型筛选请使用 ``supported_mimetypes`` 参数，而非脚本。
+
+参数（仅PDF和Word文件）：
 
 ::
 
-    # 仅PDF和Word文件
-    if (file.mimetype == "application/pdf" || file.mimetype == "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
-        url=file.url
-        title=file.name
-        content=file.contents
-        mimetype=file.mimetype
-        filename=file.name
-        last_modified=file.client_modified
-    }
+    access_token=sl.your-dropbox-token-here
+    basic_plan=false
+    supported_mimetypes=application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document
+
+脚本：
+
+::
+
+    url=file.url
+    title=file.name
+    content=file.contents
+    mimetype=file.mimetype
+    filename=file.name
+    last_modified=file.client_modified
 
 故障排除
-======================
+========
 
 认证错误
-----------
+--------
 
 **症状**：``Invalid access token`` 或 ``401 Unauthorized``
 
@@ -384,7 +430,7 @@ Dropbox认证设置
 4. 确认应用是否被禁用
 
 无法获取文件
-----------------------
+------------
 
 **症状**：抓取成功但文件数为0
 
@@ -404,18 +450,22 @@ Dropbox认证设置
 3. 确认Dropbox账户中是否存在文件
 
 API速率限制错误
--------------------
+---------------
 
 **症状**：``429 Too Many Requests`` 错误
 
 **解决方法**：
 
-1. Basic计划时，设置 ``basic_plan=true``
-2. 增加抓取间隔
-3. 使用多个访问令牌进行负载均衡
+1. 设置 ``readInterval`` 以在各文件处理之间留出间隔
+2. 减小 ``number_of_threads`` 以降低并发请求数
+3. 将数据存储按文件夹等单位拆分为多个，并错开调度时间执行
+
+.. note::
+   ``basic_plan`` 是切换账户类型（团队/个人）的参数，
+   不影响速率限制的调整。请根据账户类型正确设置。
 
 无法获取Paper文档
--------------------------------
+-----------------
 
 **症状**：Paper文档未被抓取
 
@@ -425,22 +475,22 @@ API速率限制错误
 2. 确认权限中包含 ``files.content.read``
 3. 确认Paper文档确实存在
 
-大量文件时
-------------------------
+文件数量较多时
+--------------
 
 **症状**：抓取耗时很长或超时
 
 **解决方法**：
 
-1. 将数据存储分成多个（按文件夹等）
+1. 将数据存储拆分为多个（按文件夹等）
 2. 通过计划设置分散负载
 3. Basic计划时注意API速率限制
 
 权限和访问控制
-==================
+==============
 
 反映Dropbox共享权限
------------------------
+-------------------
 
 可以将Dropbox的共享设置反映到Fess的权限中：
 
@@ -463,7 +513,7 @@ API速率限制错误
     filename=file.name
     last_modified=file.client_modified
 
-``file.roles`` 或 ``paper.roles`` 包含Dropbox的共享信息。
+``file.roles`` 或 ``paper.roles`` 中包含Dropbox的共享信息。
 
 参考信息
 ========


### PR DESCRIPTION
## Summary

Reviewed `config/datastore/ds-dropbox.rst` (15.7) against the actual `fess-ds-dropbox` implementation and corrected several inaccuracies. Changes are applied to the Japanese source and propagated to all languages (en/de/es/fr/ko/zh-cn).

## Changes

- **Account modes clarified.** The default mode (`basic_plan=false`) operates on Dropbox **Business team** accounts — it uses the team members list, per-member file access, team-admin access, and team folders — so it requires a team-admin access token. `basic_plan=true` uses a standard user-scoped token for individual accounts. Added a mode comparison table and documented the team scopes required (`members.read`, team data/space access).
- **Invalid script example fixed.** The "crawl specific file types" example used a multi-line Groovy `if` block wrapping multiple field assignments. Datastore scripts evaluate each `field=expression` line independently, so that form does not work. Replaced it with the `supported_mimetypes` parameter, which is the implemented mechanism for MIME-type filtering.
- **Rate-limit troubleshooting corrected.** Removed advice that conflated the Dropbox subscription tier with the `basic_plan` parameter and the nonexistent "multiple access tokens" load-balancing suggestion (the connector accepts a single `access_token`). Now recommends `readInterval`, lowering `number_of_threads`, and splitting data stores.
- **Added `readInterval`** (inherited from `AbstractDataStore`, default `0` ms) to the parameter table.
- **Fixed the parameter list-table `:widths:`** which specified 2 values for a 3-column table (RST build error).

## Notes

- Verified parameter names/defaults, handler names (`DropboxDataStore`, `DropboxPaperDataStore`), and all `file.*` / `paper.*` script fields against the source.
- Non-Japanese versions were fully re-translated from the corrected Japanese source to remove pre-existing drift.
- All language files validated for RST structure and heading-underline correctness.