### PR TITLE
docs(config): correct crawler log file name in setup-memory (15.7)

### DIFF
--- a/de/15.7/config/setup-memory.rst
+++ b/de/15.7/config/setup-memory.rst
@@ -343,7 +343,7 @@ Bei folgenden Symptomen besteht möglicherweise Speichermangel.
 **Crawler:**
 
 - Crawling stoppt mittendrin
-- ``OutOfMemoryError`` in ``fess_crawler.log`` aufgezeichnet
+- ``OutOfMemoryError`` in ``fess-crawler.log`` aufgezeichnet
 - Crawlen großer Dateien schlägt fehl
 
 **OpenSearch:**

--- a/en/15.7/config/setup-memory.rst
+++ b/en/15.7/config/setup-memory.rst
@@ -342,7 +342,7 @@ If the following symptoms appear, there may be a memory shortage.
 **Crawler:**
 
 - Crawling stops midway
-- ``OutOfMemoryError`` recorded in ``fess_crawler.log``
+- ``OutOfMemoryError`` recorded in ``fess-crawler.log``
 - Large file crawling fails
 
 **OpenSearch:**

--- a/es/15.7/config/setup-memory.rst
+++ b/es/15.7/config/setup-memory.rst
@@ -341,7 +341,7 @@ Si aparecen los siguientes síntomas, es posible que haya falta de memoria.
 **Rastreador:**
 
 - El rastreo se detiene a mitad
-- ``OutOfMemoryError`` registrado en ``fess_crawler.log``
+- ``OutOfMemoryError`` registrado en ``fess-crawler.log``
 - Falla el rastreo de archivos grandes
 
 **OpenSearch:**

--- a/fr/15.7/config/setup-memory.rst
+++ b/fr/15.7/config/setup-memory.rst
@@ -340,7 +340,7 @@ Si les symptômes suivants apparaissent, il peut y avoir un manque de mémoire.
 **Crawler :**
 
 - Le crawl s'arrête en cours d'exécution
-- ``OutOfMemoryError`` enregistré dans ``fess_crawler.log``
+- ``OutOfMemoryError`` enregistré dans ``fess-crawler.log``
 - Échec du crawl de fichiers volumineux
 
 **OpenSearch :**

--- a/ja/15.7/config/setup-memory.rst
+++ b/ja/15.7/config/setup-memory.rst
@@ -342,7 +342,7 @@ OpenSearchのメモリ使用状況
 **クローラー:**
 
 - クロールが途中で停止する
-- ``OutOfMemoryError`` が ``fess_crawler.log`` に記録される
+- ``OutOfMemoryError`` が ``fess-crawler.log`` に記録される
 - 大きなファイルのクロールに失敗する
 
 **OpenSearch:**

--- a/ko/15.7/config/setup-memory.rst
+++ b/ko/15.7/config/setup-memory.rst
@@ -336,7 +336,7 @@ OpenSearch의 메모리 사용 상황
 **크롤러:**
 
 - 크롤이 중간에 중지됨
-- ``OutOfMemoryError`` 가 ``fess_crawler.log`` 에 기록됨
+- ``OutOfMemoryError`` 가 ``fess-crawler.log`` 에 기록됨
 - 큰 파일의 크롤링에 실패함
 
 **OpenSearch:**

--- a/zh-cn/15.7/config/setup-memory.rst
+++ b/zh-cn/15.7/config/setup-memory.rst
@@ -340,7 +340,7 @@ OpenSearch 的内存使用情况
 **爬虫:**
 
 - 爬取中途停止
-- ``fess_crawler.log`` 中记录了 ``OutOfMemoryError``
+- ``fess-crawler.log`` 中记录了 ``OutOfMemoryError``
 - 大型文件爬取失败
 
 **OpenSearch:**


### PR DESCRIPTION
## Summary

Reviewed `15.7/config/setup-memory.rst` against the Fess source code and corrected one technical inaccuracy in the memory troubleshooting section.

The crawler process writes to **`fess-crawler.log`** (hyphen), not `fess_crawler.log` (underscore). The doc's "memory shortage symptoms" section referenced the wrong filename.

### Verification

The actual log file name is derived in source as follows:

- `ExecJob.getLogName()` returns `"fess-" + getExecuteType()` → `fess-crawler` for the crawler process.
- The crawler `log4j2.xml` sets the log file to `${log.file.basedir}/${domain.name}.log` where `domain.name = ${sys:fess.log.name:-fess}`, i.e. `fess-crawler.log`.

This matches the existing log-naming convention used elsewhere in the docs (`fess.log`, `fess-crawler.log`, `fess-suggest.log`, `fess-thumbnail.log`).

### Other claims checked (all confirmed correct against source)

- `FESS_HEAP_SIZE` / `FESS_MIN_MEM` / `FESS_MAX_MEM` env vars and defaults (Linux 256m/2g, Windows 256m/1g) — `fess.in.sh`, `fess.in.bat`
- `jvm.crawler.options`, `jvm.suggest.options`, `jvm.thumbnail.options` defaults (heap, Metaspace, G1GC, `MaxGCPauseMillis=60000`, `HeapDumpOnOutOfMemoryError` disabled) — `fess_config.properties`
- Config file paths `app/WEB-INF/classes/fess_config.properties` and `/etc/fess/fess_config.properties` — consistent with packaging (`pom.xml`, `packaging.fess.conf.dir`)
- RPM `/etc/sysconfig/fess` and DEB `/etc/default/fess` env file paths — `packaging.properties`
- Default OpenSearch HTTP port `9201` — `fess_config.properties` (`search_engine.http.url`)

### Languages

The same fix was applied across all 7 languages: ja, en, de, es, fr, ko, zh-cn.

