### PR TITLE
docs(15.7): correct SPNEGO SSO configuration against implementation

### DIFF
--- a/de/15.7/config/sso-spnego.rst
+++ b/de/15.7/config/sso-spnego.rst
@@ -1,6 +1,6 @@
-====================================================
-SSO-Konfiguration mit Windows-Integrierte Auth
-====================================================
+=============================================
+SSO-Konfiguration mit Windows-integrierter Authentifizierung
+=============================================
 
 Übersicht
 =========
@@ -34,8 +34,8 @@ Bevor Sie die Windows-integrierte Authentifizierung konfigurieren, überprüfen 
 - Sie haben die Berechtigung, Dienstprinzipalnamen (SPN) in AD zu konfigurieren
 - Ein Konto zum Abrufen von Benutzerinformationen über LDAP ist verfügbar
 
-Active Directory-Seitige Konfiguration
-======================================
+Active Directory-seitige Konfiguration
+=======================================
 
 Registrieren des Dienstprinzipalnamens (SPN)
 --------------------------------------------
@@ -117,6 +117,10 @@ Erstellen Sie ``app/WEB-INF/classes/auth_login.conf`` mit der JAAS-Login-Konfigu
         isInitiator=false;
     };
 
+.. note::
+   Die Standarddateinamen für ``krb5.conf`` und ``auth_login.conf`` werden über ``spnego.krb5.conf`` bzw. ``spnego.login.conf`` festgelegt, die Dateien selbst müssen jedoch zwingend erstellt werden.
+   Sind diese Dateien nicht im Classpath vorhanden, schlägt die SPNEGO-Initialisierung fehl und |Fess| kann nicht gestartet werden.
+
 Erforderliche Einstellungen
 ---------------------------
 
@@ -167,7 +171,7 @@ Die folgenden Einstellungen können bei Bedarf hinzugefügt werden.
      - Unsichere Basic-Authentifizierung erlauben
      - ``true``
    * - ``spnego.prompt.ntlm``
-     - NTLM-Aufforderung anzeigen
+     - Bei Empfang eines NTLM-Tokens auf Basic-Authentifizierung zurückfallen
      - ``true``
    * - ``spnego.allow.localhost``
      - Localhost-Zugriff erlauben
@@ -179,12 +183,21 @@ Die folgenden Einstellungen können bei Bedarf hinzugefügt werden.
      - Von der Authentifizierung ausgeschlossene Verzeichnisse (kommagetrennt)
      - (Keine)
    * - ``spnego.logger.level``
-     - Protokollebene (0-7)
-     - (Auto)
+     - Interner Protokollierungsgrad der SPNEGO-Bibliothek (``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE; alle anderen Werte einschließlich ``0`` und ``5`` werden als INFO behandelt)
+     - (Automatisch)
 
 .. warning::
    ``spnego.allow.unsecure.basic=true`` kann Base64-kodierte Anmeldeinformationen über unverschlüsselte Verbindungen senden.
    Für Produktionsumgebungen wird dringend empfohlen, dies auf ``false`` zu setzen und HTTPS zu verwenden.
+
+.. note::
+   Wenn ``spnego.prompt.ntlm=true`` (Standard), muss auch ``spnego.allow.basic`` auf ``true`` gesetzt sein.
+   Wenn Sie ``spnego.allow.basic=false`` setzen, müssen Sie gleichzeitig ``spnego.prompt.ntlm=false`` setzen.
+   Wird diese Bedingung nicht erfüllt, tritt bei der SPNEGO-Initialisierung ein Fehler auf.
+
+.. note::
+   ``spnego.logger.level`` steuert den Protokollierungsgrad des internen Loggers der SPNEGO-Bibliothek (``java.util.logging``-Logger mit dem Namen ``Spnego``).
+   Wenn nicht gesetzt, wird er automatisch entsprechend dem Protokollierungsgrad von |Fess| bestimmt.
 
 LDAP-Konfiguration
 ==================
@@ -246,7 +259,7 @@ Konfigurationsbeispiele
 =======================
 
 Minimale Konfiguration (zum Testen)
------------------------------------
+------------------------------------
 
 Das Folgende ist ein minimales Konfigurationsbeispiel für eine Testumgebung.
 
@@ -296,7 +309,7 @@ Das Folgende ist ein minimales Konfigurationsbeispiel für eine Testumgebung.
     };
 
 Empfohlene Konfiguration (für Produktion)
------------------------------------------
+------------------------------------------
 
 Das Folgende ist ein empfohlenes Konfigurationsbeispiel für Produktionsumgebungen.
 
@@ -316,52 +329,61 @@ Das Folgende ist ein empfohlenes Konfigurationsbeispiel für Produktionsumgebung
     # Sicherheitseinstellungen (Produktion)
     spnego.allow.basic=false
     spnego.allow.unsecure.basic=false
+    spnego.prompt.ntlm=false
     spnego.allow.localhost=false
+
+.. note::
+   Wenn Sie ``spnego.allow.basic=false`` setzen, müssen Sie auch ``spnego.prompt.ntlm=false`` zwingend setzen.
+   Da ``spnego.prompt.ntlm`` standardmäßig ``true`` ist, tritt bei der Initialisierung ein Fehler auf, wenn diese Einstellung weggelassen wird.
 
 Fehlerbehebung
 ==============
 
 Häufige Probleme und Lösungen
------------------------------
+------------------------------
 
 Authentifizierungsdialog erscheint
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Überprüfen Sie, ob der Fess-Server in den Browser-Einstellungen zur Zone "Lokales Intranet" hinzugefügt wurde
 - Überprüfen Sie, ob "Integrierte Windows-Authentifizierung aktivieren" aktiviert ist
 - Überprüfen Sie, ob der SPN korrekt registriert ist (``setspn -L <Benutzername>``)
 
 Authentifizierungsfehler treten auf
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Überprüfen Sie, ob der Domänenname (Großbuchstaben) und der AD-Servername in ``krb5.conf`` korrekt sind
 - Überprüfen Sie, ob ``spnego.preauth.username`` und ``spnego.preauth.password`` korrekt sind
 - Überprüfen Sie die Netzwerkverbindung zum AD-Server
 
 Gruppeninformationen können nicht abgerufen werden
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Überprüfen Sie, ob die LDAP-Einstellungen korrekt sind
 - Überprüfen Sie, ob Bind-DN und Passwort korrekt sind
 - Überprüfen Sie, ob der Benutzer in AD zu Gruppen gehört
 
 Debug-Einstellungen
--------------------
+--------------------
 
-Um Probleme zu untersuchen, können Sie detaillierte SPNEGO-bezogene Protokolle ausgeben, indem Sie die |Fess|-Protokollebene anpassen.
+Um Probleme zu untersuchen, können Sie detaillierte SPNEGO-bezogene Protokolle ausgeben.
 
-Fügen Sie Folgendes zu ``app/WEB-INF/conf/system.properties`` hinzu:
+Um detaillierte interne Protokolle der SPNEGO-Bibliothek auszugeben, fügen Sie Folgendes zu ``app/WEB-INF/conf/system.properties`` hinzu.
+``spnego.logger.level=1`` gibt die ausführlichsten Protokolle (FINEST) aus.
 
 ::
 
     spnego.logger.level=1
 
-Oder fügen Sie die folgenden Logger zu ``app/WEB-INF/classes/log4j2.xml`` hinzu:
+Um detaillierte Protokolle der SPNEGO-Integrations-Verarbeitung auf der |Fess|-Seite (Paket ``org.codelibs.fess.sso.spnego``) auszugeben, fügen Sie den folgenden Logger zu ``app/WEB-INF/classes/log4j2.xml`` hinzu.
 
 ::
 
     <Logger name="org.codelibs.fess.sso.spnego" level="DEBUG"/>
-    <Logger name="org.codelibs.spnego" level="DEBUG"/>
+
+.. note::
+   Die Protokolle der SPNEGO-Bibliothek selbst werden über ``java.util.logging`` ausgegeben und daher über ``spnego.logger.level`` und nicht über ``log4j2.xml`` gesteuert.
+   Die Protokolle der Integrations-Verarbeitung auf der |Fess|-Seite werden über den Logger in ``log4j2.xml`` gesteuert.
 
 Referenz
 ========
@@ -370,4 +392,3 @@ Referenz
 - :doc:`sso-saml` - SSO-Konfiguration mit SAML-Authentifizierung
 - :doc:`sso-oidc` - SSO-Konfiguration mit OpenID Connect-Authentifizierung
 - :doc:`sso-entraid` - SSO-Konfiguration mit Microsoft Entra ID
-

--- a/en/15.7/config/sso-spnego.rst
+++ b/en/15.7/config/sso-spnego.rst
@@ -38,7 +38,7 @@ Active Directory Side Configuration
 ====================================
 
 Registering Service Principal Name (SPN)
-----------------------------------------
+-----------------------------------------
 
 You need to register an SPN for |Fess| in Active Directory.
 Open a command prompt on a Windows computer joined to the AD domain and run the ``setspn`` command.
@@ -75,7 +75,7 @@ To enable Windows Integrated Authentication, add the following setting in ``app/
     sso.type=spnego
 
 Kerberos Configuration File
----------------------------
+----------------------------
 
 Create ``app/WEB-INF/classes/krb5.conf`` with the Kerberos configuration.
 
@@ -116,6 +116,10 @@ Create ``app/WEB-INF/classes/auth_login.conf`` with the JAAS login configuration
         storeKey=true
         isInitiator=false;
     };
+
+.. note::
+   ``krb5.conf`` and ``auth_login.conf`` have their default filenames set via ``spnego.krb5.conf`` / ``spnego.login.conf``, but the files themselves must be created.
+   If these files do not exist on the classpath, SPNEGO initialization will fail and |Fess| will not start.
 
 Required Settings
 -----------------
@@ -167,7 +171,7 @@ The following settings can be added as needed.
      - Allow unsecure Basic authentication
      - ``true``
    * - ``spnego.prompt.ntlm``
-     - Show NTLM prompt
+     - Fall back to Basic authentication when an NTLM token is received
      - ``true``
    * - ``spnego.allow.localhost``
      - Allow localhost access
@@ -179,12 +183,21 @@ The following settings can be added as needed.
      - Directories to exclude from authentication (comma-separated)
      - (None)
    * - ``spnego.logger.level``
-     - Log level (0-7)
+     - Internal log level of the SPNEGO library (``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE; any other value including ``0`` and ``5`` is treated as INFO)
      - (Auto)
 
 .. warning::
    ``spnego.allow.unsecure.basic=true`` may send Base64-encoded credentials over unencrypted connections.
    For production environments, it is strongly recommended to set this to ``false`` and use HTTPS.
+
+.. note::
+   When ``spnego.prompt.ntlm=true`` (the default), ``spnego.allow.basic`` must also be ``true``.
+   If you set ``spnego.allow.basic=false``, you must also set ``spnego.prompt.ntlm=false``.
+   If this condition is not met, an error will occur during SPNEGO initialization.
+
+.. note::
+   ``spnego.logger.level`` controls the log level of the SPNEGO library's internal logger (a ``java.util.logging`` logger named ``Spnego``).
+   When not set, the level is determined automatically based on the |Fess| log level.
 
 LDAP Configuration
 ==================
@@ -219,7 +232,7 @@ Browser Settings
 Client browser settings are required to use Windows Integrated Authentication.
 
 Internet Explorer / Microsoft Edge
-----------------------------------
+-----------------------------------
 
 1. Open Internet Options
 2. Select the "Security" tab
@@ -246,7 +259,7 @@ Configuration Examples
 ======================
 
 Minimal Configuration (for Testing)
------------------------------------
+-------------------------------------
 
 The following is a minimal configuration example for a test environment.
 
@@ -296,7 +309,7 @@ The following is a minimal configuration example for a test environment.
     };
 
 Recommended Configuration (for Production)
-------------------------------------------
+-------------------------------------------
 
 The following is a recommended configuration example for production environments.
 
@@ -316,30 +329,35 @@ The following is a recommended configuration example for production environments
     # Security settings (production)
     spnego.allow.basic=false
     spnego.allow.unsecure.basic=false
+    spnego.prompt.ntlm=false
     spnego.allow.localhost=false
+
+.. note::
+   When setting ``spnego.allow.basic=false``, you must also set ``spnego.prompt.ntlm=false``.
+   Since ``spnego.prompt.ntlm`` defaults to ``true``, omitting this setting will cause an error during initialization.
 
 Troubleshooting
 ===============
 
 Common Issues and Solutions
----------------------------
+----------------------------
 
 Authentication Dialog Appears
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Verify that the Fess server is added to the Local Intranet zone in browser settings
 - Check that "Enable Integrated Windows Authentication" is enabled
 - Verify that the SPN is correctly registered (``setspn -L <username>``)
 
 Authentication Errors Occur
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Verify that the domain name (uppercase) and AD server name in ``krb5.conf`` are correct
 - Check that ``spnego.preauth.username`` and ``spnego.preauth.password`` are correct
 - Verify network connectivity to the AD server
 
 Cannot Retrieve Group Information
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Verify that LDAP settings are correct
 - Check that Bind DN and password are correct
@@ -348,20 +366,24 @@ Cannot Retrieve Group Information
 Debug Settings
 --------------
 
-To investigate issues, you can output detailed SPNEGO-related logs by adjusting the |Fess| log level.
+To investigate issues, you can output detailed SPNEGO-related logs.
 
-Add the following to ``app/WEB-INF/conf/system.properties``:
+To output verbose internal logs from the SPNEGO library, add the following to ``app/WEB-INF/conf/system.properties``.
+``spnego.logger.level=1`` outputs the most detailed logs (FINEST).
 
 ::
 
     spnego.logger.level=1
 
-Or add the following loggers to ``app/WEB-INF/classes/log4j2.xml``:
+To output detailed logs for the |Fess|-side SPNEGO integration processing (the ``org.codelibs.fess.sso.spnego`` package), add the following logger to ``app/WEB-INF/classes/log4j2.xml``:
 
 ::
 
     <Logger name="org.codelibs.fess.sso.spnego" level="DEBUG"/>
-    <Logger name="org.codelibs.spnego" level="DEBUG"/>
+
+.. note::
+   The SPNEGO library itself outputs logs via ``java.util.logging``, so its log level is controlled by ``spnego.logger.level`` rather than ``log4j2.xml``.
+   The |Fess|-side integration logs are controlled by the ``log4j2.xml`` logger.
 
 Reference
 =========
@@ -370,4 +392,3 @@ Reference
 - :doc:`sso-saml` - SSO configuration with SAML authentication
 - :doc:`sso-oidc` - SSO configuration with OpenID Connect authentication
 - :doc:`sso-entraid` - SSO configuration with Microsoft Entra ID
-

--- a/es/15.7/config/sso-spnego.rst
+++ b/es/15.7/config/sso-spnego.rst
@@ -9,7 +9,7 @@ Descripción general
 Al utilizar la Autenticación Integrada de Windows, los usuarios que han iniciado sesión en una computadora unida al dominio Windows pueden acceder a |Fess| sin operaciones de inicio de sesión adicionales.
 
 Cómo funciona la Autenticación Integrada de Windows
----------------------------------------------------
+----------------------------------------------------
 
 En la Autenticación Integrada de Windows, |Fess| utiliza el protocolo SPNEGO (Simple and Protected GSSAPI Negotiation Mechanism) para la autenticación Kerberos.
 
@@ -35,10 +35,10 @@ Antes de configurar la Autenticación Integrada de Windows, verifique los siguie
 - Una cuenta para recuperar información de usuario vía LDAP está disponible
 
 Configuración del lado de Active Directory
-===========================================
+==========================================
 
 Registro del Nombre de Principal de Servicio (SPN)
---------------------------------------------------
+---------------------------------------------------
 
 Necesita registrar un SPN para |Fess| en Active Directory.
 Abra un símbolo del sistema en una computadora Windows unida al dominio AD y ejecute el comando ``setspn``.
@@ -75,7 +75,7 @@ Para habilitar la Autenticación Integrada de Windows, agregue la siguiente conf
     sso.type=spnego
 
 Archivo de configuración de Kerberos
-------------------------------------
+-------------------------------------
 
 Cree ``app/WEB-INF/classes/krb5.conf`` con la configuración de Kerberos.
 
@@ -101,7 +101,7 @@ Cree ``app/WEB-INF/classes/krb5.conf`` con la configuración de Kerberos.
    Reemplace ``EXAMPLE.LOCAL`` con su nombre de dominio AD (en mayúsculas) y ``AD-SERVER.EXAMPLE.LOCAL`` con el nombre de host de su servidor AD.
 
 Archivo de configuración de inicio de sesión
---------------------------------------------
+---------------------------------------------
 
 Cree ``app/WEB-INF/classes/auth_login.conf`` con la configuración de inicio de sesión JAAS.
 
@@ -116,6 +116,10 @@ Cree ``app/WEB-INF/classes/auth_login.conf`` con la configuración de inicio de 
         storeKey=true
         isInitiator=false;
     };
+
+.. note::
+   Los nombres de archivo predeterminados para ``krb5.conf`` y ``auth_login.conf`` están definidos en ``spnego.krb5.conf`` y ``spnego.login.conf`` respectivamente, pero los archivos en sí deben crearse obligatoriamente.
+   Si estos archivos no están presentes en el classpath, la inicialización de SPNEGO fallará y |Fess| no podrá iniciarse.
 
 Configuración requerida
 -----------------------
@@ -167,10 +171,10 @@ Las siguientes configuraciones pueden agregarse según sea necesario.
      - Permitir autenticación Basic no segura
      - ``true``
    * - ``spnego.prompt.ntlm``
-     - Mostrar solicitud NTLM
+     - Retroceder a autenticación Basic cuando se recibe un token NTLM
      - ``true``
    * - ``spnego.allow.localhost``
-     - Permitir acceso localhost
+     - Permitir acceso desde localhost
      - ``true``
    * - ``spnego.allow.delegation``
      - Permitir delegación
@@ -179,12 +183,21 @@ Las siguientes configuraciones pueden agregarse según sea necesario.
      - Directorios excluidos de autenticación (separados por comas)
      - (Ninguno)
    * - ``spnego.logger.level``
-     - Nivel de log (0-7)
-     - (Auto)
+     - Nivel de log interno de la biblioteca SPNEGO (``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE; cualquier otro valor, incluidos ``0`` y ``5``, se trata como INFO)
+     - (Automático)
 
 .. warning::
    ``spnego.allow.unsecure.basic=true`` puede enviar credenciales codificadas en Base64 sobre conexiones no cifradas.
    Para entornos de producción, se recomienda encarecidamente establecer esto en ``false`` y usar HTTPS.
+
+.. note::
+   Cuando ``spnego.prompt.ntlm=true`` (valor predeterminado), ``spnego.allow.basic`` también debe ser ``true``.
+   Si establece ``spnego.allow.basic=false``, debe establecer también ``spnego.prompt.ntlm=false``.
+   Si no se cumple esta condición, se producirá un error durante la inicialización de SPNEGO.
+
+.. note::
+   ``spnego.logger.level`` controla el nivel de log del logger interno de la biblioteca SPNEGO (el logger llamado ``Spnego`` de ``java.util.logging``).
+   Si no se especifica, el nivel se determina automáticamente en función del nivel de log de |Fess|.
 
 Configuración LDAP
 ==================
@@ -214,12 +227,12 @@ Configure los ajustes LDAP en el panel de administración de |Fess| bajo "Sistem
      - ``memberOf``
 
 Configuración del navegador
-===========================
+============================
 
 Se requieren configuraciones del navegador del cliente para usar la Autenticación Integrada de Windows.
 
 Internet Explorer / Microsoft Edge
-----------------------------------
+-----------------------------------
 
 1. Abrir Opciones de Internet
 2. Seleccionar la pestaña "Seguridad"
@@ -243,10 +256,10 @@ Mozilla Firefox
 3. Establecer la URL o dominio del servidor Fess (ej: ``https://fess-server.example.local``)
 
 Ejemplos de configuración
-=========================
+==========================
 
 Configuración mínima (para pruebas)
------------------------------------
+------------------------------------
 
 El siguiente es un ejemplo de configuración mínima para un entorno de pruebas.
 
@@ -296,7 +309,7 @@ El siguiente es un ejemplo de configuración mínima para un entorno de pruebas.
     };
 
 Configuración recomendada (para producción)
--------------------------------------------
+--------------------------------------------
 
 El siguiente es un ejemplo de configuración recomendada para entornos de producción.
 
@@ -316,52 +329,61 @@ El siguiente es un ejemplo de configuración recomendada para entornos de produc
     # Configuración de seguridad (producción)
     spnego.allow.basic=false
     spnego.allow.unsecure.basic=false
+    spnego.prompt.ntlm=false
     spnego.allow.localhost=false
+
+.. note::
+   Al establecer ``spnego.allow.basic=false``, también debe establecer ``spnego.prompt.ntlm=false``.
+   Como ``spnego.prompt.ntlm`` es ``true`` de forma predeterminada, omitir esta configuración provocará un error durante la inicialización.
 
 Solución de problemas
 =====================
 
 Problemas comunes y soluciones
-------------------------------
+-------------------------------
 
 Aparece el diálogo de autenticación
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Verifique que el servidor Fess está agregado a la zona Intranet local en la configuración del navegador
 - Verifique que "Habilitar autenticación integrada de Windows" está habilitado
 - Verifique que el SPN está correctamente registrado (``setspn -L <nombre de usuario>``)
 
 Ocurren errores de autenticación
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Verifique que el nombre de dominio (mayúsculas) y el nombre del servidor AD en ``krb5.conf`` son correctos
 - Verifique que ``spnego.preauth.username`` y ``spnego.preauth.password`` son correctos
 - Verifique la conectividad de red al servidor AD
 
 No se puede recuperar la información de grupo
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Verifique que la configuración LDAP es correcta
 - Verifique que el Bind DN y la contraseña son correctos
 - Verifique que el usuario pertenece a grupos en AD
 
 Configuración de depuración
----------------------------
+-----------------------------
 
-Para investigar problemas, puede mostrar logs detallados relacionados con SPNEGO ajustando el nivel de log de |Fess|.
+Para investigar problemas, puede mostrar logs detallados relacionados con SPNEGO.
 
-Agregue lo siguiente a ``app/WEB-INF/conf/system.properties``:
+Para obtener el log detallado interno de la biblioteca SPNEGO, agregue lo siguiente a ``app/WEB-INF/conf/system.properties``.
+``spnego.logger.level=1`` produce el log más detallado (FINEST).
 
 ::
 
     spnego.logger.level=1
 
-O agregue los siguientes loggers a ``app/WEB-INF/classes/log4j2.xml``:
+Para obtener el log detallado del procesamiento de integración SPNEGO del lado de |Fess| (paquete ``org.codelibs.fess.sso.spnego``), agregue el siguiente logger a ``app/WEB-INF/classes/log4j2.xml``:
 
 ::
 
     <Logger name="org.codelibs.fess.sso.spnego" level="DEBUG"/>
-    <Logger name="org.codelibs.spnego" level="DEBUG"/>
+
+.. note::
+   Los logs de la propia biblioteca SPNEGO se emiten mediante ``java.util.logging`` y se controlan con ``spnego.logger.level``, no a través de ``log4j2.xml``.
+   Los logs del procesamiento de integración del lado de |Fess| se controlan con el logger de ``log4j2.xml``.
 
 Referencia
 ==========
@@ -370,4 +392,3 @@ Referencia
 - :doc:`sso-saml` - Configuración de SSO con autenticación SAML
 - :doc:`sso-oidc` - Configuración de SSO con autenticación OpenID Connect
 - :doc:`sso-entraid` - Configuración de SSO con Microsoft Entra ID
-

--- a/fr/15.7/config/sso-spnego.rst
+++ b/fr/15.7/config/sso-spnego.rst
@@ -117,6 +117,10 @@ Créez ``app/WEB-INF/classes/auth_login.conf`` avec la configuration de connexio
         isInitiator=false;
     };
 
+.. note::
+   Les noms de fichier par défaut de ``krb5.conf`` et ``auth_login.conf`` sont définis respectivement par ``spnego.krb5.conf`` et ``spnego.login.conf``, mais ces fichiers doivent impérativement être créés.
+   Si ces fichiers sont absents du classpath, l'initialisation de SPNEGO échoue et |Fess| ne peut pas démarrer.
+
 Paramètres requis
 -----------------
 
@@ -167,10 +171,10 @@ Les paramètres suivants peuvent être ajoutés si nécessaire.
      - Autoriser l'authentification Basic non sécurisée
      - ``true``
    * - ``spnego.prompt.ntlm``
-     - Afficher l'invite NTLM
+     - Revenir à l'authentification Basic lors de la réception d'un jeton NTLM
      - ``true``
    * - ``spnego.allow.localhost``
-     - Autoriser l'accès localhost
+     - Autoriser l'accès depuis localhost
      - ``true``
    * - ``spnego.allow.delegation``
      - Autoriser la délégation
@@ -179,12 +183,21 @@ Les paramètres suivants peuvent être ajoutés si nécessaire.
      - Répertoires exclus de l'authentification (séparés par des virgules)
      - (Aucun)
    * - ``spnego.logger.level``
-     - Niveau de log (0-7)
-     - (Auto)
+     - Niveau de log interne de la bibliothèque SPNEGO (``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE ; toute autre valeur, y compris ``0`` et ``5``, est traitée comme INFO)
+     - (Automatique)
 
 .. warning::
    ``spnego.allow.unsecure.basic=true`` peut envoyer des identifiants encodés en Base64 sur des connexions non chiffrées.
    Pour les environnements de production, il est fortement recommandé de définir cette valeur sur ``false`` et d'utiliser HTTPS.
+
+.. note::
+   Lorsque ``spnego.prompt.ntlm=true`` (valeur par défaut), ``spnego.allow.basic`` doit également être ``true``.
+   Si vous définissez ``spnego.allow.basic=false``, vous devez également définir ``spnego.prompt.ntlm=false``.
+   Si cette condition n'est pas respectée, une erreur se produit lors de l'initialisation de SPNEGO.
+
+.. note::
+   ``spnego.logger.level`` contrôle le niveau de log du logger interne de la bibliothèque SPNEGO (le logger ``java.util.logging`` nommé ``Spnego``).
+   Si ce paramètre n'est pas défini, le niveau est déterminé automatiquement en fonction du niveau de log de |Fess|.
 
 Configuration LDAP
 ==================
@@ -240,7 +253,7 @@ Mozilla Firefox
 
 1. Entrer ``about:config`` dans la barre d'adresse
 2. Rechercher ``network.negotiate-auth.trusted-uris``
-3. Définir l'URL ou le domaine du serveur Fess (ex: ``https://fess-server.example.local``)
+3. Définir l'URL ou le domaine du serveur Fess (ex : ``https://fess-server.example.local``)
 
 Exemples de configuration
 =========================
@@ -316,7 +329,12 @@ Voici un exemple de configuration recommandée pour les environnements de produc
     # Paramètres de sécurité (production)
     spnego.allow.basic=false
     spnego.allow.unsecure.basic=false
+    spnego.prompt.ntlm=false
     spnego.allow.localhost=false
+
+.. note::
+   Si vous définissez ``spnego.allow.basic=false``, vous devez également définir ``spnego.prompt.ntlm=false``.
+   La valeur par défaut de ``spnego.prompt.ntlm`` est ``true`` ; omettre ce paramètre provoque une erreur lors de l'initialisation.
 
 Dépannage
 =========
@@ -348,20 +366,24 @@ Impossible de récupérer les informations de groupe
 Paramètres de débogage
 ----------------------
 
-Pour investiguer les problèmes, vous pouvez afficher des logs détaillés liés à SPNEGO en ajustant le niveau de log de |Fess|.
+Pour investiguer les problèmes, vous pouvez afficher des logs détaillés liés à SPNEGO.
 
-Ajoutez ce qui suit à ``app/WEB-INF/conf/system.properties`` :
+Pour afficher les logs détaillés internes de la bibliothèque SPNEGO, ajoutez ce qui suit à ``app/WEB-INF/conf/system.properties``.
+``spnego.logger.level=1`` produit les logs les plus détaillés (FINEST).
 
 ::
 
     spnego.logger.level=1
 
-Ou ajoutez les loggers suivants à ``app/WEB-INF/classes/log4j2.xml`` :
+Pour afficher les logs détaillés du traitement SPNEGO côté |Fess| (package ``org.codelibs.fess.sso.spnego``), ajoutez le logger suivant à ``app/WEB-INF/classes/log4j2.xml`` :
 
 ::
 
     <Logger name="org.codelibs.fess.sso.spnego" level="DEBUG"/>
-    <Logger name="org.codelibs.spnego" level="DEBUG"/>
+
+.. note::
+   Les logs de la bibliothèque SPNEGO elle-même sont émis via ``java.util.logging`` et se contrôlent avec ``spnego.logger.level``, non via ``log4j2.xml``.
+   Les logs du traitement d'intégration côté |Fess| se contrôlent via le logger ``log4j2.xml``.
 
 Référence
 =========
@@ -370,4 +392,3 @@ Référence
 - :doc:`sso-saml` - Configuration SSO avec authentification SAML
 - :doc:`sso-oidc` - Configuration SSO avec authentification OpenID Connect
 - :doc:`sso-entraid` - Configuration SSO avec Microsoft Entra ID
-

--- a/ja/15.7/config/sso-spnego.rst
+++ b/ja/15.7/config/sso-spnego.rst
@@ -117,6 +117,10 @@ Kerberos設定ファイル
         isInitiator=false;
     };
 
+.. note::
+   ``krb5.conf`` と ``auth_login.conf`` は、 ``spnego.krb5.conf`` / ``spnego.login.conf`` でデフォルトのファイル名が設定されますが、ファイル自体は必ず作成しておく必要があります。
+   これらのファイルがクラスパス上に存在しない場合、SPNEGOの初期化に失敗し |Fess| が起動できません。
+
 必須設定
 --------
 
@@ -167,7 +171,7 @@ Kerberos設定ファイル
      - 非セキュアなBasic認証を許可
      - ``true``
    * - ``spnego.prompt.ntlm``
-     - NTLMプロンプトを表示
+     - NTLMトークン受信時にBasic認証へフォールバックする
      - ``true``
    * - ``spnego.allow.localhost``
      - localhostからのアクセスを許可
@@ -179,12 +183,21 @@ Kerberos設定ファイル
      - 認証除外ディレクトリ（カンマ区切り）
      - （なし）
    * - ``spnego.logger.level``
-     - ログレベル（0-7）
+     - SPNEGOライブラリ内部のログレベル（``1`` =FINEST、 ``2`` =FINER、 ``3`` =FINE、 ``4`` =CONFIG、 ``6`` =WARNING、 ``7`` =SEVERE。これら以外の値（ ``0`` 、 ``5`` を含む）はINFO扱い）
      - （自動）
 
 .. warning::
    ``spnego.allow.unsecure.basic=true`` は、Base64エンコードされた認証情報を暗号化されていない接続で送信する可能性があります。
    本番環境では ``false`` に設定し、HTTPSを使用することを強く推奨します。
+
+.. note::
+   ``spnego.prompt.ntlm=true`` （デフォルト）の場合、 ``spnego.allow.basic`` も ``true`` である必要があります。
+   ``spnego.allow.basic=false`` に設定する場合は、 ``spnego.prompt.ntlm=false`` も併せて設定してください。
+   この条件を満たさない場合、SPNEGOの初期化時にエラーが発生します。
+
+.. note::
+   ``spnego.logger.level`` は、SPNEGOライブラリ内部のロガー（ ``java.util.logging`` の ``Spnego`` という名前のロガー）のログレベルを制御します。
+   未設定の場合は、 |Fess| のログレベルに応じて自動的に決定されます。
 
 LDAP設定
 ========
@@ -316,7 +329,12 @@ Mozilla Firefox
     # セキュリティ設定（本番環境）
     spnego.allow.basic=false
     spnego.allow.unsecure.basic=false
+    spnego.prompt.ntlm=false
     spnego.allow.localhost=false
+
+.. note::
+   ``spnego.allow.basic=false`` を設定する場合は、 ``spnego.prompt.ntlm=false`` も必ず設定してください。
+   ``spnego.prompt.ntlm`` はデフォルトで ``true`` のため、この設定を省略すると初期化時にエラーが発生します。
 
 トラブルシューティング
 ======================
@@ -348,20 +366,24 @@ Mozilla Firefox
 デバッグ設定
 ------------
 
-問題を調査するために、 |Fess| のログレベルを調整してSPNEGO関連の詳細ログを出力できます。
+問題を調査するために、SPNEGO関連の詳細ログを出力できます。
 
-``app/WEB-INF/conf/system.properties`` に以下を追加：
+SPNEGOライブラリ内部の詳細ログを出力するには、 ``app/WEB-INF/conf/system.properties`` に以下を追加します。
+``spnego.logger.level=1`` は最も詳細なログ（FINEST）を出力します。
 
 ::
 
     spnego.logger.level=1
 
-または、 ``app/WEB-INF/classes/log4j2.xml`` に以下のロガーを追加：
+|Fess| 側のSPNEGO連携処理（``org.codelibs.fess.sso.spnego`` パッケージ）の詳細ログを出力するには、 ``app/WEB-INF/classes/log4j2.xml`` に以下のロガーを追加します。
 
 ::
 
     <Logger name="org.codelibs.fess.sso.spnego" level="DEBUG"/>
-    <Logger name="org.codelibs.spnego" level="DEBUG"/>
+
+.. note::
+   SPNEGOライブラリ自体のログは ``java.util.logging`` で出力されるため、 ``log4j2.xml`` ではなく ``spnego.logger.level`` で制御します。
+   |Fess| 側の連携処理のログは ``log4j2.xml`` のロガーで制御します。
 
 参考情報
 ========

--- a/ko/15.7/config/sso-spnego.rst
+++ b/ko/15.7/config/sso-spnego.rst
@@ -117,6 +117,10 @@ Kerberos 설정 파일
         isInitiator=false;
     };
 
+.. note::
+   ``krb5.conf`` 와 ``auth_login.conf`` 는 ``spnego.krb5.conf`` / ``spnego.login.conf`` 로 기본 파일명이 설정되어 있지만, 파일 자체는 반드시 생성해 두어야 합니다.
+   이 파일들이 클래스패스 상에 존재하지 않으면 SPNEGO 초기화에 실패하여 |Fess| 가 시작되지 않습니다.
+
 필수 설정
 ----------
 
@@ -167,7 +171,7 @@ Kerberos 설정 파일
      - 비보안 Basic 인증 허용
      - ``true``
    * - ``spnego.prompt.ntlm``
-     - NTLM 프롬프트 표시
+     - NTLM 토큰 수신 시 Basic 인증으로 폴백
      - ``true``
    * - ``spnego.allow.localhost``
      - localhost에서의 접근 허용
@@ -179,12 +183,21 @@ Kerberos 설정 파일
      - 인증 제외 디렉터리(쉼표 구분)
      - (없음)
    * - ``spnego.logger.level``
-     - 로그 레벨(0-7)
+     - SPNEGO 라이브러리 내부 로그 레벨( ``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE. 이 외의 값( ``0``, ``5`` 포함)은 INFO로 처리)
      - (자동)
 
 .. warning::
    ``spnego.allow.unsecure.basic=true`` 는 Base64로 인코딩된 인증 정보를 암호화되지 않은 연결로 송신할 가능성이 있습니다.
    프로덕션 환경에서는 ``false`` 로 설정하고 HTTPS를 사용할 것을 강력히 권장합니다.
+
+.. note::
+   ``spnego.prompt.ntlm=true`` (기본값)인 경우, ``spnego.allow.basic`` 도 ``true`` 이어야 합니다.
+   ``spnego.allow.basic=false`` 로 설정하는 경우에는 ``spnego.prompt.ntlm=false`` 도 함께 설정하십시오.
+   이 조건을 충족하지 않으면 SPNEGO 초기화 시 오류가 발생합니다.
+
+.. note::
+   ``spnego.logger.level`` 은 SPNEGO 라이브러리 내부의 로거( ``java.util.logging`` 의 ``Spnego`` 라는 이름의 로거)의 로그 레벨을 제어합니다.
+   미설정 시에는 |Fess| 의 로그 레벨에 따라 자동으로 결정됩니다.
 
 LDAP 설정
 =========
@@ -316,7 +329,12 @@ Mozilla Firefox
     # 보안 설정(프로덕션 환경)
     spnego.allow.basic=false
     spnego.allow.unsecure.basic=false
+    spnego.prompt.ntlm=false
     spnego.allow.localhost=false
+
+.. note::
+   ``spnego.allow.basic=false`` 로 설정하는 경우에는 ``spnego.prompt.ntlm=false`` 도 반드시 설정하십시오.
+   ``spnego.prompt.ntlm`` 은 기본값이 ``true`` 이므로, 이 설정을 생략하면 초기화 시 오류가 발생합니다.
 
 문제 해결
 =========
@@ -348,20 +366,24 @@ Mozilla Firefox
 디버그 설정
 -----------
 
-문제를 조사하기 위해 |Fess| 의 로그 레벨을 조정하여 SPNEGO 관련 상세 로그를 출력할 수 있습니다.
+문제를 조사하기 위해 SPNEGO 관련 상세 로그를 출력할 수 있습니다.
 
-``app/WEB-INF/conf/system.properties`` 에 다음을 추가:
+SPNEGO 라이브러리 내부의 상세 로그를 출력하려면 ``app/WEB-INF/conf/system.properties`` 에 다음을 추가합니다.
+``spnego.logger.level=1`` 은 가장 상세한 로그(FINEST)를 출력합니다.
 
 ::
 
     spnego.logger.level=1
 
-또는 ``app/WEB-INF/classes/log4j2.xml`` 에 다음 로거를 추가:
+|Fess| 측의 SPNEGO 연계 처리( ``org.codelibs.fess.sso.spnego`` 패키지)의 상세 로그를 출력하려면 ``app/WEB-INF/classes/log4j2.xml`` 에 다음 로거를 추가합니다.
 
 ::
 
     <Logger name="org.codelibs.fess.sso.spnego" level="DEBUG"/>
-    <Logger name="org.codelibs.spnego" level="DEBUG"/>
+
+.. note::
+   SPNEGO 라이브러리 자체의 로그는 ``java.util.logging`` 으로 출력되므로 ``log4j2.xml`` 이 아닌 ``spnego.logger.level`` 로 제어합니다.
+   |Fess| 측의 연계 처리 로그는 ``log4j2.xml`` 의 로거로 제어합니다.
 
 참고 정보
 =========

--- a/zh-cn/15.7/config/sso-spnego.rst
+++ b/zh-cn/15.7/config/sso-spnego.rst
@@ -117,6 +117,10 @@ Kerberos配置文件
         isInitiator=false;
     };
 
+.. note::
+   ``krb5.conf`` 和 ``auth_login.conf`` 的默认文件名分别由 ``spnego.krb5.conf`` / ``spnego.login.conf`` 指定，但这两个文件本身必须事先创建好。
+   如果这些文件不存在于类路径上，SPNEGO初始化将失败，|Fess| 将无法启动。
+
 必需设置
 --------
 
@@ -167,7 +171,7 @@ Kerberos配置文件
      - 允许非安全Basic认证
      - ``true``
    * - ``spnego.prompt.ntlm``
-     - 显示NTLM提示
+     - 收到NTLM令牌时回退到Basic认证
      - ``true``
    * - ``spnego.allow.localhost``
      - 允许localhost访问
@@ -179,12 +183,21 @@ Kerberos配置文件
      - 排除认证的目录（逗号分隔）
      - （无）
    * - ``spnego.logger.level``
-     - 日志级别（0-7）
+     - SPNEGO库内部日志级别（``1`` =FINEST、``2`` =FINER、``3`` =FINE、``4`` =CONFIG、``6`` =WARNING、``7`` =SEVERE。这些值以外的值（包括 ``0`` 和 ``5``）均视为INFO）
      - （自动）
 
 .. warning::
    ``spnego.allow.unsecure.basic=true`` 可能通过未加密的连接发送Base64编码的凭据。
    对于生产环境，强烈建议将此设置为 ``false`` 并使用HTTPS。
+
+.. note::
+   ``spnego.prompt.ntlm=true``（默认值）时，``spnego.allow.basic`` 也必须为 ``true``。
+   若要将 ``spnego.allow.basic`` 设为 ``false``，则必须同时将 ``spnego.prompt.ntlm`` 设为 ``false``。
+   不满足此条件时，SPNEGO初始化时将发生错误。
+
+.. note::
+   ``spnego.logger.level`` 控制SPNEGO库内部日志记录器（``java.util.logging`` 中名为 ``Spnego`` 的日志记录器）的日志级别。
+   未设置时，将根据 |Fess| 的日志级别自动确定。
 
 LDAP配置
 ========
@@ -316,7 +329,12 @@ Mozilla Firefox
     # 安全设置（生产环境）
     spnego.allow.basic=false
     spnego.allow.unsecure.basic=false
+    spnego.prompt.ntlm=false
     spnego.allow.localhost=false
+
+.. note::
+   设置 ``spnego.allow.basic=false`` 时，必须同时设置 ``spnego.prompt.ntlm=false``。
+   由于 ``spnego.prompt.ntlm`` 默认为 ``true``，省略此设置将导致初始化时发生错误。
 
 故障排除
 ========
@@ -348,26 +366,29 @@ Mozilla Firefox
 调试设置
 --------
 
-要调查问题，您可以通过调整 |Fess| 的日志级别来输出详细的SPNEGO相关日志。
+要调查问题，可以输出SPNEGO相关的详细日志。
 
-在 ``app/WEB-INF/conf/system.properties`` 中添加以下内容：
+要输出SPNEGO库内部的详细日志，请在 ``app/WEB-INF/conf/system.properties`` 中添加以下内容。
+``spnego.logger.level=1`` 将输出最详细的日志（FINEST）。
 
 ::
 
     spnego.logger.level=1
 
-或在 ``app/WEB-INF/classes/log4j2.xml`` 中添加以下日志记录器：
+要输出 |Fess| 侧SPNEGO联动处理（``org.codelibs.fess.sso.spnego`` 包）的详细日志，请在 ``app/WEB-INF/classes/log4j2.xml`` 中添加以下日志记录器。
 
 ::
 
     <Logger name="org.codelibs.fess.sso.spnego" level="DEBUG"/>
-    <Logger name="org.codelibs.spnego" level="DEBUG"/>
 
-参考
-====
+.. note::
+   SPNEGO库本身的日志通过 ``java.util.logging`` 输出，因此通过 ``spnego.logger.level`` 而非 ``log4j2.xml`` 进行控制。
+   |Fess| 侧联动处理的日志通过 ``log4j2.xml`` 中的日志记录器进行控制。
+
+参考信息
+========
 
 - :doc:`security-role` - 基于角色的搜索配置
 - :doc:`sso-saml` - SAML认证SSO配置
 - :doc:`sso-oidc` - OpenID Connect认证SSO配置
 - :doc:`sso-entraid` - Microsoft Entra ID SSO配置
-


### PR DESCRIPTION
## Summary

Verified `ja/15.7/config/sso-spnego.rst` against the `SpnegoAuthenticator` implementation and the bundled `org.codelibs:spnego` library, corrected the inaccuracies, and propagated the corrections to all languages (`en`, `de`, `es`, `fr`, `ko`, `zh-cn`).

## Corrections

- **Production config example was broken.** Setting `spnego.allow.basic=false` while `spnego.prompt.ntlm` keeps its default (`true`) makes SPNEGO initialization throw at startup (`SpnegoFilterConfig`: "If prompt ntlm is true, then allow basic auth must also be true."). The production example now also sets `spnego.prompt.ntlm=false`, and a note documents the dependency.
- **Ineffective debug logger removed.** The library logs via `java.util.logging` under the logger name `Spnego` (not log4j2), so a log4j2 logger named `org.codelibs.spnego` captures nothing. Removed it; kept `org.codelibs.fess.sso.spnego` for the Fess-side integration and clarified that the library's verbosity is controlled by `spnego.logger.level`.
- **`spnego.logger.level` description corrected.** Actual mapping: `1`=FINEST, `2`=FINER, `3`=FINE, `4`=CONFIG, `6`=WARNING, `7`=SEVERE; any other value (including `0` and `5`) is treated as INFO. Default is derived automatically from the Fess log level.
- **`spnego.prompt.ntlm` description corrected** to "fall back to Basic authentication when an NTLM token is received" (default `true`).
- **Added a note** that `krb5.conf` and `auth_login.conf` must exist on the classpath; otherwise SPNEGO initialization fails and Fess will not start.

## Scope

Documentation only. Verified property names, defaults, file paths, and the authentication flow against the source; all other content was already accurate.