### PR TITLE
docs(config): align 15.7 rate limiting docs with implementation

### DIFF
--- a/de/15.7/config/rate-limiting.rst
+++ b/de/15.7/config/rate-limiting.rst
@@ -92,6 +92,15 @@ Beachtung von robots.txt
     User-agent: *
     Crawl-delay: 10
 
+Die robots.txt-Verarbeitung wird über ``crawler.ignore.robots.txt`` in
+``app/WEB-INF/classes/fess_config.properties`` gesteuert (Standard: ``false``).
+Bei Setzen auf ``true`` wird die robots.txt-Verarbeitung einschließlich Crawl-delay deaktiviert.
+
+::
+
+    # robots.txt ignorieren (Standard: false)
+    crawler.ignore.robots.txt=false
+
 Alle Rate-Limiting-Einstellungen
 =================================
 
@@ -129,8 +138,14 @@ Alle in ``app/WEB-INF/classes/fess_config.properties`` konfigurierbaren Eigensch
      - Vertrauenswürdige Proxy-IPs (für X-Forwarded-For/X-Real-IP)
      - ``127.0.0.1,::1``
    * - ``rate.limit.cleanup.interval``
-     - Bereinigungsintervall zur Vermeidung von Speicherlecks (Anfragenzahl)
+     - Bereinigungsintervall (Anfragenzahl, reserviert)
      - ``1000``
+
+.. note::
+   ``rate.limit.cleanup.interval`` ist eine für zukünftige Erweiterungen reservierte Einstellung.
+   In der aktuellen Implementierung werden die Anfragezähler und die Informationen zu blockierten IPs
+   automatisch auf Basis des internen Cache-Ablaufs (``rate.limit.window.ms`` und
+   ``rate.limit.block.duration.ms``) bereinigt, sodass dieser Wert nicht verwendet wird.
 
 Erweiterte Rate-Limiting-Konfiguration
 ======================================

--- a/en/15.7/config/rate-limiting.rst
+++ b/en/15.7/config/rate-limiting.rst
@@ -92,6 +92,15 @@ Respecting robots.txt
     User-agent: *
     Crawl-delay: 10
 
+robots.txt handling is controlled by ``crawler.ignore.robots.txt`` in
+``app/WEB-INF/classes/fess_config.properties`` (default: ``false``).
+Setting it to ``true`` disables robots.txt handling, including Crawl-delay.
+
+::
+
+    # Ignore robots.txt (default: false)
+    crawler.ignore.robots.txt=false
+
 All Rate Limiting Properties
 ============================
 
@@ -129,8 +138,15 @@ All properties configurable in ``app/WEB-INF/classes/fess_config.properties``.
      - Trusted proxy IPs (for X-Forwarded-For/X-Real-IP resolution)
      - ``127.0.0.1,::1``
    * - ``rate.limit.cleanup.interval``
-     - Cleanup interval to prevent memory leaks (number of requests)
+     - Cleanup interval (number of requests, reserved)
      - ``1000``
+
+.. note::
+   ``rate.limit.cleanup.interval`` is a setting reserved for future use.
+   In the current implementation, the request counters and blocked IP information
+   are cleaned up automatically based on the internal cache expiration
+   (``rate.limit.window.ms`` and ``rate.limit.block.duration.ms``),
+   so this value is not used.
 
 Advanced Rate Limiting Configuration
 =====================================

--- a/es/15.7/config/rate-limiting.rst
+++ b/es/15.7/config/rate-limiting.rst
@@ -92,6 +92,15 @@ Respeto de robots.txt
     User-agent: *
     Crawl-delay: 10
 
+El manejo de robots.txt se controla mediante ``crawler.ignore.robots.txt`` en
+``app/WEB-INF/classes/fess_config.properties`` (predeterminado: ``false``).
+Al establecerlo en ``true``, se deshabilita el manejo de robots.txt, incluyendo Crawl-delay.
+
+::
+
+    # Ignorar robots.txt (predeterminado: false)
+    crawler.ignore.robots.txt=false
+
 Todas las opciones de configuracion de limite de tasa
 =====================================================
 
@@ -129,8 +138,15 @@ Todas las propiedades configurables en ``app/WEB-INF/classes/fess_config.propert
      - IPs de proxies confiables (para obtener X-Forwarded-For/X-Real-IP)
      - ``127.0.0.1,::1``
    * - ``rate.limit.cleanup.interval``
-     - Intervalo de limpieza para prevenir fugas de memoria (numero de solicitudes)
+     - Intervalo de limpieza (numero de solicitudes, reservado)
      - ``1000``
+
+.. note::
+   ``rate.limit.cleanup.interval`` es una configuracion reservada para uso futuro.
+   En la implementacion actual, los contadores de solicitudes y la informacion de IPs bloqueadas
+   se limpian automaticamente en funcion de la expiracion de la cache interna
+   (``rate.limit.window.ms`` y ``rate.limit.block.duration.ms``),
+   por lo que este valor no se utiliza.
 
 Configuracion avanzada de limite de tasa
 ========================================

--- a/fr/15.7/config/rate-limiting.rst
+++ b/fr/15.7/config/rate-limiting.rst
@@ -92,6 +92,15 @@ Respect de robots.txt
     User-agent: *
     Crawl-delay: 10
 
+Le traitement de robots.txt est controle par ``crawler.ignore.robots.txt`` dans
+``app/WEB-INF/classes/fess_config.properties`` (defaut : ``false``).
+En le definissant sur ``true``, le traitement de robots.txt, y compris Crawl-delay, est desactive.
+
+::
+
+    # Ignorer robots.txt (defaut : false)
+    crawler.ignore.robots.txt=false
+
 Liste complete des proprietes de limitation de debit
 ======================
 
@@ -129,8 +138,15 @@ Toutes les proprietes configurables dans ``app/WEB-INF/classes/fess_config.prope
      - IP de proxies de confiance (pour obtenir l'IP client via X-Forwarded-For/X-Real-IP)
      - ``127.0.0.1,::1``
    * - ``rate.limit.cleanup.interval``
-     - Intervalle de nettoyage pour prevenir les fuites memoire (nombre de requetes)
+     - Intervalle de nettoyage (nombre de requetes, reserve)
      - ``1000``
+
+.. note::
+   ``rate.limit.cleanup.interval`` est un parametre reserve pour une utilisation future.
+   Dans l'implementation actuelle, les compteurs de requetes et les informations sur les IP bloquees
+   sont nettoyes automatiquement en fonction de l'expiration du cache interne
+   (``rate.limit.window.ms`` et ``rate.limit.block.duration.ms``),
+   de sorte que cette valeur n'est pas utilisee.
 
 Configuration avancee de limitation de debit
 ====================

--- a/ja/15.7/config/rate-limiting.rst
+++ b/ja/15.7/config/rate-limiting.rst
@@ -92,6 +92,15 @@ robots.txtの尊重
     User-agent: *
     Crawl-delay: 10
 
+robots.txtの処理は ``app/WEB-INF/classes/fess_config.properties`` の
+``crawler.ignore.robots.txt`` で制御します（デフォルト: ``false``）。
+``true`` に設定すると、Crawl-delay を含む robots.txt の処理が無効になります。
+
+::
+
+    # robots.txtを無視する（デフォルト: false）
+    crawler.ignore.robots.txt=false
+
 レート制限の全設定項目
 ======================
 
@@ -129,8 +138,14 @@ robots.txtの尊重
      - 信頼するプロキシIP（X-Forwarded-For/X-Real-IPの取得元）
      - ``127.0.0.1,::1``
    * - ``rate.limit.cleanup.interval``
-     - メモリリーク防止のためのクリーンアップ間隔（リクエスト数）
+     - クリーンアップ間隔（リクエスト数、予約済み）
      - ``1000``
+
+.. note::
+   ``rate.limit.cleanup.interval`` は将来の拡張のために予約されている設定項目です。
+   現在の実装では、リクエストカウンターおよびブロックIPの情報は内部キャッシュの
+   有効期限（``rate.limit.window.ms`` および ``rate.limit.block.duration.ms``）に
+   基づいて自動的にクリーンアップされるため、この設定値は使用されません。
 
 高度なレート制限設定
 ====================

--- a/ko/15.7/config/rate-limiting.rst
+++ b/ko/15.7/config/rate-limiting.rst
@@ -92,6 +92,15 @@ robots.txt 준수
     User-agent: *
     Crawl-delay: 10
 
+robots.txt 처리는 ``app/WEB-INF/classes/fess_config.properties`` 의
+``crawler.ignore.robots.txt`` 로 제어합니다(기본값: ``false``).
+``true`` 로 설정하면 Crawl-delay 를 포함한 robots.txt 처리가 비활성화됩니다.
+
+::
+
+    # robots.txt를 무시한다(기본값: false)
+    crawler.ignore.robots.txt=false
+
 속도 제한 전체 설정 항목
 =========================
 
@@ -129,8 +138,14 @@ robots.txt 준수
      - 신뢰하는 프록시 IP(X-Forwarded-For/X-Real-IP 취득원)
      - ``127.0.0.1,::1``
    * - ``rate.limit.cleanup.interval``
-     - 메모리 누수 방지를 위한 클린업 간격(요청 수)
+     - 클린업 간격(요청 수, 예약됨)
      - ``1000``
+
+.. note::
+   ``rate.limit.cleanup.interval`` 은 미래 확장을 위해 예약된 설정 항목입니다.
+   현재 구현에서는 요청 카운터 및 블록 IP 정보가 내부 캐시의
+   유효 기간(``rate.limit.window.ms`` 및 ``rate.limit.block.duration.ms``)에
+   따라 자동으로 클린업되므로, 이 설정값은 사용되지 않습니다.
 
 고급 속도 제한 설정
 ====================

--- a/zh-cn/15.7/config/rate-limiting.rst
+++ b/zh-cn/15.7/config/rate-limiting.rst
@@ -92,6 +92,14 @@ Web爬取设置
     User-agent: *
     Crawl-delay: 10
 
+robots.txt的处理由 ``app/WEB-INF/classes/fess_config.properties`` 中的 ``crawler.ignore.robots.txt`` 控制（默认值: ``false``）。
+将其设置为 ``true`` 可禁用robots.txt的处理，包括Crawl-delay的遵守。
+
+::
+
+    # 忽略robots.txt（默认: false）
+    crawler.ignore.robots.txt=false
+
 速率限制的全部配置项
 ======================
 
@@ -129,8 +137,12 @@ Web爬取设置
      - 信任的代理IP（从X-Forwarded-For/X-Real-IP获取客户端IP）
      - ``127.0.0.1,::1``
    * - ``rate.limit.cleanup.interval``
-     - 防止内存泄漏的清理间隔（请求数）
+     - 清理间隔（请求数，预留）
      - ``1000``
+
+.. note::
+   ``rate.limit.cleanup.interval`` 是为将来使用而预留的设置项。
+   在当前实现中，请求计数器和被阻止的IP信息会根据内部缓存过期时间（``rate.limit.window.ms`` 和 ``rate.limit.block.duration.ms``）自动清理，因此该值不会被使用。
 
 高级速率限制设置
 ====================


### PR DESCRIPTION
## Summary

Reviewed `config/rate-limiting.rst` for the 15.7 documentation against the actual Fess implementation (`RateLimitFilter`, `RateLimitHelper`, `fess_config.properties`) and corrected two inaccuracies.

The existing content was largely accurate — all nine `rate.limit.*` properties and their default values matched the source, and the HTTP behavior (429 with `Retry-After`, 403 for blocked IPs, trusted-proxy header handling, fixed-window blocking) was described correctly. This PR fixes the two points that did not match the implementation.

## Changes

- **`rate.limit.cleanup.interval`**: The property exists in `fess_config.properties` (default `1000`) and has a `FessConfig` getter, but it is not consumed anywhere in the current implementation. Cleanup is handled automatically by the internal cache expiration driven by `rate.limit.window.ms` and `rate.limit.block.duration.ms`. The docs previously described it as actively preventing memory leaks. Updated the table description to mark it as reserved and added a note explaining the actual behavior.
- **robots.txt handling**: Documented `crawler.ignore.robots.txt` (default `false`) as the property that controls robots.txt processing, including the `Crawl-delay` directive. Setting it to `true` disables robots.txt handling.

## Languages

Applied consistently across all language versions: `ja`, `en`, `de`, `fr`, `es`, `ko`, `zh-cn`.
