### PR TITLE
docs(15.7): correct scripting-overview against implementation

### DIFF
--- a/de/15.7/config/scripting-overview.rst
+++ b/de/15.7/config/scripting-overview.rst
@@ -1,18 +1,18 @@
-==================================
+=====================================
 Skripting-Übersicht
-==================================
+=====================================
 
 Übersicht
-==========
+=========
 
-|Fess| ermoeglicht es Ihnen, in verschiedenen Szenarien benutzerdefinierte Logik mithilfe von Skripten zu implementieren.
-Durch die Nutzung von Skripten koennen Sie die Datenverarbeitung waehrend des Crawlings,
-die Anpassung von Suchergebnissen und die Ausfuehrung geplanter Aufgaben flexibel steuern.
+|Fess| ermöglicht es, in verschiedenen Situationen benutzerdefinierte Logik mithilfe von Skripten zu implementieren.
+Durch den Einsatz von Skripten lassen sich Datenverarbeitung beim Crawling, URL-Transformationen
+und die Ausführung geplanter Aufgaben flexibel steuern.
 
-Unterstuetzte Skriptsprachen
+Unterstützte Skriptsprachen
 ============================
 
-|Fess| unterstuetzt die folgenden Skriptsprachen:
+|Fess| unterstützt die folgenden Skriptsprachen:
 
 .. list-table::
    :header-rows: 1
@@ -23,71 +23,110 @@ Unterstuetzte Skriptsprachen
      - Beschreibung
    * - Groovy
      - ``groovy``
-     - Die Standard-Skriptsprache. Java-kompatibel mit leistungsstarken Funktionen
+     - Die standardmäßig registrierte Skriptsprache. Java-kompatibel mit leistungsstarken Funktionen
 
 .. note::
-   Groovy wird am haeufigsten verwendet, und die Beispiele in dieser Dokumentation sind in Groovy geschrieben.
+   Das einzige standardmäßig in |Fess| registrierte Skript-Engine ist Groovy.
+   Die Standardskriptsprache ist ``groovy`` (``Constants.DEFAULT_SCRIPT``).
+   Alle Skriptbeispiele in dieser Dokumentation sind in Groovy-Syntax verfasst.
 
-Anwendungsfaelle fuer Skripte
-=============================
+Anwendungsfälle für Skripte
+============================
 
 Datenspeicher-Konfiguration
----------------------------
+----------------------------
 
 Datenspeicher-Konnektoren verwenden Skripte, um abgerufene Daten auf Indexfelder abzubilden.
+Die Konfiguration wird im Format ``Feldname=Ausdruck`` zeilenweise angegeben;
+jede Zeile wird als eigenständiger Groovy-Ausdruck ausgewertet.
 
 ::
 
-    url="https://example.com/article/" + data.id
-    title=data.name
-    content=data.description
-    lastModified=data.updated_at
+    url=site_url
+    title=name
+    content=description
+    last_modified=updated_at
+
+Die im Datenspeicher-Skript verfügbaren Variablennamen hängen vom jeweiligen Konnektor ab.
+Bei CSV- und JSON-Datenspeichern sind die Spalten- bzw. Feldnamen direkt als Variablen
+verfügbar (es wird kein gemeinsames Präfix wie ``data`` vorangestellt).
+Bei dateibasierten Konnektoren (Box, Google Drive, OneDrive usw.) lautet das Präfix ``file.*``,
+bei Slack ``message.*`` — das Präfix variiert je nach Konnektor.
+Details zu den verfügbaren Variablen entnehmen Sie bitte der Dokumentation des jeweiligen
+Datenspeicher-Konnektors.
+
+.. note::
+   Da jede Zeile eines Datenspeicher-Skripts als einzelner Ausdruck ausgewertet wird, sind
+   mehrzeilige ``if``-Blöcke, ``import``-Anweisungen und ``def``-Variablendeklarationen
+   nicht zulässig.
+   Für wertabhängige Felder verwenden Sie den ternären Operator
+   (z. B. ``title=enabled == "true" ? name : null``). Klassen werden über ihren
+   vollständig qualifizierten Namen (FQCN) inline referenziert.
 
 Pfad-Mapping
 ------------
 
-Skripte koennen fuer URL-Normalisierung und Pfadkonvertierung verwendet werden.
+Pfad-Mapping dient zur Normalisierung und Transformation von Crawling-URLs.
+Standardmäßig wird es als Paar aus „Regulärem Ausdruck" und „Ersetzungszeichenkette"
+konfiguriert — dies ist kein Groovy-Skript.
+Beispielsweise ersetzt der reguläre Ausdruck ``http://`` mit der Ersetzungszeichenkette
+``https://`` das URL-Schema.
+
+Nur wenn der Ersetzungszeichenkette das Präfix ``groovy:`` vorangestellt wird, wird der
+nachfolgende Teil als Groovy-Skript ausgewertet. In diesem Skript stehen ``url``
+(die zu transformierende URL-Zeichenkette) und ``matcher``
+(der ``java.util.regex.Matcher`` des regulären Ausdrucks) zur Verfügung.
 
 ::
 
-    # URL transformieren
-    url.replaceAll("http://", "https://")
+    groovy:url.replaceAll("http://", "https://")
 
 Geplante Aufgaben
 -----------------
 
-Geplante Aufgaben ermoeglichen es Ihnen, benutzerdefinierte Verarbeitungslogik in Groovy-Skripten zu schreiben.
+Bei geplanten Aufgaben kann benutzerdefinierte Verarbeitungslogik als Groovy-Skript verfasst
+werden. Das gesamte Skript wird als ein einziges Groovy-Skript ausgewertet, sodass
+mehrzeilige Anweisungen, ``import``-Anweisungen und ``def``-Variablendeklarationen
+verwendet werden können.
 
 ::
 
-    return container.getComponent("crawlJob").execute();
+    return container.getComponent("crawlJob").logLevel("info").gcLogging().execute(executor);
+
+Methoden wie ``logLevel("info")`` gehören zur Job-Klasse (``ExecJob`` und deren
+Unterklassen) und können per Method-Chaining aufgerufen werden. Informationen zur
+``executor``-Variablen finden Sie im Abschnitt „Ausführungskontext und verfügbare Objekte".
 
 Grundlegende Syntax
 ===================
+
+Im Folgenden finden Sie grundlegende Groovy-Syntaxbeispiele. Kommentare werden mit ``//``
+(Zeilenkommentar) oder ``/* */`` (Blockkommentar) angegeben. Beachten Sie, dass Kommentare
+mit ``#`` in Groovy nicht verwendet werden können.
 
 Variablenzugriff
 ----------------
 
 ::
 
-    # Auf Datenspeicherdaten zugreifen
-    data.fieldName
+    // Datenspeicher-Feld (bei CSV/JSON über Spalten- bzw. Feldnamen zugreifen)
+    title
 
-    # Auf Systemkomponenten zugreifen
-    container.getComponent("componentName")
+    // Komponente aus dem DI-Container abrufen
+    container.getComponent("systemHelper")
 
 Zeichenkettenoperationen
 ------------------------
 
 ::
 
-    # Verkettung
+    // Verkettung
     title + " - " + category
 
-    # Ersetzung
+    // Ersetzung
     content.replaceAll("old", "new")
 
-    # Aufteilung
+    // Aufteilung
     tags.split(",")
 
 Bedingte Verzweigung
@@ -95,80 +134,111 @@ Bedingte Verzweigung
 
 ::
 
-    # Ternaerer Operator
-    data.status == "active" ? "Aktiv" : "Inaktiv"
+    // Ternärer Operator
+    status == "active" ? "Aktiv" : "Inaktiv"
 
-    # Null-Pruefung
-    data.description ?: "Keine Beschreibung"
+    // Standardwert bei null/leer (Elvis-Operator)
+    description ?: "Keine Beschreibung"
 
 Datumsoperationen
 -----------------
 
 ::
 
-    # Aktuelles Datum/Uhrzeit
+    // Aktuelles Datum/Uhrzeit
     new Date()
 
-    # Formatierung
-    new java.text.SimpleDateFormat("yyyy-MM-dd").format(data.date)
+    // Formatierung
+    new java.text.SimpleDateFormat("yyyy-MM-dd").format(updated_at)
 
-Verfuegbare Objekte
-===================
+Ausführungskontext und verfügbare Objekte
+==========================================
 
-Hauptobjekte, die innerhalb von Skripten verfuegbar sind:
+Die in einem Skript verfügbaren Objekte hängen vom jeweiligen Ausführungskontext ab.
+Nur ``container`` ist in allen Kontexten verfügbar.
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 75
+   :widths: 30 25 45
 
-   * - Objekt
+   * - Ausführungskontext
+     - Verfügbare Objekte
      - Beschreibung
-   * - ``data``
-     - Aus dem Datenspeicher abgerufene Daten
-   * - ``container``
-     - DI-Container (Zugriff auf Komponenten)
-   * - ``container.getComponent("systemHelper")``
-     - System-Helfer (Zugriff ueber Container)
-   * - ``container.getComponent("fessConfig")``
-     - |Fess| Konfiguration (Zugriff ueber Container)
+   * - Alle Kontexte
+     - ``container``
+     - DI-Container. Zugriff auf einzelne Komponenten über
+       ``container.getComponent("systemHelper")`` oder
+       ``container.getComponent("fessConfig")``
+   * - Datenspeicher-Skript
+     - Konnektor-spezifische Feldvariablen
+     - Die vom Datenspeicher abgerufenen Felder stehen als Variablen zur Verfügung
+       (Variablennamen und Präfixe variieren je nach Konnektor; bei CSV/JSON werden
+       Feldnamen direkt als Variablen verwendet)
+   * - Pfad-Mapping
+     - ``url`` ``matcher``
+     - Die zu transformierende URL-Zeichenkette und der ``Matcher`` des regulären Ausdrucks
+       (nur bei Ersetzungen mit dem Präfix ``groovy:``)
+   * - Geplante Aufgaben
+     - ``executor``
+     - Job-Ausführungsinstanz (``JobExecutor``). Wird zur Steuerung des Job-Shutdowns verwendet
+
+.. note::
+   Andere Objekte als ``container`` werden nur in bestimmten Kontexten injiziert.
+   Beispielsweise ist ``executor`` ausschließlich in geplanten Aufgaben verfügbar und
+   steht in Datenspeicher-Skripten oder beim Pfad-Mapping nicht zur Verfügung.
 
 Sicherheit
 ==========
 
 .. warning::
-   Skripte haben leistungsstarke Faehigkeiten, verwenden Sie sie daher nur aus vertrauenswuerdigen Quellen.
+   Skripte besitzen weitreichende Fähigkeiten — verwenden Sie sie daher ausschließlich
+   aus vertrauenswürdigen Quellen.
 
-- Skripte werden auf dem Server ausgefuehrt
-- Zugriff auf das Dateisystem und Netzwerk ist moeglich
-- Stellen Sie sicher, dass nur Benutzer mit Administratorrechten Skripte bearbeiten koennen
+- Skripte werden auf dem Server ausgeführt
+- Zugriff auf das Dateisystem und Netzwerk ist möglich
+- Stellen Sie sicher, dass nur Benutzer mit Administratorrechten Skripte bearbeiten können
+- Die Skriptausführung wird im Audit-Log (``audit.log``) protokolliert.
+  Die Protokollierung wird über ``script.audit.log.enabled`` gesteuert; der Standardwert
+  ist ``true``. Die maximale Länge der protokollierten Skriptzeichenkette wird über
+  ``script.audit.log.max.length`` gesteuert; der Standardwert beträgt ``100`` Zeichen.
 
 Leistung
 ========
 
-Tipps zur Optimierung der Skriptleistung:
+Hinweise zur Optimierung der Skript-Leistung:
 
-1. **Komplexe Verarbeitung vermeiden**: Skripte werden fuer jedes Dokument ausgefuehrt
-2. **Zugriff auf externe Ressourcen minimieren**: Netzwerkaufrufe verursachen Verzoegerungen
-3. **Caching verwenden**: Erwaegen Sie das Caching von Werten, die wiederholt verwendet werden
+1. **Komplexe Verarbeitung vermeiden**: Datenspeicher-Skripte werden für jedes Dokument ausgeführt
+2. **Zugriff auf externe Ressourcen minimieren**: Netzwerkaufrufe verursachen Verzögerungen
+3. **Caching nutzen**: Erwägen Sie das Zwischenspeichern von wiederholt verwendeten Werten
 
 Debugging
 =========
 
-Verwenden Sie Protokollausgaben zum Debuggen von Skripten:
+Da Skripte für geplante Aufgaben als ein einziges Groovy-Skript ausgewertet werden, können
+Protokollausgaben zum Debugging eingesetzt werden.
+(Datenspeicher-Skripte werden zeilenweise als einzelne Ausdrücke ausgewertet, daher sind
+``import``-Anweisungen und mehrzeilige Verarbeitungslogik dort nicht möglich.)
 
 ::
 
     import org.apache.logging.log4j.LogManager
-    def logger = LogManager.getLogger("script")
-    logger.info("data.id = {}", data.id)
+    def logger = LogManager.getLogger("fess.script")
+    logger.info("executor = {}", executor)
 
-Protokollebenen-Konfiguration:
-
-``app/WEB-INF/classes/log4j2.xml``:
+Das obige Beispiel verwendet einen Logger mit dem Namen ``fess.script``.
+Um diese Protokollausgabe zu aktivieren, fügen Sie die entsprechende Logger-Konfiguration
+in ``app/WEB-INF/classes/log4j2.xml`` ein.
 
 ::
 
-    <Logger name="script" level="DEBUG"/>
+    <Logger name="fess.script" level="DEBUG"/>
+
+Um Debug-Protokolle der Skript-Engine selbst zu aktivieren, setzen Sie den Protokolllevel
+des Pakets ``org.codelibs.fess.script`` auf ``DEBUG``.
+
+::
+
+    <Logger name="org.codelibs.fess.script" level="DEBUG"/>
 
 Referenzinformationen
 =====================

--- a/en/15.7/config/scripting-overview.rst
+++ b/en/15.7/config/scripting-overview.rst
@@ -7,10 +7,10 @@ Overview
 
 |Fess| allows you to implement custom logic using scripts in various scenarios.
 By utilizing scripts, you can flexibly control data processing during crawling,
-search result customization, and scheduled job execution.
+URL transformation, and scheduled job execution.
 
 Supported Scripting Languages
-=============================
+==============================
 
 |Fess| supports the following scripting languages:
 
@@ -23,11 +23,12 @@ Supported Scripting Languages
      - Description
    * - Groovy
      - ``groovy``
-     - The default scripting language. Java-compatible with powerful features
-     - A familiar language for web developers
+     - The scripting language registered by default. Java-compatible with powerful features
 
 .. note::
-   Groovy is the most widely used, and the examples in this documentation are written in Groovy.
+   The only scripting engine registered in |Fess| by default is Groovy.
+   The default scripting language is ``groovy`` (``Constants.DEFAULT_SCRIPT``).
+   All script examples in this documentation are written in Groovy syntax.
 
 Use Cases for Scripts
 =====================
@@ -36,59 +37,91 @@ Data Store Configuration
 ------------------------
 
 Data store connectors use scripts to map retrieved data to index fields.
+Configuration is written one line per entry in the format ``field=expression``,
+and each line is evaluated as a single independent Groovy expression.
 
 ::
 
-    url="https://example.com/article/" + data.id
-    title=data.name
-    content=data.description
-    lastModified=data.updated_at
+    url=site_url
+    title=name
+    content=description
+    last_modified=updated_at
+
+The variable names available in data store scripts differ depending on the connector type.
+For example, in the CSV data store and JSON data store, each column name or field name is
+available directly as a variable (no common prefix such as ``data`` is added).
+For file-based connectors (Box, Google Drive, OneDrive, etc.) the prefix is ``file.*``,
+for Slack it is ``message.*``, and so on — each connector has its own prefix convention.
+Refer to the documentation for each data store connector for details on available variables.
+
+.. note::
+   Because each line in a data store script is evaluated as a single expression,
+   multi-line ``if`` blocks, ``import`` statements, and variable declarations using ``def``
+   cannot be used. To conditionally assign a value, use the ternary operator on a per-field basis
+   (e.g., ``title=enabled == "true" ? name : null``). When referencing a class, write its
+   fully qualified class name (FQCN) inline.
 
 Path Mapping
 ------------
 
-Scripts can be used for URL normalization and path conversion.
+Path mapping is a feature for normalizing and transforming crawl target URLs.
+By default, it is configured as a pair of a regular expression and a replacement string,
+and is not a Groovy script.
+For example, specifying ``http://`` as the regular expression and ``https://`` as the
+replacement string replaces the URL scheme.
+
+A replacement string is evaluated as a Groovy script only when it is prefixed with ``groovy:``.
+Inside this script, ``url`` (the URL string being transformed) and ``matcher``
+(the ``java.util.regex.Matcher`` for the regular expression) are available.
 
 ::
 
-    # Transform URL
-    url.replaceAll("http://", "https://")
+    groovy:url.replaceAll("http://", "https://")
 
 Scheduled Jobs
 --------------
 
 Scheduled jobs allow you to write custom processing logic in Groovy scripts.
+Because the entire script is evaluated as a single Groovy script,
+multi-line expressions, ``import`` statements, and variable declarations using ``def``
+are all supported.
 
 ::
 
-    return container.getComponent("crawlJob").execute();
+    return container.getComponent("crawlJob").logLevel("info").gcLogging().execute(executor);
+
+Methods such as ``logLevel("info")`` are methods of the job class (``ExecJob`` and its subclasses)
+and can be chained. For the ``executor`` variable, see "Execution Context and Available Objects".
 
 Basic Syntax
 ============
+
+The following are basic Groovy syntax examples. Comments use ``//`` (line comments) or
+``/* */`` (block comments). Note that comments starting with ``#`` cannot be used in Groovy.
 
 Variable Access
 ---------------
 
 ::
 
-    # Access data store data
-    data.fieldName
+    // Access a data store field (in CSV/JSON, access by column name or field name)
+    title
 
-    # Access system components
-    container.getComponent("componentName")
+    // Retrieve a component from the DI container
+    container.getComponent("systemHelper")
 
 String Operations
 -----------------
 
 ::
 
-    # Concatenation
+    // Concatenation
     title + " - " + category
 
-    # Replacement
+    // Replacement
     content.replaceAll("old", "new")
 
-    # Splitting
+    // Splitting
     tags.split(",")
 
 Conditional Branching
@@ -96,42 +129,57 @@ Conditional Branching
 
 ::
 
-    # Ternary operator
-    data.status == "active" ? "Active" : "Inactive"
+    // Ternary operator
+    status == "active" ? "Active" : "Inactive"
 
-    # Null check
-    data.description ?: "No description"
+    // Default value when null or empty (Elvis operator)
+    description ?: "No description"
 
 Date Operations
 ---------------
 
 ::
 
-    # Current date/time
+    // Current date/time
     new Date()
 
-    # Formatting
-    new java.text.SimpleDateFormat("yyyy-MM-dd").format(data.date)
+    // Formatting
+    new java.text.SimpleDateFormat("yyyy-MM-dd").format(updated_at)
 
-Available Objects
-=================
+Execution Context and Available Objects
+========================================
 
-Main objects available within scripts:
+The objects available inside a script depend on the context in which the script runs.
+Only ``container`` is available in all contexts.
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 75
+   :widths: 30 25 45
 
-   * - Object
+   * - Execution Context
+     - Available Objects
      - Description
-   * - ``data``
-     - Data retrieved from the data store
-   * - ``container``
-     - DI container (access to components)
-   * - ``systemHelper``
-     - System helper
-   * - ``fessConfig``
-     - |Fess| configuration
+   * - All contexts
+     - ``container``
+     - The DI container. Access individual components via
+       ``container.getComponent("systemHelper")`` or
+       ``container.getComponent("fessConfig")``
+   * - Data store scripts
+     - Connector-specific field variables
+     - Each field retrieved from the data store is available as a variable
+       (variable names and prefixes differ by connector; CSV/JSON use the field name directly)
+   * - Path mapping
+     - ``url`` ``matcher``
+     - The URL string being transformed and the ``Matcher`` for the regular expression
+       (available only when the replacement is prefixed with ``groovy:``)
+   * - Scheduled jobs
+     - ``executor``
+     - The job execution instance (``JobExecutor``). Used to control job shutdown
+
+.. note::
+   Objects other than ``container`` are injected only in specific contexts.
+   For example, ``executor`` is available only in scheduled jobs and cannot be used
+   in data store scripts or path mapping.
 
 Security
 ========
@@ -141,35 +189,49 @@ Security
 
 - Scripts are executed on the server
 - Access to the file system and network is possible
-- Ensure only users with administrator privileges can edit scripts
+- Ensure that only users with administrator privileges can edit scripts
+- Script execution is recorded in the audit log (``audit.log``).
+  Whether recording is enabled is controlled by ``script.audit.log.enabled``, which defaults to ``true``.
+  The maximum length of the script string that is recorded is controlled by
+  ``script.audit.log.max.length``, which defaults to ``100`` characters.
 
 Performance
 ===========
 
 Tips for optimizing script performance:
 
-1. **Avoid complex processing**: Scripts are executed for each document
+1. **Avoid complex processing**: Data store scripts are executed for each document
 2. **Minimize external resource access**: Network calls cause delays
 3. **Use caching**: Consider caching values that are used repeatedly
 
 Debugging
 =========
 
-Use log output to debug scripts:
+In scheduled job scripts, because the entire script is evaluated as a single Groovy script,
+you can use log output for debugging.
+(Data store scripts evaluate one line as one expression, so ``import`` statements and
+multi-line processing cannot be used.)
 
 ::
 
     import org.apache.logging.log4j.LogManager
-    def logger = LogManager.getLogger("script")
-    logger.info("data.id = {}", data.id)
+    def logger = LogManager.getLogger("fess.script")
+    logger.info("executor = {}", executor)
 
-Log level configuration:
-
-``app/WEB-INF/classes/log4j2.xml``:
+The example above uses a logger named ``fess.script``.
+To output this log, add the corresponding logger configuration to
+``app/WEB-INF/classes/log4j2.xml``.
 
 ::
 
-    <Logger name="script" level="DEBUG"/>
+    <Logger name="fess.script" level="DEBUG"/>
+
+To enable debug logging for the scripting engine itself, set the log level of the
+``org.codelibs.fess.script`` package to ``DEBUG``.
+
+::
+
+    <Logger name="org.codelibs.fess.script" level="DEBUG"/>
 
 Reference Information
 =====================

--- a/es/15.7/config/scripting-overview.rst
+++ b/es/15.7/config/scripting-overview.rst
@@ -1,16 +1,16 @@
-==================================
-Descripcion general de scripting
-==================================
+=======================================
+Descripcion general del scripting
+=======================================
 
 Descripcion general
 ===================
 
-En |Fess|, puede implementar logica personalizada usando scripts en varios escenarios.
-Al aprovechar los scripts, puede controlar de manera flexible el procesamiento de datos durante el crawl,
-la personalizacion de resultados de busqueda y la ejecucion de trabajos programados.
+En |Fess|, puede implementar logica personalizada usando scripts en diversos escenarios.
+Al aprovechar los scripts, puede controlar de manera flexible el procesamiento de datos
+durante el crawl, la transformacion de URLs y la ejecucion de trabajos programados.
 
 Lenguajes de scripting compatibles
-==================================
+===================================
 
 |Fess| soporta los siguientes lenguajes de scripting:
 
@@ -23,157 +23,218 @@ Lenguajes de scripting compatibles
      - Descripcion
    * - Groovy
      - ``groovy``
-     - Lenguaje de scripting predeterminado. Compatible con Java y proporciona funcionalidades potentes
+     - Lenguaje de scripting registrado de forma predeterminada. Compatible con Java y proporciona funcionalidades potentes
 
 .. note::
-   Groovy es el mas ampliamente utilizado, y los ejemplos en esta documentacion estan escritos en Groovy.
+   El unico motor de scripting registrado de forma predeterminada en |Fess| es Groovy.
+   El lenguaje de scripting por defecto es ``groovy`` ( ``Constants.DEFAULT_SCRIPT`` ).
+   Todos los ejemplos de scripts de este documento estan escritos en sintaxis Groovy.
 
-Casos de uso de scripting
-=========================
+Casos de uso del scripting
+===========================
 
-Configuracion de Data Store
----------------------------
+Configuracion de data store
+----------------------------
 
 En los conectores de data store, se usan scripts para mapear los datos obtenidos
-a los campos del indice.
+a los campos del indice. La configuracion se escribe en formato ``nombre_de_campo=expresion``
+una linea por entrada, y cada linea se evalua como una expresion Groovy independiente.
 
 ::
 
-    url="https://example.com/article/" + data.id
-    title=data.name
-    content=data.description
-    lastModified=data.updated_at
+    url=site_url
+    title=name
+    content=description
+    last_modified=updated_at
+
+Los nombres de variables disponibles en los scripts de data store varian segun el tipo de conector.
+Por ejemplo, en el data store CSV y en el data store JSON, cada nombre de columna o campo
+puede usarse directamente como variable (sin prefijo comun como ``data``).
+En los conectores de tipo archivo (Box, Google Drive, OneDrive, etc.) se usa el prefijo ``file.*``,
+en Slack se usa ``message.*``, y cada conector tiene su propio prefijo.
+Consulte la documentacion de cada conector de data store para conocer las variables disponibles.
+
+.. note::
+   Cada linea de un data store se evalua como una expresion unica, por lo que no es posible
+   usar bloques ``if`` de varias lineas, sentencias ``import`` ni declaraciones de variables
+   con ``def``. Para cambiar un valor segun una condicion, use el operador ternario por campo
+   (por ejemplo: ``title=enabled == "true" ? name : null`` ). Para referenciar clases,
+   escriba el nombre completamente cualificado (FQCN) en linea.
 
 Mapeo de rutas
 --------------
 
-Puede usar scripts para normalizar URLs o transformar rutas.
+El mapeo de rutas es una funcion para normalizar y transformar las URLs a crawlear.
+De forma predeterminada, se configura mediante un par de "expresion regular" y "cadena de
+reemplazo", y no es un script Groovy. Por ejemplo, si se especifica ``http://`` como
+expresion regular y ``https://`` como cadena de reemplazo, se sustituye el esquema de la URL.
+
+Solo cuando la cadena de reemplazo comienza con el prefijo ``groovy:``, la cadena restante
+se evalua como un script Groovy. Dentro de este script, se puede usar ``url`` para la cadena
+de URL a transformar y ``matcher`` para el ``java.util.regex.Matcher`` de la expresion regular.
 
 ::
 
-    # Transformar URL
-    url.replaceAll("http://", "https://")
+    groovy:url.replaceAll("http://", "https://")
 
 Trabajos programados
 --------------------
 
-En los trabajos programados, puede escribir logica de procesamiento personalizada en scripts Groovy.
+En los trabajos programados, puede escribir logica de procesamiento personalizada en scripts
+Groovy. El script completo se evalua como un unico script Groovy, por lo que es posible
+usar multiples lineas, sentencias ``import`` y declaraciones de variables con ``def``.
 
 ::
 
-    return container.getComponent("crawlJob").execute();
+    return container.getComponent("crawlJob").logLevel("info").gcLogging().execute(executor);
+
+Los metodos como ``logLevel("info")`` son metodos de la clase del trabajo ( ``ExecJob`` y sus
+subclases) y pueden encadenarse. Consulte "Contexto de ejecucion y objetos disponibles" para
+obtener informacion sobre la variable ``executor``.
 
 Sintaxis basica
 ===============
+
+A continuacion se muestran ejemplos de sintaxis basica de Groovy. Los comentarios se escriben
+con ``//`` (comentario de linea) o ``/* */`` (comentario de bloque). Tenga en cuenta que los
+comentarios que comienzan con ``#`` no son validos en Groovy.
 
 Acceso a variables
 ------------------
 
 ::
 
-    # Acceder a datos del data store
-    data.fieldName
+    // Campo del data store (en CSV/JSON, se accede por nombre de columna o campo)
+    title
 
-    # Acceder a componentes del sistema
-    container.getComponent("componentName")
+    // Obtener un componente del contenedor DI
+    container.getComponent("systemHelper")
 
 Operaciones de cadenas
 ----------------------
 
 ::
 
-    # Concatenacion
+    // Concatenacion
     title + " - " + category
 
-    # Reemplazo
+    // Reemplazo
     content.replaceAll("old", "new")
 
-    # Division
+    // Division
     tags.split(",")
 
 Estructuras condicionales
--------------------------
+--------------------------
 
 ::
 
-    # Operador ternario
-    data.status == "active" ? "Activo" : "Inactivo"
+    // Operador ternario
+    status == "active" ? "Activo" : "Inactivo"
 
-    # Verificacion de null
-    data.description ?: "Sin descripcion"
+    // Valor por defecto cuando es null o vacio (operador Elvis)
+    description ?: "Sin descripcion"
 
 Operaciones de fecha
 --------------------
 
 ::
 
-    # Fecha actual
+    // Fecha y hora actual
     new Date()
 
-    # Formato
-    new java.text.SimpleDateFormat("yyyy-MM-dd").format(data.date)
+    // Formato
+    new java.text.SimpleDateFormat("yyyy-MM-dd").format(updated_at)
 
-Objetos disponibles
-===================
+Contexto de ejecucion y objetos disponibles
+============================================
 
-Principales objetos disponibles dentro de los scripts:
+Los objetos disponibles dentro de un script varian segun el contexto en que se ejecuta.
+Solo ``container`` esta disponible en todos los contextos.
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 75
+   :widths: 30 25 45
 
-   * - Objeto
+   * - Contexto de ejecucion
+     - Objetos disponibles
      - Descripcion
-   * - ``data``
-     - Datos obtenidos del data store
-   * - ``container``
-     - Contenedor DI (acceso a componentes)
-   * - ``container.getComponent("systemHelper")``
-     - Helper del sistema
-   * - ``container.getComponent("fessConfig")``
-     - Configuracion de |Fess|
+   * - Todos los contextos
+     - ``container``
+     - Contenedor DI. Acceso a componentes mediante
+       ``container.getComponent("systemHelper")`` o
+       ``container.getComponent("fessConfig")``
+   * - Script de data store
+     - Variables de campo especificas del conector
+     - Cada campo obtenido del data store esta disponible como variable
+       (los nombres de variable y prefijos varian segun el conector; en CSV/JSON el nombre del campo se usa directamente como variable)
+   * - Mapeo de rutas
+     - ``url`` ``matcher``
+     - La cadena de URL a transformar y el ``Matcher`` de la expresion regular (solo cuando se usa el prefijo ``groovy:``)
+   * - Trabajos programados
+     - ``executor``
+     - Instancia de ejecucion del trabajo ( ``JobExecutor`` ). Se usa para controlar el apagado del trabajo
+
+.. note::
+   Los objetos distintos de ``container`` solo se inyectan en contextos especificos.
+   Por ejemplo, ``executor`` solo esta disponible en trabajos programados y no puede
+   usarse en scripts de data store ni en mapeo de rutas.
 
 Seguridad
 =========
 
 .. warning::
-   Los scripts tienen funcionalidades poderosas, por lo que solo uselos de fuentes confiables.
+   Los scripts tienen funcionalidades muy potentes; uselos unicamente desde fuentes de confianza.
 
 - Los scripts se ejecutan en el servidor
-- Es posible el acceso al sistema de archivos y la red
+- Es posible acceder al sistema de archivos y a la red
 - Asegurese de que solo los usuarios con privilegios de administrador puedan editar scripts
+- La ejecucion de scripts se registra en el log de auditoria ( ``audit.log`` ).
+  El registro puede controlarse con ``script.audit.log.enabled`` y esta activado por defecto ( ``true`` ).
+  La longitud maxima de la cadena de script registrada se controla con ``script.audit.log.max.length``
+  y el valor por defecto es ``100`` caracteres.
 
 Rendimiento
 ===========
 
 Consejos para optimizar el rendimiento de los scripts:
 
-1. **Evitar procesamiento complejo**: Los scripts se ejecutan para cada documento
-2. **Minimizar acceso a recursos externos**: Las llamadas de red causan latencia
-3. **Usar cache**: Considere cache para valores usados repetidamente
+1. **Evitar procesamiento complejo**: Los scripts de data store se ejecutan por cada documento
+2. **Minimizar el acceso a recursos externos**: Las llamadas de red son una fuente de latencia
+3. **Aprovechar la cache**: Considere usar cache para valores que se usan repetidamente
 
 Depuracion
 ==========
 
-Para depurar scripts, use la salida de logs:
+En los scripts de trabajos programados, el script completo se evalua como un unico script
+Groovy, por lo que puede usar la salida de logs para depurar.
+(En los scripts de data store, cada linea se evalua como una expresion individual, por lo que
+no es posible usar sentencias ``import`` ni procesamiento en varias lineas.)
 
 ::
 
     import org.apache.logging.log4j.LogManager
-    def logger = LogManager.getLogger("script")
-    logger.info("data.id = {}", data.id)
+    def logger = LogManager.getLogger("fess.script")
+    logger.info("executor = {}", executor)
 
-Configuracion del nivel de log:
-
-``app/WEB-INF/classes/log4j2.xml``:
+El ejemplo anterior usa un logger denominado ``fess.script``.
+Para que este log se emita, agregue la configuracion del logger correspondiente
+en ``app/WEB-INF/classes/log4j2.xml``.
 
 ::
 
-    <Logger name="script" level="DEBUG"/>
+    <Logger name="fess.script" level="DEBUG"/>
+
+Ademas, para activar los logs de depuracion del propio motor de scripting, establezca
+el nivel de log del paquete ``org.codelibs.fess.script`` en ``DEBUG``.
+
+::
+
+    <Logger name="org.codelibs.fess.script" level="DEBUG"/>
 
 Informacion de referencia
-=========================
+==========================
 
 - :doc:`scripting-groovy` - Guia de scripting Groovy
-- :doc:`../admin/dataconfig-guide` - Guia de configuracion de Data Store
-- :doc:`../admin/scheduler-guide` - Guia de configuracion del programador
+- :doc:`../admin/dataconfig-guide` - Guia de configuracion de data store
+- :doc:`../admin/scheduler-guide` - Guia de configuracion del planificador

--- a/fr/15.7/config/scripting-overview.rst
+++ b/fr/15.7/config/scripting-overview.rst
@@ -1,16 +1,16 @@
-==================================
+====================================
 Apercu du scripting
-==================================
+====================================
 
 Apercu
-====
+======
 
 Dans |Fess|, vous pouvez utiliser des scripts pour implementer une logique personnalisee dans diverses situations.
-En utilisant des scripts, vous pouvez controler de maniere flexible le traitement des donnees lors du crawl,
-la personnalisation des resultats de recherche, l'execution de taches planifiees, etc.
+En tirant parti des scripts, vous pouvez controler de maniere flexible le traitement des donnees lors du crawl,
+la transformation des URL et l'execution des taches planifiees.
 
 Langages de script pris en charge
-==================
+==================================
 
 |Fess| prend en charge les langages de script suivants :
 
@@ -23,157 +23,219 @@ Langages de script pris en charge
      - Description
    * - Groovy
      - ``groovy``
-     - Langage de script par defaut. Compatible avec Java et offre des fonctionnalites puissantes
+     - Langage de script enregistre par defaut. Compatible avec Java et offre des fonctionnalites puissantes
 
 .. note::
-   Groovy est le plus largement utilise, et les exemples de cette documentation sont ecrits en Groovy.
+   Le seul moteur de script enregistre par defaut dans |Fess| est Groovy.
+   Le langage de script par defaut est ``groovy`` (``Constants.DEFAULT_SCRIPT``).
+   Tous les exemples de scripts de cette documentation sont ecrits en syntaxe Groovy.
 
 Cas d'utilisation des scripts
-====================
+==============================
 
 Configuration du Data Store
-----------------
+----------------------------
 
-Dans les connecteurs Data Store, les scripts sont utilises pour mapper les donnees recuperees
-aux champs d'index.
+Dans les connecteurs Data Store, des scripts sont utilises pour mapper les donnees recuperees
+vers les champs de l'index. La configuration s'ecrit au format ``nom_de_champ=expression``, une par ligne ;
+chaque ligne est evaluee comme une expression Groovy independante.
 
 ::
 
-    url="https://example.com/article/" + data.id
-    title=data.name
-    content=data.description
-    lastModified=data.updated_at
+    url=site_url
+    title=name
+    content=description
+    last_modified=updated_at
+
+Les noms de variables disponibles dans les scripts Data Store varient selon le type de connecteur.
+Par exemple, pour les Data Stores CSV et JSON, chaque nom de colonne ou de champ est disponible
+directement en tant que variable (sans prefixe commun tel que ``data``).
+Pour les connecteurs de type fichier (Box, Google Drive, OneDrive, etc.), le prefixe est ``file.*`` ;
+pour Slack, c'est ``message.*`` ; le prefixe differe selon le connecteur.
+Consultez la documentation de chaque connecteur Data Store pour connaitre les variables disponibles.
+
+.. note::
+   Chaque ligne d'un Data Store etant evaluee comme une expression unique, les blocs ``if`` multi-lignes,
+   les instructions ``import`` et les declarations de variables avec ``def`` ne peuvent pas etre utilises.
+   Pour conditionner une valeur, utilisez l'operateur ternaire pour chaque champ
+   (exemple : ``title=enabled == "true" ? name : null``). Pour referencer une classe, utilisez
+   le nom completement qualifie (FQCN) en ligne.
 
 Mapping de chemin
---------------
+-----------------
 
-Les scripts peuvent etre utilises pour la normalisation d'URL et la conversion de chemin.
+Le mapping de chemin est une fonctionnalite permettant de normaliser et de transformer les URL crawlees.
+Par defaut, il se configure avec un couple « expression reguliere » / « chaine de remplacement » et
+ne constitue pas un script Groovy. Par exemple, en indiquant ``http://`` comme expression reguliere
+et ``https://`` comme chaine de remplacement, le schema de l'URL est remplace.
+
+Lorsque la chaine de remplacement commence par ``groovy:``, la partie suivante est evaluee en tant
+que script Groovy. Dans ce script, ``url`` represente la chaine URL a transformer et ``matcher``
+represente le ``java.util.regex.Matcher`` de l'expression reguliere.
 
 ::
 
-    # Convertir l'URL
-    url.replaceAll("http://", "https://")
+    groovy:url.replaceAll("http://", "https://")
 
 Taches planifiees
-------------------
+-----------------
 
 Dans les taches planifiees, vous pouvez ecrire une logique de traitement personnalisee en script Groovy.
+L'ensemble du script est evalue comme un seul script Groovy, ce qui permet d'utiliser des instructions
+multi-lignes, des instructions ``import`` et des declarations de variables avec ``def``.
 
 ::
 
-    return container.getComponent("crawlJob").execute();
+    return container.getComponent("crawlJob").logLevel("info").gcLogging().execute(executor);
+
+Les methodes comme ``logLevel("info")`` sont des methodes de la classe du job (``ExecJob`` et ses
+sous-classes) et peuvent etre enchainées. Pour la variable ``executor``, consultez la section
+« Contexte d'execution et objets disponibles ».
 
 Syntaxe de base
-============
+===============
+
+Voici des exemples de syntaxe Groovy de base. Les commentaires utilisent ``//`` (commentaire de ligne)
+ou ``/* */`` (commentaire de bloc). Notez que les commentaires commencant par ``#`` ne sont pas
+utilisables en Groovy.
 
 Acces aux variables
-------------
+-------------------
 
 ::
 
-    # Acceder aux donnees du data store
-    data.fieldName
+    // Champ d'un Data Store (CSV/JSON : acces par nom de colonne ou de champ)
+    title
 
-    # Acceder aux composants systeme
-    container.getComponent("componentName")
+    // Recuperer un composant depuis le conteneur DI
+    container.getComponent("systemHelper")
 
 Manipulation de chaines
+------------------------
+
+::
+
+    // Concatenation
+    title + " - " + category
+
+    // Remplacement
+    content.replaceAll("old", "new")
+
+    // Division
+    tags.split(",")
+
+Conditions
 ----------
 
 ::
 
-    # Concatenation
-    title + " - " + category
+    // Operateur ternaire
+    status == "active" ? "Actif" : "Inactif"
 
-    # Remplacement
-    content.replaceAll("old", "new")
-
-    # Division
-    tags.split(",")
-
-Conditions
---------
-
-::
-
-    # Operateur ternaire
-    data.status == "active" ? "Actif" : "Inactif"
-
-    # Verification de null
-    data.description ?: "Pas de description"
+    // Valeur par defaut si null ou vide (operateur Elvis)
+    description ?: "Aucune description"
 
 Manipulation de dates
---------
+---------------------
 
 ::
 
-    # Date et heure actuelle
+    // Date et heure actuelles
     new Date()
 
-    # Formatage
-    new java.text.SimpleDateFormat("yyyy-MM-dd").format(data.date)
+    // Formatage
+    new java.text.SimpleDateFormat("yyyy-MM-dd").format(updated_at)
 
-Objets disponibles
-======================
+Contexte d'execution et objets disponibles
+===========================================
 
-Principaux objets utilisables dans les scripts :
+Les objets disponibles dans un script dependent du contexte dans lequel il est execute.
+Seul ``container`` est disponible dans tous les contextes.
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 75
+   :widths: 30 25 45
 
-   * - Objet
+   * - Contexte d'execution
+     - Objets disponibles
      - Description
-   * - ``data``
-     - Donnees recuperees du data store
-   * - ``container``
-     - Conteneur DI (acces aux composants)
-   * - ``systemHelper``
-     - Helper systeme (``container.getComponent("systemHelper")``)
-   * - ``fessConfig``
-     - Configuration de |Fess| (``container.getComponent("fessConfig")``)
+   * - Tous les contextes
+     - ``container``
+     - Conteneur DI. Acces aux composants via ``container.getComponent("systemHelper")``
+       ou ``container.getComponent("fessConfig")``
+   * - Scripts Data Store
+     - Variables de champs specifiques au connecteur
+     - Chaque champ recupere du Data Store est disponible en tant que variable
+       (le nom de variable et le prefixe varient selon le connecteur ; CSV/JSON utilisent
+       directement le nom du champ comme variable)
+   * - Mapping de chemin
+     - ``url`` ``matcher``
+     - La chaine URL a transformer et le ``Matcher`` de l'expression reguliere
+       (uniquement lors d'un remplacement avec le prefixe ``groovy:``)
+   * - Taches planifiees
+     - ``executor``
+     - Instance d'execution du job (``JobExecutor``). Utilise pour controler l'arret du job
+
+.. note::
+   Les objets autres que ``container`` ne sont injectes que dans des contextes specifiques.
+   Par exemple, ``executor`` n'est disponible que dans les taches planifiees et ne l'est pas
+   dans les scripts Data Store ni dans le mapping de chemin.
 
 Securite
-============
+========
 
 .. warning::
-   Les scripts ont des capacites puissantes, utilisez-les uniquement depuis des sources fiables.
+   Les scripts disposant de capacites puissantes, utilisez-les uniquement depuis des sources fiables.
 
 - Les scripts sont executes sur le serveur
 - L'acces au systeme de fichiers et au reseau est possible
-- Assurez-vous que seuls les utilisateurs avec droits d'administration peuvent modifier les scripts
+- Assurez-vous que seuls les utilisateurs disposant de droits d'administration peuvent modifier les scripts
+- L'execution des scripts est enregistree dans le journal d'audit (``audit.log``).
+  L'enregistrement est controle par ``script.audit.log.enabled`` (valeur par defaut : ``true``).
+  La longueur maximale de la chaine de script enregistree est controlee par
+  ``script.audit.log.max.length`` (valeur par defaut : ``100`` caracteres).
 
 Performance
-==============
+===========
 
 Conseils pour optimiser les performances des scripts :
 
-1. **Eviter les traitements complexes** : Les scripts sont executes pour chaque document
-2. **Minimiser l'acces aux ressources externes** : Les appels reseau causent des delais
-3. **Utiliser le cache** : Envisagez le cache pour les valeurs utilisees de maniere repetee
+1. **Eviter les traitements complexes** : les scripts Data Store sont executes pour chaque document
+2. **Minimiser l'acces aux ressources externes** : les appels reseau sont source de latence
+3. **Tirer parti du cache** : envisagez la mise en cache pour les valeurs utilisees de maniere repetee
 
 Debogage
 ========
 
-Pour le debogage des scripts, utilisez la sortie de logs :
+Dans les scripts de taches planifiees, l'ensemble du script est evalue comme un seul script Groovy,
+ce qui permet d'utiliser la sortie de logs pour le debogage.
+(Les scripts Data Store evaluent chaque ligne comme une expression unique ; les instructions ``import``
+et les traitements multi-lignes ne sont pas utilisables.)
 
 ::
 
     import org.apache.logging.log4j.LogManager
-    def logger = LogManager.getLogger("script")
-    logger.info("data.id = {}", data.id)
+    def logger = LogManager.getLogger("fess.script")
+    logger.info("executor = {}", executor)
 
-Configuration du niveau de log :
-
-``app/WEB-INF/classes/log4j2.xml`` :
+L'exemple ci-dessus utilise un logger nomme ``fess.script``.
+Pour activer la sortie de ce log, ajoutez la configuration du logger correspondant
+dans ``app/WEB-INF/classes/log4j2.xml``.
 
 ::
 
-    <Logger name="script" level="DEBUG"/>
+    <Logger name="fess.script" level="DEBUG"/>
+
+Pour activer les logs de debogage du moteur de script lui-meme, configurez le niveau de log
+du package ``org.codelibs.fess.script`` a ``DEBUG``.
+
+::
+
+    <Logger name="org.codelibs.fess.script" level="DEBUG"/>
 
 Informations de reference
-========
+==========================
 
-- :doc:`scripting-groovy` - Guide de script Groovy
+- :doc:`scripting-groovy` - Guide du scripting Groovy
 - :doc:`../admin/dataconfig-guide` - Guide de configuration Data Store
 - :doc:`../admin/scheduler-guide` - Guide de configuration du planificateur

--- a/ja/15.7/config/scripting-overview.rst
+++ b/ja/15.7/config/scripting-overview.rst
@@ -6,7 +6,7 @@
 ====
 
 |Fess| では、様々な場面でスクリプトを使用してカスタムロジックを実装できます。
-スクリプトを活用することで、クロール時のデータ加工、検索結果のカスタマイズ、
+スクリプトを活用することで、クロール時のデータ加工、URLの変換、
 スケジュールジョブの実行などを柔軟に制御できます。
 
 対応スクリプト言語
@@ -23,10 +23,12 @@
      - 説明
    * - Groovy
      - ``groovy``
-     - デフォルトのスクリプト言語。Java互換で強力な機能を提供
+     - 標準で登録されているスクリプト言語。Java互換で強力な機能を提供
 
 .. note::
-   |Fess| のスクリプトエンジンとしてはGroovyが登録されています。
+   |Fess| に標準で登録されているスクリプトエンジンはGroovyのみです。
+   デフォルトのスクリプト言語は ``groovy`` です（ ``Constants.DEFAULT_SCRIPT`` ）。
+   本ドキュメントのスクリプト例はすべてGroovy構文で記述しています。
 
 スクリプトの使用場面
 ====================
@@ -35,60 +37,91 @@
 ----------------
 
 データストアコネクタでは、取得したデータをインデックスフィールドにマッピングするために
-スクリプトを使用します。
+スクリプトを使用します。設定は ``フィールド名=式`` の形式で1行ごとに記述し、
+各行はそれぞれ独立した1つのGroovy式として評価されます。
 
 ::
 
-    url="https://example.com/article/" + data.id
-    title=data.name
-    content=data.description
-    lastModified=data.updated_at
+    url=site_url
+    title=name
+    content=description
+    last_modified=updated_at
+
+データストアスクリプトで参照できる変数名は、コネクタの種類によって異なります。
+たとえばCSVデータストアやJSONデータストアでは、各カラム名・フィールド名が
+そのまま変数として利用できます（ ``data`` のような共通の接頭辞は付きません）。
+ファイル系コネクタ（Box、Google Drive、OneDrive など）では ``file.*`` 、
+Slackでは ``message.*`` など、コネクタごとに接頭辞が異なります。
+利用できる変数の詳細は、各データストアコネクタのドキュメントを参照してください。
+
+.. note::
+   データストアの各行は1つの式として評価されるため、複数行にまたがる
+   ``if`` ブロックや ``import`` 文、 ``def`` による変数宣言は使用できません。
+   条件によって値を変える場合は、フィールドごとに三項演算子を使用してください
+   （例: ``title=enabled == "true" ? name : null`` ）。クラスを参照する場合は
+   完全修飾名（FQCN）をインラインで記述します。
 
 パスマッピング
 --------------
 
-URLの正規化やパスの変換にスクリプトを使用できます。
+パスマッピングは、クロール対象のURLを正規化・変換するための機能です。
+標準では「正規表現」と「置換文字列」のペアで設定し、Groovyスクリプトではありません。
+たとえば、正規表現に ``http://`` 、置換文字列に ``https://`` を指定すると、
+URLのスキームを置き換えられます。
+
+置換文字列の先頭に ``groovy:`` を付けた場合に限り、以降の文字列がGroovyスクリプトとして
+評価されます。このスクリプト内では、変換対象のURL文字列を表す ``url`` と、
+正規表現の ``java.util.regex.Matcher`` を表す ``matcher`` が利用できます。
 
 ::
 
-    # URLを変換
-    url.replaceAll("http://", "https://")
+    groovy:url.replaceAll("http://", "https://")
 
 スケジュールジョブ
 ------------------
 
 スケジュールジョブでは、カスタムの処理ロジックをGroovyスクリプトで記述できます。
+スクリプトはスクリプト全体が1つのGroovyスクリプトとして評価されるため、
+複数行の記述や ``import`` 文、 ``def`` による変数宣言も使用できます。
 
 ::
 
-    return container.getComponent("crawlJob").logLevel("info").execute(executor);
+    return container.getComponent("crawlJob").logLevel("info").gcLogging().execute(executor);
+
+``logLevel("info")`` などのメソッドはジョブクラス（ ``ExecJob`` とそのサブクラス）の
+メソッドで、メソッドチェーンで記述できます。 ``executor`` 変数については
+「実行コンテキストと利用可能なオブジェクト」を参照してください。
 
 基本的な構文
 ============
+
+以下はGroovyの基本的な構文例です。コメントは ``//`` （行コメント）または
+``/* */`` （ブロックコメント）を使用します。 ``#`` で始まるコメントはGroovyでは
+使用できない点に注意してください。
 
 変数アクセス
 ------------
 
 ::
 
-    # データストアのデータにアクセス
-    data.fieldName
+    // データストアのフィールド（CSV/JSONではカラム名・フィールド名でアクセス）
+    title
 
-    # システムコンポーネントにアクセス
-    container.getComponent("componentName")
+    // DIコンテナからコンポーネントを取得
+    container.getComponent("systemHelper")
 
 文字列操作
 ----------
 
 ::
 
-    # 連結
+    // 連結
     title + " - " + category
 
-    # 置換
+    // 置換
     content.replaceAll("old", "new")
 
-    # 分割
+    // 分割
     tags.split(",")
 
 条件分岐
@@ -96,40 +129,55 @@ URLの正規化やパスの変換にスクリプトを使用できます。
 
 ::
 
-    # 三項演算子
-    data.status == "active" ? "有効" : "無効"
+    // 三項演算子
+    status == "active" ? "有効" : "無効"
 
-    # nullチェック
-    data.description ?: "説明なし"
+    // null/空の場合のデフォルト値（Elvis演算子）
+    description ?: "説明なし"
 
 日付操作
 --------
 
 ::
 
-    # 現在日時
+    // 現在日時
     new Date()
 
-    # フォーマット
-    new java.text.SimpleDateFormat("yyyy-MM-dd").format(data.date)
+    // フォーマット
+    new java.text.SimpleDateFormat("yyyy-MM-dd").format(updated_at)
 
-利用可能なオブジェクト
-======================
+実行コンテキストと利用可能なオブジェクト
+========================================
 
-スクリプト内で使用可能な主なオブジェクト:
+スクリプト内で使用できるオブジェクトは、スクリプトを実行するコンテキストによって
+異なります。 ``container`` のみがすべてのコンテキストで利用可能です。
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 75
+   :widths: 30 25 45
 
-   * - オブジェクト
+   * - 実行コンテキスト
+     - 利用可能なオブジェクト
      - 説明
-   * - ``data``
-     - データストアから取得したデータ（データストアスクリプトで使用可能）
-   * - ``container``
-     - DIコンテナ（ ``container.getComponent("systemHelper")`` や ``container.getComponent("fessConfig")`` で各コンポーネントにアクセス可能）
-   * - ``executor``
-     - ジョブ実行インスタンス（スケジュールジョブスクリプトで使用可能。ジョブのシャットダウン制御に使用）
+   * - すべてのコンテキスト
+     - ``container``
+     - DIコンテナ。 ``container.getComponent("systemHelper")`` や
+       ``container.getComponent("fessConfig")`` で各コンポーネントにアクセス可能
+   * - データストアスクリプト
+     - コネクタ固有のフィールド変数
+     - データストアから取得した各フィールドが変数として利用可能
+       （変数名・接頭辞はコネクタによって異なる。CSV/JSONはフィールド名がそのまま変数になる）
+   * - パスマッピング
+     - ``url`` ``matcher``
+     - 変換対象のURL文字列と、正規表現の ``Matcher`` （ ``groovy:`` 接頭辞付きの置換時のみ）
+   * - スケジュールジョブ
+     - ``executor``
+     - ジョブ実行インスタンス（ ``JobExecutor`` ）。ジョブのシャットダウン制御に使用
+
+.. note::
+   ``container`` 以外のオブジェクトは特定のコンテキストでのみ注入されます。
+   たとえば ``executor`` はスケジュールジョブでのみ利用可能で、データストアスクリプトや
+   パスマッピングでは利用できません。
 
 セキュリティ
 ============
@@ -140,35 +188,48 @@ URLの正規化やパスの変換にスクリプトを使用できます。
 - スクリプトはサーバー上で実行されます
 - ファイルシステムやネットワークへのアクセスが可能です
 - 管理者権限を持つユーザーのみがスクリプトを編集できるようにしてください
-- スクリプトの実行は監査ログに記録されます（ ``script.audit.log.enabled`` で制御、デフォルト: ``true`` ）
+- スクリプトの実行は監査ログ（ ``audit.log`` ）に記録されます。
+  記録の有無は ``script.audit.log.enabled`` で制御し、デフォルトは ``true`` です。
+  記録されるスクリプト文字列の最大長は ``script.audit.log.max.length`` で制御し、
+  デフォルトは ``100`` 文字です。
 
 パフォーマンス
 ==============
 
 スクリプトのパフォーマンスを最適化するためのヒント:
 
-1. **複雑な処理を避ける**: スクリプトはドキュメントごとに実行されます
+1. **複雑な処理を避ける**: データストアスクリプトはドキュメントごとに実行されます
 2. **外部リソースへのアクセスを最小化**: ネットワーク呼び出しは遅延の原因になります
 3. **キャッシュを活用**: 繰り返し使用する値はキャッシュを検討
 
 デバッグ
 ========
 
-スクリプトのデバッグには、ログ出力を活用します:
+スケジュールジョブのスクリプトでは、スクリプト全体が1つのGroovyスクリプトとして
+評価されるため、ログ出力を活用してデバッグできます。
+（データストアスクリプトは1行が1つの式として評価されるため、 ``import`` 文や
+複数行の処理は使用できません。）
 
 ::
 
     import org.apache.logging.log4j.LogManager
-    def logger = LogManager.getLogger("script")
-    logger.info("data.id = {}", data.id)
+    def logger = LogManager.getLogger("fess.script")
+    logger.info("executor = {}", executor)
 
-ログレベルの設定:
-
-``app/WEB-INF/classes/log4j2.xml``:
+上記の例では ``fess.script`` という名前のロガーを使用しています。
+このログを出力するには、 ``app/WEB-INF/classes/log4j2.xml`` に対応するロガー設定を
+追加します。
 
 ::
 
-    <Logger name="script" level="DEBUG"/>
+    <Logger name="fess.script" level="DEBUG"/>
+
+また、スクリプトエンジン自体のデバッグログを有効にするには、 ``org.codelibs.fess.script``
+パッケージのログレベルを ``DEBUG`` に設定します。
+
+::
+
+    <Logger name="org.codelibs.fess.script" level="DEBUG"/>
 
 参考情報
 ========

--- a/ko/15.7/config/scripting-overview.rst
+++ b/ko/15.7/config/scripting-overview.rst
@@ -6,7 +6,7 @@
 ====
 
 |Fess|에서는 다양한 장면에서 스크립트를 사용하여 커스텀 로직을 구현할 수 있습니다.
-스크립트를 활용하면 크롤링 시 데이터 가공, 검색 결과 커스터마이즈,
+스크립트를 활용하면 크롤링 시 데이터 가공, URL 변환,
 스케줄 작업 실행 등을 유연하게 제어할 수 있습니다.
 
 지원 스크립트 언어
@@ -23,157 +23,216 @@
      - 설명
    * - Groovy
      - ``groovy``
-     - 기본 스크립트 언어. Java 호환으로 강력한 기능 제공
-     - 웹 개발자에게 친숙한 언어
+     - 기본으로 등록된 스크립트 언어. Java 호환으로 강력한 기능 제공
 
 .. note::
-   Groovy가 가장 널리 사용되며, 본 문서의 예제는 Groovy로 작성되어 있습니다.
+   |Fess|에 기본으로 등록된 스크립트 엔진은 Groovy뿐입니다.
+   기본 스크립트 언어는 ``groovy``입니다（ ``Constants.DEFAULT_SCRIPT`` ）.
+   이 문서의 스크립트 예제는 모두 Groovy 구문으로 작성되어 있습니다.
 
 스크립트 사용 장면
-====================
+==================
 
 데이터 스토어 설정
-----------------
-
-데이터 스토어 커넥터에서는 가져온 데이터를 인덱스 필드에 매핑하기 위해
-스크립트를 사용합니다.
-
-::
-
-    url="https://example.com/article/" + data.id
-    title=data.name
-    content=data.description
-    lastModified=data.updated_at
-
-경로 매핑
---------------
-
-URL 정규화나 경로 변환에 스크립트를 사용할 수 있습니다.
-
-::
-
-    # URL 변환
-    url.replaceAll("http://", "https://")
-
-스케줄 작업
 ------------------
 
-스케줄 작업에서는 커스텀 처리 로직을 Groovy 스크립트로 작성할 수 있습니다.
+데이터 스토어 커넥터에서는 가져온 데이터를 인덱스 필드에 매핑하기 위해
+스크립트를 사용합니다. 설정은 ``필드명=식`` 형식으로 한 줄씩 기술하며,
+각 줄은 독립된 하나의 Groovy 식으로 평가됩니다.
 
 ::
 
-    return container.getComponent("crawlJob").execute();
+    url=site_url
+    title=name
+    content=description
+    last_modified=updated_at
+
+데이터 스토어 스크립트에서 참조할 수 있는 변수명은 커넥터 종류에 따라 다릅니다.
+예를 들어 CSV 데이터 스토어나 JSON 데이터 스토어에서는 각 컬럼명·필드명을
+그대로 변수로 사용할 수 있습니다（ ``data`` 와 같은 공통 접두사는 붙지 않습니다）.
+파일 계열 커넥터（Box, Google Drive, OneDrive 등）에서는 ``file.*``,
+Slack에서는 ``message.*`` 등 커넥터마다 접두사가 다릅니다.
+사용 가능한 변수의 자세한 내용은 각 데이터 스토어 커넥터 문서를 참조하세요.
+
+.. note::
+   데이터 스토어의 각 줄은 하나의 식으로 평가되기 때문에, 여러 줄에 걸친
+   ``if`` 블록이나 ``import`` 문, ``def`` 에 의한 변수 선언은 사용할 수 없습니다.
+   조건에 따라 값을 변경할 경우에는 필드마다 삼항 연산자를 사용하세요
+   （예: ``title=enabled == "true" ? name : null`` ）. 클래스를 참조할 경우에는
+   완전 한정 이름（FQCN）을 인라인으로 기술합니다.
+
+경로 매핑
+---------
+
+경로 매핑은 크롤링 대상 URL을 정규화·변환하기 위한 기능입니다.
+기본적으로는 「정규 표현식」과 「치환 문자열」의 쌍으로 설정하며, Groovy 스크립트가 아닙니다.
+예를 들어 정규 표현식에 ``http://``, 치환 문자열에 ``https://``를 지정하면
+URL의 스킴을 교체할 수 있습니다.
+
+치환 문자열 앞에 ``groovy:``를 붙인 경우에 한해, 이후 문자열이 Groovy 스크립트로
+평가됩니다. 이 스크립트 내에서는 변환 대상 URL 문자열을 나타내는 ``url``과,
+정규 표현식의 ``java.util.regex.Matcher``를 나타내는 ``matcher``를 사용할 수 있습니다.
+
+::
+
+    groovy:url.replaceAll("http://", "https://")
+
+스케줄 작업
+-----------
+
+스케줄 작업에서는 커스텀 처리 로직을 Groovy 스크립트로 작성할 수 있습니다.
+스크립트 전체가 하나의 Groovy 스크립트로 평가되기 때문에,
+여러 줄 기술이나 ``import`` 문, ``def``에 의한 변수 선언도 사용할 수 있습니다.
+
+::
+
+    return container.getComponent("crawlJob").logLevel("info").gcLogging().execute(executor);
+
+``logLevel("info")`` 등의 메서드는 작업 클래스（ ``ExecJob`` 및 그 서브클래스）의
+메서드이며, 메서드 체인으로 기술할 수 있습니다. ``executor`` 변수에 대해서는
+「실행 컨텍스트와 사용 가능한 객체」를 참조하세요.
 
 기본 구문
-============
+=========
+
+다음은 Groovy의 기본 구문 예제입니다. 주석은 ``//``（줄 주석）또는
+``/* */``（블록 주석）을 사용합니다. ``#``으로 시작하는 주석은 Groovy에서
+사용할 수 없다는 점에 주의하세요.
 
 변수 접근
-------------
+---------
 
 ::
 
-    # 데이터 스토어의 데이터에 접근
-    data.fieldName
+    // 데이터 스토어의 필드（CSV/JSON에서는 컬럼명·필드명으로 접근）
+    title
 
-    # 시스템 컴포넌트에 접근
-    container.getComponent("componentName")
+    // DI 컨테이너에서 컴포넌트 취득
+    container.getComponent("systemHelper")
 
 문자열 조작
-----------
+-----------
 
 ::
 
-    # 연결
+    // 연결
     title + " - " + category
 
-    # 치환
+    // 치환
     content.replaceAll("old", "new")
 
-    # 분할
+    // 분할
     tags.split(",")
 
 조건 분기
---------
+---------
 
 ::
 
-    # 삼항 연산자
-    data.status == "active" ? "활성화" : "비활성화"
+    // 삼항 연산자
+    status == "active" ? "유효" : "무효"
 
-    # null 체크
-    data.description ?: "설명 없음"
+    // null/빈 값인 경우의 기본값（Elvis 연산자）
+    description ?: "설명 없음"
 
 날짜 조작
---------
+---------
 
 ::
 
-    # 현재 날짜/시간
+    // 현재 날짜/시간
     new Date()
 
-    # 포맷
-    new java.text.SimpleDateFormat("yyyy-MM-dd").format(data.date)
+    // 포맷
+    new java.text.SimpleDateFormat("yyyy-MM-dd").format(updated_at)
 
-사용 가능한 객체
-======================
+실행 컨텍스트와 사용 가능한 객체
+=================================
 
-스크립트 내에서 사용 가능한 주요 객체:
+스크립트 내에서 사용할 수 있는 객체는 스크립트를 실행하는 컨텍스트에 따라
+다릅니다. ``container``만이 모든 컨텍스트에서 사용 가능합니다.
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 75
+   :widths: 30 25 45
 
-   * - 객체
+   * - 실행 컨텍스트
+     - 사용 가능한 객체
      - 설명
-   * - ``data``
-     - 데이터 스토어에서 가져온 데이터
-   * - ``container``
-     - DI 컨테이너(컴포넌트에 접근)
-   * - ``systemHelper``
-     - 시스템 헬퍼
-   * - ``fessConfig``
-     - |Fess| 설정
+   * - 모든 컨텍스트
+     - ``container``
+     - DI 컨테이너. ``container.getComponent("systemHelper")`` 나
+       ``container.getComponent("fessConfig")`` 로 각 컴포넌트에 접근 가능
+   * - 데이터 스토어 스크립트
+     - 커넥터 고유의 필드 변수
+     - 데이터 스토어에서 가져온 각 필드가 변수로 사용 가능
+       （변수명·접두사는 커넥터에 따라 다름. CSV/JSON은 필드명이 그대로 변수가 됨）
+   * - 경로 매핑
+     - ``url`` ``matcher``
+     - 변환 대상 URL 문자열과 정규 표현식의 ``Matcher``（ ``groovy:`` 접두사 부가 시의 치환에서만）
+   * - 스케줄 작업
+     - ``executor``
+     - 작업 실행 인스턴스（ ``JobExecutor`` ）. 작업의 셧다운 제어에 사용
+
+.. note::
+   ``container`` 이외의 객체는 특정 컨텍스트에서만 주입됩니다.
+   예를 들어 ``executor``는 스케줄 작업에서만 사용 가능하며, 데이터 스토어 스크립트나
+   경로 매핑에서는 사용할 수 없습니다.
 
 보안
-============
+====
 
 .. warning::
-   스크립트는 강력한 기능을 가지므로 신뢰할 수 있는 소스에서만 사용하세요.
+   스크립트는 강력한 기능을 갖기 때문에 신뢰할 수 있는 소스에서만 사용하세요.
 
 - 스크립트는 서버에서 실행됩니다
 - 파일 시스템이나 네트워크에 접근할 수 있습니다
 - 관리자 권한을 가진 사용자만 스크립트를 편집할 수 있도록 하세요
+- 스크립트 실행은 감사 로그（ ``audit.log`` ）에 기록됩니다.
+  기록 여부는 ``script.audit.log.enabled``로 제어하며 기본값은 ``true``입니다.
+  기록되는 스크립트 문자열의 최대 길이는 ``script.audit.log.max.length``로 제어하며
+  기본값은 ``100``자입니다.
 
 성능
-==============
+====
 
-스크립트의 성능을 최적화하기 위한 팁:
+스크립트 성능을 최적화하기 위한 팁:
 
-1. **복잡한 처리 피하기**: 스크립트는 문서마다 실행됩니다
+1. **복잡한 처리 피하기**: 데이터 스토어 스크립트는 문서마다 실행됩니다
 2. **외부 리소스 접근 최소화**: 네트워크 호출은 지연의 원인이 됩니다
-3. **캐시 활용**: 반복적으로 사용하는 값은 캐시 검토
+3. **캐시 활용**: 반복적으로 사용하는 값은 캐시를 검토
 
 디버그
-========
+======
 
-스크립트 디버깅에는 로그 출력을 활용합니다:
+스케줄 작업의 스크립트에서는 스크립트 전체가 하나의 Groovy 스크립트로
+평가되기 때문에 로그 출력을 활용하여 디버깅할 수 있습니다.
+（데이터 스토어 스크립트는 한 줄이 하나의 식으로 평가되기 때문에 ``import`` 문이나
+여러 줄의 처리는 사용할 수 없습니다.）
 
 ::
 
     import org.apache.logging.log4j.LogManager
-    def logger = LogManager.getLogger("script")
-    logger.info("data.id = {}", data.id)
+    def logger = LogManager.getLogger("fess.script")
+    logger.info("executor = {}", executor)
 
-로그 레벨 설정:
-
-``app/WEB-INF/classes/log4j2.xml``:
+위 예제에서는 ``fess.script``라는 이름의 로거를 사용합니다.
+이 로그를 출력하려면 ``app/WEB-INF/classes/log4j2.xml``에 해당 로거 설정을
+추가합니다.
 
 ::
 
-    <Logger name="script" level="DEBUG"/>
+    <Logger name="fess.script" level="DEBUG"/>
+
+또한 스크립트 엔진 자체의 디버그 로그를 활성화하려면 ``org.codelibs.fess.script``
+패키지의 로그 레벨을 ``DEBUG``로 설정합니다.
+
+::
+
+    <Logger name="org.codelibs.fess.script" level="DEBUG"/>
 
 참고 정보
-========
+=========
 
 - :doc:`scripting-groovy` - Groovy 스크립트 가이드
 - :doc:`../admin/dataconfig-guide` - 데이터 스토어 설정 가이드

--- a/zh-cn/15.7/config/scripting-overview.rst
+++ b/zh-cn/15.7/config/scripting-overview.rst
@@ -1,18 +1,18 @@
-==================================
+============================
 脚本概述
-==================================
+============================
 
 概述
 ====
 
 在 |Fess| 中，可以使用脚本在各种场景中实现自定义逻辑。
-通过活用脚本，可以灵活控制爬取时的数据处理、搜索结果定制、
+通过活用脚本，可以灵活控制爬取时的数据处理、URL 转换、
 计划任务执行等。
 
 支持的脚本语言
-==================
+==============
 
-|Fess| 支持以下脚本语言:
+|Fess| 支持以下脚本语言：
 
 .. list-table::
    :header-rows: 1
@@ -23,71 +23,105 @@
      - 说明
    * - Groovy
      - ``groovy``
-     - 默认脚本语言。与Java兼容，提供强大功能
+     - 默认注册的脚本语言。与 Java 兼容，提供强大功能
 
 .. note::
-   Groovy使用最广泛，本文档中的示例以Groovy编写。
+   |Fess| 默认注册的脚本引擎仅为 Groovy。
+   默认脚本语言为 ``groovy`` （ ``Constants.DEFAULT_SCRIPT`` ）。
+   本文档中的脚本示例均使用 Groovy 语法编写。
 
 脚本使用场景
-====================
-
-数据存储设置
-----------------
-
-在数据存储连接器中，使用脚本将获取的数据映射到索引字段。
-
-::
-
-    url="https://example.com/article/" + data.id
-    title=data.name
-    content=data.description
-    lastModified=data.updated_at
-
-路径映射
---------------
-
-可以使用脚本进行URL规范化或路径转换。
-
-::
-
-    # 转换URL
-    url.replaceAll("http://", "https://")
-
-计划任务
-------------------
-
-在计划任务中，可以使用Groovy脚本编写自定义处理逻辑。
-
-::
-
-    return container.getComponent("crawlJob").execute();
-
-基本语法
 ============
 
-变量访问
+数据存储设置
 ------------
+
+在数据存储连接器中，使用脚本将获取的数据映射到索引字段。
+配置格式为 ``字段名=表达式``，每行单独记述，
+每行作为一个独立的 Groovy 表达式进行求值。
 
 ::
 
-    # 访问数据存储的数据
-    data.fieldName
+    url=site_url
+    title=name
+    content=description
+    last_modified=updated_at
 
-    # 访问系统组件
-    container.getComponent("componentName")
+数据存储脚本中可引用的变量名因连接器类型而异。
+例如，CSV 数据存储和 JSON 数据存储中，各列名、字段名可直接作为变量使用
+（不带 ``data`` 之类的公共前缀）。
+文件类连接器（Box、Google Drive、OneDrive 等）使用 ``file.*``，
+Slack 使用 ``message.*``，不同连接器的前缀各不相同。
+可用变量的详细信息，请参阅各数据存储连接器的文档。
+
+.. note::
+   数据存储的每行作为一个表达式求值，因此不能使用跨多行的
+   ``if`` 块、 ``import`` 语句或 ``def`` 变量声明。
+   需要根据条件改变值时，请针对每个字段使用三元运算符
+   （例： ``title=enabled == "true" ? name : null`` ）。引用类时
+   请以内联方式写出完全限定名（FQCN）。
+
+路径映射
+--------
+
+路径映射是用于对爬取目标 URL 进行规范化和转换的功能。
+默认情况下，以"正则表达式"与"替换字符串"的组合进行配置，并非 Groovy 脚本。
+例如，将正则表达式设为 ``http://``、替换字符串设为 ``https://``，
+即可替换 URL 的协议部分。
+
+仅当替换字符串以 ``groovy:`` 开头时，后续字符串才会作为 Groovy 脚本求值。
+在该脚本中，可使用表示转换目标 URL 字符串的 ``url``，
+以及表示正则表达式 ``java.util.regex.Matcher`` 的 ``matcher``。
+
+::
+
+    groovy:url.replaceAll("http://", "https://")
+
+计划任务
+--------
+
+在计划任务中，可以使用 Groovy 脚本编写自定义处理逻辑。
+整个脚本作为一个 Groovy 脚本求值，因此可以使用多行记述、
+``import`` 语句以及 ``def`` 变量声明。
+
+::
+
+    return container.getComponent("crawlJob").logLevel("info").gcLogging().execute(executor);
+
+``logLevel("info")`` 等方法是任务类（ ``ExecJob`` 及其子类）的
+方法，可以链式调用。关于 ``executor`` 变量，
+请参阅"执行上下文与可用对象"。
+
+基本语法
+========
+
+以下是 Groovy 的基本语法示例。注释使用 ``//`` （行注释）或
+``/* */`` （块注释）。请注意，以 ``#`` 开头的注释在 Groovy 中
+不可使用。
+
+变量访问
+--------
+
+::
+
+    // 访问数据存储字段（CSV/JSON 中以列名、字段名访问）
+    title
+
+    // 从 DI 容器获取组件
+    container.getComponent("systemHelper")
 
 字符串操作
 ----------
 
 ::
 
-    # 连接
+    // 连接
     title + " - " + category
 
-    # 替换
+    // 替换
     content.replaceAll("old", "new")
 
-    # 分割
+    // 分割
     tags.split(",")
 
 条件分支
@@ -95,84 +129,111 @@
 
 ::
 
-    # 三元运算符
-    data.status == "active" ? "有效" : "无效"
+    // 三元运算符
+    status == "active" ? "有效" : "无效"
 
-    # null检查
-    data.description ?: "无描述"
+    // null/空时的默认值（Elvis 运算符）
+    description ?: "无说明"
 
 日期操作
 --------
 
 ::
 
-    # 当前日期时间
+    // 当前日期时间
     new Date()
 
-    # 格式化
-    new java.text.SimpleDateFormat("yyyy-MM-dd").format(data.date)
+    // 格式化
+    new java.text.SimpleDateFormat("yyyy-MM-dd").format(updated_at)
 
-可用对象
-======================
+执行上下文与可用对象
+====================
 
-脚本中可使用的主要对象:
+脚本中可使用的对象因执行脚本的上下文而异。
+仅 ``container`` 在所有上下文中均可使用。
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 75
+   :widths: 30 25 45
 
-   * - 对象
+   * - 执行上下文
+     - 可用对象
      - 说明
-   * - ``data``
-     - 从数据存储获取的数据
-   * - ``container``
-     - DI容器（访问组件）
-   * - ``container.getComponent("systemHelper")``
-     - 系统帮助器
-   * - ``container.getComponent("fessConfig")``
-     - |Fess| 的配置
+   * - 所有上下文
+     - ``container``
+     - DI 容器。可通过 ``container.getComponent("systemHelper")`` 或
+       ``container.getComponent("fessConfig")`` 访问各组件
+   * - 数据存储脚本
+     - 连接器特有的字段变量
+     - 从数据存储获取的各字段可作为变量使用
+       （变量名、前缀因连接器而异。CSV/JSON 中字段名直接成为变量名）
+   * - 路径映射
+     - ``url`` ``matcher``
+     - 转换目标 URL 字符串及正则表达式 ``Matcher``（仅在带 ``groovy:`` 前缀的替换时）
+   * - 计划任务
+     - ``executor``
+     - 任务执行实例（ ``JobExecutor`` ）。用于控制任务的关闭
+
+.. note::
+   ``container`` 以外的对象仅在特定上下文中注入。
+   例如， ``executor`` 仅在计划任务中可用，在数据存储脚本和
+   路径映射中不可使用。
 
 安全性
-============
+======
 
 .. warning::
    脚本具有强大功能，请仅使用来自可信来源的脚本。
 
 - 脚本在服务器上执行
-- 可以访问文件系统和网络
+- 可访问文件系统和网络
 - 请确保只有具有管理员权限的用户才能编辑脚本
+- 脚本执行会记录在审计日志（ ``audit.log`` ）中。
+  是否记录由 ``script.audit.log.enabled`` 控制，默认值为 ``true``。
+  记录的脚本字符串的最大长度由 ``script.audit.log.max.length`` 控制，
+  默认值为 ``100`` 个字符。
 
 性能
-==============
+====
 
-优化脚本性能的提示:
+优化脚本性能的建议：
 
-1. **避免复杂处理**: 脚本会为每个文档执行
-2. **最小化外部资源访问**: 网络调用会导致延迟
-3. **利用缓存**: 考虑缓存重复使用的值
+1. **避免复杂处理**：数据存储脚本会针对每个文档执行
+2. **最小化外部资源访问**：网络调用会导致延迟
+3. **利用缓存**：考虑对重复使用的值进行缓存
 
 调试
-========
+====
 
-使用日志输出进行脚本调试:
+计划任务的脚本会作为一个完整的 Groovy 脚本求值，
+因此可以利用日志输出进行调试。
+（数据存储脚本中每行作为一个表达式求值，因此不能使用 ``import`` 语句或
+多行处理。）
 
 ::
 
     import org.apache.logging.log4j.LogManager
-    def logger = LogManager.getLogger("script")
-    logger.info("data.id = {}", data.id)
+    def logger = LogManager.getLogger("fess.script")
+    logger.info("executor = {}", executor)
 
-日志级别设置:
-
-``app/WEB-INF/classes/log4j2.xml``:
+上述示例使用名为 ``fess.script`` 的日志记录器。
+要输出该日志，需在 ``app/WEB-INF/classes/log4j2.xml`` 中
+添加相应的日志记录器配置。
 
 ::
 
-    <Logger name="script" level="DEBUG"/>
+    <Logger name="fess.script" level="DEBUG"/>
+
+此外，要启用脚本引擎本身的调试日志，需将 ``org.codelibs.fess.script``
+包的日志级别设为 ``DEBUG``。
+
+::
+
+    <Logger name="org.codelibs.fess.script" level="DEBUG"/>
 
 参考信息
 ========
 
-- :doc:`scripting-groovy` - Groovy脚本指南
+- :doc:`scripting-groovy` - Groovy 脚本指南
 - :doc:`../admin/dataconfig-guide` - 数据存储配置指南
 - :doc:`../admin/scheduler-guide` - 调度器配置指南


### PR DESCRIPTION
## Summary

Reviewed `config/scripting-overview` (15.7) against the Fess source code and corrected several technical inaccuracies. The Japanese version was fixed first as the source of truth, then the same corrections were applied to all other languages (en, de, es, fr, ko, zh-cn).

## Corrections

- **Data store scripts**: Removed the non-existent `data` variable prefix. Retrieved fields are exposed as top-level variables whose names/prefixes vary by connector (CSV/JSON use field names directly; file connectors use `file.*`, Slack uses `message.*`, etc.). Added a note that each line is a single Groovy expression (no multi-line `if`, `import`, or `def`).
- **Path mapping**: Clarified that it uses regex + replacement-string pairs by default and is not a Groovy script; Groovy is evaluated only when the replacement is prefixed with `groovy:`, exposing the `url` and `matcher` variables.
- **Available objects**: Replaced the flat object list with a per-context table. `container` is available in all contexts; `executor` is injected only in scheduled jobs; `url`/`matcher` are available in path mapping.
- **Scheduled job example**: Matched the shipped default script (includes `gcLogging()`).
- **Groovy syntax**: Replaced invalid `#` comments with `//` in all code examples.
- **Debugging**: Use a `fess.script` logger and document the `org.codelibs.fess.script` engine logger; previous `script` logger guidance was corrected.
- **Security**: Documented `script.audit.log.enabled` (default `true`) and `script.audit.log.max.length` (default `100`).

## Verification

- All technical claims verified against Fess source (`GroovyEngine`, `ScriptExecutor`, `AbstractDataStore`, `PathMappingHelper`, `ExecJob`/`CrawlJob`, `ActivityHelper`, `fess_config.properties`, `scheduled_job.bulk`).
- Confirmed no leftover `#` comments or `data.` prefixes in code blocks.
- Validated RST section underline widths across all 7 language files.