### PR TITLE
docs: correct Windows service setup guide for 15.7

### DIFF
--- a/de/15.7/config/setup-windows-service.rst
+++ b/de/15.7/config/setup-windows-service.rst
@@ -1,23 +1,26 @@
-===================
+================================
 Registrierung als Windows-Dienst
-===================
+================================
 
 Registrierung als Windows-Dienst
-======================
+=================================
 
-|Fess| kann als Windows-Dienst registriert werden.
+|Fess| kann als Windows-Dienst registriert werden. Nach der Registrierung als Dienst kann |Fess| beim Systemstart automatisch gestartet werden.
 Zum Betrieb von |Fess| muss OpenSearch gestartet sein.
-In diesem Dokument wird davon ausgegangen, dass |Fess| unter ``c:\opt\fess`` und OpenSearch unter ``c:\opt\opensearch`` installiert sind.
+In diesem Dokument wird davon ausgegangen, dass |Fess| unter ``c:\opt\fess`` und OpenSearch unter ``c:\opt\opensearch`` installiert sind (passen Sie die Pfade an Ihre Umgebung an).
+
+.. note::
+   |Fess| und OpenSearch unterstützen ausschließlich die 64-Bit-Version.
 
 Vorbereitung
-------
+------------
 
-Setzen Sie JAVA_HOME als Systemumgebungsvariable.
+Setzen Sie ``JAVA_HOME`` als Systemumgebungsvariable. ``service.bat`` wird mit einem Fehler beendet, wenn ``JAVA_HOME`` nicht gesetzt ist.
 
 Registrierung von OpenSearch als Dienst
--------------------------
+----------------------------------------
 
-Führen Sie ``c:\opt\opensearch\bin\opensearch-service.bat`` als Administrator von der Eingabeaufforderung aus.
+Öffnen Sie die Eingabeaufforderung mit Administratorrechten und führen Sie ``c:\opt\opensearch\bin\opensearch-service.bat`` aus.
 
 ::
 
@@ -26,30 +29,58 @@ Führen Sie ``c:\opt\opensearch\bin\opensearch-service.bat`` als Administrator v
     ...
     The service 'opensearch-service-x64' has been installed.
 
-Weitere Informationen finden Sie in der `OpenSearch-Dokumentation <https://opensearch.org/docs/2.4/install-and-configure/install-opensearch/windows/>`_.
+Weitere Informationen finden Sie in der `OpenSearch-Dokumentation <https://opensearch.org/docs/latest/install-and-configure/install-opensearch/windows/>`_.
 
-Konfiguration
-----
+Konfiguration von |Fess|
+------------------------
 
-Bearbeiten Sie ``c:\opt\fess\bin\fess.in.bat`` und setzen Sie den Installationspfad von OpenSearch in SEARCH_ENGINE_HOME.
+Der Dienst wird über ``c:\opt\fess\bin\service.bat`` registriert. ``service.bat`` liest bei der Registrierung ``bin\fess.in.bat`` ein und übernimmt dessen Inhalt als Startoptionen für |Fess|.
+Fügen Sie die Verbindungseinstellungen für OpenSearch in ``c:\opt\fess\bin\fess.in.bat`` ein.
 
 ::
 
-    set SEARCH_ENGINE_HOME=c:/opt/opensearch
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=c:/opt/opensearch/data/config/
 
-Die Standardportnummer für Such- und Verwaltungsoberfläche von |Fess| ist 8080. Um auf Port 80 zu ändern, ändern Sie fess.port in ``c:\opt\fess\bin\fess.in.bat``.
+.. note::
+   - Geben Sie unter ``fess.search_engine.http_address`` die Verbindungsadresse des registrierten OpenSearch-Dienstes an. Ohne diese Einstellung kann |Fess| die Verbindungsadresse nicht ermitteln und startet die eingebettete OpenSearch-Version, die in Produktionsumgebungen nicht empfohlen wird.
+   - Wenn OpenSearch auf einem anderen Host läuft, ändern Sie den Hostnamen oder die IP-Adresse entsprechend.
+   - Verwenden Sie ``/`` als Pfadtrennzeichen.
+
+Die Standard-Portnummer für Such- und Verwaltungsoberfläche von |Fess| ist ``8080``. Um den Port zu ändern, bearbeiten Sie ``-Dfess.port`` in ``c:\opt\fess\bin\fess.in.bat``.
 
 ::
 
     set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.port=80
 
 .. note::
-   Die Datei ``bin\service.bat`` enthält ebenfalls einen fest eingetragenen Wert ``-Dfess.port=8080`` in ``FESS_PARAMS``. Wenn Sie den Port ändern, müssen Sie diesen Wert auch in ``service.bat`` anpassen.
+   Bei der Registrierung als Dienst ist ``-Dfess.port=8080`` auch in ``FESS_PARAMS`` in ``bin\service.bat`` fest eingetragen. Da dieser Wert Vorrang vor der Einstellung in ``fess.in.bat`` hat, muss beim Ändern des Ports auch ``FESS_PARAMS`` in ``service.bat`` entsprechend angepasst werden.
+
+Dienstanpassung (optional)
+--------------------------
+
+Durch das Setzen von Umgebungsvariablen vor der Ausführung von ``service.bat install`` kann die Dienstkonfiguration angepasst werden. Die wichtigsten Umgebungsvariablen sind:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Umgebungsvariable
+     - Beschreibung
+   * - ``FESS_START_TYPE``
+     - Starttyp (``auto`` oder ``manual``). Standardwert ist ``manual``.
+   * - ``FESS_HEAP_SIZE``
+     - Heap-Größe (z. B. ``1g``). Um minimale und maximale Heap-Größe separat anzugeben, verwenden Sie ``FESS_MIN_MEM`` (Standard ``256m``) und ``FESS_MAX_MEM`` (Standard ``1g``).
+   * - ``SERVICE_USERNAME`` / ``SERVICE_PASSWORD``
+     - Windows-Konto, unter dem der Dienst ausgeführt wird.
+   * - ``SERVICE_DISPLAY_NAME``
+     - Anzeigename des Dienstes.
+   * - ``SERVICE_DESCRIPTION``
+     - Beschreibung des Dienstes.
 
 Registrierungsmethode
-------
+---------------------
 
-Führen Sie ``c:\opt\fess\bin\service.bat`` als Administrator von der Eingabeaufforderung aus.
+Führen Sie ``c:\opt\fess\bin\service.bat`` aus einer Eingabeaufforderung mit Administratorrechten aus.
 
 ::
 
@@ -58,15 +89,14 @@ Führen Sie ``c:\opt\fess\bin\service.bat`` als Administrator von der Eingabeauf
     ...
     The service 'fess-service-x64' has been installed.
 
-
 Dienstkonfiguration
------------
+-------------------
 
 Beim manuellen Start des Dienstes starten Sie zuerst den OpenSearch-Dienst und dann den |Fess|-Dienst.
-Für den automatischen Start fügen Sie eine Abhängigkeit hinzu.
+Für den automatischen Start beim Systemstart werden Starttyp und Abhängigkeiten konfiguriert.
 
-1. Setzen Sie in den allgemeinen Diensteinstellungen den Starttyp auf „Automatisch (verzögerter Start)".
-2. Dienstabhängigkeiten werden in der Registry konfiguriert.
+1. Setzen Sie in den allgemeinen Diensteinstellungen den Starttyp auf „Automatisch (Verzögerter Start)".
+2. Dienstabhängigkeiten werden in der Registrierung konfiguriert.
 
 Fügen Sie im Registrierungs-Editor (regedit) den folgenden Schlüssel und Wert hinzu.
 
@@ -78,3 +108,27 @@ Fügen Sie im Registrierungs-Editor (regedit) den folgenden Schlüssel und Wert 
      - ``opensearch-service-x64``
 
 Nach dem Hinzufügen wird opensearch-service-x64 in den Abhängigkeiten der |Fess|-Diensteigenschaften angezeigt.
+
+.. note::
+   Wenn Sie die Umgebungsvariable ``FESS_START_TYPE=auto`` vor ``service.bat install`` setzen, wird der Starttyp als „Automatisch" registriert. Da „Automatisch (Verzögerter Start)" und die Konfiguration von Abhängigkeiten über ``service.bat`` nicht möglich sind, führen Sie diese Einstellungen wie oben beschrieben durch.
+
+Dienstverwaltung
+----------------
+
+Mit ``service.bat`` können die folgenden Befehle zur Steuerung des Dienstes verwendet werden.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Befehl
+     - Beschreibung
+   * - ``service.bat install``
+     - Registriert den Dienst.
+   * - ``service.bat remove``
+     - Entfernt den Dienst.
+   * - ``service.bat start``
+     - Startet den Dienst.
+   * - ``service.bat stop``
+     - Stoppt den Dienst.
+   * - ``service.bat manager``
+     - Startet die grafische Benutzeroberfläche zur Dienstverwaltung.

--- a/en/15.7/config/setup-windows-service.rst
+++ b/en/15.7/config/setup-windows-service.rst
@@ -3,21 +3,24 @@ Windows Service Registration
 =============================
 
 Registering as a Windows Service
-=================================
+==================================
 
-You can register |Fess| as a Windows service.
+|Fess| can be registered as a Windows service. Registering as a service allows |Fess| to start automatically when the system boots.
 To run |Fess|, OpenSearch must be started first.
-This guide assumes |Fess| is installed in ``c:\opt\fess`` and OpenSearch in ``c:\opt\opensearch``.
+This guide assumes |Fess| is installed in ``c:\opt\fess`` and OpenSearch in ``c:\opt\opensearch`` (adjust the paths to match your environment).
+
+.. note::
+   |Fess| and OpenSearch support 64-bit editions only.
 
 Prerequisites
 -------------
 
-Set JAVA_HOME as a system environment variable.
+Set ``JAVA_HOME`` as a system environment variable. ``service.bat`` will exit with an error if ``JAVA_HOME`` is not set.
 
 Registering OpenSearch as a Service
 ------------------------------------
 
-From the command prompt, run ``c:\opt\opensearch\bin\opensearch-service.bat`` as administrator.
+Open a command prompt with administrator privileges and run ``c:\opt\opensearch\bin\opensearch-service.bat``.
 
 ::
 
@@ -26,30 +29,58 @@ From the command prompt, run ``c:\opt\opensearch\bin\opensearch-service.bat`` as
     ...
     The service 'opensearch-service-x64' has been installed.
 
-For details, refer to the `OpenSearch documentation <https://opensearch.org/docs/2.4/install-and-configure/install-opensearch/windows/>`_.
+For details, refer to the `OpenSearch documentation <https://opensearch.org/docs/latest/install-and-configure/install-opensearch/windows/>`_.
 
-Configuration
--------------
+|Fess| Configuration
+---------------------
 
-Edit ``c:\opt\fess\bin\fess.in.bat`` and set the OpenSearch installation path in SEARCH_ENGINE_HOME.
+The service is registered via ``c:\opt\fess\bin\service.bat``. When registering, ``service.bat`` reads ``bin\fess.in.bat`` and applies its contents to the |Fess| startup options.
+Add the settings required to connect to OpenSearch to ``c:\opt\fess\bin\fess.in.bat``.
 
 ::
 
-    set SEARCH_ENGINE_HOME=c:/opt/opensearch
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=c:/opt/opensearch/data/config/
 
-The default port number for |Fess| search and administration screens is 8080. To change it to port 80, modify fess.port in ``c:\opt\fess\bin\fess.in.bat``.
+.. note::
+   - ``fess.search_engine.http_address`` specifies the connection target for the registered OpenSearch service. If this setting is omitted, |Fess| cannot locate the connection target and will start the embedded OpenSearch, which is not recommended for production environments.
+   - If OpenSearch is running on a different host, change the hostname or IP address accordingly.
+   - Use ``/`` as the path separator.
+
+The default port number for the |Fess| search and administration screens is ``8080``. To change it to a different port, edit ``-Dfess.port`` in ``c:\opt\fess\bin\fess.in.bat``.
 
 ::
 
     set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.port=80
 
 .. note::
-   When registering as a service, ``-Dfess.port=8080`` is also hardcoded in ``FESS_PARAMS`` in ``bin\service.bat``. When changing the port, also edit ``service.bat`` accordingly.
+   When registering as a service, ``-Dfess.port=8080`` is also hardcoded in ``FESS_PARAMS`` inside ``bin\service.bat``. Because this value takes precedence over the settings in ``fess.in.bat``, also edit ``FESS_PARAMS`` in ``service.bat`` when changing the port.
+
+Service Customization (Optional)
+---------------------------------
+
+You can change the service configuration by setting environment variables before running ``service.bat install``. The main environment variables are listed below.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Environment Variable
+     - Description
+   * - ``FESS_START_TYPE``
+     - Startup type (``auto`` or ``manual``). Default is ``manual``.
+   * - ``FESS_HEAP_SIZE``
+     - Heap size (e.g. ``1g``). To specify minimum and maximum heap sizes individually, use ``FESS_MIN_MEM`` (default ``256m``) and ``FESS_MAX_MEM`` (default ``1g``).
+   * - ``SERVICE_USERNAME`` / ``SERVICE_PASSWORD``
+     - Windows account under which the service runs.
+   * - ``SERVICE_DISPLAY_NAME``
+     - Display name of the service.
+   * - ``SERVICE_DESCRIPTION``
+     - Description of the service.
 
 Registration Procedure
 ----------------------
 
-From the command prompt, run ``c:\opt\fess\bin\service.bat`` as administrator.
+From a command prompt with administrator privileges, run ``c:\opt\fess\bin\service.bat``.
 
 ::
 
@@ -58,12 +89,11 @@ From the command prompt, run ``c:\opt\fess\bin\service.bat`` as administrator.
     ...
     The service 'fess-service-x64' has been installed.
 
-
 Service Configuration
 ---------------------
 
-If manually starting the service, start the OpenSearch service first, then start the |Fess| service.
-For automatic startup, add service dependencies.
+If starting the service manually, start the OpenSearch service first and then start the |Fess| service.
+To start automatically at system boot, configure the startup type and service dependencies.
 
 1. In the service General settings, set the Startup type to "Automatic (Delayed Start)".
 2. Configure service dependencies in the registry.
@@ -77,4 +107,28 @@ Add the following key and value in the Registry Editor (regedit).
    * - *Value*
      - ``opensearch-service-x64``
 
-Once added, opensearch-service-x64 will appear in the |Fess| service properties dependencies.
+Once added, opensearch-service-x64 will appear in the Dependencies tab of the |Fess| service properties.
+
+.. note::
+   Setting the environment variable ``FESS_START_TYPE=auto`` before running ``service.bat install`` registers the service with a startup type of "Automatic". However, "Automatic (Delayed Start)" and dependency configuration cannot be performed through ``service.bat``, so use the procedure described above for those settings.
+
+Service Management
+------------------
+
+The following commands are available in ``service.bat`` to manage the service.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Command
+     - Description
+   * - ``service.bat install``
+     - Registers the service.
+   * - ``service.bat remove``
+     - Removes the service.
+   * - ``service.bat start``
+     - Starts the service.
+   * - ``service.bat stop``
+     - Stops the service.
+   * - ``service.bat manager``
+     - Launches the GUI for managing the service.

--- a/es/15.7/config/setup-windows-service.rst
+++ b/es/15.7/config/setup-windows-service.rst
@@ -5,19 +5,22 @@ Registro como Servicio de Windows
 Registro como Servicio de Windows
 ==================================
 
-Puede registrar |Fess| como un servicio de Windows.
+Puede registrar |Fess| como un servicio de Windows. Al registrarlo como servicio, |Fess| puede iniciarse automáticamente al arrancar el sistema.
 Para ejecutar |Fess|, es necesario que OpenSearch esté en ejecución.
-Aquí se asume que |Fess| está instalado en ``c:\opt\fess`` y OpenSearch en ``c:\opt\opensearch``.
+Aquí se asume que |Fess| está instalado en ``c:\opt\fess`` y OpenSearch en ``c:\opt\opensearch`` (ajuste las rutas según su entorno).
+
+.. note::
+   |Fess| y OpenSearch solo admiten la versión de 64 bits.
 
 Preparación Previa
 ------------------
 
-Configure JAVA_HOME como variable de entorno del sistema.
+Configure ``JAVA_HOME`` como variable de entorno del sistema. Si ``JAVA_HOME`` no está definida, ``service.bat`` finalizará con un error.
 
 Registrar OpenSearch como Servicio
 -----------------------------------
 
-| Ejecute ``c:\opt\opensearch\bin\opensearch-service.bat`` desde el símbolo del sistema como administrador.
+Abra el símbolo del sistema con privilegios de administrador y ejecute ``c:\opt\opensearch\bin\opensearch-service.bat``.
 
 ::
 
@@ -26,30 +29,58 @@ Registrar OpenSearch como Servicio
     ...
     The service 'opensearch-service-x64' has been installed.
 
-Para más detalles, consulte la `documentación de OpenSearch <https://opensearch.org/docs/2.4/install-and-configure/install-opensearch/windows/>`_.
+Para más detalles, consulte la `documentación de OpenSearch <https://opensearch.org/docs/latest/install-and-configure/install-opensearch/windows/>`_.
 
-Configuración
--------------
+Configuración de |Fess|
+------------------------
 
-Edite ``c:\opt\fess\bin\fess.in.bat`` y configure el directorio de instalación de OpenSearch en SEARCH_ENGINE_HOME.
+El servicio se registra mediante ``c:\opt\fess\bin\service.bat``. Al registrarlo, ``service.bat`` lee ``bin\fess.in.bat`` y aplica su contenido a las opciones de inicio de |Fess|.
+Agregue la configuración de conexión a OpenSearch en ``c:\opt\fess\bin\fess.in.bat``.
 
 ::
 
-    set SEARCH_ENGINE_HOME=c:/opt/opensearch
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=c:/opt/opensearch/data/config/
 
-El número de puerto predeterminado para la pantalla de búsqueda y pantalla de administración de |Fess| es 8080. Para cambiar al puerto 80, modifique fess.port en ``c:\opt\fess\bin\fess.in.bat``.
+.. note::
+   - En ``fess.search_engine.http_address`` especifique el destino de conexión del servicio OpenSearch registrado. Si no se configura esta opción, |Fess| no podrá encontrar el destino de conexión e iniciará la versión embebida de OpenSearch, que no es recomendada para entornos de producción.
+   - Si OpenSearch se ejecuta en un host diferente, cambie el nombre de host o la dirección IP según corresponda.
+   - Utilice ``/`` como separador de ruta.
+
+El número de puerto predeterminado para la pantalla de búsqueda y la pantalla de administración de |Fess| es ``8080``. Para cambiar a otro puerto, edite ``-Dfess.port`` en ``c:\opt\fess\bin\fess.in.bat``.
 
 ::
 
     set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.port=80
 
 .. note::
-   Al registrar como servicio, ``-Dfess.port=8080`` también está codificado en ``FESS_PARAMS`` en ``bin\service.bat``. Al cambiar el puerto, edite también ``service.bat`` de la misma manera.
+   Al registrar como servicio, ``-Dfess.port=8080`` también está codificado en ``FESS_PARAMS`` dentro de ``bin\service.bat``. Este valor tiene prioridad sobre la configuración de ``fess.in.bat``, por lo que al cambiar el puerto también debe editar ``FESS_PARAMS`` en ``service.bat`` de la misma manera.
+
+Personalización del Servicio (opcional)
+-----------------------------------------
+
+Es posible modificar la configuración del servicio estableciendo variables de entorno antes de ejecutar ``service.bat install``. Las principales variables de entorno son las siguientes.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Variable de entorno
+     - Descripción
+   * - ``FESS_START_TYPE``
+     - Tipo de inicio (``auto`` o ``manual``). El valor predeterminado es ``manual``.
+   * - ``FESS_HEAP_SIZE``
+     - Tamaño del heap (por ejemplo: ``1g``). Para especificar el tamaño mínimo y máximo del heap de forma individual, use ``FESS_MIN_MEM`` (predeterminado ``256m``) y ``FESS_MAX_MEM`` (predeterminado ``1g``).
+   * - ``SERVICE_USERNAME`` / ``SERVICE_PASSWORD``
+     - Cuenta de Windows bajo la que se ejecuta el servicio.
+   * - ``SERVICE_DISPLAY_NAME``
+     - Nombre para mostrar del servicio.
+   * - ``SERVICE_DESCRIPTION``
+     - Descripción del servicio.
 
 Método de Registro
 ------------------
 
-Ejecute ``c:\opt\fess\bin\service.bat`` desde el símbolo del sistema como administrador.
+Ejecute ``c:\opt\fess\bin\service.bat`` desde el símbolo del sistema con privilegios de administrador.
 
 ::
 
@@ -58,12 +89,11 @@ Ejecute ``c:\opt\fess\bin\service.bat`` desde el símbolo del sistema como admin
     ...
     The service 'fess-service-x64' has been installed.
 
-
 Configuración del Servicio
 ---------------------------
 
 Al iniciar el servicio manualmente, inicie primero el servicio de OpenSearch y luego el servicio de |Fess|.
-Para inicio automático, agregue la relación de dependencia.
+Para que se inicie automáticamente al arrancar el sistema, configure el tipo de inicio y las dependencias.
 
 1. En la configuración general del servicio, establezca el tipo de inicio como "Automático (Inicio retrasado)".
 2. La dependencia del servicio se configura en el registro.
@@ -73,8 +103,32 @@ Agregue la siguiente clave y valor en el Editor del Registro (regedit).
 .. list-table::
 
    * - *Clave*
-     - ``Equipo\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\fess-service-x64\DependOnService``
+     - ``Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\fess-service-x64\DependOnService``
    * - *Valor*
      - ``opensearch-service-x64``
 
 Una vez agregado, opensearch-service-x64 se mostrará en las dependencias de las propiedades del servicio de |Fess|.
+
+.. note::
+   Si establece la variable de entorno ``FESS_START_TYPE=auto`` antes de ejecutar ``service.bat install``, el servicio se registrará con el tipo de inicio "Automático". Sin embargo, "Automático (Inicio retrasado)" y la configuración de dependencias no pueden realizarse mediante ``service.bat``, por lo que deberá configurarlos siguiendo el procedimiento indicado anteriormente.
+
+Gestión del Servicio
+---------------------
+
+Con ``service.bat`` puede administrar el servicio mediante los siguientes comandos.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Comando
+     - Descripción
+   * - ``service.bat install``
+     - Registra el servicio.
+   * - ``service.bat remove``
+     - Elimina el servicio.
+   * - ``service.bat start``
+     - Inicia el servicio.
+   * - ``service.bat stop``
+     - Detiene el servicio.
+   * - ``service.bat manager``
+     - Inicia la interfaz gráfica de administración del servicio.

--- a/fr/15.7/config/setup-windows-service.rst
+++ b/fr/15.7/config/setup-windows-service.rst
@@ -1,23 +1,26 @@
-===================
+==========================================
 Enregistrement en tant que service Windows
-===================
+==========================================
 
 Enregistrement en tant que service Windows
-======================
+==========================================
 
-|Fess| peut être enregistré en tant que service Windows.
+|Fess| peut être enregistré en tant que service Windows. L'enregistrement en tant que service permet de démarrer automatiquement |Fess| au démarrage du système.
 Pour exécuter |Fess|, OpenSearch doit être démarré au préalable.
-Nous supposons ici que |Fess| est installé dans ``c:\opt\fess`` et OpenSearch dans ``c:\opt\opensearch``.
+Nous supposons ici que |Fess| est installé dans ``c:\opt\fess`` et OpenSearch dans ``c:\opt\opensearch`` (adaptez les chemins à votre environnement).
+
+.. note::
+   |Fess| et OpenSearch ne prennent en charge que les versions 64 bits.
 
 Préparation préalable
-------
+---------------------
 
-Veuillez définir JAVA_HOME comme variable d'environnement système.
+Veuillez définir ``JAVA_HOME`` comme variable d'environnement système. ``service.bat`` se termine avec une erreur si ``JAVA_HOME`` n'est pas défini.
 
 Enregistrement d'OpenSearch en tant que service
--------------------------
+-----------------------------------------------
 
-| Exécutez ``c:\opt\opensearch\bin\opensearch-service.bat`` en tant qu'administrateur depuis l'invite de commandes.
+Ouvrez une invite de commandes avec des droits d'administrateur et exécutez ``c:\opt\opensearch\bin\opensearch-service.bat``.
 
 ::
 
@@ -26,30 +29,58 @@ Enregistrement d'OpenSearch en tant que service
     ...
     The service 'opensearch-service-x64' has been installed.
 
-Pour plus de détails, consultez la `documentation OpenSearch <https://opensearch.org/docs/2.4/install-and-configure/install-opensearch/windows/>`_.
+Pour plus de détails, consultez la `documentation OpenSearch <https://opensearch.org/docs/latest/install-and-configure/install-opensearch/windows/>`_.
 
-Configuration
-----
+Configuration de |Fess|
+-----------------------
 
-Éditez ``c:\opt\fess\bin\fess.in.bat`` et configurez SEARCH_ENGINE_HOME avec le répertoire d'installation d'OpenSearch.
+Le service est enregistré depuis ``c:\opt\fess\bin\service.bat``. Lors de l'enregistrement, ``service.bat`` lit ``bin\fess.in.bat`` et applique son contenu aux options de démarrage de |Fess|.
+Ajoutez la configuration de connexion à OpenSearch dans ``c:\opt\fess\bin\fess.in.bat``.
 
 ::
 
-    set SEARCH_ENGINE_HOME=c:/opt/opensearch
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=c:/opt/opensearch/data/config/
 
-Le numéro de port par défaut pour l'interface de recherche et d'administration de |Fess| est 8080. Pour le changer en 80, modifiez fess.port dans ``c:\opt\fess\bin\fess.in.bat``.
+.. note::
+   - ``fess.search_engine.http_address`` permet de spécifier la destination de connexion du service OpenSearch enregistré. Sans cette configuration, |Fess| ne peut pas trouver la destination de connexion et démarre une instance OpenSearch embarquée, déconseillée en environnement de production.
+   - Si vous exécutez OpenSearch sur un hôte différent, modifiez le nom d'hôte ou l'adresse IP en conséquence.
+   - Utilisez ``/`` comme séparateur de chemin.
+
+Le numéro de port par défaut pour l'interface de recherche et d'administration de |Fess| est ``8080``. Pour le changer, modifiez ``-Dfess.port`` dans ``c:\opt\fess\bin\fess.in.bat``.
 
 ::
 
     set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.port=80
 
 .. note::
-   Lors de l'enregistrement en tant que service, ``-Dfess.port=8080`` est également codé en dur dans ``FESS_PARAMS`` dans ``bin\service.bat``. Lors du changement de port, modifiez également ``service.bat`` en conséquence.
+   Lors de l'enregistrement en tant que service, ``-Dfess.port=8080`` est également codé en dur dans ``FESS_PARAMS`` dans ``bin\service.bat``. Cette valeur est prioritaire sur la configuration de ``fess.in.bat``. Par conséquent, lors du changement de port, modifiez également ``FESS_PARAMS`` dans ``service.bat``.
 
-Méthode d'enregistrement
-------
+Personnalisation du service (facultatif)
+----------------------------------------
 
-Exécutez ``c:\opt\fess\bin\service.bat`` en tant qu'administrateur depuis l'invite de commandes.
+Vous pouvez modifier la configuration du service en définissant des variables d'environnement avant d'exécuter ``service.bat install``. Les principales variables d'environnement sont les suivantes.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Variable d'environnement
+     - Description
+   * - ``FESS_START_TYPE``
+     - Type de démarrage (``auto`` ou ``manual``). La valeur par défaut est ``manual``.
+   * - ``FESS_HEAP_SIZE``
+     - Taille du tas (ex. : ``1g``). Pour spécifier séparément la taille minimale et maximale du tas, utilisez ``FESS_MIN_MEM`` (valeur par défaut ``256m``) et ``FESS_MAX_MEM`` (valeur par défaut ``1g``).
+   * - ``SERVICE_USERNAME`` / ``SERVICE_PASSWORD``
+     - Compte Windows sous lequel le service s'exécute.
+   * - ``SERVICE_DISPLAY_NAME``
+     - Nom d'affichage du service.
+   * - ``SERVICE_DESCRIPTION``
+     - Description du service.
+
+Procédure d'enregistrement
+---------------------------
+
+Exécutez ``c:\opt\fess\bin\service.bat`` depuis une invite de commandes avec des droits d'administrateur.
 
 ::
 
@@ -58,12 +89,11 @@ Exécutez ``c:\opt\fess\bin\service.bat`` en tant qu'administrateur depuis l'inv
     ...
     The service 'fess-service-x64' has been installed.
 
-
 Configuration du service
------------
+------------------------
 
 Pour démarrer le service manuellement, démarrez d'abord le service OpenSearch, puis démarrez le service |Fess|.
-Pour un démarrage automatique, ajoutez une dépendance.
+Pour un démarrage automatique au démarrage du système, configurez le type de démarrage et les dépendances.
 
 1. Dans les paramètres généraux du service, définissez le type de démarrage sur « Automatique (début différé) ».
 2. Les dépendances du service sont configurées dans le registre.
@@ -73,8 +103,32 @@ Ajoutez la clé et la valeur suivantes dans l'éditeur de registre (regedit).
 .. list-table::
 
    * - *Clé*
-     - ``Ordinateur\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\fess-service-x64\DependOnService``
+     - ``Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\fess-service-x64\DependOnService``
    * - *Valeur*
      - ``opensearch-service-x64``
 
 Une fois ajouté, opensearch-service-x64 apparaîtra dans les dépendances des propriétés du service |Fess|.
+
+.. note::
+   En définissant la variable d'environnement ``FESS_START_TYPE=auto`` avant ``service.bat install``, vous pouvez enregistrer le type de démarrage sur « Automatique ». Cependant, « Automatique (début différé) » et la configuration des dépendances ne peuvent pas être effectués via ``service.bat`` ; veuillez les configurer selon la procédure décrite ci-dessus.
+
+Gestion du service
+------------------
+
+Avec ``service.bat``, vous pouvez gérer le service à l'aide des commandes suivantes.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Commande
+     - Description
+   * - ``service.bat install``
+     - Enregistre le service.
+   * - ``service.bat remove``
+     - Supprime le service.
+   * - ``service.bat start``
+     - Démarre le service.
+   * - ``service.bat stop``
+     - Arrête le service.
+   * - ``service.bat manager``
+     - Lance l'interface graphique de gestion du service.

--- a/ja/15.7/config/setup-windows-service.rst
+++ b/ja/15.7/config/setup-windows-service.rst
@@ -1,23 +1,26 @@
-===================
+==========================
 Windowsサービスへの登録
-===================
+==========================
 
 Windowsサービスとしての登録
-======================
+============================
 
-|Fess| を Windows のサービスとして登録することができます。
+|Fess| を Windows のサービスとして登録することができます。サービスとして登録すると、システム起動時に |Fess| を自動的に起動できます。
 |Fess| を動かすには、OpenSearch を起動しておく必要があります。
-ここでは |Fess| を ``c:\opt\fess`` に、OpenSearch を ``c:\opt\opensearch`` にインストールしてあるものとします。
+ここでは |Fess| を ``c:\opt\fess`` に、OpenSearch を ``c:\opt\opensearch`` にインストールしてあるものとします（パスは環境に合わせて読み替えてください）。
+
+.. note::
+   |Fess| および OpenSearch は 64 ビット版のみをサポートしています。
 
 事前準備
-------
+--------
 
-システムの環境変数として JAVA_HOME を設定してください。
+システムの環境変数として ``JAVA_HOME`` を設定してください。``service.bat`` は ``JAVA_HOME`` が設定されていない場合、エラーで終了します。
 
 OpenSearchをサービスとして登録
--------------------------
+------------------------------
 
-| コマンドプロンプトから ``c:\opt\opensearch\bin\opensearch-service.bat`` を管理者で実行します。
+コマンドプロンプトを管理者権限で起動し、``c:\opt\opensearch\bin\opensearch-service.bat`` を実行します。
 
 ::
 
@@ -26,31 +29,58 @@ OpenSearchをサービスとして登録
     ...
     The service 'opensearch-service-x64' has been installed.
 
-詳細は `OpenSearch のドキュメント <https://opensearch.org/docs/2.4/install-and-configure/install-opensearch/windows/>`_ を参照してください。
+詳細は `OpenSearch のドキュメント <https://opensearch.org/docs/latest/install-and-configure/install-opensearch/windows/>`_ を参照してください。
 
-設定
-----
+|Fess| の設定
+-------------
 
-``c:\opt\fess\bin\fess.in.bat`` を編集して SEARCH_ENGINE_HOME に OpenSearch のインストール先を設定します。
+サービスは ``c:\opt\fess\bin\service.bat`` から登録します。``service.bat`` は登録時に ``bin\fess.in.bat`` を読み込み、その内容を |Fess| の起動オプションに反映します。
+OpenSearch へ接続するための設定を ``c:\opt\fess\bin\fess.in.bat`` に追加してください。
 
 ::
 
-    set SEARCH_ENGINE_HOME=c:/opt/opensearch
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=c:/opt/opensearch/data/config/
 
-|Fess| の検索画面、管理画面のデフォルトのポート番号は 8080 になっています。80 番に変更する場合は ``c:\opt\fess\bin\fess.in.bat`` の fess.port を変更します。
+.. note::
+   - ``fess.search_engine.http_address`` には、登録した OpenSearch サービスの接続先を指定します。この設定を行わない場合、|Fess| は接続先を見つけられず、本番環境では非推奨の埋め込み版 OpenSearch を起動します。
+   - OpenSearch を別のホストで実行している場合は、ホスト名または IP アドレスを適切に変更してください。
+   - パスの区切り文字には ``/`` を使用してください。
+
+|Fess| の検索画面・管理画面のデフォルトのポート番号は ``8080`` です。別のポートに変更する場合は ``c:\opt\fess\bin\fess.in.bat`` の ``-Dfess.port`` を編集します。
 
 ::
 
     set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.port=80
 
 .. note::
-   サービスとして登録する場合は、``bin\service.bat`` 内の ``FESS_PARAMS`` にも ``-Dfess.port=8080`` がハードコードされています。ポートを変更する際は ``service.bat`` も同様に編集してください。
+   サービスとして登録する場合、``bin\service.bat`` 内の ``FESS_PARAMS`` にも ``-Dfess.port=8080`` がハードコードされています。この値は ``fess.in.bat`` の設定よりも優先されるため、ポートを変更する際は ``service.bat`` の ``FESS_PARAMS`` も同様に編集してください。
 
+サービスのカスタマイズ（任意）
+------------------------------
+
+``service.bat install`` を実行する前に環境変数を設定することで、サービスの構成を変更できます。主な環境変数は次のとおりです。
+
+.. list-table::
+   :header-rows: 1
+
+   * - 環境変数
+     - 説明
+   * - ``FESS_START_TYPE``
+     - スタートアップの種類（``auto`` または ``manual``）。デフォルトは ``manual`` です。
+   * - ``FESS_HEAP_SIZE``
+     - ヒープサイズ（例: ``1g``）。最小・最大ヒープサイズを個別に指定する場合は ``FESS_MIN_MEM``（デフォルト ``256m``）と ``FESS_MAX_MEM``（デフォルト ``1g``）を使用します。
+   * - ``SERVICE_USERNAME`` / ``SERVICE_PASSWORD``
+     - サービスを実行する Windows アカウント。
+   * - ``SERVICE_DISPLAY_NAME``
+     - サービスの表示名。
+   * - ``SERVICE_DESCRIPTION``
+     - サービスの説明。
 
 登録方法
-------
+--------
 
-コマンドプロンプトから ``c:\opt\fess\bin\service.bat`` を管理者で実行します。
+管理者権限のコマンドプロンプトから ``c:\opt\fess\bin\service.bat`` を実行します。
 
 ::
 
@@ -59,12 +89,11 @@ OpenSearchをサービスとして登録
     ...
     The service 'fess-service-x64' has been installed.
 
-
 サービスの設定
------------
+--------------
 
-サービスを手動で起動する場合は OpenSearch サービスを先に起動し、その後 |Fess| サービスを起動します。
-自動起動する場合は依存関係を追加します。
+サービスを手動で起動する場合は、OpenSearch サービスを先に起動し、その後 |Fess| サービスを起動します。
+システム起動時に自動的に起動する場合は、スタートアップの種類と依存関係を設定します。
 
 1. サービスの全般設定でスタートアップの種類を「自動（遅延開始）」とします。
 2. サービスの依存関係はレジストリで設定します。
@@ -79,3 +108,27 @@ OpenSearchをサービスとして登録
      - ``opensearch-service-x64``
 
 追加すると、 |Fess| サービスのプロパティの依存関係に opensearch-service-x64 が表示されます。
+
+.. note::
+   ``service.bat install`` の前に環境変数 ``FESS_START_TYPE=auto`` を設定しておくと、スタートアップの種類を「自動」で登録できます。ただし「自動（遅延開始）」や依存関係の設定は ``service.bat`` では行えないため、上記の手順で設定してください。
+
+サービスの管理
+--------------
+
+``service.bat`` では、以下のコマンドでサービスを操作できます。
+
+.. list-table::
+   :header-rows: 1
+
+   * - コマンド
+     - 説明
+   * - ``service.bat install``
+     - サービスを登録します。
+   * - ``service.bat remove``
+     - サービスを削除します。
+   * - ``service.bat start``
+     - サービスを起動します。
+   * - ``service.bat stop``
+     - サービスを停止します。
+   * - ``service.bat manager``
+     - サービス管理用の GUI を起動します。

--- a/ko/15.7/config/setup-windows-service.rst
+++ b/ko/15.7/config/setup-windows-service.rst
@@ -1,23 +1,26 @@
-===================
+==========================
 Windows 서비스 등록
-===================
+==========================
 
 Windows 서비스로 등록
 ======================
 
-|Fess| 를 Windows의 서비스로 등록할 수 있습니다.
-|Fess| 를 실행하려면 OpenSearch를 시작해 두어야 합니다.
-여기서는 |Fess| 를 ``c:\opt\fess`` 에, OpenSearch를 ``c:\opt\opensearch`` 에 설치했다고 가정합니다.
+|Fess| 를 Windows 서비스로 등록할 수 있습니다. 서비스로 등록하면 시스템 시작 시 |Fess| 를 자동으로 시작할 수 있습니다.
+|Fess| 를 실행하려면 OpenSearch를 미리 시작해 두어야 합니다.
+여기서는 |Fess| 를 ``c:\opt\fess`` 에, OpenSearch를 ``c:\opt\opensearch`` 에 설치했다고 가정합니다（경로는 환경에 맞게 읽어 주십시오）.
+
+.. note::
+   |Fess| 및 OpenSearch는 64비트 버전만 지원합니다.
 
 사전 준비
-------
+---------
 
-시스템 환경 변수로 JAVA_HOME을 설정하십시오.
+시스템 환경 변수로 ``JAVA_HOME`` 을 설정하십시오. ``service.bat`` 는 ``JAVA_HOME`` 이 설정되어 있지 않으면 오류로 종료됩니다.
 
 OpenSearch를 서비스로 등록
--------------------------
+--------------------------
 
-| 명령 프롬프트에서 ``c:\opt\opensearch\bin\opensearch-service.bat`` 를 관리자 권한으로 실행합니다.
+명령 프롬프트를 관리자 권한으로 시작하고 ``c:\opt\opensearch\bin\opensearch-service.bat`` 를 실행합니다.
 
 ::
 
@@ -26,30 +29,58 @@ OpenSearch를 서비스로 등록
     ...
     The service 'opensearch-service-x64' has been installed.
 
-자세한 내용은 `OpenSearch 문서 <https://opensearch.org/docs/2.4/install-and-configure/install-opensearch/windows/>`_ 를 참조하십시오.
+자세한 내용은 `OpenSearch 문서 <https://opensearch.org/docs/latest/install-and-configure/install-opensearch/windows/>`_ 를 참조하십시오.
 
-설정
-----
+|Fess| 설정
+-----------
 
-``c:\opt\fess\bin\fess.in.bat`` 를 편집하여 SEARCH_ENGINE_HOME에 OpenSearch의 설치 경로를 설정합니다.
+서비스는 ``c:\opt\fess\bin\service.bat`` 에서 등록합니다. ``service.bat`` 는 등록 시 ``bin\fess.in.bat`` 를 읽어 그 내용을 |Fess| 의 시작 옵션에 반영합니다.
+OpenSearch에 연결하기 위한 설정을 ``c:\opt\fess\bin\fess.in.bat`` 에 추가하십시오.
 
 ::
 
-    set SEARCH_ENGINE_HOME=c:/opt/opensearch
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=c:/opt/opensearch/data/config/
 
-|Fess| 의 검색 화면, 관리 화면의 기본 포트 번호는 8080입니다. 80번으로 변경하는 경우 ``c:\opt\fess\bin\fess.in.bat`` 의 fess.port를 변경합니다.
+.. note::
+   - ``fess.search_engine.http_address`` 에는 등록한 OpenSearch 서비스의 연결 대상을 지정합니다. 이 설정을 하지 않으면 |Fess| 는 연결 대상을 찾지 못하고 프로덕션 환경에서는 권장하지 않는 내장 OpenSearch를 시작합니다.
+   - OpenSearch를 다른 호스트에서 실행하는 경우 호스트명 또는 IP 주소를 적절히 변경하십시오.
+   - 경로 구분 문자는 ``/`` 를 사용하십시오.
+
+|Fess| 의 검색 화면·관리 화면의 기본 포트 번호는 ``8080`` 입니다. 다른 포트로 변경하는 경우 ``c:\opt\fess\bin\fess.in.bat`` 의 ``-Dfess.port`` 를 편집합니다.
 
 ::
 
     set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.port=80
 
 .. note::
-   서비스로 등록하는 경우, ``bin\service.bat`` 의 ``FESS_PARAMS`` 에 ``-Dfess.port=8080`` 이 하드코딩되어 있습니다. 포트를 변경하는 경우 ``service.bat`` 도 마찬가지로 편집하십시오.
+   서비스로 등록하는 경우 ``bin\service.bat`` 의 ``FESS_PARAMS`` 에 ``-Dfess.port=8080`` 이 하드코딩되어 있습니다. 이 값은 ``fess.in.bat`` 의 설정보다 우선되므로 포트를 변경할 때는 ``service.bat`` 의 ``FESS_PARAMS`` 도 함께 편집하십시오.
+
+서비스 커스터마이즈（선택）
+----------------------------
+
+``service.bat install`` 을 실행하기 전에 환경 변수를 설정하면 서비스 구성을 변경할 수 있습니다. 주요 환경 변수는 다음과 같습니다.
+
+.. list-table::
+   :header-rows: 1
+
+   * - 환경 변수
+     - 설명
+   * - ``FESS_START_TYPE``
+     - 시작 유형（``auto`` 또는 ``manual``）. 기본값은 ``manual`` 입니다.
+   * - ``FESS_HEAP_SIZE``
+     - 힙 크기（예: ``1g``）. 최소·최대 힙 크기를 개별로 지정하는 경우 ``FESS_MIN_MEM``（기본값 ``256m``）과 ``FESS_MAX_MEM``（기본값 ``1g``）을 사용합니다.
+   * - ``SERVICE_USERNAME`` / ``SERVICE_PASSWORD``
+     - 서비스를 실행할 Windows 계정.
+   * - ``SERVICE_DISPLAY_NAME``
+     - 서비스 표시 이름.
+   * - ``SERVICE_DESCRIPTION``
+     - 서비스 설명.
 
 등록 방법
-------
+---------
 
-명령 프롬프트에서 ``c:\opt\fess\bin\service.bat`` 를 관리자 권한으로 실행합니다.
+관리자 권한의 명령 프롬프트에서 ``c:\opt\fess\bin\service.bat`` 를 실행합니다.
 
 ::
 
@@ -58,12 +89,11 @@ OpenSearch를 서비스로 등록
     ...
     The service 'fess-service-x64' has been installed.
 
-
 서비스 설정
 -----------
 
 서비스를 수동으로 시작하는 경우 OpenSearch 서비스를 먼저 시작하고, 그 후 |Fess| 서비스를 시작합니다.
-자동 시작하는 경우 의존 관계를 추가합니다.
+시스템 시작 시 자동으로 시작하는 경우 시작 유형과 의존 관계를 설정합니다.
 
 1. 서비스의 일반 설정에서 시작 유형을 "자동(지연된 시작)"으로 설정합니다.
 2. 서비스의 의존 관계는 레지스트리에서 설정합니다.
@@ -73,8 +103,32 @@ OpenSearch를 서비스로 등록
 .. list-table::
 
    * - *키*
-     - ``컴퓨터\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\fess-service-x64\DependOnService``
+     - ``Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\fess-service-x64\DependOnService``
    * - *값*
      - ``opensearch-service-x64``
 
-추가하면 |Fess| 서비스의 속성의 의존 관계에 opensearch-service-x64가 표시됩니다.
+추가하면 |Fess| 서비스의 속성 의존 관계에 opensearch-service-x64가 표시됩니다.
+
+.. note::
+   ``service.bat install`` 전에 환경 변수 ``FESS_START_TYPE=auto`` 를 설정해 두면 시작 유형을 "자동"으로 등록할 수 있습니다. 다만 "자동(지연된 시작)"이나 의존 관계 설정은 ``service.bat`` 에서는 수행할 수 없으므로 위의 절차로 설정하십시오.
+
+서비스 관리
+-----------
+
+``service.bat`` 에서 다음 명령으로 서비스를 조작할 수 있습니다.
+
+.. list-table::
+   :header-rows: 1
+
+   * - 명령
+     - 설명
+   * - ``service.bat install``
+     - 서비스를 등록합니다.
+   * - ``service.bat remove``
+     - 서비스를 삭제합니다.
+   * - ``service.bat start``
+     - 서비스를 시작합니다.
+   * - ``service.bat stop``
+     - 서비스를 정지합니다.
+   * - ``service.bat manager``
+     - 서비스 관리용 GUI를 시작합니다.

--- a/zh-cn/15.7/config/setup-windows-service.rst
+++ b/zh-cn/15.7/config/setup-windows-service.rst
@@ -1,23 +1,26 @@
-===================
+========================
 注册为 Windows 服务
-===================
+========================
 
 注册为 Windows 服务
-======================
+====================
 
-可以将 |Fess| 注册为 Windows 服务。
-要运行 |Fess|,需要先启动 OpenSearch。
-本文档假设已将 |Fess| 安装在 ``c:\opt\fess``,OpenSearch 安装在 ``c:\opt\opensearch``。
+可以将 |Fess| 注册为 Windows 服务。注册为服务后，可以在系统启动时自动启动 |Fess|。
+要运行 |Fess|，需要先启动 OpenSearch。
+本文档假设已将 |Fess| 安装在 ``c:\opt\fess``，OpenSearch 安装在 ``c:\opt\opensearch``（请根据实际环境替换路径）。
 
-准备工作
-------
+.. note::
+   |Fess| 和 OpenSearch 仅支持 64 位版本。
 
-请将 JAVA_HOME 设置为系统环境变量。
+前期准备
+--------
+
+请将 ``JAVA_HOME`` 设置为系统环境变量。若未设置 ``JAVA_HOME``，``service.bat`` 将报错退出。
 
 将 OpenSearch 注册为服务
--------------------------
+------------------------
 
-| 在命令提示符中以管理员身份执行 ``c:\opt\opensearch\bin\opensearch-service.bat``。
+以管理员权限启动命令提示符，执行 ``c:\opt\opensearch\bin\opensearch-service.bat``。
 
 ::
 
@@ -26,31 +29,58 @@
     ...
     The service 'opensearch-service-x64' has been installed.
 
-详情请参阅 `OpenSearch 文档 <https://opensearch.org/docs/2.4/install-and-configure/install-opensearch/windows/>`_。
+详情请参阅 `OpenSearch 文档 <https://opensearch.org/docs/latest/install-and-configure/install-opensearch/windows/>`_。
 
-配置
-----
+|Fess| 的配置
+-------------
 
-编辑 ``c:\opt\fess\bin\fess.in.bat`` 文件,在 SEARCH_ENGINE_HOME 中设置 OpenSearch 的安装路径。
+服务通过 ``c:\opt\fess\bin\service.bat`` 进行注册。``service.bat`` 在注册时会读取 ``bin\fess.in.bat``，并将其内容反映到 |Fess| 的启动选项中。
+请在 ``c:\opt\fess\bin\fess.in.bat`` 中添加连接 OpenSearch 的配置。
 
 ::
 
-    set SEARCH_ENGINE_HOME=c:/opt/opensearch
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.search_engine.http_address=http://localhost:9200
+    set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.dictionary.path=c:/opt/opensearch/data/config/
 
-|Fess| 的搜索页面和管理页面的默认端口号为 8080。如需更改为 80 端口,请修改 ``c:\opt\fess\bin\fess.in.bat`` 中的 fess.port。
+.. note::
+   - ``fess.search_engine.http_address`` 用于指定已注册的 OpenSearch 服务的连接地址。若不进行此配置，|Fess| 将无法找到连接目标，并会启动不推荐在生产环境中使用的内嵌版 OpenSearch。
+   - 若 OpenSearch 运行在其他主机上，请将主机名或 IP 地址修改为适当的值。
+   - 路径分隔符请使用 ``/``。
+
+|Fess| 搜索页面和管理页面的默认端口号为 ``8080``。如需更改为其他端口，请编辑 ``c:\opt\fess\bin\fess.in.bat`` 中的 ``-Dfess.port``。
 
 ::
 
     set FESS_JAVA_OPTS=%FESS_JAVA_OPTS% -Dfess.port=80
 
 .. note::
-   注册为服务时，``bin\service.bat`` 中的 ``FESS_PARAMS`` 也硬编码了 ``-Dfess.port=8080``。变更端口时，请同样编辑 ``service.bat``。
+   注册为服务时，``bin\service.bat`` 中的 ``FESS_PARAMS`` 也硬编码了 ``-Dfess.port=8080``。由于该值优先于 ``fess.in.bat`` 的配置，更改端口时请同样编辑 ``service.bat`` 中的 ``FESS_PARAMS``。
 
+服务自定义（可选）
+------------------
+
+在执行 ``service.bat install`` 之前设置环境变量，可以更改服务的配置。主要的环境变量如下。
+
+.. list-table::
+   :header-rows: 1
+
+   * - 环境变量
+     - 说明
+   * - ``FESS_START_TYPE``
+     - 启动类型（``auto`` 或 ``manual``）。默认为 ``manual``。
+   * - ``FESS_HEAP_SIZE``
+     - 堆大小（例如：``1g``）。如需分别指定最小和最大堆大小，请使用 ``FESS_MIN_MEM``（默认 ``256m``）和 ``FESS_MAX_MEM``（默认 ``1g``）。
+   * - ``SERVICE_USERNAME`` / ``SERVICE_PASSWORD``
+     - 运行服务的 Windows 账户。
+   * - ``SERVICE_DISPLAY_NAME``
+     - 服务的显示名称。
+   * - ``SERVICE_DESCRIPTION``
+     - 服务的描述。
 
 注册方法
-------
+--------
 
-在命令提示符中以管理员身份执行 ``c:\opt\fess\bin\service.bat``。
+以管理员权限启动命令提示符，执行 ``c:\opt\fess\bin\service.bat``。
 
 ::
 
@@ -59,23 +89,46 @@
     ...
     The service 'fess-service-x64' has been installed.
 
-
 服务配置
------------
+--------
 
-如需手动启动服务,请先启动 OpenSearch 服务,然后再启动 |Fess| 服务。
-如需自动启动,请添加依赖关系。
+如需手动启动服务，请先启动 OpenSearch 服务，再启动 |Fess| 服务。
+如需在系统启动时自动启动，请配置启动类型和依赖关系。
 
-1. 在服务的常规设置中,将启动类型设置为"自动(延迟启动)"。
+1. 在服务的常规设置中，将启动类型设置为"自动（延迟启动）"。
 2. 在注册表中配置服务依赖关系。
 
-在注册表编辑器(regedit)中添加以下键和值。
+在注册表编辑器（regedit）中添加以下键和值。
 
 .. list-table::
 
    * - *键*
-     - ``计算机\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\fess-service-x64\DependOnService``
+     - ``Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\fess-service-x64\DependOnService``
    * - *值*
      - ``opensearch-service-x64``
 
-添加后,opensearch-service-x64 将显示在 |Fess| 服务属性的依赖关系中。
+添加后，opensearch-service-x64 将显示在 |Fess| 服务属性的依赖关系中。
+
+.. note::
+   在执行 ``service.bat install`` 之前设置环境变量 ``FESS_START_TYPE=auto``，可以将启动类型注册为"自动"。但是，"自动（延迟启动）"和依赖关系的配置无法通过 ``service.bat`` 完成，请按照上述步骤进行设置。
+
+服务管理
+--------
+
+使用 ``service.bat`` 可以通过以下命令操作服务。
+
+.. list-table::
+   :header-rows: 1
+
+   * - 命令
+     - 说明
+   * - ``service.bat install``
+     - 注册服务。
+   * - ``service.bat remove``
+     - 删除服务。
+   * - ``service.bat start``
+     - 启动服务。
+   * - ``service.bat stop``
+     - 停止服务。
+   * - ``service.bat manager``
+     - 启动服务管理 GUI。


### PR DESCRIPTION
## Summary

Corrects the Windows service registration guide (`15.7/config/setup-windows-service.rst`) so it matches the current implementation (`service.bat`, `fess.in.bat`) and the actual OpenSearch connection behavior. Applied to all languages (ja, en, de, es, fr, ko, zh-cn).

## Background

The previous guide instructed users to set `SEARCH_ENGINE_HOME` to point at the externally installed OpenSearch. This is incorrect: `SEARCH_ENGINE_HOME` (`-Dfess.es.dir`) is only used to launch an **embedded** OpenSearch node. When OpenSearch runs as a separate Windows service, Fess connects to it over HTTP and the relevant setting is `fess.search_engine.http_address`. With only `SEARCH_ENGINE_HOME` set, Fess would start an embedded OpenSearch (logged as "not recommended for production use") instead of connecting to the installed service.

## Changes

- Replace the `SEARCH_ENGINE_HOME` instruction with `-Dfess.search_engine.http_address` (and `-Dfess.dictionary.path`), consistent with the Windows installation guide. These settings in `fess.in.bat` are picked up by the service at install time.
- Update the OpenSearch documentation link to the current (`latest`) version.
- Add a 64-bit-only note and clarify the `JAVA_HOME` prerequisite.
- Document the `service.bat` management commands: `install` / `remove` / `start` / `stop` / `manager`.
- Add an optional service customization section for install-time environment variables: `FESS_START_TYPE`, `FESS_HEAP_SIZE` (`FESS_MIN_MEM` / `FESS_MAX_MEM`), `SERVICE_USERNAME` / `SERVICE_PASSWORD`, `SERVICE_DISPLAY_NAME`, `SERVICE_DESCRIPTION`.
- Clarify that the hardcoded `-Dfess.port=8080` in `service.bat`'s `FESS_PARAMS` takes precedence over `fess.in.bat`, so the port must be changed in both places.

## Verification

- Cross-checked against `service.bat`, `fess.in.bat`, `SearchEngineClient.java`, and `common-bin.xml` (service binaries are bundled).
- All 7 language files updated consistently (identical code blocks, technical values, registry key, and table structure).