### PR TITLE
docs(15.7): correct scroll search documentation against implementation

### DIFF
--- a/de/15.7/config/search-scroll.rst
+++ b/de/15.7/config/search-scroll.rst
@@ -1,99 +1,110 @@
-==================
+================================
 Massen-Abruf von Suchergebnissen
-==================
+================================
 
 Übersicht
-====
+=========
 
-Bei normaler Suche in |Fess| wird durch Paging-Funktion nur eine bestimmte Anzahl von Suchergebnissen angezeigt.
-Wenn Sie alle Suchergebnisse auf einmal abrufen möchten, verwenden Sie die Scroll-Search-Funktion.
+Bei der normalen Suche in |Fess| wird durch die Paging-Funktion nur eine bestimmte Anzahl von
+Suchergebnissen angezeigt.
+Wenn Sie alle Suchergebnisse auf einmal abrufen möchten, verwenden Sie die Scroll-Search-Funktion
+(Scroll-Suche).
 
 Diese Funktion ist nützlich, wenn alle Suchergebnisse verarbeitet werden müssen,
-z. B. für Massen-Datenexport, Backup oder Analyse großer Datenmengen.
+z. B. für den Massen-Datenexport, Backup oder die Analyse großer Datenmengen.
 
 Anwendungsfälle
-============
+===============
 
 Scroll-Suche eignet sich für folgende Zwecke:
 
 - Vollständiger Export von Suchergebnissen
-- Abruf großer Datenmengen für Datenanalyse
-- Datenabruf in Batch-Verarbeitung
+- Abruf großer Datenmengen für die Datenanalyse
+- Datenabruf in der Batch-Verarbeitung
 - Datensynchronisation mit externen Systemen
-- Datenerfassung für Berichtsgenerierung
+- Datenerfassung für die Berichtsgenerierung
 
 .. warning::
-   Scroll-Suche gibt große Datenmengen zurück und verbraucht daher mehr
-   Serverressourcen im Vergleich zur normalen Suche. Aktivieren Sie nur bei Bedarf.
+   Scroll-Suche gibt große Datenmengen zurück und verbraucht daher im Vergleich zur normalen
+   Suche mehr Serverressourcen. Aktivieren Sie diese Funktion nur bei Bedarf.
 
-Konfigurationsmethode
-========
+Konfiguration
+=============
 
 Aktivierung der Scroll-Suche
-----------------------
+-----------------------------
 
-Standardmäßig ist Scroll-Suche aus Sicherheits- und Leistungsgründen deaktiviert.
-Zur Aktivierung ändern Sie in ``app/WEB-INF/classes/fess_config.properties`` oder ``/etc/fess/fess_config.properties``
-folgende Einstellung:
+Standardmäßig ist die Scroll-Suche aus Sicherheits- und Leistungsgründen deaktiviert.
+Zur Aktivierung ändern Sie folgende Einstellung in
+``app/WEB-INF/classes/fess_config.properties`` (bei RPM/DEB-Paketen in
+``/etc/fess/fess_config.properties``):
 
 ::
 
     api.search.scroll=true
 
 .. note::
-   Nach Konfigurationsänderung muss |Fess| neu gestartet werden.
+   Nach einer Konfigurationsänderung muss |Fess| neu gestartet werden.
 
-Konfiguration von Response-Feldern
---------------------------
+Gültigkeitsdauer des Scroll-Kontexts
+--------------------------------------
 
-Sie können Felder anpassen, die in Suchergebnissen enthalten sind.
-Standardmäßig werden viele Felder zurückgegeben, Sie können jedoch zusätzliche Felder angeben.
+Die Gültigkeitsdauer des Scroll-Kontexts ist in |Fess| intern auf ``1m`` (1 Minute) festgelegt.
+Dieser Wert kann über ``fess_config.properties`` nicht geändert werden.
+
+.. note::
+   Die Einstellung ``index.scroll.search.timeout`` ist vorhanden, wird jedoch für interne
+   Operationen (update by query / delete by query) verwendet, die mit Indexaktualisierungen oder
+   -löschungen verbunden sind. Sie hat keinen Einfluss auf den Timeout dieser Funktion
+   (Scroll-Suche).
+
+Konfiguration der Response-Felder
+-----------------------------------
+
+Sie können die Felder anpassen, die in den Suchergebnissen enthalten sind.
+Standardmäßig werden zahlreiche Felder zurückgegeben; Sie können jedoch zusätzliche Felder
+angeben.
 
 ::
 
     query.additional.scroll.response.fields=content
 
+Mehrere Felder werden durch Komma getrennt aufgelistet.
+
 .. note::
-   ``content`` ist standardmäßig nicht in den Response-Feldern enthalten.
+   Das Feld ``content`` ist standardmäßig nicht in den Response-Feldern enthalten.
+   Fügen Sie es mit der obigen Einstellung hinzu, wenn Sie den vollständigen Text abrufen
+   möchten.
 
-Timeout-Einstellung für Scroll
-----------------------------
-
-Die Gültigkeitsdauer des Scroll-Kontexts wird serverseitig konfiguriert.
-Standard ist ``3m`` (3 Minuten).
-
-::
-
-    index.scroll.search.timeout=3m
-
-Verwendungsmethode
-========
+Verwendung
+==========
 
 Grundlegende Verwendung
-----------------
+------------------------
 
-Zugriff auf Scroll-Suche erfolgt über folgende URL:
+Der Zugriff auf die Scroll-Suche erfolgt über folgende URL:
 
 ::
 
-    http://localhost:8080/api/v1/documents/all?q=Suchschlüsselwort
+    http://localhost:8080/api/v2/documents/all?q=Suchbegriff
 
-Suchergebnisse werden im NDJSON-Format (Newline Delimited JSON) zurückgegeben.
+Die Suchergebnisse werden im NDJSON-Format (Newline Delimited JSON) zurückgegeben.
 Pro Zeile wird ein Dokument im JSON-Format ausgegeben.
 
 **Beispiel:**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess"
 
 Request-Parameter
---------------------
+------------------
 
-Für Scroll-Suche können folgende Parameter verwendet werden:
+Für die Scroll-Suche können folgende Parameter verwendet werden:
 
 .. note::
-   Scroll-Suche unterstützt nur die GET-Methode.
+   Die Scroll-Suche unterstützt nur die GET-Methode. Bei Verwendung einer anderen HTTP-Methode
+   wird ``405 Method Not Allowed`` zurückgegeben.
 
 .. list-table::
    :header-rows: 1
@@ -104,120 +115,161 @@ Für Scroll-Suche können folgende Parameter verwendet werden:
    * - ``q``
      - Suchabfrage (erforderlich)
    * - ``num``
-     - Anzahl pro Scroll-Abruf (Standard: 10, Maximum: 100)
+     - Anzahl der Treffer pro Scroll-Abruf (Standard: 10, Maximum: 100)
    * - ``fields.label``
      - Filterung nach Label
 
 .. note::
-   Der maximale Wert von ``num`` wird durch ``paging.search.page.max.size`` gesteuert.
+   Der maximale Wert von ``num`` wird durch ``paging.search.page.max.size`` (Standard: 100)
+   gesteuert. Wird ein Wert angegeben, der das Maximum überschreitet, wird er automatisch auf
+   den Maximalwert begrenzt. Als Standardwert wird ``paging.search.page.size`` (Standard: 10)
+   verwendet. Wird für ``num`` ein Wert von 0 oder kleiner angegeben, wird ein Fehler
+   (``INVALID_REQUEST``) zurückgegeben.
 
 Angabe von Suchabfragen
-----------------
+------------------------
 
-Sie können Suchabfragen wie bei normaler Suche angeben.
+Sie können Suchabfragen wie bei der normalen Suche angeben.
 
 **Beispiel: Schlüsselwortsuche**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Suchmaschine"
+    curl "http://localhost:8080/api/v2/documents/all?q=Suchmaschine"
 
 **Beispiel: Feldspezifische Suche**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=title:Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=title:Fess"
 
 **Beispiel: Vollständiger Abruf (ohne Suchbedingung)**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*"
 
 Angabe der Abrufanzahl
---------------
+-----------------------
 
-Sie können die Anzahl pro Scroll-Abruf ändern.
+Sie können die Anzahl der Treffer pro Scroll-Abruf ändern.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess&num=100"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess&num=100"
 
 .. note::
-   Zu großer ``num``-Parameter erhöht Speichernutzung.
-   Normalerweise wird ein Wert bis maximal 100 empfohlen.
+   Ein zu großer ``num``-Parameter erhöht die Speichernutzung. Der Standardmaximalwert ist 100.
+   Falls ein größerer Wert benötigt wird, ändern Sie die Einstellung
+   ``paging.search.page.max.size``.
 
 Filterung nach Label
---------------------------
+---------------------
 
 Sie können nur Dokumente bestimmter Labels abrufen.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*&fields.label=public"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*&fields.label=public"
 
-Hinweis zur Authentifizierung
------------------------------
+Zugriffskontrolle
+------------------
+
+.. note::
+   Bei der Scroll-Suche wird wie bei der normalen Suche die rollenbasierte Zugriffskontrolle
+   (RBAC) angewendet. Es werden nur Dokumente zurückgegeben, auf die der anfragende Benutzer
+   gemäß seinen Rolleninformationen Zugriff hat. Dokumente ohne Leseberechtigung sind nicht
+   im Ergebnis enthalten.
 
 .. warning::
-   Bei der Scroll-Suche wird die rollenbasierte Zugriffskontrolle (RBAC) von |Fess| nicht angewendet.
-   Alle Dokumente, die den Suchkriterien entsprechen, werden unabhängig von den Benutzerberechtigungen zurückgegeben.
-   Falls Zugriffsbeschränkungen erforderlich sind, konfigurieren Sie IP-Adressen-Beschränkung oder Authentifizierung über einen Reverse-Proxy.
+   Der Endpunkt der Scroll-Suche erfordert standardmäßig keine Authentifizierung (er ist für
+   jeden zugänglich). Die zurückgegebenen Dokumente werden jedoch durch die oben beschriebene
+   rollenbasierte Zugriffskontrolle gefiltert. Falls der Zugriff auf den Endpunkt selbst
+   eingeschränkt werden soll, konfigurieren Sie eine IP-Adressen-Beschränkung oder
+   Authentifizierung über einen Reverse-Proxy.
 
 Response-Format
-==============
+===============
 
 NDJSON-Format
-----------
+--------------
 
-Scroll-Such-Response wird im NDJSON-Format (Newline Delimited JSON) zurückgegeben.
-Jede Zeile repräsentiert ein Dokument.
+Die Response der Scroll-Suche wird im NDJSON-Format (Newline Delimited JSON) zurückgegeben.
+Der Content-Type ist ``application/x-ndjson; charset=UTF-8``.
+Jede Zeile repräsentiert ein Dokument, das in der Form ``{"data": {...}}`` eingeschlossen ist.
 
 **Beispiel:**
 
 ::
 
-    {"url":"http://example.com/page1","title":"Page 1","content":"..."}
-    {"url":"http://example.com/page2","title":"Page 2","content":"..."}
-    {"url":"http://example.com/page3","title":"Page 3","content":"..."}
+    {"data":{"url":"http://example.com/page1","title":"Page 1","digest":"..."}}
+    {"data":{"url":"http://example.com/page2","title":"Page 2","digest":"..."}}
+    {"data":{"url":"http://example.com/page3","title":"Page 3","digest":"..."}}
+
+.. note::
+   Jedes Dokument wird unter dem Schlüssel ``data`` gespeichert. Auf Client-Seite ist nach dem
+   Parsen jeder Zeile der Wert unter dem Schlüssel ``data`` zu lesen.
+
+Verhalten im Fehlerfall
+------------------------
+
+Tritt auf der Serverseite ein Fehler auf, nachdem die Übertragung des Streams begonnen hat,
+wird in der letzten Zeile der Response folgende Fehler-Abschlusszeile ausgegeben:
+
+::
+
+    {"error":{"code":"internal_error","message":"stream error"}}
+
+.. note::
+   Auf Client-Seite kann durch Prüfen, ob die letzte Zeile den Schlüssel ``error`` enthält,
+   unterschieden werden, ob der Stream normal abgeschlossen wurde oder ob auf der Serverseite
+   ein Fehler aufgetreten ist. Falls das Schreiben der Fehler-Abschlusszeile selbst fehlschlägt,
+   wird keine Abschlusszeile ausgegeben und der Stream endet vorzeitig. Behandeln Sie daher auch
+   unerwartete Verbindungsabbrüche als Fehler.
 
 Response-Felder
---------------------
+----------------
 
 Standardmäßig enthaltene Felder:
 
-- ``url``: Dokument-URL
-- ``doc_id``: Dokument-ID
-- ``title``: Titel
-- ``score``: Such-Score
+- ``score``: Suchscore
+- ``_id``: Dokument-ID (OpenSearch-Dokument-ID)
+- ``doc_id``: Dokument-ID (intern in |Fess|)
 - ``boost``: Boost-Wert
 - ``content_length``: Inhaltslänge
 - ``host``: Hostname
 - ``site``: Site
-- ``content_title``: Inhaltstitel
-- ``content_description``: Inhaltsbeschreibung
-- ``url_link``: URL-Link
 - ``last_modified``: Letztes Änderungsdatum
 - ``timestamp``: Zeitstempel
-- ``created``: Erstellungsdatum
 - ``mimetype``: MIME-Typ
 - ``filetype``: Dateityp
 - ``filename``: Dateiname
-- ``favorite_count``: Favoritenanzahl
+- ``created``: Erstellungsdatum
+- ``title``: Titel
+- ``digest``: Textauszug
+- ``url``: Dokument-URL
+- ``thumbnail``: Vorschaubild
 - ``click_count``: Klickanzahl
-- ``config_id``: Konfiguration-ID
-- ``_id``: Interne ID
-- ``label``: Label
+- ``favorite_count``: Favoritenanzahl
+- ``has_cache``: Cache vorhanden
+- ``content_title``: Anzeige-Titel
+- ``content_description``: Textauszug für die Anzeige
+- ``url_link``: Anzeige-Link-URL
+- ``site_path``: Site-Pfad
 
 .. note::
-   ``content`` ist standardmäßig nicht in den Response-Feldern enthalten.
-   Um ``content`` zu erhalten, konfigurieren Sie ``query.additional.scroll.response.fields=content``.
+   Die tatsächlich ausgegebenen Felder sind auf die für die API-Response zugelassenen Felder
+   beschränkt. Felder ohne Wert werden nicht ausgegeben.
+
+.. note::
+   ``content`` (Volltext) ist standardmäßig nicht enthalten.
+   Er kann über ``query.additional.scroll.response.fields`` hinzugefügt werden.
 
 Datenverarbeitungsbeispiele
-============
+============================
 
 Verarbeitungsbeispiel mit Python
-----------------
+---------------------------------
 
 .. code-block:: python
 
@@ -225,7 +277,7 @@ Verarbeitungsbeispiel mit Python
     import json
 
     # Scroll-Suche ausführen
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {
         "q": "Fess",
         "num": 100
@@ -236,46 +288,52 @@ Verarbeitungsbeispiel mit Python
     # NDJSON-Response zeilenweise verarbeiten
     for line in response.iter_lines():
         if line:
-            doc = json.loads(line)
+            record = json.loads(line)
+            if "error" in record:
+                # Fehler mitten im Stream
+                print("stream error:", record["error"])
+                break
+            doc = record["data"]
             print(f"Title: {doc.get('title')}")
             print(f"URL: {doc.get('url')}")
             print("---")
 
-Speichern in Datei
-----------------
+Speichern in eine Datei
+------------------------
 
-Beispiel zum Speichern von Suchergebnissen in Datei:
+Beispiel zum Speichern von Suchergebnissen in eine Datei:
 
 .. code-block:: bash
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*" > all_documents.ndjson
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*" > all_documents.ndjson
 
 Konvertierung zu CSV
------------
+---------------------
 
-Beispiel für Konvertierung zu CSV mit jq-Befehl:
+Beispiel für die Konvertierung zu CSV mit dem jq-Befehl:
 
 .. code-block:: bash
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess" | \
-        jq -r '[.url, .title, .score] | @csv' > results.csv
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess" | \
+        jq -r '.data | [.url, .title, .score] | @csv' > results.csv
 
 Datenanalyse
-----------
+-------------
 
-Beispiel für Analyse abgerufener Daten:
+Beispiel für die Analyse abgerufener Daten:
 
 .. code-block:: python
 
     import json
     import pandas as pd
-    from collections import Counter
 
-    # NDJSON-Datei einlesen
+    # NDJSON-Datei einlesen (data-Schlüssel aus jeder Zeile entnehmen)
     documents = []
     with open('all_documents.ndjson', 'r') as f:
         for line in f:
-            documents.append(json.loads(line))
+            record = json.loads(line)
+            if "data" in record:
+                documents.append(record["data"])
 
     # In DataFrame konvertieren
     df = pd.DataFrame(documents)
@@ -289,58 +347,63 @@ Beispiel für Analyse abgerufener Daten:
     print(df['domain'].value_counts())
 
 Leistung und Best Practices
-==================================
+============================
 
 Effiziente Verwendung
-----------------
+----------------------
 
-1. **Angemessene num-Parameter-Einstellung**
+1. **Angemessene Einstellung des num-Parameters**
 
-   - Zu klein erhöht Kommunikations-Overhead
-   - Zu groß erhöht Speichernutzung
-   - Standard-Maximum: 100
+   - Zu klein erhöht den Kommunikations-Overhead
+   - Zu groß erhöht die Speichernutzung
+   - Standardmaximalwert: 100
 
-2. **Optimierung von Suchbedingungen**
+2. **Optimierung der Suchbedingungen**
 
    - Suchbedingungen so angeben, dass nur benötigte Dokumente abgerufen werden
    - Vollständigen Abruf nur bei wirklichem Bedarf ausführen
 
-3. **Nutzung von Off-Peak-Zeiten**
+3. **Nutzung von Nebenzeiten**
 
    - Abruf großer Datenmengen in Zeiten niedriger Systemlast ausführen
 
-4. **Verwendung in Batch-Verarbeitung**
+4. **Verwendung in der Batch-Verarbeitung**
 
    - Regelmäßige Datensynchronisation als Batch-Job ausführen
 
 Optimierung der Speichernutzung
---------------------
+---------------------------------
 
-Bei Verarbeitung großer Datenmengen verwenden Sie Streaming-Verarbeitung zur Reduzierung der Speichernutzung.
+Bei der Verarbeitung großer Datenmengen verwenden Sie Streaming-Verarbeitung, um die
+Speichernutzung zu reduzieren.
 
 .. code-block:: python
 
     import requests
     import json
 
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {"q": "*:*", "num": 100}
 
     # Mit Streaming verarbeiten
     with requests.get(url, params=params, stream=True) as response:
         for line in response.iter_lines(decode_unicode=True):
             if line:
-                doc = json.loads(line)
-                # Dokumentverarbeitung
-                process_document(doc)
+                record = json.loads(line)
+                if "error" in record:
+                    break
+                # Dokument verarbeiten
+                process_document(record["data"])
 
 Sicherheitsüberlegungen
-====================
+========================
 
 Zugriffsbeschränkung
-------------
+---------------------
 
-Da Scroll-Suche große Datenmengen zurückgibt, konfigurieren Sie angemessene Zugriffsbeschränkungen.
+Da die Scroll-Suche große Datenmengen zurückgibt, konfigurieren Sie angemessene
+Zugriffsbeschränkungen. Da der Endpunkt selbst standardmäßig keine Authentifizierung erfordert,
+erwägen Sie bei Bedarf folgende Maßnahmen:
 
 1. **IP-Adressen-Beschränkung**
 
@@ -348,50 +411,52 @@ Da Scroll-Suche große Datenmengen zurückgibt, konfigurieren Sie angemessene Zu
 
 2. **API-Authentifizierung**
 
-   API-Token oder Basic-Authentifizierung verwenden
+   API-Token oder Basic-Authentifizierung über einen Reverse-Proxy verwenden
 
-3. **Rollenbasierte Beschränkung**
+3. **Rollenbasierte Zugriffskontrolle**
 
-   Zugriff nur für Benutzer mit bestimmten Rollen erlauben
+   Die zurückgegebenen Dokumente werden durch die rollenbasierte Zugriffskontrolle von |Fess|
+   gefiltert
 
 Rate-Limiting
-----------
+--------------
 
-Zur Vermeidung übermäßigen Zugriffs wird Konfiguration von Rate-Limiting im Reverse-Proxy empfohlen.
+Zur Vermeidung übermäßiger Zugriffe wird empfohlen, Rate-Limiting im Reverse-Proxy zu
+konfigurieren.
 
-Fehlersuche
-======================
+Fehlerbehebung
+==============
 
 Scroll-Suche nicht verfügbar
-----------------------------
+------------------------------
 
 1. Überprüfen Sie, ob ``api.search.scroll`` auf ``true`` gesetzt ist.
 2. Überprüfen Sie, ob |Fess| neu gestartet wurde.
-3. Überprüfen Sie Fehlerprotokolle.
+3. Überprüfen Sie die Fehlerprotokolle.
 
 Timeout-Fehler tritt auf
-----------------------------
+-------------------------
 
-1. Erhöhen Sie Wert von ``index.scroll.search.timeout``.
-2. Verkleinern Sie ``num``-Parameter für verteilte Verarbeitung.
-3. Grenzen Sie Suchbedingungen ein, um abzurufende Datenmenge zu reduzieren.
+1. Verkleinern Sie den ``num``-Parameter, um die Verarbeitung zu verteilen.
+2. Grenzen Sie die Suchbedingungen ein, um die abzurufende Datenmenge zu reduzieren.
 
 Speichermangel-Fehler
-----------------
+----------------------
 
-1. Verkleinern Sie ``num``-Parameter.
-2. Erhöhen Sie Heap-Speichergröße von |Fess|.
-3. Überprüfen Sie Heap-Speichergröße von OpenSearch.
+1. Verkleinern Sie den ``num``-Parameter.
+2. Erhöhen Sie den Heap-Speicher von |Fess|.
+3. Überprüfen Sie den Heap-Speicher von OpenSearch.
 
 Response ist leer
---------------------
+------------------
 
-1. Überprüfen Sie, ob Suchabfrage korrekt ist.
-2. Überprüfen Sie, ob angegebene Labels oder Filterbedingungen korrekt sind.
-3. Überprüfen Sie Berechtigungseinstellungen für rollenbasierte Suche.
+1. Überprüfen Sie, ob die Suchabfrage korrekt ist.
+2. Überprüfen Sie, ob die angegebenen Labels oder Filterbedingungen korrekt sind.
+3. Aufgrund der rollenbasierten Zugriffskontrolle sind Dokumente ohne Leseberechtigung nicht
+   im Ergebnis enthalten. Überprüfen Sie die Rolleneinstellungen des Requests.
 
 Referenzinformationen
-========
+=====================
 
 - :doc:`search-basic` - Details zu Suchfunktionen
 - :doc:`search-advanced` - Suchbezogene Konfigurationen

--- a/en/15.7/config/search-scroll.rst
+++ b/en/15.7/config/search-scroll.rst
@@ -1,6 +1,6 @@
-==========================
+================================
 Bulk Retrieval of Search Results
-==========================
+================================
 
 Overview
 ========
@@ -17,7 +17,7 @@ Use Cases
 Scroll search is suitable for purposes such as:
 
 - Exporting all search results
-- Retrieving large amounts of data for analysis
+- Retrieving large amounts of data for data analysis
 - Data retrieval in batch processing
 - Data synchronization to external systems
 - Data collection for report generation
@@ -33,7 +33,8 @@ Enabling Scroll Search
 ----------------------
 
 By default, scroll search is disabled from security and performance perspectives.
-To enable it, change the following setting in ``app/WEB-INF/classes/fess_config.properties`` or ``/etc/fess/fess_config.properties``.
+To enable it, change the following setting in ``app/WEB-INF/classes/fess_config.properties`` (or
+``/etc/fess/fess_config.properties`` for RPM/DEB packages).
 
 ::
 
@@ -42,11 +43,22 @@ To enable it, change the following setting in ``app/WEB-INF/classes/fess_config.
 .. note::
    After changing settings, you must restart |Fess|.
 
+Scroll Context Lifetime
+-----------------------
+
+The scroll context lifetime for scroll search is fixed internally in |Fess| at ``1m`` (1 minute).
+This value cannot be changed from ``fess_config.properties``.
+
+.. note::
+   There is a setting called ``index.scroll.search.timeout``, but it is used for internal operations
+   involving index updates or deletions (update by query / delete by query) and does not affect
+   the timeout for this feature (search scrolling).
+
 Response Field Configuration
 -----------------------------
 
-You can customize fields included in search result responses.
-By default, many fields are returned, but you can specify additional fields.
+You can customize the fields included in search result responses.
+By default, many fields are returned, but you can also specify additional fields.
 
 ::
 
@@ -55,7 +67,8 @@ By default, many fields are returned, but you can specify additional fields.
 When specifying multiple fields, list them separated by commas.
 
 .. note::
-   ``content`` is not included in default response fields.
+   The ``content`` field is not included in the default response.
+   To retrieve full text, add it using the setting above.
 
 Usage
 =====
@@ -67,7 +80,7 @@ Access scroll search using the following URL:
 
 ::
 
-    http://localhost:8080/api/v1/documents/all?q=search keyword
+    http://localhost:8080/api/v2/documents/all?q=search keyword
 
 Search results are returned in NDJSON (Newline Delimited JSON) format.
 Each line outputs one document in JSON format.
@@ -76,7 +89,7 @@ Each line outputs one document in JSON format.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess"
 
 Request Parameters
 ------------------
@@ -84,7 +97,8 @@ Request Parameters
 The following parameters can be used with scroll search:
 
 .. note::
-   Scroll search only supports the GET method.
+   Scroll search only supports the GET method. Accessing with any method other than GET returns
+   ``405 Method Not Allowed``.
 
 .. list-table::
    :header-rows: 1
@@ -100,7 +114,10 @@ The following parameters can be used with scroll search:
      - Filtering by label
 
 .. note::
-   The maximum value of ``num`` is controlled by ``paging.search.page.max.size`` (default: 100). Values exceeding the maximum are automatically capped.
+   The maximum value of ``num`` is controlled by ``paging.search.page.max.size`` (default: 100).
+   Values exceeding the maximum are automatically capped.
+   The default value uses ``paging.search.page.size`` (default: 10).
+   If a value of 0 or less is specified for ``num``, an error (``INVALID_REQUEST``) is returned.
 
 Specifying Search Queries
 --------------------------
@@ -111,19 +128,19 @@ You can specify search queries just like normal searches.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=search engine"
+    curl "http://localhost:8080/api/v2/documents/all?q=search engine"
 
 **Example: Field-specific search**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=title:Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=title:Fess"
 
 **Example: Retrieve all (no search conditions)**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*"
 
 Specifying Retrieval Count
 ---------------------------
@@ -132,11 +149,12 @@ You can change the number of items retrieved per scroll.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess&num=100"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess&num=100"
 
 .. note::
-   The ``num`` parameter has a default maximum of 100.
-   To allow larger values, change ``paging.search.page.max.size``.
+   Increasing the ``num`` parameter too much will increase memory usage.
+   The default maximum is 100. If a larger value is needed, change the
+   ``paging.search.page.max.size`` setting.
 
 Filtering by Label
 ------------------
@@ -145,15 +163,21 @@ You can retrieve only documents belonging to a specific label.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*&fields.label=public"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*&fields.label=public"
 
-About Authentication
+About Access Control
 --------------------
 
+.. note::
+   Scroll search applies role-based access control (RBAC) just like normal search.
+   Only documents accessible based on the role information in the request are returned;
+   documents for which the user does not have view permissions are not included in the results.
+
 .. warning::
-   Scroll search does not apply |Fess| role-based access control (RBAC).
-   All documents matching the search criteria are returned regardless of user permissions.
-   If access restrictions are needed, configure IP address restrictions or authentication via a reverse proxy.
+   The scroll search endpoint does not require authentication by default (anyone can access it).
+   However, the documents returned are filtered by the role-based access control described above.
+   If you wish to restrict access to the endpoint itself, configure IP address restrictions or
+   authentication via a reverse proxy or similar mechanism.
 
 Response Format
 ===============
@@ -162,15 +186,37 @@ NDJSON Format
 -------------
 
 Scroll search responses are returned in NDJSON (Newline Delimited JSON) format.
-Each line represents one document.
+The Content-Type is ``application/x-ndjson; charset=UTF-8``.
+Each line represents one document wrapped in the ``{"data": {...}}`` format.
 
 **Example:**
 
 ::
 
-    {"url":"http://example.com/page1","title":"Page 1","content":"..."}
-    {"url":"http://example.com/page2","title":"Page 2","content":"..."}
-    {"url":"http://example.com/page3","title":"Page 3","content":"..."}
+    {"data":{"url":"http://example.com/page1","title":"Page 1","digest":"..."}}
+    {"data":{"url":"http://example.com/page2","title":"Page 2","digest":"..."}}
+    {"data":{"url":"http://example.com/page3","title":"Page 3","digest":"..."}}
+
+.. note::
+   Each document is stored under the ``data`` key. On the client side, parse each line and
+   then refer to the value of the ``data`` key.
+
+Error Behavior
+--------------
+
+If an error occurs on the server side after the stream has started being sent, the following
+error terminator line is output as the final line of the response.
+
+::
+
+    {"error":{"code":"internal_error","message":"stream error"}}
+
+.. note::
+   On the client side, you can determine whether the stream completed successfully or whether
+   a server-side error occurred mid-stream by checking whether the final line contains the
+   ``error`` key. Note that if writing the error terminator line itself fails, the terminator
+   line will not be output and the stream will end mid-way; treat unexpected disconnections
+   as errors as well.
 
 Response Fields
 ---------------
@@ -178,8 +224,8 @@ Response Fields
 Fields included by default:
 
 - ``score``: Search score
-- ``id``: Document ID
-- ``doc_id``: Document ID (internal)
+- ``_id``: Document ID (OpenSearch document ID)
+- ``doc_id``: Document ID (internal to |Fess|)
 - ``boost``: Boost value
 - ``content_length``: Content length
 - ``host``: Hostname
@@ -196,9 +242,15 @@ Fields included by default:
 - ``thumbnail``: Thumbnail
 - ``click_count``: Click count
 - ``favorite_count``: Favorite count
-- ``config_id``: Config ID
-- ``lang``: Language
 - ``has_cache``: Cache availability
+- ``content_title``: Display title
+- ``content_description``: Display body excerpt
+- ``url_link``: Display link URL
+- ``site_path``: Site path
+
+.. note::
+   The fields actually output are limited to those permitted as API response fields.
+   Fields with no value are not output.
 
 .. note::
    ``content`` (full text) is not included by default.
@@ -216,7 +268,7 @@ Python Processing Example
     import json
 
     # Execute scroll search
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {
         "q": "Fess",
         "num": 100
@@ -227,7 +279,12 @@ Python Processing Example
     # Process NDJSON response line by line
     for line in response.iter_lines():
         if line:
-            doc = json.loads(line)
+            record = json.loads(line)
+            if "error" in record:
+                # An error occurred mid-stream
+                print("stream error:", record["error"])
+                break
+            doc = record["data"]
             print(f"Title: {doc.get('title')}")
             print(f"URL: {doc.get('url')}")
             print("---")
@@ -239,17 +296,17 @@ Example of saving search results to a file:
 
 .. code-block:: bash
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*" > all_documents.ndjson
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*" > all_documents.ndjson
 
 Converting to CSV
 -----------------
 
-Example of converting to CSV using jq command:
+Example of converting to CSV using the jq command:
 
 .. code-block:: bash
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess" | \
-        jq -r '[.url, .title, .score] | @csv' > results.csv
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess" | \
+        jq -r '.data | [.url, .title, .score] | @csv' > results.csv
 
 Data Analysis
 -------------
@@ -260,13 +317,14 @@ Example of analyzing retrieved data:
 
     import json
     import pandas as pd
-    from collections import Counter
 
-    # Read NDJSON file
+    # Read NDJSON file (extract the data key from each line)
     documents = []
     with open('all_documents.ndjson', 'r') as f:
         for line in f:
-            documents.append(json.loads(line))
+            record = json.loads(line)
+            if "data" in record:
+                documents.append(record["data"])
 
     # Convert to DataFrame
     df = pd.DataFrame(documents)
@@ -280,12 +338,12 @@ Example of analyzing retrieved data:
     print(df['domain'].value_counts())
 
 Performance and Best Practices
-===============================
+================================
 
 Efficient Usage
 ---------------
 
-1. **Set appropriate num parameter**
+1. **Set an appropriate num parameter**
 
    - Too small increases communication overhead
    - Too large increases memory usage
@@ -298,7 +356,7 @@ Efficient Usage
 
 3. **Use off-peak hours**
 
-   - Retrieve large amounts of data during low system load periods
+   - Retrieve large amounts of data during periods of low system load
 
 4. **Use in batch processing**
 
@@ -314,16 +372,18 @@ When processing large amounts of data, use streaming processing to reduce memory
     import requests
     import json
 
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {"q": "*:*", "num": 100}
 
     # Process with streaming
     with requests.get(url, params=params, stream=True) as response:
         for line in response.iter_lines(decode_unicode=True):
             if line:
-                doc = json.loads(line)
+                record = json.loads(line)
+                if "error" in record:
+                    break
                 # Process document
-                process_document(doc)
+                process_document(record["data"])
 
 Security Considerations
 =======================
@@ -331,7 +391,8 @@ Security Considerations
 Access Restrictions
 -------------------
 
-Since scroll search returns large amounts of data, set appropriate access restrictions.
+Since scroll search returns large amounts of data, configure appropriate access restrictions.
+The endpoint does not require authentication by default, so consider the following measures as needed.
 
 1. **IP Address Restriction**
 
@@ -339,11 +400,11 @@ Since scroll search returns large amounts of data, set appropriate access restri
 
 2. **API Authentication**
 
-   Use API tokens or Basic authentication
+   Use API tokens or Basic authentication via a reverse proxy or similar mechanism
 
-3. **Role-Based Restrictions**
+3. **Role-Based Access Control**
 
-   Allow access only to users with specific roles
+   Documents returned are filtered by |Fess| role-based access control
 
 Rate Limiting
 -------------
@@ -364,21 +425,21 @@ Timeout Errors Occur
 --------------------
 
 1. Reduce the ``num`` parameter to distribute processing.
-2. Narrow search conditions to reduce amount of retrieved data.
+2. Narrow search conditions to reduce the amount of retrieved data.
 
 Out of Memory Errors
 --------------------
 
 1. Reduce the ``num`` parameter.
-2. Increase |Fess| heap memory size.
-3. Check OpenSearch heap memory size.
+2. Increase the |Fess| heap memory size.
+3. Check the OpenSearch heap memory size.
 
 Response is Empty
 -----------------
 
 1. Verify that the search query is correct.
 2. Verify that specified labels or filter conditions are correct.
-3. Verify role-based search permission settings.
+3. Role-based access control means documents for which the user does not have view permissions are not included in the results. Verify the role settings on the request.
 
 References
 ==========

--- a/es/15.7/config/search-scroll.rst
+++ b/es/15.7/config/search-scroll.rst
@@ -1,6 +1,6 @@
-========================================
+==========================================
 Obtención Masiva de Resultados de Búsqueda
-========================================
+==========================================
 
 Descripción General
 ===================
@@ -28,10 +28,11 @@ Método de Configuración
 =======================
 
 Habilitación de la Búsqueda Scroll
-----------------------------------
+------------------------------------
 
 Por defecto, la búsqueda scroll está deshabilitada por motivos de seguridad y rendimiento.
-Para habilitarla, modifique la siguiente configuración en ``app/WEB-INF/classes/fess_config.properties`` o ``/etc/fess/fess_config.properties``.
+Para habilitarla, modifique la siguiente configuración en ``app/WEB-INF/classes/fess_config.properties`` (en paquetes RPM/DEB,
+``/etc/fess/fess_config.properties``).
 
 ::
 
@@ -40,8 +41,17 @@ Para habilitarla, modifique la siguiente configuración en ``app/WEB-INF/classes
 .. note::
    Después de cambiar la configuración, es necesario reiniciar |Fess|.
 
+Duración del Contexto de Scroll
+---------------------------------
+
+La duración del contexto de scroll de la búsqueda scroll está fijada internamente en |Fess| en ``1m`` (1 minuto).
+Este valor no se puede cambiar desde ``fess_config.properties``.
+
+.. note::
+   Existe una configuración llamada ``index.scroll.search.timeout``, pero esta se utiliza para operaciones internas que implican actualización o eliminación del índice (update by query / delete by query) y no afecta al tiempo de espera de esta función (scroll de búsqueda).
+
 Configuración de Campos de Respuesta
--------------------------------------
+--------------------------------------
 
 Puede personalizar los campos que se incluyen en la respuesta de los resultados de búsqueda.
 Por defecto, se devuelven muchos campos, pero puede especificar campos adicionales.
@@ -50,10 +60,11 @@ Por defecto, se devuelven muchos campos, pero puede especificar campos adicional
 
     query.additional.scroll.response.fields=content
 
-.. note::
-   El campo ``content`` no está incluido en la respuesta predeterminada. Si necesita el contenido del documento, agréguelo explícitamente como se muestra arriba.
-
 Al especificar múltiples campos, enumérelos separados por comas.
+
+.. note::
+   El campo ``content`` no está incluido en la respuesta predeterminada.
+   Si necesita el texto completo, agréguelo mediante la configuración indicada anteriormente.
 
 Método de Uso
 =============
@@ -65,7 +76,7 @@ Para acceder a la búsqueda scroll, utilice la siguiente URL.
 
 ::
 
-    http://localhost:8080/api/v1/documents/all?q=palabra_clave_búsqueda
+    http://localhost:8080/api/v2/documents/all?q=palabra_clave_búsqueda
 
 Los resultados de búsqueda se devuelven en formato NDJSON (Newline Delimited JSON).
 Cada línea representa un documento en formato JSON.
@@ -74,15 +85,16 @@ Cada línea representa un documento en formato JSON.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess"
 
 Parámetros de Solicitud
------------------------
+------------------------
 
 En la búsqueda scroll, puede utilizar los siguientes parámetros.
 
 .. note::
-   La búsqueda scroll solo admite el método GET.
+   La búsqueda scroll solo admite el método GET. Si se accede con un método distinto a GET,
+   se devuelve ``405 Method Not Allowed``.
 
 .. list-table::
    :header-rows: 1
@@ -98,7 +110,10 @@ En la búsqueda scroll, puede utilizar los siguientes parámetros.
      - Filtrado por etiqueta
 
 .. note::
-   El valor máximo de ``num`` se puede cambiar con la propiedad ``paging.search.page.max.size`` en ``fess_config.properties``.
+   El valor máximo de ``num`` se controla mediante ``paging.search.page.max.size`` (predeterminado: 100).
+   Si se especifica un valor superior al máximo, se recortará automáticamente al valor máximo.
+   El valor predeterminado se toma de ``paging.search.page.size`` (predeterminado: 10).
+   Si se especifica un valor de 0 o inferior en ``num``, se devuelve un error (``INVALID_REQUEST``).
 
 Especificación de Consulta de Búsqueda
 ---------------------------------------
@@ -109,49 +124,56 @@ Puede especificar consultas de búsqueda de la misma manera que en las búsqueda
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=motor_búsqueda"
+    curl "http://localhost:8080/api/v2/documents/all?q=motor_búsqueda"
 
 **Ejemplo: Búsqueda con campo especificado**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=title:Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=title:Fess"
 
 **Ejemplo: Obtención completa (sin condiciones de búsqueda)**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*"
 
 Especificación del Número de Registros a Obtener
--------------------------------------------------
+--------------------------------------------------
 
 Puede cambiar el número de registros a obtener en cada scroll.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess&num=100"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess&num=100"
 
 .. note::
    Si el parámetro ``num`` es demasiado grande, aumentará el uso de memoria.
-   El valor máximo predeterminado es 100, configurable mediante ``paging.search.page.max.size``.
+   El valor máximo predeterminado es 100. Si necesita un valor mayor,
+   modifique la configuración ``paging.search.page.max.size``.
 
 Filtrado por Etiqueta
----------------------
+----------------------
 
 Puede obtener solo los documentos que pertenecen a una etiqueta específica.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*&fields.label=public"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*&fields.label=public"
 
-Acerca de la Autenticación
----------------------------
+Acerca del Control de Acceso
+------------------------------
+
+.. note::
+   En la búsqueda scroll, al igual que en las búsquedas normales, se aplica el control de acceso basado en roles (RBAC).
+   Solo se devuelven los documentos a los que se puede acceder según la información de roles de la solicitud,
+   por lo que los documentos sin permiso de visualización no se incluyen en los resultados.
 
 .. warning::
-   La búsqueda scroll no aplica el control de acceso basado en roles (RBAC) de |Fess|.
-   Todos los documentos que coincidan con los criterios de búsqueda se devuelven independientemente de los permisos del usuario.
-   Si se necesitan restricciones de acceso, configure restricciones de dirección IP o autenticación a través de un proxy inverso.
+   El endpoint de la búsqueda scroll no requiere autenticación de forma predeterminada (cualquiera puede acceder a él).
+   Sin embargo, los documentos devueltos son filtrados por el control de acceso basado en roles descrito anteriormente.
+   Si desea restringir el acceso al propio endpoint, configure restricciones de dirección IP o
+   autenticación mediante un proxy inverso u otro mecanismo.
 
 Formato de Respuesta
 ====================
@@ -160,52 +182,81 @@ Formato NDJSON
 --------------
 
 La respuesta de la búsqueda scroll se devuelve en formato NDJSON (Newline Delimited JSON).
-Cada línea representa un documento.
+El Content-Type es ``application/x-ndjson; charset=UTF-8``.
+Cada línea representa un documento envuelto en el formato ``{"data": {...}}``.
 
 **Ejemplo:**
 
 ::
 
-    {"url":"http://example.com/page1","title":"Page 1","content":"..."}
-    {"url":"http://example.com/page2","title":"Page 2","content":"..."}
-    {"url":"http://example.com/page3","title":"Page 3","content":"..."}
+    {"data":{"url":"http://example.com/page1","title":"Page 1","digest":"..."}}
+    {"data":{"url":"http://example.com/page2","title":"Page 2","digest":"..."}}
+    {"data":{"url":"http://example.com/page3","title":"Page 3","digest":"..."}}
+
+.. note::
+   Cada documento se almacena bajo la clave ``data``. En el lado del cliente, tras parsear cada línea,
+   acceda al valor de la clave ``data``.
+
+Comportamiento ante Errores
+-----------------------------
+
+Si se produce un error en el servidor después de que ha comenzado el envío del stream, se emite
+en la última línea de la respuesta la siguiente línea terminadora de error:
+
+::
+
+    {"error":{"code":"internal_error","message":"stream error"}}
+
+.. note::
+   En el lado del cliente, puede determinar si el stream se completó correctamente o si se produjo
+   un error intermedio en el servidor verificando si la última línea contiene la clave ``error``.
+   Tenga en cuenta que si la escritura de la propia línea terminadora de error falla, no se emite
+   dicha línea y el stream finaliza de forma incompleta, por lo que trate también las desconexiones
+   inesperadas como errores.
 
 Campos de Respuesta
--------------------
+--------------------
 
 Campos incluidos por defecto:
 
-- ``url``: URL del documento
-- ``title``: Título
 - ``score``: Puntuación de búsqueda
+- ``_id``: ID del documento (ID de documento de OpenSearch)
+- ``doc_id``: ID del documento (interno de |Fess|)
 - ``boost``: Valor de boost
-- ``created``: Fecha de creación
-- ``last_modified``: Fecha de última modificación
 - ``content_length``: Longitud del contenido
-- ``doc_id``: ID del documento
-- ``host``: Host
+- ``host``: Nombre del host
 - ``site``: Sitio
-- ``content_title``: Título del contenido
-- ``content_description``: Descripción del contenido
-- ``digest``: Resumen
+- ``last_modified``: Fecha y hora de la última modificación
 - ``timestamp``: Marca de tiempo
-- ``label``: Etiqueta
-- ``segment``: Segmento
-- ``click_count``: Número de clics
-- ``favorite_count``: Número de favoritos
-- ``config_id``: ID de configuración
+- ``mimetype``: Tipo MIME
 - ``filetype``: Tipo de archivo
 - ``filename``: Nombre de archivo
+- ``created``: Fecha y hora de creación
+- ``title``: Título
+- ``digest``: Extracto del contenido
+- ``url``: URL del documento
 - ``thumbnail``: Miniatura
+- ``click_count``: Número de clics
+- ``favorite_count``: Número de favoritos
+- ``has_cache``: Disponibilidad de caché
+- ``content_title``: Título para visualización
+- ``content_description``: Extracto del contenido para visualización
+- ``url_link``: URL de enlace para visualización
+- ``site_path``: Ruta del sitio
 
 .. note::
-   El campo ``content`` no está incluido en la respuesta predeterminada. Para incluirlo, configure ``query.additional.scroll.response.fields=content`` en ``fess_config.properties``.
+   Los campos efectivamente emitidos se limitan a los campos permitidos como respuesta de la API.
+   Los campos sin valor no se emiten.
+
+.. note::
+   ``content`` (texto completo) no está incluido por defecto.
+   Puede agregarse mediante ``query.additional.scroll.response.fields``.
 
 Ejemplos de Procesamiento de Datos
-===================================
+====================================
 
 Ejemplo de Procesamiento en Python
------------------------------------
+-------------------------------------
 
 .. code-block:: python
 
@@ -213,7 +264,7 @@ Ejemplo de Procesamiento en Python
     import json
 
     # Ejecutar búsqueda scroll
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {
         "q": "Fess",
         "num": 100
@@ -224,7 +275,12 @@ Ejemplo de Procesamiento en Python
     # Procesar respuesta NDJSON línea por línea
     for line in response.iter_lines():
         if line:
-            doc = json.loads(line)
+            record = json.loads(line)
+            if "error" in record:
+                # Se produjo un error durante el stream
+                print("stream error:", record["error"])
+                break
+            doc = record["data"]
             print(f"Title: {doc.get('title')}")
             print(f"URL: {doc.get('url')}")
             print("---")
@@ -236,7 +292,7 @@ Ejemplo de cómo guardar los resultados de búsqueda en un archivo:
 
 .. code-block:: bash
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*" > all_documents.ndjson
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*" > all_documents.ndjson
 
 Conversión a CSV
 ----------------
@@ -245,8 +301,8 @@ Ejemplo de conversión a CSV utilizando el comando jq:
 
 .. code-block:: bash
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess" | \
-        jq -r '[.url, .title, .score] | @csv' > results.csv
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess" | \
+        jq -r '.data | [.url, .title, .score] | @csv' > results.csv
 
 Análisis de Datos
 -----------------
@@ -257,13 +313,14 @@ Ejemplo de análisis de datos obtenidos:
 
     import json
     import pandas as pd
-    from collections import Counter
 
-    # Leer archivo NDJSON
+    # Leer archivo NDJSON (extrayendo la clave data de cada línea)
     documents = []
     with open('all_documents.ndjson', 'r') as f:
         for line in f:
-            documents.append(json.loads(line))
+            record = json.loads(line)
+            if "data" in record:
+                documents.append(record["data"])
 
     # Convertir a DataFrame
     df = pd.DataFrame(documents)
@@ -277,7 +334,7 @@ Ejemplo de análisis de datos obtenidos:
     print(df['domain'].value_counts())
 
 Rendimiento y Mejores Prácticas
-================================
+=================================
 
 Uso Eficiente
 -------------
@@ -302,7 +359,7 @@ Uso Eficiente
    - Ejecute sincronizaciones de datos periódicas como trabajos por lotes
 
 Optimización del Uso de Memoria
---------------------------------
+---------------------------------
 
 Al procesar grandes volúmenes de datos, utilice procesamiento en streaming para reducir el uso de memoria.
 
@@ -311,24 +368,28 @@ Al procesar grandes volúmenes de datos, utilice procesamiento en streaming para
     import requests
     import json
 
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {"q": "*:*", "num": 100}
 
     # Procesar en streaming
     with requests.get(url, params=params, stream=True) as response:
         for line in response.iter_lines(decode_unicode=True):
             if line:
-                doc = json.loads(line)
+                record = json.loads(line)
+                if "error" in record:
+                    break
                 # Procesar documento
-                process_document(doc)
+                process_document(record["data"])
 
 Consideraciones de Seguridad
-=============================
+==============================
 
 Restricciones de Acceso
------------------------
+------------------------
 
 Dado que la búsqueda scroll devuelve grandes volúmenes de datos, configure restricciones de acceso apropiadas.
+El endpoint en sí no requiere autenticación de forma predeterminada, por lo que considere las siguientes
+medidas según sea necesario.
 
 1. **Restricción por Dirección IP**
 
@@ -336,32 +397,32 @@ Dado que la búsqueda scroll devuelve grandes volúmenes de datos, configure res
 
 2. **Autenticación de API**
 
-   Utilizar tokens de API o autenticación básica
+   Utilizar tokens de API o autenticación básica mediante un proxy inverso u otro mecanismo
 
-3. **Restricción Basada en Roles**
+3. **Control de Acceso Basado en Roles**
 
-   Permitir acceso solo a usuarios con roles específicos
+   Los documentos devueltos son filtrados por el control de acceso basado en roles de |Fess|
 
 Limitación de Tasa
-------------------
+-------------------
 
 Se recomienda configurar limitación de tasa en el proxy inverso para evitar accesos excesivos.
 
 Solución de Problemas
-=====================
+======================
 
 La Búsqueda Scroll No Está Disponible
---------------------------------------
+---------------------------------------
 
 1. Verifique que ``api.search.scroll`` esté configurado como ``true``.
 2. Verifique que haya reiniciado |Fess|.
 3. Revise los registros de errores.
 
 Se Produce un Error de Tiempo de Espera
-----------------------------------------
+-----------------------------------------
 
 1. Reduzca el parámetro ``num`` para distribuir el procesamiento.
-3. Refine las condiciones de búsqueda para reducir la cantidad de datos obtenidos.
+2. Refine las condiciones de búsqueda para reducir la cantidad de datos obtenidos.
 
 Error de Memoria Insuficiente
 ------------------------------
@@ -375,7 +436,7 @@ La Respuesta Está Vacía
 
 1. Verifique que la consulta de búsqueda sea correcta.
 2. Verifique que las etiquetas o condiciones de filtro especificadas sean correctas.
-3. Verifique la configuración de permisos de búsqueda basada en roles.
+3. Los documentos sin permiso de visualización no se incluyen en los resultados debido al control de acceso basado en roles. Verifique la configuración de roles de la solicitud.
 
 Información de Referencia
 ==========================

--- a/fr/15.7/config/search-scroll.rst
+++ b/fr/15.7/config/search-scroll.rst
@@ -1,18 +1,18 @@
-==================
+================================================
 Récupération en masse des résultats de recherche
-==================
+================================================
 
 Aperçu
-====
+======
 
 La recherche normale de |Fess| affiche uniquement un nombre limité de résultats de recherche grâce à la fonction de pagination.
 Si vous souhaitez récupérer tous les résultats de recherche en une seule fois, utilisez la fonction de recherche par défilement (Scroll Search).
 
 Cette fonction est utile lorsque vous devez traiter tous les résultats de recherche,
-comme pour l'export de données en masse, les sauvegardes ou l'analyse de grandes quantités de données.
+par exemple pour l'export de données en masse, les sauvegardes ou l'analyse de grandes quantités de données.
 
 Cas d'utilisation
-============
+=================
 
 La recherche par défilement est adaptée aux utilisations suivantes :
 
@@ -27,13 +27,14 @@ La recherche par défilement est adaptée aux utilisations suivantes :
    plus de ressources serveur que la recherche normale. Activez-la uniquement si nécessaire.
 
 Méthode de configuration
-========
+========================
 
 Activation de la recherche par défilement
-----------------------
+------------------------------------------
 
 Par défaut, la recherche par défilement est désactivée pour des raisons de sécurité et de performances.
-Pour l'activer, modifiez le paramètre suivant dans ``app/WEB-INF/classes/fess_config.properties`` ou ``/etc/fess/fess_config.properties``.
+Pour l'activer, modifiez le paramètre suivant dans ``app/WEB-INF/classes/fess_config.properties``
+(ou ``/etc/fess/fess_config.properties`` pour les packages RPM/DEB).
 
 ::
 
@@ -42,8 +43,19 @@ Pour l'activer, modifiez le paramètre suivant dans ``app/WEB-INF/classes/fess_c
 .. note::
    Après avoir modifié les paramètres, vous devez redémarrer |Fess|.
 
+Durée de vie du contexte de défilement
+---------------------------------------
+
+La durée de vie du contexte de défilement est fixée en interne à ``1m`` (1 minute) dans |Fess|.
+Cette valeur ne peut pas être modifiée via ``fess_config.properties``.
+
+.. note::
+   Le paramètre ``index.scroll.search.timeout`` existe, mais il est utilisé pour les traitements
+   internes impliquant la mise à jour ou la suppression d'index (update by query / delete by query).
+   Il n'a aucun effet sur le délai d'expiration de la présente fonctionnalité (défilement de recherche).
+
 Configuration des champs de réponse
---------------------------
+-------------------------------------
 
 Vous pouvez personnaliser les champs inclus dans la réponse des résultats de recherche.
 Par défaut, de nombreux champs sont renvoyés, mais vous pouvez spécifier des champs supplémentaires.
@@ -55,20 +67,20 @@ Par défaut, de nombreux champs sont renvoyés, mais vous pouvez spécifier des 
 Pour spécifier plusieurs champs, énumérez-les séparés par des virgules.
 
 .. note::
-   Le champ ``content`` n'est pas inclus par défaut dans la réponse. Ajoutez-le explicitement si nécessaire.
-
+   Le champ ``content`` n'est pas inclus par défaut dans la réponse.
+   Ajoutez-le via le paramètre ci-dessus si vous souhaitez récupérer le texte intégral.
 
 Méthode d'utilisation
-========
+=====================
 
 Utilisation de base
-----------------
+--------------------
 
 L'accès à la recherche par défilement s'effectue via l'URL suivante.
 
 ::
 
-    http://localhost:8080/api/v1/documents/all?q=mot-clé
+    http://localhost:8080/api/v2/documents/all?q=mot-clé
 
 Les résultats de recherche sont renvoyés au format NDJSON (Newline Delimited JSON).
 Chaque ligne contient un document au format JSON.
@@ -77,15 +89,16 @@ Chaque ligne contient un document au format JSON.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess"
 
 Paramètres de requête
---------------------
+----------------------
 
 Les paramètres suivants peuvent être utilisés pour la recherche par défilement.
 
 .. note::
-   La recherche par défilement ne prend en charge que la méthode GET.
+   La recherche par défilement ne prend en charge que la méthode GET. Si vous accédez avec
+   une méthode autre que GET, ``405 Method Not Allowed`` est renvoyé.
 
 .. list-table::
    :header-rows: 1
@@ -101,10 +114,13 @@ Les paramètres suivants peuvent être utilisés pour la recherche par défileme
      - Filtrage par étiquette
 
 .. note::
-   La valeur maximale de ``num`` peut être modifiée via le paramètre ``paging.search.page.max.size`` dans ``fess_config.properties``.
+   La valeur maximale de ``num`` est contrôlée par ``paging.search.page.max.size`` (par défaut : 100).
+   Si une valeur supérieure au maximum est spécifiée, elle est automatiquement ramenée au maximum.
+   La valeur par défaut est celle de ``paging.search.page.size`` (par défaut : 10).
+   Si une valeur inférieure ou égale à 0 est spécifiée pour ``num``, une erreur (``INVALID_REQUEST``) est renvoyée.
 
 Spécification de la requête de recherche
-----------------
+-----------------------------------------
 
 Vous pouvez spécifier une requête de recherche comme dans une recherche normale.
 
@@ -112,103 +128,142 @@ Vous pouvez spécifier une requête de recherche comme dans une recherche normal
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=moteur de recherche"
+    curl "http://localhost:8080/api/v2/documents/all?q=moteur de recherche"
 
 **Exemple : Recherche par champ spécifique**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=title:Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=title:Fess"
 
 **Exemple : Récupération de tous les éléments (sans condition de recherche)**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*"
 
 Spécification du nombre d'éléments à récupérer
---------------
+------------------------------------------------
 
 Vous pouvez modifier le nombre d'éléments récupérés par défilement.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess&num=100"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess&num=100"
 
 .. note::
    Si le paramètre ``num`` est trop élevé, l'utilisation de la mémoire augmente.
-   La valeur maximale par défaut est 100. Elle peut être modifiée via ``paging.search.page.max.size``.
+   La valeur maximale par défaut est 100. Si vous avez besoin d'une valeur plus élevée,
+   modifiez le paramètre ``paging.search.page.max.size``.
 
 Filtrage par étiquette
---------------------------
+-----------------------
 
 Vous pouvez récupérer uniquement les documents appartenant à une étiquette spécifique.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*&fields.label=public"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*&fields.label=public"
 
-À propos de l'authentification
--------------------------------
+À propos du contrôle d'accès
+------------------------------
+
+.. note::
+   La recherche par défilement applique également le contrôle d'accès basé sur les rôles (RBAC),
+   comme la recherche normale. Seuls les documents accessibles selon les informations de rôle de la
+   requête sont renvoyés ; les documents pour lesquels l'utilisateur ne dispose pas de droits de
+   consultation ne sont pas inclus dans les résultats.
 
 .. warning::
-   La recherche par défilement n'applique pas le contrôle d'accès basé sur les rôles (RBAC) de |Fess|.
-   Tous les documents correspondant aux critères de recherche sont renvoyés indépendamment des autorisations de l'utilisateur.
-   Si des restrictions d'accès sont nécessaires, configurez des restrictions d'adresses IP ou une authentification via un proxy inverse.
+   Par défaut, l'endpoint de la recherche par défilement ne requiert pas d'authentification
+   (tout le monde peut y accéder). Cependant, les documents renvoyés sont filtrés par le
+   contrôle d'accès basé sur les rôles décrit ci-dessus. Si vous souhaitez restreindre l'accès
+   à l'endpoint lui-même, configurez une restriction par adresse IP ou une authentification
+   via un proxy inverse.
 
 Format de réponse
-==============
+=================
 
 Format NDJSON
-----------
+--------------
 
 La réponse de la recherche par défilement est renvoyée au format NDJSON (Newline Delimited JSON).
-Chaque ligne représente un document.
+Le Content-Type est ``application/x-ndjson; charset=UTF-8``.
+Chaque ligne représente un document encapsulé dans le format ``{"data": {...}}``.
 
 **Exemple :**
 
 ::
 
-    {"url":"http://example.com/page1","title":"Page 1","content":"..."}
-    {"url":"http://example.com/page2","title":"Page 2","content":"..."}
-    {"url":"http://example.com/page3","title":"Page 3","content":"..."}
+    {"data":{"url":"http://example.com/page1","title":"Page 1","digest":"..."}}
+    {"data":{"url":"http://example.com/page2","title":"Page 2","digest":"..."}}
+    {"data":{"url":"http://example.com/page3","title":"Page 3","digest":"..."}}
+
+.. note::
+   Chaque document est stocké sous la clé ``data``. Côté client, après avoir analysé chaque
+   ligne, référencez la valeur de la clé ``data``.
+
+Comportement en cas d'erreur
+------------------------------
+
+Si une erreur survient côté serveur après le début de l'envoi du flux, une ligne terminatrice
+d'erreur est émise sur la dernière ligne de la réponse, comme suit :
+
+::
+
+    {"error":{"code":"internal_error","message":"stream error"}}
+
+.. note::
+   Côté client, vous pouvez déterminer si « le flux s'est terminé normalement » ou si
+   « une erreur est survenue côté serveur en cours de traitement » en vérifiant si la
+   dernière ligne contient la clé ``error``. Notez que si l'écriture de la ligne
+   terminatrice d'erreur elle-même échoue, cette ligne ne sera pas émise et le flux
+   se terminera en cours de route ; traitez donc également les déconnexions inattendues
+   comme des erreurs.
 
 Champs de réponse
---------------------
+------------------
 
-Principaux champs inclus par défaut :
+Champs inclus par défaut :
 
-- ``url_link`` : URL du document (lien)
-- ``url`` : URL du document
-- ``doc_id`` : Identifiant du document
-- ``site`` : Site
-- ``host`` : Hôte
+- ``score`` : Score de recherche
+- ``_id`` : Identifiant du document (identifiant de document OpenSearch)
+- ``doc_id`` : Identifiant du document (interne à |Fess|)
+- ``boost`` : Valeur de boost
 - ``content_length`` : Taille du contenu
+- ``host`` : Nom d'hôte
+- ``site`` : Site
 - ``last_modified`` : Date de dernière modification
 - ``timestamp`` : Horodatage
-- ``created`` : Date de création
-- ``boost`` : Valeur de boost
-- ``title`` : Titre
-- ``click_count`` : Nombre de clics
-- ``favorite_count`` : Nombre de favoris
 - ``mimetype`` : Type MIME
 - ``filetype`` : Type de fichier
 - ``filename`` : Nom du fichier
-- ``_id`` : Identifiant interne
-- ``digest`` : Résumé
-- ``score`` : Score de recherche
-- ``content_title`` : Titre du contenu
-- ``content_description`` : Description du contenu
+- ``created`` : Date de création
+- ``title`` : Titre
+- ``digest`` : Extrait du corps du document
+- ``url`` : URL du document
+- ``thumbnail`` : Miniature
+- ``click_count`` : Nombre de clics
+- ``favorite_count`` : Nombre de favoris
+- ``has_cache`` : Présence du cache
+- ``content_title`` : Titre affiché
+- ``content_description`` : Extrait affiché du corps du document
+- ``url_link`` : URL du lien affiché
 - ``site_path`` : Chemin du site
 
 .. note::
-   Le champ ``content`` n'est pas inclus par défaut. Pour l'ajouter, configurez ``query.additional.scroll.response.fields=content``.
+   Les champs effectivement émis sont limités aux champs autorisés dans la réponse de l'API.
+   Les champs sans valeur ne sont pas émis.
+
+.. note::
+   Le champ ``content`` (texte intégral) n'est pas inclus par défaut.
+   Vous pouvez l'ajouter via ``query.additional.scroll.response.fields``.
 
 Exemples de traitement de données
-============
+==================================
 
 Exemple de traitement en Python
-----------------
+---------------------------------
 
 .. code-block:: python
 
@@ -216,7 +271,7 @@ Exemple de traitement en Python
     import json
 
     # Exécution de la recherche par défilement
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {
         "q": "Fess",
         "num": 100
@@ -227,32 +282,37 @@ Exemple de traitement en Python
     # Traitement de la réponse NDJSON ligne par ligne
     for line in response.iter_lines():
         if line:
-            doc = json.loads(line)
+            record = json.loads(line)
+            if "error" in record:
+                # Une erreur est survenue en cours de flux
+                print("stream error:", record["error"])
+                break
+            doc = record["data"]
             print(f"Title: {doc.get('title')}")
             print(f"URL: {doc.get('url')}")
             print("---")
 
 Enregistrement dans un fichier
-----------------
+--------------------------------
 
 Exemple d'enregistrement des résultats de recherche dans un fichier :
 
 .. code-block:: bash
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*" > all_documents.ndjson
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*" > all_documents.ndjson
 
 Conversion en CSV
------------
+------------------
 
 Exemple de conversion en CSV à l'aide de la commande jq :
 
 .. code-block:: bash
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess" | \
-        jq -r '[.url, .title, .score] | @csv' > results.csv
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess" | \
+        jq -r '.data | [.url, .title, .score] | @csv' > results.csv
 
 Analyse de données
-----------
+-------------------
 
 Exemple d'analyse des données récupérées :
 
@@ -260,13 +320,14 @@ Exemple d'analyse des données récupérées :
 
     import json
     import pandas as pd
-    from collections import Counter
 
-    # Lecture du fichier NDJSON
+    # Lecture du fichier NDJSON (extraction de la clé data de chaque ligne)
     documents = []
     with open('all_documents.ndjson', 'r') as f:
         for line in f:
-            documents.append(json.loads(line))
+            record = json.loads(line)
+            if "data" in record:
+                documents.append(record["data"])
 
     # Conversion en DataFrame
     df = pd.DataFrame(documents)
@@ -280,10 +341,10 @@ Exemple d'analyse des données récupérées :
     print(df['domain'].value_counts())
 
 Performances et meilleures pratiques
-==================================
+=====================================
 
 Méthodes d'utilisation efficaces
-----------------
+----------------------------------
 
 1. **Configuration appropriée du paramètre num**
 
@@ -305,7 +366,7 @@ Méthodes d'utilisation efficaces
    - Exécutez la synchronisation régulière de données en tant que tâches par lots
 
 Optimisation de l'utilisation de la mémoire
---------------------
+---------------------------------------------
 
 Lors du traitement de grandes quantités de données, utilisez le traitement en streaming pour réduire l'utilisation de la mémoire.
 
@@ -314,24 +375,27 @@ Lors du traitement de grandes quantités de données, utilisez le traitement en 
     import requests
     import json
 
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {"q": "*:*", "num": 100}
 
     # Traitement en streaming
     with requests.get(url, params=params, stream=True) as response:
         for line in response.iter_lines(decode_unicode=True):
             if line:
-                doc = json.loads(line)
+                record = json.loads(line)
+                if "error" in record:
+                    break
                 # Traitement du document
-                process_document(doc)
+                process_document(record["data"])
 
 Considérations de sécurité
-====================
+============================
 
 Restrictions d'accès
-------------
+----------------------
 
 Étant donné que la recherche par défilement renvoie de grandes quantités de données, veuillez configurer des restrictions d'accès appropriées.
+L'endpoint lui-même ne requiert pas d'authentification par défaut ; envisagez les mesures suivantes si nécessaire.
 
 1. **Restriction par adresse IP**
 
@@ -339,35 +403,35 @@ Restrictions d'accès
 
 2. **Authentification API**
 
-   Utiliser des jetons API ou l'authentification Basic
+   Utiliser des jetons API ou l'authentification Basic via un proxy inverse
 
-3. **Restriction basée sur les rôles**
+3. **Contrôle d'accès basé sur les rôles**
 
-   Autoriser l'accès uniquement aux utilisateurs ayant des rôles spécifiques
+   Les documents renvoyés sont filtrés par le contrôle d'accès basé sur les rôles de |Fess|
 
 Limitation de débit
-----------
+---------------------
 
 Pour éviter les accès excessifs, il est recommandé de configurer une limitation de débit sur le proxy inverse.
 
 Dépannage
-======================
+==========
 
 La recherche par défilement n'est pas disponible
-----------------------------
+-------------------------------------------------
 
 1. Vérifiez que ``api.search.scroll`` est défini sur ``true``.
 2. Vérifiez que vous avez redémarré |Fess|.
 3. Consultez les journaux d'erreurs.
 
 Une erreur de délai d'expiration se produit
-----------------------------
+---------------------------------------------
 
 1. Réduisez le paramètre ``num`` pour répartir le traitement.
 2. Affinez les conditions de recherche pour réduire la quantité de données récupérées.
 
 Erreur de mémoire insuffisante
-----------------
+--------------------------------
 
 1. Réduisez le paramètre ``num``.
 2. Augmentez la taille de la mémoire heap de |Fess|.
@@ -378,11 +442,11 @@ La réponse est vide
 
 1. Vérifiez que la requête de recherche est correcte.
 2. Vérifiez que l'étiquette ou les conditions de filtre spécifiées sont correctes.
-3. Vérifiez les paramètres de permission de recherche basée sur les rôles.
+3. En raison du contrôle d'accès basé sur les rôles, les documents pour lesquels l'utilisateur ne dispose pas de droits de consultation ne sont pas inclus dans les résultats. Vérifiez les paramètres de rôle de la requête.
 
 Informations de référence
-========
+==========================
 
 - :doc:`search-basic` - Détails de la fonction de recherche
 - :doc:`search-advanced` - Paramètres liés à la recherche
-- `API Scroll d'OpenSearch <https://opensearch.org/docs/latest/api-reference/scroll/>`_
+- `OpenSearch Scroll API <https://opensearch.org/docs/latest/api-reference/scroll/>`_

--- a/ja/15.7/config/search-scroll.rst
+++ b/ja/15.7/config/search-scroll.rst
@@ -33,8 +33,8 @@
 ----------------------
 
 デフォルトでは、セキュリティとパフォーマンスの観点からスクロール検索は無効になっています。
-有効にするには、 ``app/WEB-INF/classes/fess_config.properties`` または ``/etc/fess/fess_config.properties`` で
-以下の設定を変更します。
+有効にするには、 ``app/WEB-INF/classes/fess_config.properties`` (RPM/DEB パッケージの場合は
+``/etc/fess/fess_config.properties`` )で以下の設定を変更します。
 
 ::
 
@@ -43,15 +43,16 @@
 .. note::
    設定変更後は、|Fess| を再起動する必要があります。
 
-スクロールタイムアウトの設定
-----------------------------
+スクロールコンテキストの有効期間
+--------------------------------
 
-スクロールコンテキストの有効時間はサーバー側の設定で制御されます。
-デフォルトは ``3m`` (3分)です。
+スクロール検索のスクロールコンテキストの有効期間は、|Fess| 内部で ``1m`` (1分)に固定されています。
+この値は ``fess_config.properties`` から変更することはできません。
 
-::
-
-    index.scroll.search.timeout=3m
+.. note::
+   ``index.scroll.search.timeout`` という設定がありますが、これはインデックスの更新・削除を
+   伴う内部処理(update by query / delete by query)で使用されるものであり、本機能(検索の
+   スクロール)のタイムアウトには影響しません。
 
 レスポンスフィールドの設定
 --------------------------
@@ -79,7 +80,7 @@
 
 ::
 
-    http://localhost:8080/api/v1/documents/all?q=検索キーワード
+    http://localhost:8080/api/v2/documents/all?q=検索キーワード
 
 検索結果は NDJSON(Newline Delimited JSON)形式で返却されます。
 1行ごとに1つのドキュメントがJSON形式で出力されます。
@@ -88,7 +89,7 @@
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess"
 
 リクエストパラメータ
 --------------------
@@ -96,7 +97,8 @@
 スクロール検索では、以下のパラメータを使用できます。
 
 .. note::
-   スクロール検索は GET メソッドのみ対応しています。
+   スクロール検索は GET メソッドのみ対応しています。GET 以外のメソッドでアクセスした場合は
+   ``405 Method Not Allowed`` が返されます。
 
 .. list-table::
    :header-rows: 1
@@ -114,6 +116,8 @@
 .. note::
    ``num`` の最大値は ``paging.search.page.max.size`` (デフォルト: 100)で制御されます。
    最大値を超える値を指定した場合、自動的に最大値に切り詰められます。
+   デフォルト値は ``paging.search.page.size`` (デフォルト: 10)が使用されます。
+   ``num`` に 0 以下の値を指定した場合は、エラー(``INVALID_REQUEST``)が返されます。
 
 検索クエリの指定
 ----------------
@@ -124,19 +128,19 @@
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=検索エンジン"
+    curl "http://localhost:8080/api/v2/documents/all?q=検索エンジン"
 
 **例: フィールド指定検索**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=title:Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=title:Fess"
 
 **例: 全件取得(検索条件なし)**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*"
 
 取得件数の指定
 --------------
@@ -145,7 +149,7 @@
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess&num=100"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess&num=100"
 
 .. note::
    ``num`` パラメータを大きくしすぎると、メモリ使用量が増加します。
@@ -159,15 +163,21 @@
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*&fields.label=public"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*&fields.label=public"
 
-認証について
-------------
+アクセス制御について
+--------------------
+
+.. note::
+   スクロール検索でも、通常の検索と同様にロールベースのアクセス制御(RBAC)が適用されます。
+   リクエストのロール情報に基づいてアクセス可能なドキュメントのみが返されるため、
+   閲覧権限のないドキュメントは結果に含まれません。
 
 .. warning::
-   スクロール検索では、|Fess| のロールベースアクセス制御(RBAC)は適用されません。
-   検索条件に一致するすべてのドキュメントがユーザーの権限に関係なく返されます。
-   アクセス制限が必要な場合は、リバースプロキシ等でIPアドレス制限や認証を設定してください。
+   スクロール検索のエンドポイントは、デフォルトでは認証を要求しません(誰でもアクセスできます)。
+   ただし、返されるドキュメントは上記のロールベースのアクセス制御によってフィルタリングされます。
+   エンドポイント自体へのアクセスを制限したい場合は、リバースプロキシ等でIPアドレス制限や
+   認証を設定してください。
 
 レスポンス形式
 ==============
@@ -176,15 +186,36 @@ NDJSON形式
 ----------
 
 スクロール検索のレスポンスは、NDJSON(Newline Delimited JSON)形式で返されます。
-各行が1つのドキュメントを表します。
+Content-Type は ``application/x-ndjson; charset=UTF-8`` です。
+各行は ``{"data": {...}}`` の形式でラップされた1つのドキュメントを表します。
 
 **例:**
 
 ::
 
-    {"url":"http://example.com/page1","title":"Page 1","content":"..."}
-    {"url":"http://example.com/page2","title":"Page 2","content":"..."}
-    {"url":"http://example.com/page3","title":"Page 3","content":"..."}
+    {"data":{"url":"http://example.com/page1","title":"Page 1","digest":"..."}}
+    {"data":{"url":"http://example.com/page2","title":"Page 2","digest":"..."}}
+    {"data":{"url":"http://example.com/page3","title":"Page 3","digest":"..."}}
+
+.. note::
+   各ドキュメントは ``data`` キーの下に格納されます。クライアント側では各行をパースした後、
+   ``data`` キーの値を参照してください。
+
+エラー時の動作
+--------------
+
+ストリームの送信開始後にサーバー側でエラーが発生した場合、レスポンスの最終行に
+以下のようなエラー終端行が出力されます。
+
+::
+
+    {"error":{"code":"internal_error","message":"stream error"}}
+
+.. note::
+   クライアント側では、最終行に ``error`` キーが含まれているかを確認することで、
+   「ストリームが正常に完了した」のか「サーバー側で途中エラーが発生した」のかを
+   判別できます。なお、エラー終端行の書き込み自体に失敗した場合は終端行が出力されず
+   ストリームが途中で終了するため、予期しない切断もエラーとして扱ってください。
 
 レスポンスフィールド
 --------------------
@@ -192,8 +223,8 @@ NDJSON形式
 デフォルトで含まれるフィールド:
 
 - ``score``: 検索スコア
-- ``id``: ドキュメントID
-- ``doc_id``: ドキュメントID(内部)
+- ``_id``: ドキュメントID(OpenSearch のドキュメントID)
+- ``doc_id``: ドキュメントID(|Fess| 内部)
 - ``boost``: ブースト値
 - ``content_length``: コンテンツ長
 - ``host``: ホスト名
@@ -210,9 +241,15 @@ NDJSON形式
 - ``thumbnail``: サムネイル
 - ``click_count``: クリック数
 - ``favorite_count``: お気に入り数
-- ``config_id``: 設定ID
-- ``lang``: 言語
 - ``has_cache``: キャッシュ有無
+- ``content_title``: 表示用タイトル
+- ``content_description``: 表示用の本文抜粋
+- ``url_link``: 表示用リンクURL
+- ``site_path``: サイトパス
+
+.. note::
+   実際に出力されるフィールドは、API レスポンスとして許可されたフィールドに限定されます。
+   値が存在しないフィールドは出力されません。
 
 .. note::
    ``content`` (全文)はデフォルトでは含まれません。
@@ -230,7 +267,7 @@ Pythonでの処理例
     import json
 
     # スクロール検索の実行
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {
         "q": "Fess",
         "num": 100
@@ -241,7 +278,12 @@ Pythonでの処理例
     # NDJSON形式のレスポンスを1行ずつ処理
     for line in response.iter_lines():
         if line:
-            doc = json.loads(line)
+            record = json.loads(line)
+            if "error" in record:
+                # ストリーム途中でエラーが発生
+                print("stream error:", record["error"])
+                break
+            doc = record["data"]
             print(f"Title: {doc.get('title')}")
             print(f"URL: {doc.get('url')}")
             print("---")
@@ -253,7 +295,7 @@ Pythonでの処理例
 
 .. code-block:: bash
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*" > all_documents.ndjson
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*" > all_documents.ndjson
 
 CSVへの変換
 -----------
@@ -262,8 +304,8 @@ jqコマンドを使用してCSVに変換する例:
 
 .. code-block:: bash
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess" | \
-        jq -r '[.url, .title, .score] | @csv' > results.csv
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess" | \
+        jq -r '.data | [.url, .title, .score] | @csv' > results.csv
 
 データ分析
 ----------
@@ -274,13 +316,14 @@ jqコマンドを使用してCSVに変換する例:
 
     import json
     import pandas as pd
-    from collections import Counter
 
-    # NDJSONファイルの読み込み
+    # NDJSONファイルの読み込み(各行の data キーを取り出す)
     documents = []
     with open('all_documents.ndjson', 'r') as f:
         for line in f:
-            documents.append(json.loads(line))
+            record = json.loads(line)
+            if "data" in record:
+                documents.append(record["data"])
 
     # DataFrameに変換
     df = pd.DataFrame(documents)
@@ -328,16 +371,18 @@ jqコマンドを使用してCSVに変換する例:
     import requests
     import json
 
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {"q": "*:*", "num": 100}
 
     # ストリーミングで処理
     with requests.get(url, params=params, stream=True) as response:
         for line in response.iter_lines(decode_unicode=True):
             if line:
-                doc = json.loads(line)
+                record = json.loads(line)
+                if "error" in record:
+                    break
                 # ドキュメントの処理
-                process_document(doc)
+                process_document(record["data"])
 
 セキュリティ考慮事項
 ====================
@@ -346,6 +391,8 @@ jqコマンドを使用してCSVに変換する例:
 ------------
 
 スクロール検索は大量のデータを返すため、適切なアクセス制限を設定してください。
+エンドポイント自体はデフォルトで認証を要求しないため、必要に応じて以下のような対策を
+検討してください。
 
 1. **IPアドレス制限**
 
@@ -353,11 +400,11 @@ jqコマンドを使用してCSVに変換する例:
 
 2. **API認証**
 
-   APIトークンやBasic認証を使用
+   リバースプロキシ等でAPIトークンやBasic認証を使用
 
-3. **ロールベース制限**
+3. **ロールベースのアクセス制御**
 
-   特定のロールを持つユーザーのみアクセスを許可
+   返されるドキュメントは |Fess| のロールベースのアクセス制御によりフィルタリングされます
 
 レート制限
 ----------
@@ -392,7 +439,7 @@ jqコマンドを使用してCSVに変換する例:
 
 1. 検索クエリが正しいか確認してください。
 2. 指定したラベルやフィルタ条件が正しいか確認してください。
-3. ロールベース検索の権限設定を確認してください。
+3. ロールベースのアクセス制御により、閲覧権限のないドキュメントは結果に含まれません。リクエストのロール設定を確認してください。
 
 参考情報
 ========

--- a/ko/15.7/config/search-scroll.rst
+++ b/ko/15.7/config/search-scroll.rst
@@ -1,6 +1,6 @@
-==================
+====================
 검색 결과 일괄 취득
-==================
+====================
 
 개요
 ====
@@ -9,10 +9,10 @@
 모든 검색 결과를 일괄로 취득하려면 스크롤 검색(Scroll Search) 기능을 이용합니다.
 
 이 기능은 데이터의 일괄 내보내기나 백업, 대량 데이터 분석 등
-모든 검색 결과를 처리해야 하는 경우 유용합니다.
+모든 검색 결과를 처리해야 하는 경우에 유용합니다.
 
 활용 사례
-============
+=========
 
 스크롤 검색은 다음과 같은 용도에 적합합니다.
 
@@ -27,14 +27,14 @@
    서버 리소스를 많이 소비합니다. 필요한 경우에만 활성화하십시오.
 
 설정 방법
-========
+=========
 
 스크롤 검색 활성화
-----------------------
+------------------
 
 기본적으로 보안과 성능 관점에서 스크롤 검색은 비활성화되어 있습니다.
-활성화하려면 ``app/WEB-INF/classes/fess_config.properties`` 또는 ``/etc/fess/fess_config.properties`` 에서
-다음 설정을 변경합니다.
+활성화하려면 ``app/WEB-INF/classes/fess_config.properties`` (RPM/DEB 패키지의 경우
+``/etc/fess/fess_config.properties`` )에서 다음 설정을 변경합니다.
 
 ::
 
@@ -43,30 +43,44 @@
 .. note::
    설정 변경 후 |Fess| 를 재시작해야 합니다.
 
-응답 필드 설정
+스크롤 컨텍스트 유효 기간
 --------------------------
 
+스크롤 검색의 스크롤 컨텍스트 유효 기간은 |Fess| 내부에서 ``1m`` (1분)으로 고정되어 있습니다.
+이 값은 ``fess_config.properties`` 에서 변경할 수 없습니다.
+
+.. note::
+   ``index.scroll.search.timeout`` 라는 설정이 있지만, 이는 인덱스의 업데이트·삭제를
+   수반하는 내부 처리(update by query / delete by query)에서 사용되는 것으로,
+   본 기능(검색 스크롤)의 타임아웃에는 영향을 주지 않습니다.
+
+응답 필드 설정
+--------------
+
 검색 결과 응답에 포함할 필드를 사용자 정의할 수 있습니다.
-기본적으로 많은 필드가 반환되지만 추가 필드를 지정할 수 있습니다.
+기본적으로 많은 필드가 반환되지만 추가 필드를 지정할 수도 있습니다.
 
 ::
 
     query.additional.scroll.response.fields=content
 
+여러 필드를 지정하는 경우 쉼표로 구분하여 나열합니다.
+
 .. note::
-   ``content`` 필드는 기본 응답에 포함되지 않습니다. 필요한 경우 위 설정으로 추가하십시오.
+   ``content`` 필드는 기본 응답에 포함되지 않습니다.
+   전문을 취득하려면 위 설정으로 추가하십시오.
 
 사용 방법
-========
+=========
 
 기본 사용 방법
-----------------
+--------------
 
 스크롤 검색에 접근하려면 다음 URL로 실행합니다.
 
 ::
 
-    http://localhost:8080/api/v1/documents/all?q=검색키워드
+    http://localhost:8080/api/v2/documents/all?q=검색키워드
 
 검색 결과는 NDJSON(Newline Delimited JSON) 형식으로 반환됩니다.
 1행마다 1개의 문서가 JSON 형식으로 출력됩니다.
@@ -75,15 +89,16 @@
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess"
 
 요청 파라미터
---------------------
+-------------
 
 스크롤 검색에서는 다음 파라미터를 사용할 수 있습니다.
 
 .. note::
-   스크롤 검색은 GET 메서드만 지원합니다.
+   스크롤 검색은 GET 메서드만 지원합니다. GET 이외의 메서드로 접근하면
+   ``405 Method Not Allowed`` 가 반환됩니다.
 
 .. list-table::
    :header-rows: 1
@@ -99,10 +114,13 @@
      - 레이블에 의한 필터링
 
 .. note::
-   ``num`` 의 최대값은 ``paging.search.page.max.size`` 설정에 의해 결정됩니다.
+   ``num`` 의 최대값은 ``paging.search.page.max.size`` (기본값: 100)로 제어됩니다.
+   최대값을 초과하는 값을 지정하면 자동으로 최대값으로 잘립니다.
+   기본값은 ``paging.search.page.size`` (기본값: 10)가 사용됩니다.
+   ``num`` 에 0 이하의 값을 지정하면 오류( ``INVALID_REQUEST`` )가 반환됩니다.
 
 검색 쿼리 지정
-----------------
+--------------
 
 일반 검색과 동일하게 검색 쿼리를 지정할 수 있습니다.
 
@@ -110,19 +128,19 @@
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=검색엔진"
+    curl "http://localhost:8080/api/v2/documents/all?q=검색엔진"
 
 **예: 필드 지정 검색**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=title:Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=title:Fess"
 
 **예: 전체 취득(검색 조건 없음)**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*"
 
 취득 건수 지정
 --------------
@@ -131,83 +149,117 @@
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess&num=100"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess&num=100"
 
 .. note::
    ``num`` 파라미터를 너무 크게 하면 메모리 사용량이 증가합니다.
-   최대값은 ``paging.search.page.max.size`` 설정(기본값: 100)에 의해 결정됩니다.
+   기본 최대값은 100입니다. 더 큰 값이 필요한 경우에는
+   ``paging.search.page.max.size`` 설정을 변경하십시오.
 
 레이블에 의한 필터링
---------------------------
+--------------------
 
 특정 레이블에 속하는 문서만 취득할 수 있습니다.
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*&fields.label=public"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*&fields.label=public"
 
-인증에 대하여
---------------
+접근 제어에 대하여
+------------------
+
+.. note::
+   스크롤 검색에서도 일반 검색과 동일하게 역할 기반 접근 제어(RBAC)가 적용됩니다.
+   요청의 역할 정보를 기반으로 접근 가능한 문서만 반환되므로
+   열람 권한이 없는 문서는 결과에 포함되지 않습니다.
 
 .. warning::
-   스크롤 검색에서는 |Fess| 의 역할 기반 접근 제어(RBAC)가 적용되지 않습니다.
-   검색 조건에 일치하는 모든 문서가 사용자의 권한에 관계없이 반환됩니다.
-   접근 제한이 필요한 경우 리버스 프록시 등에서 IP 주소 제한이나 인증을 설정하십시오.
+   스크롤 검색 엔드포인트는 기본적으로 인증을 요구하지 않습니다(누구나 접근 가능합니다).
+   단, 반환되는 문서는 위의 역할 기반 접근 제어에 의해 필터링됩니다.
+   엔드포인트 자체에 대한 접근을 제한하려면 리버스 프록시 등에서 IP 주소 제한이나
+   인증을 설정하십시오.
 
 응답 형식
-==============
+=========
 
 NDJSON 형식
-----------
+-----------
 
 스크롤 검색의 응답은 NDJSON(Newline Delimited JSON) 형식으로 반환됩니다.
-각 행이 1개의 문서를 나타냅니다.
+Content-Type 은 ``application/x-ndjson; charset=UTF-8`` 입니다.
+각 행은 ``{"data": {...}}`` 형식으로 래핑된 1개의 문서를 나타냅니다.
 
 **예:**
 
 ::
 
-    {"url":"http://example.com/page1","title":"Page 1","content":"..."}
-    {"url":"http://example.com/page2","title":"Page 2","content":"..."}
-    {"url":"http://example.com/page3","title":"Page 3","content":"..."}
+    {"data":{"url":"http://example.com/page1","title":"Page 1","digest":"..."}}
+    {"data":{"url":"http://example.com/page2","title":"Page 2","digest":"..."}}
+    {"data":{"url":"http://example.com/page3","title":"Page 3","digest":"..."}}
+
+.. note::
+   각 문서는 ``data`` 키 아래에 저장됩니다. 클라이언트 측에서는 각 행을 파싱한 후
+   ``data`` 키의 값을 참조하십시오.
+
+오류 발생 시의 동작
+-------------------
+
+스트림 전송 시작 후 서버 측에서 오류가 발생한 경우, 응답의 마지막 행에
+다음과 같은 오류 종단 행이 출력됩니다.
+
+::
+
+    {"error":{"code":"internal_error","message":"stream error"}}
+
+.. note::
+   클라이언트 측에서는 마지막 행에 ``error`` 키가 포함되어 있는지 확인함으로써
+   「스트림이 정상적으로 완료되었는지」아니면 「서버 측에서 중간에 오류가 발생했는지」를
+   판별할 수 있습니다. 또한 오류 종단 행의 기록 자체가 실패한 경우에는 종단 행이 출력되지 않고
+   스트림이 중간에 종료되므로 예기치 않은 연결 끊김도 오류로 처리하십시오.
 
 응답 필드
---------------------
+---------
 
 기본적으로 포함되는 필드:
 
-- ``url_link``: 표시용 URL
-- ``content_description``: 콘텐츠 설명
-- ``site_path``: 사이트 경로
-- ``content_title``: 콘텐츠 제목
+- ``score``: 검색 점수
+- ``_id``: 문서 ID(OpenSearch 의 문서 ID)
+- ``doc_id``: 문서 ID( |Fess| 내부)
+- ``boost``: 부스트 값
 - ``content_length``: 콘텐츠 길이
 - ``host``: 호스트명
+- ``site``: 사이트
 - ``last_modified``: 최종 수정 날짜 및 시간
 - ``timestamp``: 타임스탬프
-- ``cache``: 캐시 데이터
-- ``doc_id``: 문서 ID
-- ``url``: 문서의 URL
-- ``created``: 생성 날짜 및 시간
-- ``site``: 사이트
-- ``boost``: 부스트 값
-- ``title``: 제목
-- ``click_count``: 클릭 수
 - ``mimetype``: MIME 타입
-- ``favorite_count``: 즐겨찾기 수
-- ``_id``: 내부 ID
 - ``filetype``: 파일 유형
 - ``filename``: 파일명
-- ``score``: 검색 점수
+- ``created``: 생성 날짜 및 시간
+- ``title``: 제목
+- ``digest``: 본문 발췌
+- ``url``: 문서의 URL
+- ``thumbnail``: 썸네일
+- ``click_count``: 클릭 수
+- ``favorite_count``: 즐겨찾기 수
+- ``has_cache``: 캐시 유무
+- ``content_title``: 표시용 제목
+- ``content_description``: 표시용 본문 발췌
+- ``url_link``: 표시용 링크 URL
+- ``site_path``: 사이트 경로
 
 .. note::
-   ``content`` 필드는 기본 응답에 포함되지 않습니다.
-   ``query.additional.scroll.response.fields=content`` 설정으로 추가할 수 있습니다.
+   실제로 출력되는 필드는 API 응답으로 허용된 필드에 한정됩니다.
+   값이 존재하지 않는 필드는 출력되지 않습니다.
+
+.. note::
+   ``content`` (전문)은 기본적으로 포함되지 않습니다.
+   ``query.additional.scroll.response.fields`` 로 추가할 수 있습니다.
 
 데이터 처리 예
-============
+==============
 
 Python으로 처리하는 예
-----------------
+----------------------
 
 .. code-block:: python
 
@@ -215,7 +267,7 @@ Python으로 처리하는 예
     import json
 
     # 스크롤 검색 실행
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {
         "q": "Fess",
         "num": 100
@@ -226,32 +278,37 @@ Python으로 처리하는 예
     # NDJSON 형식의 응답을 1행씩 처리
     for line in response.iter_lines():
         if line:
-            doc = json.loads(line)
+            record = json.loads(line)
+            if "error" in record:
+                # 스트림 도중에 오류 발생
+                print("stream error:", record["error"])
+                break
+            doc = record["data"]
             print(f"Title: {doc.get('title')}")
             print(f"URL: {doc.get('url')}")
             print("---")
 
 파일에 저장
-----------------
+-----------
 
 검색 결과를 파일에 저장하는 예:
 
 .. code-block:: bash
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*" > all_documents.ndjson
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*" > all_documents.ndjson
 
 CSV로 변환
------------
+----------
 
 jq 명령을 사용하여 CSV로 변환하는 예:
 
 .. code-block:: bash
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess" | \
-        jq -r '[.url, .title, .score] | @csv' > results.csv
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess" | \
+        jq -r '.data | [.url, .title, .score] | @csv' > results.csv
 
 데이터 분석
-----------
+-----------
 
 취득한 데이터를 분석하는 예:
 
@@ -259,13 +316,14 @@ jq 명령을 사용하여 CSV로 변환하는 예:
 
     import json
     import pandas as pd
-    from collections import Counter
 
-    # NDJSON 파일 읽기
+    # NDJSON 파일 읽기(각 행의 data 키를 꺼냄)
     documents = []
     with open('all_documents.ndjson', 'r') as f:
         for line in f:
-            documents.append(json.loads(line))
+            record = json.loads(line)
+            if "data" in record:
+                documents.append(record["data"])
 
     # DataFrame으로 변환
     df = pd.DataFrame(documents)
@@ -279,10 +337,10 @@ jq 명령을 사용하여 CSV로 변환하는 예:
     print(df['domain'].value_counts())
 
 성능 및 모범 사례
-==================================
+=================
 
 효율적인 사용 방법
-----------------
+------------------
 
 1. **적절한 num 파라미터 설정**
 
@@ -295,11 +353,11 @@ jq 명령을 사용하여 CSV로 변환하는 예:
    - 필요한 문서만 취득하도록 검색 조건 지정
    - 전체 취득은 정말 필요한 경우에만 실행
 
-3. **오프피크 시간 이용**
+3. **오프피크 시간 활용**
 
    - 대량 데이터 취득은 시스템 부하가 낮은 시간대에 실행
 
-4. **배치 처리에서 이용**
+4. **배치 처리에서 활용**
 
    - 정기적인 데이터 동기화 등은 배치 작업으로 실행
 
@@ -313,24 +371,28 @@ jq 명령을 사용하여 CSV로 변환하는 예:
     import requests
     import json
 
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {"q": "*:*", "num": 100}
 
     # 스트리밍으로 처리
     with requests.get(url, params=params, stream=True) as response:
         for line in response.iter_lines(decode_unicode=True):
             if line:
-                doc = json.loads(line)
+                record = json.loads(line)
+                if "error" in record:
+                    break
                 # 문서 처리
-                process_document(doc)
+                process_document(record["data"])
 
 보안 고려 사항
-====================
+==============
 
 접근 제한
-------------
+---------
 
 스크롤 검색은 대량의 데이터를 반환하므로 적절한 접근 제한을 설정하십시오.
+엔드포인트 자체는 기본적으로 인증을 요구하지 않으므로 필요에 따라 다음과 같은
+대책을 검토하십시오.
 
 1. **IP 주소 제한**
 
@@ -338,19 +400,19 @@ jq 명령을 사용하여 CSV로 변환하는 예:
 
 2. **API 인증**
 
-   API 토큰이나 Basic 인증 사용
+   리버스 프록시 등에서 API 토큰이나 Basic 인증 사용
 
-3. **역할 기반 제한**
+3. **역할 기반 접근 제어**
 
-   특정 역할을 가진 사용자만 접근 허용
+   반환되는 문서는 |Fess| 의 역할 기반 접근 제어에 의해 필터링됩니다
 
 속도 제한
-----------
+---------
 
 과도한 접근을 방지하기 위해 리버스 프록시에서 속도 제한을 설정하는 것을 권장합니다.
 
 문제 해결
-======================
+=========
 
 스크롤 검색을 이용할 수 없음
 ----------------------------
@@ -360,7 +422,7 @@ jq 명령을 사용하여 CSV로 변환하는 예:
 3. 오류 로그를 확인하십시오.
 
 타임아웃 오류가 발생함
-----------------------------
+----------------------
 
 1. ``num`` 파라미터를 작게 하여 처리를 분산하십시오.
 2. 검색 조건을 좁혀 취득하는 데이터 양을 줄이십시오.
@@ -373,14 +435,14 @@ jq 명령을 사용하여 CSV로 변환하는 예:
 3. OpenSearch의 힙 메모리 크기를 확인하십시오.
 
 응답이 비어 있음
---------------------
+----------------
 
 1. 검색 쿼리가 올바른지 확인하십시오.
 2. 지정한 레이블이나 필터 조건이 올바른지 확인하십시오.
-3. 역할 기반 검색의 권한 설정을 확인하십시오.
+3. 역할 기반 접근 제어로 인해 열람 권한이 없는 문서는 결과에 포함되지 않습니다. 요청의 역할 설정을 확인하십시오.
 
 참고 정보
-========
+=========
 
 - :doc:`search-basic` - 검색 기능 자세히 보기
 - :doc:`search-advanced` - 검색 관련 설정

--- a/zh-cn/15.7/config/search-scroll.rst
+++ b/zh-cn/15.7/config/search-scroll.rst
@@ -1,18 +1,18 @@
-==================
+========================
 批量获取搜索结果
-==================
+========================
 
 概述
 ====
 
 |Fess| 的常规搜索通过分页功能仅显示一定数量的搜索结果。
-如需批量获取所有搜索结果,请使用滚动搜索(Scroll Search)功能。
+如需批量获取所有搜索结果，请使用滚动搜索（Scroll Search）功能。
 
 此功能适用于数据批量导出、备份、大量数据分析等
 需要处理所有搜索结果的情况。
 
 用例
-============
+====
 
 滚动搜索适用于以下用途。
 
@@ -23,69 +23,81 @@
 - 报告生成用数据收集
 
 .. warning::
-   滚动搜索会返回大量数据,与常规搜索相比
+   滚动搜索会返回大量数据，与常规搜索相比
    会消耗更多服务器资源。请仅在必要时启用。
 
 配置方法
 ========
 
 启用滚动搜索
-----------------------
+------------
 
-默认情况下,出于安全和性能考虑,滚动搜索被禁用。
-要启用,请在 ``app/WEB-INF/classes/fess_config.properties`` 或 ``/etc/fess/fess_config.properties`` 中
-修改以下配置。
+默认情况下，出于安全和性能考虑，滚动搜索被禁用。
+要启用，请在 ``app/WEB-INF/classes/fess_config.properties`` （RPM/DEB 包的情况下为
+``/etc/fess/fess_config.properties`` ）中修改以下配置。
 
 ::
 
     api.search.scroll=true
 
 .. note::
-   配置变更后,需要重启 |Fess|。
+   配置变更后，需要重启 |Fess|。
+
+滚动上下文有效期
+----------------
+
+滚动搜索的滚动上下文有效期在 |Fess| 内部固定为 ``1m`` （1分钟）。
+该值无法通过 ``fess_config.properties`` 修改。
+
+.. note::
+   ``index.scroll.search.timeout`` 配置项存在，但该项用于涉及索引更新、删除的
+   内部处理（update by query / delete by query），不会影响本功能（搜索
+   滚动）的超时时间。
 
 响应字段配置
---------------------------
+------------
 
 可以自定义搜索结果响应中包含的字段。
-默认返回多个字段,但可以通过以下配置追加字段。
+默认返回多个字段，但可以通过以下配置追加字段。
 
 ::
 
     query.additional.scroll.response.fields=content
 
-指定多个字段时,请用逗号分隔。
+指定多个字段时，请用逗号分隔。
 
 .. note::
-   ``content`` 字段默认不包含在响应中。如需获取正文内容,请通过上述配置追加。
+   ``content`` 字段默认不包含在响应中。如需获取正文全文，请通过上述配置追加。
 
 使用方法
 ========
 
 基本使用方法
-----------------
+------------
 
 滚动搜索通过以下 URL 访问。
 
 ::
 
-    http://localhost:8080/api/v1/documents/all?q=搜索关键词
+    http://localhost:8080/api/v2/documents/all?q=搜索关键词
 
-搜索结果以 NDJSON(Newline Delimited JSON)格式返回。
+搜索结果以 NDJSON（Newline Delimited JSON）格式返回。
 每行以 JSON 格式输出一个文档。
 
 **示例:**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess"
 
 请求参数
---------------------
+--------
 
 滚动搜索可使用以下参数。
 
 .. note::
-   滚动搜索仅支持 GET 方法。
+   滚动搜索仅支持 GET 方法。使用 GET 以外的方法访问时，将返回
+   ``405 Method Not Allowed``。
 
 .. list-table::
    :header-rows: 1
@@ -94,121 +106,159 @@
    * - 参数名
      - 说明
    * - ``q``
-     - 搜索查询(必需)
+     - 搜索查询（必需）
    * - ``num``
-     - 一次获取的条数(默认: 10, 最大: 100)
+     - 一次滚动获取的条数（默认值：10，最大值：100）
    * - ``fields.label``
      - 按标签过滤
 
 .. note::
-   最大获取条数可通过 ``paging.search.page.max.size`` 进行变更。
+   ``num`` 的最大值由 ``paging.search.page.max.size`` （默认值：100）控制。
+   指定超过最大值的数值时，将自动截断为最大值。
+   默认值使用 ``paging.search.page.size`` （默认值：10）。
+   ``num`` 指定 0 以下的值时，将返回错误（``INVALID_REQUEST``）。
 
 指定搜索查询
-----------------
+------------
 
 可以像常规搜索一样指定搜索查询。
 
-**示例: 关键词搜索**
+**示例：关键词搜索**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=搜索引擎"
+    curl "http://localhost:8080/api/v2/documents/all?q=搜索引擎"
 
-**示例: 字段指定搜索**
-
-::
-
-    curl "http://localhost:8080/api/v1/documents/all?q=title:Fess"
-
-**示例: 全量获取(无搜索条件)**
+**示例：字段指定搜索**
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*"
+    curl "http://localhost:8080/api/v2/documents/all?q=title:Fess"
+
+**示例：全量获取（无搜索条件）**
+
+::
+
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*"
 
 指定获取条数
---------------
+------------
 
 可以更改一次滚动获取的条数。
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess&num=100"
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess&num=100"
 
 .. note::
-   ``num`` 参数的最大值默认为100。
-   可通过 ``paging.search.page.max.size`` 进行变更。
+   ``num`` 参数设置过大会导致内存使用量增加。
+   默认最大值为 100。如需更大的值，请修改
+   ``paging.search.page.max.size`` 配置。
 
 按标签过滤
---------------------------
+----------
 
 可以仅获取属于特定标签的文档。
 
 ::
 
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*&fields.label=public"
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*&fields.label=public"
 
-关于认证
-----------
+关于访问控制
+------------
+
+.. note::
+   滚动搜索与常规搜索相同，同样会应用基于角色的访问控制（RBAC）。
+   仅返回基于请求角色信息可访问的文档，
+   无查看权限的文档不会包含在结果中。
 
 .. warning::
-   滚动搜索不会应用 |Fess| 的基于角色的访问控制（RBAC）。
-   与搜索条件匹配的所有文档将无视用户权限返回。
-   如需访问限制,请通过反向代理等配置 IP 地址限制或认证。
+   滚动搜索端点默认不要求认证（任何人均可访问）。
+   但返回的文档会经过上述基于角色的访问控制进行过滤。
+   如需限制端点本身的访问，请通过反向代理等设置 IP 地址限制或
+   认证。
 
 响应格式
-==============
+========
 
 NDJSON 格式
-----------
+-----------
 
-滚动搜索的响应以 NDJSON(Newline Delimited JSON)格式返回。
-每行表示一个文档。
+滚动搜索的响应以 NDJSON（Newline Delimited JSON）格式返回。
+Content-Type 为 ``application/x-ndjson; charset=UTF-8``。
+每行表示以 ``{"data": {...}}`` 形式包装的一个文档。
 
 **示例:**
 
 ::
 
-    {"url":"http://example.com/page1","title":"Page 1","content":"..."}
-    {"url":"http://example.com/page2","title":"Page 2","content":"..."}
-    {"url":"http://example.com/page3","title":"Page 3","content":"..."}
+    {"data":{"url":"http://example.com/page1","title":"Page 1","digest":"..."}}
+    {"data":{"url":"http://example.com/page2","title":"Page 2","digest":"..."}}
+    {"data":{"url":"http://example.com/page3","title":"Page 3","digest":"..."}}
+
+.. note::
+   每个文档存储在 ``data`` 键下。客户端在解析每行后，
+   请引用 ``data`` 键的值。
+
+错误时的行为
+------------
+
+流式传输开始后若服务器端发生错误，响应的最后一行将
+输出如下错误终止行。
+
+::
+
+    {"error":{"code":"internal_error","message":"stream error"}}
+
+.. note::
+   客户端可通过检查最后一行是否包含 ``error`` 键，来判断
+   "流是否正常完成"还是"服务器端中途发生了错误"。
+   需要注意的是，若错误终止行本身的写入失败，则终止行不会输出，
+   流将中途结束，因此请将意外断开也视为错误处理。
 
 响应字段
---------------------
+--------
 
-默认包含的主要字段:
+默认包含的字段：
 
-- ``url_link``: 显示用 URL
-- ``url``: 文档 URL
-- ``doc_id``: 文档 ID
+- ``score``: 搜索评分
+- ``_id``: 文档 ID（OpenSearch 的文档 ID）
+- ``doc_id``: 文档 ID（|Fess| 内部）
+- ``boost``: 提升值
 - ``content_length``: 内容长度
 - ``host``: 主机名
 - ``site``: 站点
 - ``last_modified``: 最后更新时间
 - ``timestamp``: 时间戳
-- ``boost``: 提升值
-- ``click_count``: 点击次数
-- ``favorite_count``: 收藏次数
-- ``config_id``: 配置 ID
-- ``parent_id``: 父文档 ID
-- ``segment``: 段
-- ``score``: 搜索评分
-- ``digest``: 摘要
-- ``title``: 标题
+- ``mimetype``: MIME 类型
 - ``filetype``: 文件类型
 - ``filename``: 文件名
-- ``mimetype``: MIME 类型
 - ``created``: 创建时间
-- ``content_title``: 内容标题
+- ``title``: 标题
+- ``digest``: 正文摘要
+- ``url``: 文档 URL
+- ``thumbnail``: 缩略图
+- ``click_count``: 点击次数
+- ``favorite_count``: 收藏次数
+- ``has_cache``: 是否有缓存
+- ``content_title``: 显示用标题
+- ``content_description``: 显示用正文摘要
+- ``url_link``: 显示用链接 URL
+- ``site_path``: 站点路径
 
 .. note::
-   ``content`` 字段默认不包含在响应中。如需获取正文内容,请在 ``query.additional.scroll.response.fields`` 中追加 ``content``。
+   实际输出的字段仅限于 API 响应中允许的字段。
+   不存在值的字段不会输出。
+
+.. note::
+   ``content`` （正文全文）默认不包含在响应中。
+   可通过 ``query.additional.scroll.response.fields`` 追加。
 
 数据处理示例
 ============
 
 Python 处理示例
-----------------
+---------------
 
 .. code-block:: python
 
@@ -216,7 +266,7 @@ Python 处理示例
     import json
 
     # 执行滚动搜索
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {
         "q": "Fess",
         "num": 100
@@ -227,46 +277,52 @@ Python 处理示例
     # 逐行处理 NDJSON 格式的响应
     for line in response.iter_lines():
         if line:
-            doc = json.loads(line)
+            record = json.loads(line)
+            if "error" in record:
+                # 流传输中途发生错误
+                print("stream error:", record["error"])
+                break
+            doc = record["data"]
             print(f"Title: {doc.get('title')}")
             print(f"URL: {doc.get('url')}")
             print("---")
 
 保存到文件
-----------------
-
-将搜索结果保存到文件的示例:
-
-.. code-block:: bash
-
-    curl "http://localhost:8080/api/v1/documents/all?q=*:*" > all_documents.ndjson
-
-转换为 CSV
------------
-
-使用 jq 命令转换为 CSV 的示例:
-
-.. code-block:: bash
-
-    curl "http://localhost:8080/api/v1/documents/all?q=Fess" | \
-        jq -r '[.url, .title, .score] | @csv' > results.csv
-
-数据分析
 ----------
 
-分析获取数据的示例:
+将搜索结果保存到文件的示例：
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/api/v2/documents/all?q=*:*" > all_documents.ndjson
+
+转换为 CSV
+----------
+
+使用 jq 命令转换为 CSV 的示例：
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/api/v2/documents/all?q=Fess" | \
+        jq -r '.data | [.url, .title, .score] | @csv' > results.csv
+
+数据分析
+--------
+
+分析获取数据的示例：
 
 .. code-block:: python
 
     import json
     import pandas as pd
-    from collections import Counter
 
-    # 读取 NDJSON 文件
+    # 读取 NDJSON 文件（提取每行的 data 键）
     documents = []
     with open('all_documents.ndjson', 'r') as f:
         for line in f:
-            documents.append(json.loads(line))
+            record = json.loads(line)
+            if "data" in record:
+                documents.append(record["data"])
 
     # 转换为 DataFrame
     df = pd.DataFrame(documents)
@@ -279,24 +335,24 @@ Python 处理示例
     df['domain'] = df['url'].apply(lambda x: x.split('/')[2])
     print(df['domain'].value_counts())
 
-性能和最佳实践
-==================================
+性能与最佳实践
+==============
 
 高效使用方法
-----------------
+------------
 
 1. **设置适当的 num 参数**
 
-   - 太小会增加通信开销
-   - 太大会增加内存使用量
-   - 默认最大值: 100
+   - 过小会增加通信开销
+   - 过大会增加内存使用量
+   - 默认最大值：100
 
 2. **优化搜索条件**
 
    - 指定搜索条件以仅获取所需文档
    - 仅在确实需要时执行全量获取
 
-3. **使用非高峰时间**
+3. **使用非高峰时段**
 
    - 大量数据获取请在系统负载较低的时段执行
 
@@ -305,33 +361,36 @@ Python 处理示例
    - 定期数据同步等作为批处理任务执行
 
 内存使用量优化
---------------------
+--------------
 
-处理大量数据时,使用流处理来抑制内存使用量。
+处理大量数据时，请使用流式处理来抑制内存使用量。
 
 .. code-block:: python
 
     import requests
     import json
 
-    url = "http://localhost:8080/api/v1/documents/all"
+    url = "http://localhost:8080/api/v2/documents/all"
     params = {"q": "*:*", "num": 100}
 
     # 流式处理
     with requests.get(url, params=params, stream=True) as response:
         for line in response.iter_lines(decode_unicode=True):
             if line:
-                doc = json.loads(line)
+                record = json.loads(line)
+                if "error" in record:
+                    break
                 # 处理文档
-                process_document(doc)
+                process_document(record["data"])
 
 安全注意事项
-====================
+============
 
 访问限制
-------------
+--------
 
-滚动搜索会返回大量数据,请设置适当的访问限制。
+滚动搜索会返回大量数据，请设置适当的访问限制。
+端点本身默认不要求认证，请根据需要考虑以下对策。
 
 1. **IP 地址限制**
 
@@ -339,46 +398,46 @@ Python 处理示例
 
 2. **API 认证**
 
-   使用 API 令牌或 Basic 认证
+   通过反向代理等使用 API 令牌或 Basic 认证
 
-3. **基于角色的限制**
+3. **基于角色的访问控制**
 
-   仅允许具有特定角色的用户访问
+   返回的文档经 |Fess| 的基于角色的访问控制过滤
 
 速率限制
-----------
+--------
 
-为防止过度访问,建议在反向代理上设置速率限制。
+为防止过度访问，建议在反向代理上设置速率限制。
 
 故障排除
-======================
+========
 
 无法使用滚动搜索
-----------------------------
+----------------
 
 1. 请确认 ``api.search.scroll`` 是否设置为 ``true``。
 2. 请确认是否已重启 |Fess|。
 3. 请确认错误日志。
 
 发生超时错误
-----------------------------
+------------
 
 1. 请减小 ``num`` 参数以分散处理。
 2. 请缩小搜索条件以减少获取数据量。
 
 内存不足错误
-----------------
+------------
 
 1. 请减小 ``num`` 参数。
 2. 请增加 |Fess| 的堆内存大小。
 3. 请确认 OpenSearch 的堆内存大小。
 
 响应为空
---------------------
+--------
 
 1. 请确认搜索查询是否正确。
 2. 请确认指定的标签和过滤条件是否正确。
-3. 请确认基于角色的搜索权限设置。
+3. 基于角色的访问控制会将无查看权限的文档排除在结果之外。请确认请求的角色配置。
 
 参考信息
 ========


### PR DESCRIPTION
## Summary

Reviewed `config/search-scroll.rst` (Scroll Search / bulk retrieval) for Fess 15.7 against the actual implementation and corrected several technical inaccuracies. The corrections were applied to the Japanese source and re-translated to all other languages (en, de, es, fr, ko, zh-cn).

## Corrections

- **Endpoint path**: `/api/v1/documents/all` → `/api/v2/documents/all`. The v1 scroll endpoint no longer exists; 15.7 serves this via `SearchApiV2Manager` / `ScrollSearchHandler`.
- **RBAC**: The previous text claimed role-based access control was *not* applied and that all matching documents were returned regardless of permissions. This is incorrect — scroll search applies the same role query as regular search (it does not call `skipRoleQuery()`). Rewrote the access-control section accordingly, while keeping the note that the endpoint itself is unauthenticated by default.
- **NDJSON envelope**: Each response line is wrapped as `{"data":{...}}`, not a bare document object. Updated the format description and the Python / jq / pandas examples to unwrap `data`.
- **Mid-stream error terminator**: Documented the `{"error":{"code":"internal_error","message":"stream error"}}` line that is emitted when a failure occurs after streaming has started, and how clients should detect it.
- **Scroll context lifetime**: The search scroll context is fixed at `1m` internally and is not configurable via `fess_config.properties`. Clarified that `index.scroll.search.timeout` (3m) applies only to update-by-query / delete-by-query operations, not to this endpoint. (Previously documented as a configurable 3m timeout.)
- **Response fields**: Renamed `id` → `_id`; removed `config_id` and `lang` (requested from the engine but filtered out of the API response); added the computed fields `content_title`, `content_description`, `url_link`, `site_path` that actually appear in output.
- **`num` parameter**: Noted that the default comes from `paging.search.page.size` (10), the max from `paging.search.page.max.size` (100), and that values `<= 0` are rejected with `INVALID_REQUEST`.
- **GET-only note**: Mentioned that other HTTP methods return `405 Method Not Allowed`.

## Verification

- Each claim was verified against the 15.7 source: `ScrollSearchHandler`, `SearchApiV2Manager`, `V2JsonRequestParams`, `QueryFieldConfig`, `SearchHelper`, `SearchEngineClient`, and `fess_config.properties`.
- Confirmed no leftover `/api/v1` references and consistent `/api/v2` usage across all 7 language files.
- Checked RST section-heading underline lengths (display-width aware) for all languages; docutils parses cleanly (only benign Pygments-not-installed warnings in the local check environment).

## Files

`{ja,en,de,es,fr,ko,zh-cn}/15.7/config/search-scroll.rst`