### PR TITLE
docs: correct LDAP integration guide against implementation (15.7)

### DIFF
--- a/de/15.7/config/ldap-integration.rst
+++ b/de/15.7/config/ldap-integration.rst
@@ -1,188 +1,324 @@
-==================================
+=====================================
 LDAP-Integrationsleitfaden
-==================================
+=====================================
 
 Übersicht
-==========
+=========
 
-|Fess| unterstuetzt die Integration mit LDAP-Servern (Lightweight Directory Access Protocol),
-was Authentifizierung und Benutzerverwaltung in Unternehmensumgebungen ermoeglicht.
+|Fess| unterstützt die Integration mit LDAP-Servern (Lightweight Directory Access Protocol)
+und ermöglicht damit Authentifizierung und Benutzerverwaltung in Unternehmensumgebungen.
 
-Die LDAP-Integration ermoeglicht:
+Die LDAP-Integration ermöglicht:
 
-- Benutzerauthentifizierung mit Active Directory oder OpenLDAP
-- Gruppenbasierte Zugriffskontrolle
-- Automatische Benutzerinformations-Synchronisation
+- Benutzerauthentifizierung (Anmeldung) über Active Directory oder OpenLDAP
+- Gruppen- und rollenbasierte Zugriffskontrolle
+- Verwaltung von LDAP-Benutzern, -Rollen und -Gruppen über die Verwaltungsoberfläche (optional)
 
-Unterstuetzte LDAP-Server
-=========================
+Unterstützte LDAP-Server
+========================
 
-|Fess| unterstuetzt die Integration mit den folgenden LDAP-Servern:
+|Fess| unterstützt die Integration mit folgenden LDAP-Servern:
 
 - Microsoft Active Directory
 - OpenLDAP
 - 389 Directory Server
 - Apache Directory Server
-- Andere LDAP v3-kompatible Server
+- Andere LDAP-v3-kompatible Server
 
 Voraussetzungen
 ===============
 
 - Netzwerkzugriff auf den LDAP-Server
-- Dienstkonto fuer LDAP-Suchen (Bind DN)
-- Verstaendnis der LDAP-Struktur (Base DN, Attributnamen usw.)
+- Dienstkonto für LDAP-Suchen (Bind-DN)
+- Kenntnisse der LDAP-Struktur (Base-DN, Attributnamen usw.)
 
-Grundkonfiguration
-==================
+Übersicht der Konfigurationsmethoden
+=====================================
 
-Fuegen Sie die folgende Konfiguration zu ``app/WEB-INF/conf/system.properties`` hinzu.
+Die LDAP-Konfiguration von |Fess| wird je nach Verwendungszweck an zwei Stellen verwaltet.
 
-LDAP-Verbindungseinstellungen
------------------------------
+Verbindungs- und Authentifizierungseinstellungen (Verwaltungsoberfläche / ``system.properties``)
+   Dies sind Einstellungen für die Verbindung zum LDAP-Server und die Anmeldeauthentifizierung.
+   Sie können im Abschnitt „LDAP" auf der Seite **„System > Allgemein"** der Verwaltungsoberfläche
+   konfiguriert werden und werden in ``app/WEB-INF/conf/system.properties`` gespeichert.
 
-::
-
-    # LDAP-Authentifizierung aktivieren
-    ldap.admin.enabled=true
-
-    # LDAP-Server-URL
-    ldap.provider.url=ldap://ldap.example.com:389
-
-    # Fuer sichere Verbindung (LDAPS)
-    # ldap.provider.url=ldaps://ldap.example.com:636
-
-    # Base DN
-    ldap.base.dn=dc=example,dc=com
-
-    # Bind-DN-Vorlage fuer Benutzerauthentifizierung (%s wird durch den Benutzernamen ersetzt)
-    ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
-
-    # Admin-Bind-DN (Dienstkonto fuer LDAP-Suche)
-    ldap.admin.security.principal=cn=fess,ou=services,dc=example,dc=com
-
-    # Admin-Bind-Passwort
-    ldap.admin.security.credentials=your_password
-
-Benutzersuche-Einstellungen
----------------------------
-
-::
-
-    # Benutzersuche Base DN
-    ldap.user.search.base=ou=users,dc=example,dc=com
-
-    # Benutzersuche-Filter
-    ldap.account.filter=(uid=%s)
-
-    # Benutzername-Attribut
-    ldap.user.name.attribute=uid
-
-    # Admin-Benutzersuchfilter fuer die LDAP-Verwaltungskonsole
-    ldap.admin.user.filter=uid=%s
+LDAP-Verwaltungsfunktionen und Verhaltenseinstellungen (``fess_config.properties``)
+   Dies sind Einstellungen für die Funktion zur Verwaltung von LDAP-Benutzern, -Rollen und
+   -Gruppen über die Verwaltungsoberfläche sowie für das Verhalten bei der Rollenauflösung.
+   Diese sind in ``app/WEB-INF/classes/fess_config.properties`` definiert.
+   Zum Ändern von Werten bearbeiten Sie diese Datei direkt.
 
 .. note::
 
-   ``ldap.account.filter`` ist der Suchfilter fuer die Benutzerauthentifizierung,
-   ``ldap.admin.user.filter`` ist der Benutzersuchfilter fuer die LDAP-Verwaltungskonsole.
-   Konfigurieren Sie beide entsprechend, da sie unterschiedliche Zwecke erfuellen.
+   Wenn Sie ausschließlich die Anmeldeauthentifizierung verwenden möchten, genügen die
+   „Verbindungs- und Authentifizierungseinstellungen". Die „LDAP-Verwaltungsfunktion"
+   (``ldap.admin.enabled``) ist nur erforderlich, wenn Sie LDAP-Benutzer, -Rollen oder
+   -Gruppen über die Verwaltungsoberfläche erstellen, aktualisieren oder löschen möchten.
 
-LDAP-Admin-Basis-DN-Einstellungen
-----------------------------------
+Verbindungs- und Authentifizierungseinstellungen
+================================================
+
+Diese Einstellungen können im Abschnitt „LDAP" unter „System > Allgemein" der
+Verwaltungsoberfläche konfiguriert werden und werden in
+``app/WEB-INF/conf/system.properties`` gespeichert. Sie können die Datei auch direkt
+bearbeiten.
+
+.. list-table:: Verbindungs- und Authentifizierungseigenschaften
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Eigenschaft
+     - Standardwert
+     - Beschreibung
+   * - ``ldap.provider.url``
+     - (keiner)
+     - URL des LDAP-Servers. Beispiel: ``ldap://ldap.example.com:389``. Für LDAPS: ``ldaps://ldap.example.com:636``. Mehrere URLs durch Leerzeichen getrennt ermöglichen Failover.
+   * - ``ldap.base.dn``
+     - (keiner)
+     - Basis-DN für die LDAP-Suche. Beispiel: ``dc=example,dc=com``
+   * - ``ldap.security.principal``
+     - (keiner)
+     - DN-Vorlage für die Benutzerauthentifizierung (Bind). ``%s`` wird durch den Benutzernamen ersetzt. Beispiel: ``uid=%s,ou=People,dc=example,dc=com``
+   * - ``ldap.security.authentication``
+     - ``simple``
+     - LDAP-Authentifizierungsmethode (JNDI ``java.naming.security.authentication``). In der Regel wird ``simple`` verwendet.
+   * - ``ldap.initial.context.factory``
+     - ``com.sun.jndi.ldap.LdapCtxFactory``
+     - JNDI-Klasse für die initiale Kontextfabrik. In der Regel ist keine Änderung erforderlich.
+   * - ``ldap.admin.security.principal``
+     - (keiner)
+     - Bind-DN des Dienstkontos für LDAP-Suchen. Beispiel: ``cn=fess,ou=services,dc=example,dc=com``
+   * - ``ldap.admin.security.credentials``
+     - (keiner)
+     - Passwort des oben genannten Dienstkontos.
+   * - ``ldap.account.filter``
+     - (keiner)
+     - Filter zur Suche nach Benutzereinträgen bei der Rollenauflösung. ``%s`` wird durch den Benutzernamen ersetzt. Beispiel: ``uid=%s``
+   * - ``ldap.group.filter``
+     - (leer)
+     - Suchfilter für die Gruppenauflösung. ``%s`` wird durch den DN des Benutzers o. Ä. ersetzt. Beispiel: ``(member=%s)``
+   * - ``ldap.memberof.attribute``
+     - ``memberOf``
+     - Attributname für die Gruppenmitgliedschaft. Wird zur Rollenauflösung bei Active Directory und Servern mit diesem Attribut verwendet.
+
+Konfigurationsbeispiel (bei direkter Bearbeitung von ``system.properties``):
 
 ::
 
-    # Benutzer-Suche-Basis-DN
-    ldap.admin.user.base.dn=ou=People,dc=example,dc=com
+    # URL des LDAP-Servers
+    ldap.provider.url=ldap://ldap.example.com:389
 
-    # Rollen-Suche-Basis-DN
-    ldap.admin.role.base.dn=ou=Roles,dc=example,dc=com
+    # Basis-DN
+    ldap.base.dn=dc=example,dc=com
 
-    # Gruppen-Suche-Basis-DN
-    ldap.admin.group.base.dn=ou=Groups,dc=example,dc=com
+    # Bind-DN-Vorlage fuer die Benutzerauthentifizierung (%s wird durch den Benutzernamen ersetzt)
+    ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-Gruppensuche-Einstellungen
---------------------------
+    # Bind-DN und Passwort des Dienstkontos fuer Suchen
+    ldap.admin.security.principal=cn=fess,ou=services,dc=example,dc=com
+    ldap.admin.security.credentials=your_password
 
-::
-
-    # Gruppensuche Base DN
-    ldap.group.search.base=ou=groups,dc=example,dc=com
-
-    # Gruppensuche-Filter
+    # Filter fuer die Rollenaufloesung
+    ldap.account.filter=uid=%s
     ldap.group.filter=(member=%s)
 
-    # Gruppenname-Attribut
-    ldap.group.name.attribute=cn
+.. note::
+
+   Der ``%s``-Platzhalter wird durch Javas ``String.format()`` verarbeitet.
+   ``ldap.security.principal``, ``ldap.account.filter``, ``ldap.group.filter`` und
+   alle administrativen Filter verwenden das ``%s``-Format (nicht das ``{0}``-Format).
+   Der an die Filter übergebene Benutzername wird in |Fess| intern automatisch
+   gegen LDAP-Injection-Angriffe escapet.
+
+LDAP-Verwaltungsfunktionen und Verhaltenseinstellungen
+======================================================
+
+Die folgenden Eigenschaften sind in ``app/WEB-INF/classes/fess_config.properties``
+definiert. Zum Ändern von Werten bearbeiten Sie diese Datei.
+
+Aktivierung der Verwaltungsfunktion
+------------------------------------
+
+.. list-table:: Eigenschaften der Verwaltungsfunktion
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Eigenschaft
+     - Standardwert
+     - Beschreibung
+   * - ``ldap.admin.enabled``
+     - ``false``
+     - Aktiviert die Funktion zum Erstellen, Aktualisieren und Löschen von LDAP-Benutzern, -Rollen und -Gruppen über die Verwaltungsoberfläche. **Nicht erforderlich für die Anmeldeauthentifizierung** — die LDAP-Anmeldung funktioniert auch ohne Aktivierung.
+   * - ``ldap.admin.sync.password``
+     - ``true``
+     - Synchronisiert das |Fess|-Passwort mit LDAP, wenn ein Benutzer über die Verwaltungsoberfläche aktualisiert wird.
+   * - ``ldap.auth.validation``
+     - ``true``
+     - Überprüft die LDAP-Authentifizierung beim Anmelden.
+
+Filter und Basis-DNs für die Benutzer-/Rollen-/Gruppenverwaltung
+-----------------------------------------------------------------
+
+Wird verwendet, um LDAP-Einträge über die Verwaltungsoberfläche zu bearbeiten, wenn ``ldap.admin.enabled=true`` gesetzt ist.
+
+.. list-table:: Administrative Filter und Basis-DNs
+   :header-rows: 1
+   :widths: 38 47 15
+
+   * - Eigenschaft
+     - Beschreibung
+     - Standardwert
+   * - ``ldap.admin.user.filter``
+     - Benutzer-Suchfilter (``%s`` wird durch den Benutzernamen ersetzt)
+     - ``uid=%s``
+   * - ``ldap.admin.user.base.dn``
+     - Basis-DN für die Benutzersuche
+     - ``ou=People,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.user.object.classes``
+     - objectClass bei der Benutzererstellung
+     - ``organizationalPerson,top,person,inetOrgPerson``
+   * - ``ldap.admin.role.filter``
+     - Rollen-Suchfilter
+     - ``cn=%s``
+   * - ``ldap.admin.role.base.dn``
+     - Basis-DN für die Rollensuche
+     - ``ou=Role,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.role.object.classes``
+     - objectClass bei der Rollenerstellung
+     - ``groupOfNames``
+   * - ``ldap.admin.group.filter``
+     - Gruppen-Suchfilter
+     - ``cn=%s``
+   * - ``ldap.admin.group.base.dn``
+     - Basis-DN für die Gruppensuche
+     - ``ou=Group,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.group.object.classes``
+     - objectClass bei der Gruppenerstellung
+     - ``groupOfNames``
+
+Steuerung der Rollenauflösung und des Verhaltens
+-------------------------------------------------
+
+Steuert das Verhalten bei der Rollen- und Gruppenauflösung nach der Anmeldung.
+
+.. list-table:: Verhaltenssteuerungseigenschaften
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - Eigenschaft
+     - Standardwert
+     - Beschreibung
+   * - ``ldap.role.search.user.enabled``
+     - ``true``
+     - Weist Rollen basierend auf dem Benutzernamen zu.
+   * - ``ldap.role.search.group.enabled``
+     - ``true``
+     - Weist Rollen basierend auf Gruppen zu.
+   * - ``ldap.role.search.role.enabled``
+     - ``true``
+     - Weist Rollen basierend auf Rollen zu.
+   * - ``ldap.allow.empty.permission``
+     - ``true``
+     - Erlaubt die Anmeldung für Benutzer ohne Gruppen oder Rollen.
+   * - ``ldap.ignore.netbios.name``
+     - ``true``
+     - Entfernt NetBIOS-Präfixe (Format ``DOMAIN\``) aus Gruppennamen u. Ä.
+   * - ``ldap.group.name.with.underscores``
+     - ``false``
+     - Erlaubt Unterstriche in Gruppennamen.
+   * - ``ldap.lowercase.permission.name``
+     - ``false``
+     - Konvertiert Berechtigungsnamen in Kleinbuchstaben.
+   * - ``ldap.samaccountname.group``
+     - ``false``
+     - Verwendet das Attribut ``sAMAccountName`` als Gruppenname (für Active Directory).
+   * - ``ldap.max.username.length``
+     - ``-1``
+     - Maximale Länge des Benutzernamens. ``-1`` bedeutet keine Einschränkung.
+
+Attributzuordnung
+-----------------
+
+Die Zuordnung von LDAP-Attributen zu |Fess|-Benutzerattributen wird über
+``ldap.attr.*``-Eigenschaften definiert. In der Regel ist keine Änderung erforderlich,
+sie kann jedoch bei abweichendem Schema angepasst werden. Typische Beispiele:
+
+::
+
+    ldap.attr.surname=sn
+    ldap.attr.givenName=givenName
+    ldap.attr.mail=mail
+    ldap.attr.displayName=displayName
+    ldap.attr.telephoneNumber=telephoneNumber
+
+.. note::
+
+   Einige Eigenschaften stimmen nicht mit dem LDAP-Attributnamen überein, z. B. wird
+   ``ldap.attr.state`` auf ``st`` und ``ldap.attr.city`` auf ``l`` gemappt.
+   Die vollständige Liste finden Sie in ``fess_config.properties`` in den Zeilen,
+   die mit ``ldap.attr.`` beginnen.
 
 Active-Directory-Konfiguration
 ==============================
 
-Konfigurationsbeispiel fuer Microsoft Active Directory.
-
-Grundkonfiguration
-------------------
+Konfigurationsbeispiel für Microsoft Active Directory (``system.properties`` oder Verwaltungsoberfläche).
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://ad.example.com:389
     ldap.base.dn=dc=example,dc=com
 
-    # Bind-DN-Vorlage fuer Benutzerauthentifizierung (UPN-Format)
+    # Bind-DN-Vorlage fuer die Benutzerauthentifizierung (UPN-Format)
     ldap.security.principal=%s@example.com
 
-    # Admin-Bind-DN (Dienstkonto)
+    # Dienstkonto fuer Suchen
     ldap.admin.security.principal=cn=fess,cn=Users,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
-    # Benutzersuche
-    ldap.user.search.base=ou=Users,dc=example,dc=com
-    ldap.account.filter=(sAMAccountName=%s)
-    ldap.user.name.attribute=sAMAccountName
+    # Kontofilter
+    ldap.account.filter=sAMAccountName=%s
 
-    # Gruppensuche
-    ldap.group.search.base=ou=Groups,dc=example,dc=com
+    # memberOf-Attribut verwenden
+    ldap.memberof.attribute=memberOf
+
+    # Gruppenfilter
     ldap.group.filter=(member=%s)
-    ldap.group.name.attribute=cn
 
-Active-Directory-spezifische Einstellungen
-------------------------------------------
+Zur Auflösung verschachtelter Gruppen (Nested Groups) kann die Active-Directory-spezifische
+``LDAP_MATCHING_RULE_IN_CHAIN``-Regel verwendet werden.
 
 ::
 
-    # Verschachtelte Gruppenaufloesung
-    ldap.memberof.enabled=true
-
-    # memberOf-Attribut verwenden
     ldap.group.filter=(member:1.2.840.113556.1.4.1941:=%s)
 
 OpenLDAP-Konfiguration
 ======================
 
-Konfigurationsbeispiel fuer OpenLDAP.
+Konfigurationsbeispiel für OpenLDAP.
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://openldap.example.com:389
     ldap.base.dn=dc=example,dc=com
 
-    # Bind-DN-Vorlage fuer Benutzerauthentifizierung
+    # Bind-DN-Vorlage fuer die Benutzerauthentifizierung
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # Admin-Bind-DN (Dienstkonto)
+    # Dienstkonto fuer Suchen
     ldap.admin.security.principal=cn=admin,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
-    # Benutzersuche
-    ldap.user.search.base=ou=people,dc=example,dc=com
-    ldap.account.filter=(uid=%s)
-    ldap.user.name.attribute=uid
+    # Kontofilter
+    ldap.account.filter=uid=%s
 
-    # Gruppensuche
-    ldap.group.search.base=ou=groups,dc=example,dc=com
+    # Gruppenfilter (fuer posixGroup)
     ldap.group.filter=(memberUid=%s)
-    ldap.group.name.attribute=cn
+
+.. note::
+
+   Standard-OpenLDAP verfügt nicht über das Attribut ``memberOf``, daher werden
+   Gruppen über ``ldap.group.filter`` aufgelöst. Wenn das ``memberof``-Overlay
+   aktiviert ist, kann auch ``ldap.memberof.attribute`` verwendet werden.
 
 Sicherheitseinstellungen
 ========================
@@ -190,17 +326,14 @@ Sicherheitseinstellungen
 LDAPS (SSL/TLS)
 ---------------
 
-Verschluesselte Verbindungen verwenden:
+Verschlüsselte Verbindung verwenden:
 
 ::
 
     # LDAPS verwenden
     ldap.provider.url=ldaps://ldap.example.com:636
 
-    # StartTLS verwenden
-    ldap.start.tls=true
-
-Fuer selbstsignierte Zertifikate importieren Sie das Zertifikat in den Java-Truststore:
+Bei selbstsignierten Zertifikaten importieren Sie das Zertifikat in den Java-Truststore.
 
 ::
 
@@ -210,89 +343,19 @@ Fuer selbstsignierte Zertifikate importieren Sie das Zertifikat in den Java-Trus
 Passwortschutz
 --------------
 
-Passwoerter ueber Umgebungsvariablen festlegen:
-
-::
-
-    ldap.admin.security.credentials=${LDAP_PASSWORD}
-
-Rollenzuordnung
-===============
-
-Sie koennen LDAP-Gruppen zu |Fess|-Rollen zuordnen.
-
-Automatische Zuordnung
-----------------------
-
-Gruppennamen werden direkt als Rollennamen verwendet:
-
-::
-
-    # LDAP-Gruppe "fess-users" -> Fess-Rolle "fess-users"
-    ldap.group.role.mapping.enabled=true
-
-Benutzerdefinierte Zuordnung
-----------------------------
-
-::
-
-    # Gruppennamen zu Rollen zuordnen
-    ldap.group.role.mapping.Administrators=admin
-    ldap.group.role.mapping.PowerUsers=editor
-    ldap.group.role.mapping.Users=guest
-
-Benutzerinformations-Synchronisation
-====================================
-
-Sie koennen Benutzerinformationen von LDAP zu |Fess| synchronisieren.
-
-Automatische Synchronisation
-----------------------------
-
-Benutzerinformationen bei Anmeldung automatisch synchronisieren:
-
-::
-
-    ldap.user.sync.enabled=true
-
-Zu synchronisierende Attribute
-------------------------------
-
-::
-
-    # E-Mail-Adresse
-    ldap.user.email.attribute=mail
-
-    # Anzeigename
-    ldap.user.displayname.attribute=displayName
-
-Verbindungs-Pooling
-===================
-
-Verbindungspool-Einstellungen zur Leistungsverbesserung:
-
-::
-
-    # Verbindungspool aktivieren
-    ldap.connection.pool.enabled=true
-
-    # Minimale Verbindungen
-    ldap.connection.pool.min=1
-
-    # Maximale Verbindungen
-    ldap.connection.pool.max=10
-
-    # Verbindungs-Timeout (Millisekunden)
-    ldap.connection.timeout=5000
+``ldap.admin.security.credentials`` wird in ``system.properties`` gespeichert.
+Die über die Verwaltungsoberfläche eingegebenen Anmeldedaten werden intern
+verschlüsselt abgelegt. Beschränken Sie die Dateizugriffsberechtigungen
+entsprechend.
 
 Failover
 ========
 
-Failover zu mehreren LDAP-Servern:
+Um ein Failover auf mehrere LDAP-Server zu konfigurieren, geben Sie in
+``ldap.provider.url`` mehrere URLs durch Leerzeichen getrennt an.
 
 ::
 
-    # Mehrere URLs durch Leerzeichen getrennt angeben
     ldap.provider.url=ldap://ldap1.example.com:389 ldap://ldap2.example.com:389
 
 Fehlerbehebung
@@ -301,43 +364,54 @@ Fehlerbehebung
 Verbindungsfehler
 -----------------
 
-**Symptom**: LDAP-Verbindung schlaegt fehl
+**Symptom**: LDAP-Verbindung schlägt fehl
 
-**Pruefen**:
+**Zu prüfen**:
 
 1. Ist der LDAP-Server gestartet?
-2. Ist der Port in der Firewall geoeffnet (389 oder 636)?
-3. Ist die URL korrekt (``ldap://`` oder ``ldaps://``)?
-4. Sind Bind DN und Passwort korrekt?
+2. Ist der Port in der Firewall geöffnet (389 oder 636)?
+3. Ist ``ldap.provider.url`` korrekt (``ldap://`` oder ``ldaps://``)?
+4. Sind ``ldap.admin.security.principal`` und das Passwort korrekt?
 
 Authentifizierungsfehler
 ------------------------
 
-**Symptom**: Benutzerauthentifizierung schlaegt fehl
+**Symptom**: Benutzerauthentifizierung schlägt fehl
 
-**Pruefen**:
+**Zu prüfen**:
 
-1. Ist der Benutzersuche-Filter korrekt?
-2. Existiert der Benutzer innerhalb des Suche-Base DN?
-3. Ist das Benutzername-Attribut korrekt?
+1. Ist die Vorlage in ``ldap.security.principal`` korrekt (enthält sie ``%s``)?
+2. Existiert der Benutzer innerhalb des angegebenen Basis-DN?
+3. Ist ``ldap.account.filter`` korrekt?
 
-Gruppen koennen nicht abgerufen werden
---------------------------------------
+Gruppen/Rollen können nicht abgerufen werden
+--------------------------------------------
 
-**Symptom**: Benutzergruppen koennen nicht abgerufen werden
+**Symptom**: Gruppen oder Rollen des Benutzers können nicht abgerufen werden
 
-**Pruefen**:
+**Zu prüfen**:
 
-1. Ist der Gruppensuche-Filter korrekt?
-2. Ist das Gruppenmitgliedschafts-Attribut korrekt?
-3. Existieren die Gruppen innerhalb des Suche-Base DN?
+1. Ist ``ldap.group.filter`` korrekt?
+2. Ist ``ldap.memberof.attribute`` korrekt (bei Active Directory)?
+3. Befinden sich die Gruppen innerhalb des Suche-Basis-DN?
+4. Sind die ``ldap.role.search.*.enabled``-Einstellungen aktiviert?
+
+Benutzerverwaltung über die Verwaltungsoberfläche nicht möglich
+---------------------------------------------------------------
+
+**Symptom**: LDAP-Benutzer können über die Verwaltungsoberfläche nicht erstellt, bearbeitet oder gelöscht werden
+
+**Zu prüfen**:
+
+1. Ist ``ldap.admin.enabled`` auf ``true`` gesetzt?
+2. Sind die administrativen Basis-DNs wie ``ldap.admin.user.base.dn`` korrekt?
+3. Hat das Dienstkonto von ``ldap.admin.security.principal`` Schreibrechte?
 
 Debug-Einstellungen
 -------------------
 
-Detaillierte Protokolle ausgeben:
-
-``app/WEB-INF/classes/log4j2.xml``:
+Um detaillierte Protokolle auszugeben, fügen Sie einen Logger in
+``app/WEB-INF/classes/log4j2.xml`` hinzu.
 
 ::
 
@@ -347,5 +421,5 @@ Referenzinformationen
 =====================
 
 - :doc:`security-role` - Rollenbasierte Zugriffskontrolle
-- :doc:`sso-spnego` - SPNEGO (Kerberos) Authentifizierung
+- :doc:`sso-spnego` - SPNEGO (Kerberos)-Authentifizierung
 - :doc:`../admin/user-guide` - Benutzerverwaltungsleitfaden

--- a/en/15.7/config/ldap-integration.rst
+++ b/en/15.7/config/ldap-integration.rst
@@ -10,9 +10,9 @@ enabling authentication and user management in enterprise environments.
 
 LDAP integration enables:
 
-- User authentication with Active Directory or OpenLDAP
-- Group-based access control
-- Automatic user information synchronization
+- User authentication (login) with Active Directory or OpenLDAP
+- Group- and role-based access control
+- Management of LDAP users, roles, and groups from the administration screen (optional)
 
 Supported LDAP Servers
 ======================
@@ -32,115 +32,263 @@ Prerequisites
 - Service account for LDAP searches (bind DN)
 - Understanding of LDAP structure (base DN, attribute names, etc.)
 
-Basic Configuration
-===================
+Configuration Overview
+======================
 
-Add the following configuration to ``app/WEB-INF/conf/system.properties``.
+LDAP configuration in |Fess| is managed in two separate locations depending on its purpose.
 
-LDAP Connection Settings
-------------------------
+Connection and Authentication Settings (administration screen / ``system.properties``)
+   These settings control the connection to the LDAP server and login authentication.
+   They can be configured from the **"System > General"** page in the administration screen,
+   under the "LDAP" section, and are saved to
+   ``app/WEB-INF/conf/system.properties``.
+
+LDAP Administration and Behavior Settings (``fess_config.properties``)
+   These settings control features for managing LDAP users, roles, and groups from the
+   administration screen, as well as behaviors such as role resolution. They are defined in
+   ``app/WEB-INF/classes/fess_config.properties`` and can be changed by editing that file.
+
+.. note::
+
+   If you only need login authentication, the "Connection and Authentication Settings" alone are
+   sufficient. The "LDAP Administration" feature (``ldap.admin.enabled``) is only required when
+   you want to create, update, or delete LDAP users, roles, and groups from the administration
+   screen.
+
+Connection and Authentication Settings
+======================================
+
+These settings can be configured from the "System > General" LDAP section in the administration
+screen and are saved to ``app/WEB-INF/conf/system.properties``. You may also edit the file
+directly.
+
+.. list-table:: Connection and Authentication Properties
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Property
+     - Default
+     - Description
+   * - ``ldap.provider.url``
+     - (none)
+     - URL of the LDAP server. Example: ``ldap://ldap.example.com:389``. For LDAPS: ``ldaps://ldap.example.com:636``. Specify multiple URLs separated by spaces for failover.
+   * - ``ldap.base.dn``
+     - (none)
+     - Base DN for LDAP searches. Example: ``dc=example,dc=com``
+   * - ``ldap.security.principal``
+     - (none)
+     - DN template used for user authentication (bind). ``%s`` is replaced with the username. Example: ``uid=%s,ou=People,dc=example,dc=com``
+   * - ``ldap.security.authentication``
+     - ``simple``
+     - LDAP authentication method (JNDI ``java.naming.security.authentication``). Normally use ``simple``.
+   * - ``ldap.initial.context.factory``
+     - ``com.sun.jndi.ldap.LdapCtxFactory``
+     - JNDI initial context factory class. This normally does not need to be changed.
+   * - ``ldap.admin.security.principal``
+     - (none)
+     - Bind DN of the service account used for LDAP searches. Example: ``cn=fess,ou=services,dc=example,dc=com``
+   * - ``ldap.admin.security.credentials``
+     - (none)
+     - Password for the service account above.
+   * - ``ldap.account.filter``
+     - (none)
+     - Filter used to search for a user entry during role resolution. ``%s`` is replaced with the username. Example: ``uid=%s``
+   * - ``ldap.group.filter``
+     - (empty)
+     - Search filter used during group resolution. ``%s`` is replaced with the user's DN or similar. Example: ``(member=%s)``
+   * - ``ldap.memberof.attribute``
+     - ``memberOf``
+     - Attribute name representing group membership. Used to resolve roles on servers that carry this attribute, such as Active Directory.
+
+Example configuration (when editing ``system.properties`` directly):
 
 ::
-
-    # Enable LDAP authentication
-    ldap.admin.enabled=true
 
     # LDAP server URL
     ldap.provider.url=ldap://ldap.example.com:389
 
-    # For secure connection (LDAPS)
-    # ldap.provider.url=ldaps://ldap.example.com:636
-
     # Base DN
     ldap.base.dn=dc=example,dc=com
 
-    # User authentication bind DN template (%s is replaced with username)
+    # Bind DN template for user authentication (%s is replaced with the username)
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # Admin bind DN (service account for LDAP searches)
+    # Bind DN and password for the search service account
     ldap.admin.security.principal=cn=fess,ou=services,dc=example,dc=com
-
-    # Admin bind password
     ldap.admin.security.credentials=your_password
 
-Account Filter Settings
-------------------------
-
-::
-
-    # Account filter (search filter for user authentication)
+    # Filter for role resolution
     ldap.account.filter=uid=%s
-
-    # Admin user search filter for LDAP management console
-    ldap.admin.user.filter=uid=%s
+    ldap.group.filter=(member=%s)
 
 .. note::
 
-   ``ldap.account.filter`` is the search filter for user authentication, while
-   ``ldap.admin.user.filter`` is the user search filter for the LDAP management console.
-   Set each appropriately as they serve different purposes.
+   The ``%s`` placeholder is processed by Java's ``String.format()``.
+   ``ldap.security.principal``, ``ldap.account.filter``, ``ldap.group.filter``, and the
+   administration filters all use the ``%s`` format (not the ``{0}`` format).
+   Note that usernames passed to filters are automatically escaped inside |Fess| as a
+   protection against LDAP injection.
 
-LDAP Admin Base DN Settings
-----------------------------
+LDAP Administration and Behavior Settings
+==========================================
+
+The following properties are defined in ``app/WEB-INF/classes/fess_config.properties``.
+Edit this file to change their values.
+
+Enabling the Administration Feature
+------------------------------------
+
+.. list-table:: Administration Feature Properties
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Property
+     - Default
+     - Description
+   * - ``ldap.admin.enabled``
+     - ``false``
+     - Enables the ability to create, update, and delete LDAP users, roles, and groups from the administration screen. **Not required for login authentication** — LDAP login works without enabling this.
+   * - ``ldap.admin.sync.password``
+     - ``true``
+     - Synchronizes the |Fess| password with LDAP when a user is updated from the administration screen.
+   * - ``ldap.auth.validation``
+     - ``true``
+     - Validates LDAP authentication at login.
+
+Filters and Base DNs for User, Role, and Group Administration
+--------------------------------------------------------------
+
+Used to operate LDAP entries from the administration screen when ``ldap.admin.enabled=true``.
+
+.. list-table:: Administration Filters and Base DNs
+   :header-rows: 1
+   :widths: 38 47 15
+
+   * - Property
+     - Description
+     - Default
+   * - ``ldap.admin.user.filter``
+     - User search filter (``%s`` is replaced with the username)
+     - ``uid=%s``
+   * - ``ldap.admin.user.base.dn``
+     - User search base DN
+     - ``ou=People,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.user.object.classes``
+     - objectClass values for user creation
+     - ``organizationalPerson,top,person,inetOrgPerson``
+   * - ``ldap.admin.role.filter``
+     - Role search filter
+     - ``cn=%s``
+   * - ``ldap.admin.role.base.dn``
+     - Role search base DN
+     - ``ou=Role,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.role.object.classes``
+     - objectClass values for role creation
+     - ``groupOfNames``
+   * - ``ldap.admin.group.filter``
+     - Group search filter
+     - ``cn=%s``
+   * - ``ldap.admin.group.base.dn``
+     - Group search base DN
+     - ``ou=Group,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.group.object.classes``
+     - objectClass values for group creation
+     - ``groupOfNames``
+
+Role Resolution and Behavior Control
+--------------------------------------
+
+Controls the behavior of role and group resolution after login.
+
+.. list-table:: Behavior Control Properties
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - Property
+     - Default
+     - Description
+   * - ``ldap.role.search.user.enabled``
+     - ``true``
+     - Grants a role based on the username.
+   * - ``ldap.role.search.group.enabled``
+     - ``true``
+     - Grants roles based on group membership.
+   * - ``ldap.role.search.role.enabled``
+     - ``true``
+     - Grants roles based on LDAP roles.
+   * - ``ldap.allow.empty.permission``
+     - ``true``
+     - Allows login for users who have no groups or roles.
+   * - ``ldap.ignore.netbios.name``
+     - ``true``
+     - Strips the NetBIOS name prefix (``DOMAIN\`` format) from group names and similar values.
+   * - ``ldap.group.name.with.underscores``
+     - ``false``
+     - Allows underscores in group names.
+   * - ``ldap.lowercase.permission.name``
+     - ``false``
+     - Converts permission names to lowercase.
+   * - ``ldap.samaccountname.group``
+     - ``false``
+     - Uses the ``sAMAccountName`` attribute for group names (for Active Directory).
+   * - ``ldap.max.username.length``
+     - ``-1``
+     - Maximum length of usernames. ``-1`` means no limit.
+
+Attribute Mapping
+-----------------
+
+The mapping between LDAP attributes and |Fess| user attributes is defined via ``ldap.attr.*``
+properties. These normally do not need to be changed, but can be adjusted when the schema
+differs. Representative examples:
 
 ::
 
-    # User search base DN
-    ldap.admin.user.base.dn=ou=People,dc=example,dc=com
+    ldap.attr.surname=sn
+    ldap.attr.givenName=givenName
+    ldap.attr.mail=mail
+    ldap.attr.displayName=displayName
+    ldap.attr.telephoneNumber=telephoneNumber
 
-    # Role search base DN
-    ldap.admin.role.base.dn=ou=Roles,dc=example,dc=com
+.. note::
 
-    # Group search base DN
-    ldap.admin.group.base.dn=ou=Groups,dc=example,dc=com
-
-Group Filter Settings
-----------------------
-
-::
-
-    # Group filter
-    ldap.group.filter=(member=%s)
-
-    # memberOf attribute name
-    ldap.memberof.attribute=memberOf
+   Some property names do not match their corresponding LDAP attribute names — for example,
+   ``ldap.attr.state`` maps to ``st`` and ``ldap.attr.city`` maps to ``l``.
+   For the complete list, refer to lines beginning with ``ldap.attr.`` in
+   ``fess_config.properties``.
 
 Active Directory Configuration
 ==============================
 
-Configuration example for Microsoft Active Directory.
-
-Basic Configuration
--------------------
+Configuration example for Microsoft Active Directory (``system.properties`` or the
+administration screen).
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://ad.example.com:389
     ldap.base.dn=dc=example,dc=com
 
-    # User auth bind DN template (UPN format)
+    # Bind DN template for user authentication (UPN format)
     ldap.security.principal=%s@example.com
 
-    # Admin bind DN (service account)
+    # Search service account
     ldap.admin.security.principal=cn=fess,cn=Users,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
     # Account filter
     ldap.account.filter=sAMAccountName=%s
 
+    # Use memberOf attribute
+    ldap.memberof.attribute=memberOf
+
     # Group filter
     ldap.group.filter=(member=%s)
 
-Active Directory Specific Settings
-----------------------------------
+To resolve nested groups, you can use the Active Directory-specific
+``LDAP_MATCHING_RULE_IN_CHAIN``.
 
 ::
 
-    # Using memberOf attribute
-    ldap.memberof.attribute=memberOf
-
-    # Nested group resolution (LDAP_MATCHING_RULE_IN_CHAIN)
     ldap.group.filter=(member:1.2.840.113556.1.4.1941:=%s)
 
 OpenLDAP Configuration
@@ -150,22 +298,27 @@ Configuration example for OpenLDAP.
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://openldap.example.com:389
     ldap.base.dn=dc=example,dc=com
 
-    # User auth bind DN template
+    # Bind DN template for user authentication
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # Admin bind DN (service account)
+    # Search service account
     ldap.admin.security.principal=cn=admin,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
     # Account filter
     ldap.account.filter=uid=%s
 
-    # Group filter
+    # Group filter (for posixGroup)
     ldap.group.filter=(memberUid=%s)
+
+.. note::
+
+   Standard OpenLDAP does not have the ``memberOf`` attribute, so groups are resolved using
+   ``ldap.group.filter``. If the ``memberof`` overlay is enabled, ``ldap.memberof.attribute``
+   can also be used.
 
 Security Settings
 =================
@@ -173,14 +326,14 @@ Security Settings
 LDAPS (SSL/TLS)
 ---------------
 
-Use encrypted connections:
+Use an encrypted connection:
 
 ::
 
     # Use LDAPS
     ldap.provider.url=ldaps://ldap.example.com:636
 
-For self-signed certificates, import the certificate into the Java truststore:
+For self-signed certificates, import the certificate into the Java truststore.
 
 ::
 
@@ -190,20 +343,18 @@ For self-signed certificates, import the certificate into the Java truststore:
 Password Protection
 -------------------
 
-Set passwords using environment variables:
-
-::
-
-    ldap.admin.security.credentials=${LDAP_PASSWORD}
+``ldap.admin.security.credentials`` is stored in ``system.properties``.
+Credentials configured from the administration screen are stored encrypted internally.
+Restrict file permissions appropriately.
 
 Failover
 ========
 
-Failover to multiple LDAP servers:
+To fail over to multiple LDAP servers, specify multiple URLs separated by spaces in
+``ldap.provider.url``.
 
 ::
 
-    # Specify multiple URLs separated by spaces
     ldap.provider.url=ldap://ldap1.example.com:389 ldap://ldap2.example.com:389
 
 Troubleshooting
@@ -218,8 +369,8 @@ Connection Error
 
 1. Is the LDAP server running?
 2. Is the port open in the firewall (389 or 636)?
-3. Is the URL correct (``ldap://`` or ``ldaps://``)?
-4. Are the bind DN and password correct?
+3. Is ``ldap.provider.url`` correct (``ldap://`` or ``ldaps://``)?
+4. Are ``ldap.admin.security.principal`` and the password correct?
 
 Authentication Error
 --------------------
@@ -228,27 +379,37 @@ Authentication Error
 
 **Check**:
 
-1. Is the user search filter correct?
-2. Does the user exist within the search base DN?
-3. Is the username attribute correct?
+1. Is the ``ldap.security.principal`` template correct (does it contain ``%s``)?
+2. Does the user exist within the specified base DN?
+3. Is ``ldap.account.filter`` correct?
 
-Cannot Retrieve Groups
-----------------------
+Cannot Retrieve Groups or Roles
+--------------------------------
 
-**Symptom**: Cannot retrieve user groups
+**Symptom**: Cannot retrieve user groups or roles
 
 **Check**:
 
-1. Is the group search filter correct?
-2. Is the group membership attribute correct?
+1. Is ``ldap.group.filter`` correct?
+2. Is ``ldap.memberof.attribute`` correct (for Active Directory)?
 3. Do the groups exist within the search base DN?
+4. Are the ``ldap.role.search.*.enabled`` properties enabled?
+
+Cannot Manage Users from the Administration Screen
+--------------------------------------------------
+
+**Symptom**: Cannot create, edit, or delete LDAP users from the administration screen
+
+**Check**:
+
+1. Is ``ldap.admin.enabled`` set to ``true``?
+2. Are the administration base DNs such as ``ldap.admin.user.base.dn`` correct?
+3. Does the ``ldap.admin.security.principal`` service account have write permissions?
 
 Debug Settings
 --------------
 
-Output detailed logs:
-
-``app/WEB-INF/classes/log4j2.xml``:
+To output detailed logs, add a logger to ``app/WEB-INF/classes/log4j2.xml``.
 
 ::
 

--- a/es/15.7/config/ldap-integration.rst
+++ b/es/15.7/config/ldap-integration.rst
@@ -1,23 +1,23 @@
-==================================
+=====================================
 Guia de integracion LDAP
-==================================
+=====================================
 
 Descripcion general
 ===================
 
 |Fess| soporta la integracion con servidores LDAP (Lightweight Directory Access Protocol),
-permitiendo autenticacion y gestion de usuarios en entornos empresariales.
+lo que permite la autenticacion y la gestion de usuarios en entornos empresariales.
 
 La integracion LDAP permite:
 
-- Autenticacion de usuarios con Active Directory u OpenLDAP
-- Control de acceso basado en grupos
-- Sincronizacion automatica de informacion de usuarios
+- Autenticacion de usuarios (inicio de sesion) con Active Directory u OpenLDAP
+- Control de acceso basado en grupos y roles
+- Gestion de usuarios, roles y grupos LDAP desde la pantalla de administracion (opcional)
 
 Servidores LDAP compatibles
-===========================
+============================
 
-|Fess| soporta integracion con los siguientes servidores LDAP:
+|Fess| soporta la integracion con los siguientes servidores LDAP:
 
 - Microsoft Active Directory
 - OpenLDAP
@@ -32,160 +32,290 @@ Requisitos previos
 - Cuenta de servicio para busquedas LDAP (Bind DN)
 - Comprension de la estructura LDAP (Base DN, nombres de atributos, etc.)
 
-Configuracion basica
-====================
+Descripcion general de la configuracion
+========================================
 
-Agregue la siguiente configuracion en ``app/WEB-INF/conf/system.properties``.
+La configuracion LDAP de |Fess| se gestiona en dos ubicaciones segun el proposito.
 
-Configuracion de conexion LDAP
-------------------------------
+Configuracion de conexion y autenticacion (pantalla de administracion / ``system.properties``)
+   Configuracion relacionada con la conexion al servidor LDAP y la autenticacion de inicio de sesion.
+   Se puede configurar desde la seccion "LDAP" en la pagina **"Sistema > General"** de la pantalla de administracion,
+   y se guarda en ``app/WEB-INF/conf/system.properties``.
+
+Configuracion de la funcion de administracion LDAP y comportamiento (``fess_config.properties``)
+   Configuracion relacionada con la funcion para gestionar usuarios, roles y grupos LDAP desde la pantalla de administracion,
+   y con el comportamiento como la resolucion de roles. Estas opciones se definen en
+   ``app/WEB-INF/classes/fess_config.properties``; edite este archivo para cambiar los valores.
+
+.. note::
+
+   Si solo se utiliza la autenticacion de inicio de sesion, basta con la "Configuracion de conexion y autenticacion".
+   La "Funcion de administracion LDAP" (``ldap.admin.enabled``) solo es necesaria cuando se crean, actualizan
+   o eliminan usuarios, roles y grupos del lado LDAP desde la pantalla de administracion.
+
+Configuracion de conexion y autenticacion
+==========================================
+
+Estas configuraciones se pueden establecer desde la seccion LDAP en "Sistema > General" de la pantalla de administracion,
+y se guardan en ``app/WEB-INF/conf/system.properties``. Tambien puede editar el archivo directamente.
+
+.. list-table:: Propiedades de conexion y autenticacion
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Propiedad
+     - Valor por defecto
+     - Descripcion
+   * - ``ldap.provider.url``
+     - (ninguno)
+     - URL del servidor LDAP. Ejemplo: ``ldap://ldap.example.com:389``. Para LDAPS: ``ldaps://ldap.example.com:636``. Se pueden especificar varias URLs separadas por espacios para failover.
+   * - ``ldap.base.dn``
+     - (ninguno)
+     - Base DN para la busqueda LDAP. Ejemplo: ``dc=example,dc=com``
+   * - ``ldap.security.principal``
+     - (ninguno)
+     - Plantilla de DN para la autenticacion (enlace) de usuarios. ``%s`` se reemplaza con el nombre de usuario. Ejemplo: ``uid=%s,ou=People,dc=example,dc=com``
+   * - ``ldap.security.authentication``
+     - ``simple``
+     - Metodo de autenticacion LDAP (``java.naming.security.authentication`` de JNDI). Normalmente se utiliza ``simple``.
+   * - ``ldap.initial.context.factory``
+     - ``com.sun.jndi.ldap.LdapCtxFactory``
+     - Clase de fabrica del contexto inicial de JNDI. Normalmente no es necesario modificarla.
+   * - ``ldap.admin.security.principal``
+     - (ninguno)
+     - Bind DN de la cuenta de servicio para busquedas LDAP. Ejemplo: ``cn=fess,ou=services,dc=example,dc=com``
+   * - ``ldap.admin.security.credentials``
+     - (ninguno)
+     - Contrasena de la cuenta de servicio indicada anteriormente.
+   * - ``ldap.account.filter``
+     - (ninguno)
+     - Filtro para buscar la entrada de usuario al resolver roles de usuario. ``%s`` se reemplaza con el nombre de usuario. Ejemplo: ``uid=%s``
+   * - ``ldap.group.filter``
+     - (vacio)
+     - Filtro de busqueda utilizado para la resolucion de grupos. ``%s`` se reemplaza por el DN del usuario u otro valor. Ejemplo: ``(member=%s)``
+   * - ``ldap.memberof.attribute``
+     - ``memberOf``
+     - Nombre del atributo que representa la pertenencia a grupos. Se utiliza para resolver roles en Active Directory y otros servidores que posean este atributo.
+
+Ejemplo de configuracion (edicion directa de ``system.properties``):
 
 ::
-
-    # Habilitar autenticacion LDAP
-    ldap.admin.enabled=true
 
     # URL del servidor LDAP
     ldap.provider.url=ldap://ldap.example.com:389
 
-    # Para conexion segura (LDAPS)
-    # ldap.provider.url=ldaps://ldap.example.com:636
-
     # Base DN
     ldap.base.dn=dc=example,dc=com
 
-    # Plantilla de DN de enlace para autenticacion de usuario (%s se reemplaza con el nombre de usuario)
+    # Plantilla de Bind DN para autenticacion de usuario (%s se sustituye por el nombre de usuario)
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # DN de enlace de administracion (cuenta de servicio para busquedas LDAP)
+    # Bind DN y contrasena de la cuenta de servicio para busquedas
     ldap.admin.security.principal=cn=fess,ou=services,dc=example,dc=com
-
-    # Contrasena de enlace de administracion
     ldap.admin.security.credentials=your_password
 
-Configuracion de busqueda de usuarios
--------------------------------------
-
-::
-
-    # Base DN para busqueda de usuarios
-    ldap.user.search.base=ou=users,dc=example,dc=com
-
-    # Filtro de busqueda de usuarios
-    ldap.account.filter=(uid=%s)
-
-    # Atributo de nombre de usuario
-    ldap.user.name.attribute=uid
-
-    # Filtro de busqueda de usuarios del administrador para la consola de gestion LDAP
-    ldap.admin.user.filter=uid=%s
+    # Filtros para resolucion de roles
+    ldap.account.filter=uid=%s
+    ldap.group.filter=(member=%s)
 
 .. note::
 
-   ``ldap.account.filter`` es el filtro de busqueda para la autenticacion de usuarios,
-   mientras que ``ldap.admin.user.filter`` es el filtro de busqueda de usuarios para la
-   consola de gestion LDAP. Configure cada uno adecuadamente ya que tienen propositos diferentes.
+   El marcador de posicion ``%s`` es procesado por ``String.format()`` de Java.
+   ``ldap.security.principal``, ``ldap.account.filter``, ``ldap.group.filter`` y
+   los filtros de administracion usan el formato ``%s`` (no ``{0}``).
+   El nombre de usuario que se pasa a los filtros es escapado automaticamente
+   por |Fess| como medida de proteccion contra inyeccion LDAP.
 
-Configuracion de DN base de administracion LDAP
-------------------------------------------------
+Configuracion de la funcion de administracion LDAP y comportamiento
+====================================================================
+
+Las siguientes propiedades se definen en ``app/WEB-INF/classes/fess_config.properties``.
+Para cambiar los valores, edite este archivo.
+
+Habilitacion de la funcion de administracion
+---------------------------------------------
+
+.. list-table:: Propiedades de la funcion de administracion
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Propiedad
+     - Valor por defecto
+     - Descripcion
+   * - ``ldap.admin.enabled``
+     - ``false``
+     - Habilita la funcion para crear, actualizar y eliminar usuarios, roles y grupos LDAP desde la pantalla de administracion. **No es necesaria para la autenticacion de inicio de sesion**; el inicio de sesion con LDAP funciona aunque no este habilitada.
+   * - ``ldap.admin.sync.password``
+     - ``true``
+     - Sincroniza la contrasena del lado de |Fess| con LDAP al actualizar un usuario desde la pantalla de administracion.
+   * - ``ldap.auth.validation``
+     - ``true``
+     - Valida la autenticacion LDAP en el momento del inicio de sesion.
+
+Filtros y Base DN para la gestion de usuarios, roles y grupos
+--------------------------------------------------------------
+
+Se utilizan para manipular entradas LDAP desde la pantalla de administracion cuando ``ldap.admin.enabled=true``.
+
+.. list-table:: Filtros y Base DN de administracion
+   :header-rows: 1
+   :widths: 38 47 15
+
+   * - Propiedad
+     - Descripcion
+     - Valor por defecto
+   * - ``ldap.admin.user.filter``
+     - Filtro de busqueda de usuarios (``%s`` se reemplaza con el nombre de usuario)
+     - ``uid=%s``
+   * - ``ldap.admin.user.base.dn``
+     - Base DN de busqueda de usuarios
+     - ``ou=People,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.user.object.classes``
+     - objectClass al crear usuarios
+     - ``organizationalPerson,top,person,inetOrgPerson``
+   * - ``ldap.admin.role.filter``
+     - Filtro de busqueda de roles
+     - ``cn=%s``
+   * - ``ldap.admin.role.base.dn``
+     - Base DN de busqueda de roles
+     - ``ou=Role,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.role.object.classes``
+     - objectClass al crear roles
+     - ``groupOfNames``
+   * - ``ldap.admin.group.filter``
+     - Filtro de busqueda de grupos
+     - ``cn=%s``
+   * - ``ldap.admin.group.base.dn``
+     - Base DN de busqueda de grupos
+     - ``ou=Group,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.group.object.classes``
+     - objectClass al crear grupos
+     - ``groupOfNames``
+
+Control de la resolucion de roles y el comportamiento
+------------------------------------------------------
+
+Controla el comportamiento de la resolucion de roles y grupos tras el inicio de sesion.
+
+.. list-table:: Propiedades de control de comportamiento
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - Propiedad
+     - Valor por defecto
+     - Descripcion
+   * - ``ldap.role.search.user.enabled``
+     - ``true``
+     - Asigna roles basados en el nombre de usuario.
+   * - ``ldap.role.search.group.enabled``
+     - ``true``
+     - Asigna roles basados en grupos.
+   * - ``ldap.role.search.role.enabled``
+     - ``true``
+     - Asigna roles basados en roles.
+   * - ``ldap.allow.empty.permission``
+     - ``true``
+     - Permite el inicio de sesion de usuarios sin grupos ni roles asignados.
+   * - ``ldap.ignore.netbios.name``
+     - ``true``
+     - Elimina el nombre NetBIOS (prefijo con formato ``DOMAIN\``) de los nombres de grupo, etc.
+   * - ``ldap.group.name.with.underscores``
+     - ``false``
+     - Permite guiones bajos en los nombres de grupo.
+   * - ``ldap.lowercase.permission.name``
+     - ``false``
+     - Convierte los nombres de permiso a minusculas.
+   * - ``ldap.samaccountname.group``
+     - ``false``
+     - Utiliza el atributo ``sAMAccountName`` como nombre de grupo (para Active Directory).
+   * - ``ldap.max.username.length``
+     - ``-1``
+     - Longitud maxima del nombre de usuario. ``-1`` significa sin limite.
+
+Mapeo de atributos
+------------------
+
+La correspondencia entre los atributos LDAP y los atributos de usuario de |Fess| se define mediante las propiedades ``ldap.attr.*``.
+Normalmente no es necesario modificarlas, pero pueden ajustarse si el esquema es diferente. Algunos ejemplos representativos:
 
 ::
 
-    # DN base de busqueda de usuarios
-    ldap.admin.user.base.dn=ou=People,dc=example,dc=com
+    ldap.attr.surname=sn
+    ldap.attr.givenName=givenName
+    ldap.attr.mail=mail
+    ldap.attr.displayName=displayName
+    ldap.attr.telephoneNumber=telephoneNumber
 
-    # DN base de busqueda de roles
-    ldap.admin.role.base.dn=ou=Roles,dc=example,dc=com
+.. note::
 
-    # DN base de busqueda de grupos
-    ldap.admin.group.base.dn=ou=Groups,dc=example,dc=com
-
-Configuracion de busqueda de grupos
------------------------------------
-
-::
-
-    # Base DN para busqueda de grupos
-    ldap.group.search.base=ou=groups,dc=example,dc=com
-
-    # Filtro de busqueda de grupos
-    ldap.group.filter=(member=%s)
-
-    # Atributo de nombre de grupo
-    ldap.group.name.attribute=cn
+   Existen casos en que el nombre de la propiedad y el nombre del atributo LDAP no coinciden,
+   como ``ldap.attr.state`` que se mapea a ``st``, o ``ldap.attr.city`` que se mapea a ``l``.
+   Consulte las lineas que comienzan con ``ldap.attr.`` en ``fess_config.properties`` para ver la lista completa.
 
 Configuracion de Active Directory
-=================================
+==================================
 
-Ejemplo de configuracion para Microsoft Active Directory.
-
-Configuracion basica
---------------------
+Ejemplo de configuracion para Microsoft Active Directory (``system.properties`` o pantalla de administracion).
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://ad.example.com:389
     ldap.base.dn=dc=example,dc=com
 
-    # Plantilla de DN de enlace para autenticacion de usuario (formato UPN)
+    # Plantilla de Bind DN para autenticacion de usuario (formato UPN)
     ldap.security.principal=%s@example.com
 
-    # DN de enlace de administracion (cuenta de servicio)
+    # Cuenta de servicio para busquedas
     ldap.admin.security.principal=cn=fess,cn=Users,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
-    # Busqueda de usuarios
-    ldap.user.search.base=ou=Users,dc=example,dc=com
-    ldap.account.filter=(sAMAccountName=%s)
-    ldap.user.name.attribute=sAMAccountName
+    # Filtro de cuenta
+    ldap.account.filter=sAMAccountName=%s
 
-    # Busqueda de grupos
-    ldap.group.search.base=ou=Groups,dc=example,dc=com
+    # Usar atributo memberOf
+    ldap.memberof.attribute=memberOf
+
+    # Filtro de grupos
     ldap.group.filter=(member=%s)
-    ldap.group.name.attribute=cn
 
-Configuracion especifica de Active Directory
---------------------------------------------
+Para resolver grupos anidados (nested groups), puede utilizar
+``LDAP_MATCHING_RULE_IN_CHAIN``, especifico de Active Directory.
 
 ::
 
-    # Resolucion de grupos anidados
-    ldap.memberof.enabled=true
-
-    # Usar atributo memberOf
     ldap.group.filter=(member:1.2.840.113556.1.4.1941:=%s)
 
 Configuracion de OpenLDAP
-=========================
+==========================
 
 Ejemplo de configuracion para OpenLDAP.
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://openldap.example.com:389
     ldap.base.dn=dc=example,dc=com
 
-    # Plantilla de DN de enlace para autenticacion de usuario
+    # Plantilla de Bind DN para autenticacion de usuario
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # DN de enlace de administracion (cuenta de servicio)
+    # Cuenta de servicio para busquedas
     ldap.admin.security.principal=cn=admin,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
-    # Busqueda de usuarios
-    ldap.user.search.base=ou=people,dc=example,dc=com
-    ldap.account.filter=(uid=%s)
-    ldap.user.name.attribute=uid
+    # Filtro de cuenta
+    ldap.account.filter=uid=%s
 
-    # Busqueda de grupos
-    ldap.group.search.base=ou=groups,dc=example,dc=com
+    # Filtro de grupos (para posixGroup)
     ldap.group.filter=(memberUid=%s)
-    ldap.group.name.attribute=cn
+
+.. note::
+
+   OpenLDAP estandar no tiene el atributo ``memberOf``, por lo que los grupos
+   se resuelven mediante ``ldap.group.filter``.
+   Si tiene habilitado el overlay ``memberof``, tambien puede utilizar ``ldap.memberof.attribute``.
 
 Configuracion de seguridad
-==========================
+===========================
 
 LDAPS (SSL/TLS)
 ---------------
@@ -197,9 +327,6 @@ Usar conexion cifrada:
     # Usar LDAPS
     ldap.provider.url=ldaps://ldap.example.com:636
 
-    # Usar StartTLS
-    ldap.start.tls=true
-
 Para certificados autofirmados, importe el certificado en el truststore de Java:
 
 ::
@@ -207,52 +334,25 @@ Para certificados autofirmados, importe el certificado en el truststore de Java:
     keytool -import -alias ldap-server -keystore $JAVA_HOME/lib/security/cacerts \
             -file ldap-server.crt
 
-Proteccion de contrasena
-------------------------
+Proteccion de contrasenas
+--------------------------
 
-Configurar contrasena con variable de entorno:
-
-::
-
-    ldap.admin.security.credentials=${LDAP_PASSWORD}
-
-Mapeo de roles
-==============
-
-Puede mapear grupos LDAP a roles de |Fess|.
-
-Mapeo automatico
-----------------
-
-Los nombres de grupo se usan directamente como nombres de rol:
-
-::
-
-    # Grupo LDAP "fess-users" -> Rol Fess "fess-users"
-    ldap.group.role.mapping.enabled=true
-
-Mapeo personalizado
--------------------
-
-::
-
-    # Mapear nombre de grupo a rol
-    ldap.group.role.mapping.Administrators=admin
-    ldap.group.role.mapping.PowerUsers=editor
-    ldap.group.role.mapping.Users=guest
+``ldap.admin.security.credentials`` se guarda en ``system.properties``.
+Las credenciales configuradas desde la pantalla de administracion se almacenan cifradas internamente.
+Restrinja adecuadamente los permisos de acceso al archivo.
 
 Failover
-========
+=========
 
-Failover a multiples servidores LDAP:
+Para realizar failover a multiples servidores LDAP, especifique varias URLs
+separadas por espacios en ``ldap.provider.url``.
 
 ::
 
-    # Especificar multiples URLs separadas por espacios
     ldap.provider.url=ldap://ldap1.example.com:389 ldap://ldap2.example.com:389
 
 Solucion de problemas
-=====================
+======================
 
 Error de conexion
 -----------------
@@ -261,46 +361,56 @@ Error de conexion
 
 **Verificaciones**:
 
-1. Si el servidor LDAP esta ejecutandose
+1. Si el servidor LDAP esta en ejecucion
 2. Si el puerto esta abierto en el firewall (389 o 636)
-3. Si la URL es correcta (``ldap://`` o ``ldaps://``)
-4. Si el Bind DN y la contrasena son correctos
+3. Si ``ldap.provider.url`` es correcto (``ldap://`` o ``ldaps://``)
+4. Si ``ldap.admin.security.principal`` y la contrasena son correctos
 
 Error de autenticacion
-----------------------
+-----------------------
 
 **Sintoma**: Falla la autenticacion de usuario
 
 **Verificaciones**:
 
-1. Si el filtro de busqueda de usuarios es correcto
-2. Si el usuario existe dentro del Base DN de busqueda
-3. Si el atributo de nombre de usuario es correcto
+1. Si la plantilla de ``ldap.security.principal`` es correcta (si contiene ``%s``)
+2. Si el usuario existe dentro del Base DN especificado
+3. Si ``ldap.account.filter`` es correcto
 
-No se obtienen grupos
----------------------
+No se obtienen grupos ni roles
+--------------------------------
 
-**Sintoma**: No se pueden obtener los grupos del usuario
+**Sintoma**: No se pueden obtener los grupos o roles del usuario
 
 **Verificaciones**:
 
-1. Si el filtro de busqueda de grupos es correcto
-2. Si el atributo de membresia de grupo es correcto
+1. Si ``ldap.group.filter`` es correcto
+2. Si ``ldap.memberof.attribute`` es correcto (en caso de Active Directory)
 3. Si los grupos existen dentro del Base DN de busqueda
+4. Si ``ldap.role.search.*.enabled`` esta habilitado
+
+No se puede gestionar usuarios desde la pantalla de administracion
+------------------------------------------------------------------
+
+**Sintoma**: No se pueden crear, editar ni eliminar usuarios LDAP desde la pantalla de administracion
+
+**Verificaciones**:
+
+1. Si ``ldap.admin.enabled`` esta en ``true``
+2. Si los Base DN de administracion como ``ldap.admin.user.base.dn`` son correctos
+3. Si la cuenta de servicio de ``ldap.admin.security.principal`` tiene permisos de escritura
 
 Configuracion de depuracion
----------------------------
+-----------------------------
 
-Obtener logs detallados:
-
-``app/WEB-INF/classes/log4j2.xml``:
+Para obtener logs detallados, agregue un logger en ``app/WEB-INF/classes/log4j2.xml``.
 
 ::
 
     <Logger name="org.codelibs.fess.ldap" level="DEBUG"/>
 
 Informacion de referencia
-=========================
+==========================
 
 - :doc:`security-role` - Control de acceso basado en roles
 - :doc:`sso-spnego` - Autenticacion SPNEGO (Kerberos)

--- a/fr/15.7/config/ldap-integration.rst
+++ b/fr/15.7/config/ldap-integration.rst
@@ -1,23 +1,23 @@
-==================================
-Guide d'integration LDAP
-==================================
+=====================================
+Guide d'intégration LDAP
+=====================================
 
-Apercu
-====
+Aperçu
+======
 
-|Fess| prend en charge l'integration avec les serveurs LDAP (Lightweight Directory Access Protocol),
+|Fess| prend en charge l'intégration avec les serveurs LDAP (Lightweight Directory Access Protocol),
 permettant l'authentification et la gestion des utilisateurs dans les environnements d'entreprise.
 
-L'integration LDAP permet :
+L'intégration LDAP permet :
 
-- L'authentification des utilisateurs via Active Directory ou OpenLDAP
-- Le controle d'acces base sur les groupes
-- La synchronisation automatique des informations utilisateur
+- L'authentification des utilisateurs via Active Directory ou OpenLDAP (connexion)
+- Le contrôle d'accès basé sur les groupes et les rôles
+- La gestion des utilisateurs/rôles/groupes LDAP depuis la console d'administration (optionnel)
 
 Serveurs LDAP pris en charge
-================
+=============================
 
-|Fess| prend en charge l'integration avec les serveurs LDAP suivants :
+|Fess| prend en charge l'intégration avec les serveurs LDAP suivants :
 
 - Microsoft Active Directory
 - OpenLDAP
@@ -25,170 +25,315 @@ Serveurs LDAP pris en charge
 - Apache Directory Server
 - Autres serveurs compatibles LDAP v3
 
-Prerequis
-========
+Prérequis
+=========
 
-- Acces reseau au serveur LDAP
+- Accès réseau au serveur LDAP
 - Compte de service pour les recherches LDAP (Bind DN)
-- Comprehension de la structure LDAP (Base DN, noms d'attributs, etc.)
+- Compréhension de la structure LDAP (Base DN, noms d'attributs, etc.)
 
-Configuration de base
-========
+Vue d'ensemble de la configuration
+====================================
 
-Ajoutez les parametres suivants dans ``app/WEB-INF/conf/system.properties``.
+La configuration LDAP de |Fess| est gérée à deux endroits distincts selon l'usage.
 
-Configuration de connexion LDAP
-------------
+Paramètres de connexion et d'authentification (console d'administration / ``system.properties``)
+   Ces paramètres concernent la connexion au serveur LDAP et l'authentification lors de la connexion.
+   Ils peuvent être configurés depuis la section « LDAP » de la page **« Système > Général »** de la
+   console d'administration et sont enregistrés dans ``app/WEB-INF/conf/system.properties``.
+
+Paramètres de gestion LDAP et de comportement (``fess_config.properties``)
+   Ces paramètres concernent les fonctionnalités de gestion des utilisateurs/rôles/groupes LDAP
+   depuis la console d'administration, ainsi que les comportements tels que la résolution des rôles.
+   Ils sont définis dans ``app/WEB-INF/classes/fess_config.properties`` ; pour les modifier,
+   éditez ce fichier directement.
+
+.. note::
+
+   Si vous utilisez uniquement l'authentification lors de la connexion, les « Paramètres de connexion
+   et d'authentification » suffisent. La « Gestion LDAP » (``ldap.admin.enabled``) n'est nécessaire
+   que si vous souhaitez créer, mettre à jour ou supprimer des utilisateurs/rôles/groupes LDAP
+   depuis la console d'administration.
+
+Paramètres de connexion et d'authentification
+==============================================
+
+Ces paramètres peuvent être configurés depuis la section LDAP de la console d'administration
+« Système > Général » et sont enregistrés dans ``app/WEB-INF/conf/system.properties``.
+Vous pouvez également modifier ce fichier directement.
+
+.. list-table:: Propriétés de connexion et d'authentification
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Propriété
+     - Valeur par défaut
+     - Description
+   * - ``ldap.provider.url``
+     - (aucune)
+     - URL du serveur LDAP. Exemple : ``ldap://ldap.example.com:389``. Pour LDAPS : ``ldaps://ldap.example.com:636``. Plusieurs URL séparées par des espaces permettent le basculement (failover).
+   * - ``ldap.base.dn``
+     - (aucune)
+     - Base DN pour les recherches LDAP. Exemple : ``dc=example,dc=com``
+   * - ``ldap.security.principal``
+     - (aucune)
+     - Modèle de DN de liaison pour l'authentification des utilisateurs. ``%s`` est remplacé par le nom d'utilisateur. Exemple : ``uid=%s,ou=People,dc=example,dc=com``
+   * - ``ldap.security.authentication``
+     - ``simple``
+     - Méthode d'authentification LDAP (``java.naming.security.authentication`` de JNDI). Généralement ``simple``.
+   * - ``ldap.initial.context.factory``
+     - ``com.sun.jndi.ldap.LdapCtxFactory``
+     - Classe de fabrique de contexte initial JNDI. Généralement aucune modification requise.
+   * - ``ldap.admin.security.principal``
+     - (aucune)
+     - Bind DN du compte de service pour les recherches LDAP. Exemple : ``cn=fess,ou=services,dc=example,dc=com``
+   * - ``ldap.admin.security.credentials``
+     - (aucune)
+     - Mot de passe du compte de service ci-dessus.
+   * - ``ldap.account.filter``
+     - (aucune)
+     - Filtre utilisé pour rechercher l'entrée de l'utilisateur lors de la résolution de ses rôles. ``%s`` est remplacé par le nom d'utilisateur. Exemple : ``uid=%s``
+   * - ``ldap.group.filter``
+     - (vide)
+     - Filtre de recherche utilisé lors de la résolution des groupes. ``%s`` est remplacé par le DN de l'utilisateur, etc. Exemple : ``(member=%s)``
+   * - ``ldap.memberof.attribute``
+     - ``memberOf``
+     - Nom de l'attribut représentant l'appartenance à un groupe. Utilisé pour résoudre les rôles sur Active Directory et les serveurs disposant de cet attribut.
+
+Exemple de configuration (édition directe de ``system.properties``) :
 
 ::
-
-    # Activer l'authentification LDAP
-    ldap.admin.enabled=true
 
     # URL du serveur LDAP
     ldap.provider.url=ldap://ldap.example.com:389
 
-    # Pour une connexion securisee (LDAPS)
-    # ldap.provider.url=ldaps://ldap.example.com:636
-
     # Base DN
     ldap.base.dn=dc=example,dc=com
 
-    # Modele de DN de liaison pour l'authentification utilisateur (%s est remplace par le nom d'utilisateur)
+    # Modèle de DN de liaison pour l'authentification utilisateur (%s est remplacé par le nom d'utilisateur)
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # DN de liaison administrateur (compte de service pour les recherches LDAP)
+    # Bind DN et mot de passe du compte de service pour les recherches
     ldap.admin.security.principal=cn=fess,ou=services,dc=example,dc=com
-
-    # Mot de passe de liaison administrateur
     ldap.admin.security.credentials=your_password
 
-Configuration de recherche d'utilisateurs
-----------------
-
-::
-
-    # Base DN pour la recherche d'utilisateurs
-    ldap.user.search.base=ou=users,dc=example,dc=com
-
-    # Filtre de recherche d'utilisateurs
-    ldap.account.filter=(uid=%s)
-
-    # Attribut du nom d'utilisateur
-    ldap.user.name.attribute=uid
-
-    # Filtre de recherche d'utilisateurs administrateur pour la console de gestion LDAP
-    ldap.admin.user.filter=uid=%s
+    # Filtres pour la résolution des rôles
+    ldap.account.filter=uid=%s
+    ldap.group.filter=(member=%s)
 
 .. note::
 
-   ``ldap.account.filter`` est le filtre de recherche pour l'authentification des utilisateurs,
-   tandis que ``ldap.admin.user.filter`` est le filtre de recherche d'utilisateurs pour la
-   console de gestion LDAP. Configurez chacun de maniere appropriee car ils ont des objectifs differents.
+   Le paramètre fictif ``%s`` est traité par ``String.format()`` de Java.
+   ``ldap.security.principal``, ``ldap.account.filter``, ``ldap.group.filter`` et
+   les filtres d'administration utilisent tous le format ``%s`` (et non le format ``{0}``).
+   Le nom d'utilisateur transmis aux filtres est automatiquement échappé en interne par
+   |Fess| pour se prémunir contre les injections LDAP.
 
-Configuration des DN de base d'administration LDAP
----------------------------------------------------
+Paramètres de gestion LDAP et de comportement
+===============================================
+
+Les propriétés suivantes sont définies dans ``app/WEB-INF/classes/fess_config.properties``.
+Pour les modifier, éditez ce fichier.
+
+Activation des fonctionnalités d'administration
+------------------------------------------------
+
+.. list-table:: Propriétés des fonctionnalités d'administration
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Propriété
+     - Valeur par défaut
+     - Description
+   * - ``ldap.admin.enabled``
+     - ``false``
+     - Active la fonctionnalité de création, mise à jour et suppression des utilisateurs/rôles/groupes LDAP depuis la console d'administration. **Non requis pour l'authentification lors de la connexion** ; la connexion via LDAP fonctionne même sans activer cette option.
+   * - ``ldap.admin.sync.password``
+     - ``true``
+     - Synchronise le mot de passe côté |Fess| avec LDAP lors de la mise à jour d'un utilisateur depuis la console d'administration.
+   * - ``ldap.auth.validation``
+     - ``true``
+     - Effectue la validation de l'authentification LDAP lors de la connexion.
+
+Filtres et Base DN pour la gestion des utilisateurs/rôles/groupes
+------------------------------------------------------------------
+
+Utilisés pour manipuler les entrées LDAP depuis la console d'administration lorsque
+``ldap.admin.enabled=true``.
+
+.. list-table:: Filtres et Base DN d'administration
+   :header-rows: 1
+   :widths: 38 47 15
+
+   * - Propriété
+     - Description
+     - Valeur par défaut
+   * - ``ldap.admin.user.filter``
+     - Filtre de recherche des utilisateurs (``%s`` est remplacé par le nom d'utilisateur)
+     - ``uid=%s``
+   * - ``ldap.admin.user.base.dn``
+     - Base DN de recherche des utilisateurs
+     - ``ou=People,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.user.object.classes``
+     - objectClass lors de la création d'un utilisateur
+     - ``organizationalPerson,top,person,inetOrgPerson``
+   * - ``ldap.admin.role.filter``
+     - Filtre de recherche des rôles
+     - ``cn=%s``
+   * - ``ldap.admin.role.base.dn``
+     - Base DN de recherche des rôles
+     - ``ou=Role,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.role.object.classes``
+     - objectClass lors de la création d'un rôle
+     - ``groupOfNames``
+   * - ``ldap.admin.group.filter``
+     - Filtre de recherche des groupes
+     - ``cn=%s``
+   * - ``ldap.admin.group.base.dn``
+     - Base DN de recherche des groupes
+     - ``ou=Group,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.group.object.classes``
+     - objectClass lors de la création d'un groupe
+     - ``groupOfNames``
+
+Contrôle de la résolution des rôles et du comportement
+-------------------------------------------------------
+
+Contrôle le comportement de la résolution des rôles/groupes après la connexion.
+
+.. list-table:: Propriétés de contrôle du comportement
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - Propriété
+     - Valeur par défaut
+     - Description
+   * - ``ldap.role.search.user.enabled``
+     - ``true``
+     - Attribue des rôles basés sur le nom d'utilisateur.
+   * - ``ldap.role.search.group.enabled``
+     - ``true``
+     - Attribue des rôles basés sur les groupes.
+   * - ``ldap.role.search.role.enabled``
+     - ``true``
+     - Attribue des rôles basés sur les rôles.
+   * - ``ldap.allow.empty.permission``
+     - ``true``
+     - Autorise la connexion des utilisateurs sans groupe ni rôle.
+   * - ``ldap.ignore.netbios.name``
+     - ``true``
+     - Supprime le nom NetBIOS (préfixe de la forme ``DOMAIN\``) des noms de groupes, etc.
+   * - ``ldap.group.name.with.underscores``
+     - ``false``
+     - Autorise les caractères de soulignement dans les noms de groupes.
+   * - ``ldap.lowercase.permission.name``
+     - ``false``
+     - Convertit les noms de permissions en minuscules.
+   * - ``ldap.samaccountname.group``
+     - ``false``
+     - Utilise l'attribut ``sAMAccountName`` pour les noms de groupes (pour Active Directory).
+   * - ``ldap.max.username.length``
+     - ``-1``
+     - Longueur maximale du nom d'utilisateur. ``-1`` signifie sans limite.
+
+Correspondance des attributs
+-----------------------------
+
+La correspondance entre les attributs LDAP et les attributs utilisateur de |Fess| est définie
+par les propriétés ``ldap.attr.*``. En général, aucune modification n'est nécessaire, mais
+vous pouvez les ajuster si le schéma diffère. Exemples représentatifs :
 
 ::
 
-    # DN de base de recherche d'utilisateurs
-    ldap.admin.user.base.dn=ou=People,dc=example,dc=com
+    ldap.attr.surname=sn
+    ldap.attr.givenName=givenName
+    ldap.attr.mail=mail
+    ldap.attr.displayName=displayName
+    ldap.attr.telephoneNumber=telephoneNumber
 
-    # DN de base de recherche de roles
-    ldap.admin.role.base.dn=ou=Roles,dc=example,dc=com
+.. note::
 
-    # DN de base de recherche de groupes
-    ldap.admin.group.base.dn=ou=Groups,dc=example,dc=com
-
-Configuration de recherche de groupes
-----------------
-
-::
-
-    # Base DN pour la recherche de groupes
-    ldap.group.search.base=ou=groups,dc=example,dc=com
-
-    # Filtre de recherche de groupes
-    ldap.group.filter=(member=%s)
-
-    # Attribut du nom de groupe
-    ldap.group.name.attribute=cn
+   Certaines propriétés ne correspondent pas au nom de l'attribut LDAP, par exemple
+   ``ldap.attr.state`` est mappé sur ``st`` et ``ldap.attr.city`` sur ``l``.
+   Pour la liste complète, consultez les lignes commençant par ``ldap.attr.``
+   dans ``fess_config.properties``.
 
 Configuration Active Directory
-====================
+===============================
 
-Exemple de configuration pour Microsoft Active Directory.
-
-Configuration de base
---------
+Exemple de configuration pour Microsoft Active Directory (``system.properties`` ou console d'administration).
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://ad.example.com:389
     ldap.base.dn=dc=example,dc=com
 
-    # Modele de DN de liaison pour l'authentification utilisateur (format UPN)
+    # Modèle de DN de liaison pour l'authentification utilisateur (format UPN)
     ldap.security.principal=%s@example.com
 
-    # DN de liaison administrateur (compte de service)
+    # Compte de service pour les recherches
     ldap.admin.security.principal=cn=fess,cn=Users,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
-    # Recherche d'utilisateurs
-    ldap.user.search.base=ou=Users,dc=example,dc=com
-    ldap.account.filter=(sAMAccountName=%s)
-    ldap.user.name.attribute=sAMAccountName
+    # Filtre de compte
+    ldap.account.filter=sAMAccountName=%s
 
-    # Recherche de groupes
-    ldap.group.search.base=ou=Groups,dc=example,dc=com
+    # Utilisation de l'attribut memberOf
+    ldap.memberof.attribute=memberOf
+
+    # Filtre de groupe
     ldap.group.filter=(member=%s)
-    ldap.group.name.attribute=cn
 
+Pour résoudre les groupes imbriqués, vous pouvez utiliser la règle de correspondance
+``LDAP_MATCHING_RULE_IN_CHAIN`` spécifique à Active Directory.
+
+::
+
+    ldap.group.filter=(member:1.2.840.113556.1.4.1941:=%s)
 
 Configuration OpenLDAP
-============
+=======================
 
 Exemple de configuration pour OpenLDAP.
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://openldap.example.com:389
     ldap.base.dn=dc=example,dc=com
 
-    # Modele de DN de liaison pour l'authentification utilisateur
+    # Modèle de DN de liaison pour l'authentification utilisateur
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # DN de liaison administrateur (compte de service)
+    # Compte de service pour les recherches
     ldap.admin.security.principal=cn=admin,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
-    # Recherche d'utilisateurs
-    ldap.user.search.base=ou=people,dc=example,dc=com
-    ldap.account.filter=(uid=%s)
-    ldap.user.name.attribute=uid
+    # Filtre de compte
+    ldap.account.filter=uid=%s
 
-    # Recherche de groupes
-    ldap.group.search.base=ou=groups,dc=example,dc=com
+    # Filtre de groupe (pour posixGroup)
     ldap.group.filter=(memberUid=%s)
-    ldap.group.name.attribute=cn
 
-Configuration de securite
-================
+.. note::
+
+   OpenLDAP standard ne possède pas l'attribut ``memberOf`` ; les groupes sont donc
+   résolus via ``ldap.group.filter``. Si l'overlay ``memberof`` est activé,
+   ``ldap.memberof.attribute`` peut également être utilisé.
+
+Paramètres de sécurité
+=======================
 
 LDAPS (SSL/TLS)
-----------------
+---------------
 
-Utiliser une connexion chiffree :
+Utiliser une connexion chiffrée :
 
 ::
 
     # Utiliser LDAPS
     ldap.provider.url=ldaps://ldap.example.com:636
 
-
-Pour les certificats auto-signes, importez le certificat dans le truststore Java :
+Pour les certificats auto-signés, importez le certificat dans le truststore Java.
 
 ::
 
@@ -196,75 +341,84 @@ Pour les certificats auto-signes, importez le certificat dans le truststore Java
             -file ldap-server.crt
 
 Protection du mot de passe
-----------------
+---------------------------
 
-Configurer le mot de passe via une variable d'environnement :
+``ldap.admin.security.credentials`` est enregistré dans ``system.properties``.
+Les informations d'identification configurées depuis la console d'administration
+sont stockées chiffrées en interne. Veillez à restreindre les droits d'accès
+au fichier de manière appropriée.
+
+Basculement (Failover)
+=======================
+
+Pour basculer vers plusieurs serveurs LDAP, spécifiez plusieurs URL séparées par
+des espaces dans ``ldap.provider.url``.
 
 ::
 
-    ldap.admin.security.credentials=${LDAP_PASSWORD}
-
-Basculement
-================
-
-Basculement vers plusieurs serveurs LDAP :
-
-::
-
-    # Specifier plusieurs URL separees par des espaces
     ldap.provider.url=ldap://ldap1.example.com:389 ldap://ldap2.example.com:389
 
-Depannage
-======================
+Dépannage
+==========
 
 Erreur de connexion
-----------
+--------------------
 
-**Symptome** : Echec de connexion au serveur LDAP
+**Symptôme** : Échec de la connexion au serveur LDAP
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si le serveur LDAP est en cours d'execution
-2. Verifier si le port est ouvert dans le pare-feu (389 ou 636)
-3. Verifier si l'URL est correcte (``ldap://`` ou ``ldaps://``)
-4. Verifier si le Bind DN et le mot de passe sont corrects
+1. Le serveur LDAP est-il démarré ?
+2. Le port est-il ouvert dans le pare-feu (389 ou 636) ?
+3. ``ldap.provider.url`` est-il correct (``ldap://`` ou ``ldaps://``) ?
+4. ``ldap.admin.security.principal`` et le mot de passe sont-ils corrects ?
 
 Erreur d'authentification
-----------
+--------------------------
 
-**Symptome** : Echec de l'authentification utilisateur
+**Symptôme** : Échec de l'authentification utilisateur
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si le filtre de recherche d'utilisateurs est correct
-2. Verifier si l'utilisateur existe dans le Base DN de recherche
-3. Verifier si l'attribut du nom d'utilisateur est correct
+1. Le modèle de ``ldap.security.principal`` est-il correct (contient-il ``%s``) ?
+2. L'utilisateur existe-t-il dans le Base DN spécifié ?
+3. ``ldap.account.filter`` est-il correct ?
 
-Les groupes ne sont pas recuperes
-----------------------
+Impossibilité de récupérer les groupes/rôles
+---------------------------------------------
 
-**Symptome** : Les groupes de l'utilisateur ne sont pas recuperes
+**Symptôme** : Les groupes et rôles de l'utilisateur ne peuvent pas être récupérés
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si le filtre de recherche de groupes est correct
-2. Verifier si l'attribut d'appartenance au groupe est correct
-3. Verifier si les groupes existent dans le Base DN de recherche
+1. ``ldap.group.filter`` est-il correct ?
+2. ``ldap.memberof.attribute`` est-il correct (pour Active Directory) ?
+3. Les groupes existent-ils dans le Base DN de recherche ?
+4. Les propriétés ``ldap.role.search.*.enabled`` sont-elles activées ?
 
-Configuration de debogage
-------------
+Impossibilité de gérer les utilisateurs depuis la console d'administration
+---------------------------------------------------------------------------
 
-Afficher des logs detailles :
+**Symptôme** : Impossible de créer, modifier ou supprimer des utilisateurs LDAP depuis la console d'administration
 
-``app/WEB-INF/classes/log4j2.xml`` :
+**Points à vérifier** :
+
+1. ``ldap.admin.enabled`` est-il défini à ``true`` ?
+2. Les Base DN d'administration tels que ``ldap.admin.user.base.dn`` sont-ils corrects ?
+3. Le compte de service ``ldap.admin.security.principal`` dispose-t-il des droits en écriture ?
+
+Configuration du débogage
+--------------------------
+
+Pour afficher des journaux détaillés, ajoutez un logger dans ``app/WEB-INF/classes/log4j2.xml``.
 
 ::
 
     <Logger name="org.codelibs.fess.ldap" level="DEBUG"/>
 
-Informations de reference
-========
+Informations de référence
+==========================
 
-- :doc:`security-role` - Controle d'acces base sur les roles
+- :doc:`security-role` - Contrôle d'accès basé sur les rôles
 - :doc:`sso-spnego` - Authentification SPNEGO (Kerberos)
 - :doc:`../admin/user-guide` - Guide de gestion des utilisateurs

--- a/ja/15.7/config/ldap-integration.rst
+++ b/ja/15.7/config/ldap-integration.rst
@@ -10,9 +10,9 @@ LDAP統合ガイド
 
 LDAP統合により:
 
-- Active DirectoryやOpenLDAPでのユーザー認証
-- グループベースのアクセス制御
-- ユーザー情報の自動同期
+- Active DirectoryやOpenLDAPでのユーザー認証（ログイン）
+- グループ・ロールベースのアクセス制御
+- 管理画面からのLDAPユーザー／ロール／グループ管理（オプション）
 
 が可能になります。
 
@@ -34,24 +34,78 @@ LDAP統合により:
 - LDAP検索用のサービスアカウント（バインドDN）
 - LDAPの構造（ベースDN、属性名など）の理解
 
-基本設定
-========
+設定方法の概要
+==============
 
-``app/WEB-INF/conf/system.properties`` に以下の設定を追加します。
+|Fess| のLDAP設定は、用途によって2つの場所で管理されます。
 
-LDAP接続設定
-------------
+接続・認証設定（管理画面 / ``system.properties``）
+   LDAPサーバーへの接続とログイン認証に関する設定です。
+   管理画面の **「システム > 全般」** ページにある「LDAP」セクションから設定でき、
+   ``app/WEB-INF/conf/system.properties`` に保存されます。
+
+LDAP管理機能・動作設定（``fess_config.properties``）
+   管理画面からLDAPユーザー／ロール／グループを管理する機能や、
+   ロール解決などの動作に関する設定です。これらは
+   ``app/WEB-INF/classes/fess_config.properties`` に定義されており、
+   値を変更する場合はこのファイルを編集します。
+
+.. note::
+
+   ログイン認証だけを利用する場合は、「接続・認証設定」のみで動作します。
+   「LDAP管理機能」（``ldap.admin.enabled``）は、管理画面からLDAP側の
+   ユーザー／ロール／グループを作成・更新・削除する場合にのみ必要です。
+
+接続・認証設定
+==============
+
+これらの設定は管理画面「システム > 全般」のLDAPセクションから設定でき、
+``app/WEB-INF/conf/system.properties`` に保存されます。直接ファイルを編集することもできます。
+
+.. list-table:: 接続・認証プロパティ
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - プロパティ
+     - デフォルト値
+     - 説明
+   * - ``ldap.provider.url``
+     - （なし）
+     - LDAPサーバーのURL。例: ``ldap://ldap.example.com:389``。LDAPSの場合は ``ldaps://ldap.example.com:636``。スペース区切りで複数指定するとフェイルオーバーになります。
+   * - ``ldap.base.dn``
+     - （なし）
+     - LDAP検索のベースDN。例: ``dc=example,dc=com``
+   * - ``ldap.security.principal``
+     - （なし）
+     - ユーザー認証（バインド）に使用するDNテンプレート。``%s`` がユーザー名に置換されます。例: ``uid=%s,ou=People,dc=example,dc=com``
+   * - ``ldap.security.authentication``
+     - ``simple``
+     - LDAP認証方式（JNDIの ``java.naming.security.authentication``）。通常は ``simple`` を使用します。
+   * - ``ldap.initial.context.factory``
+     - ``com.sun.jndi.ldap.LdapCtxFactory``
+     - JNDIの初期コンテキストファクトリクラス。通常は変更不要です。
+   * - ``ldap.admin.security.principal``
+     - （なし）
+     - LDAP検索用サービスアカウントのバインドDN。例: ``cn=fess,ou=services,dc=example,dc=com``
+   * - ``ldap.admin.security.credentials``
+     - （なし）
+     - 上記サービスアカウントのパスワード。
+   * - ``ldap.account.filter``
+     - （なし）
+     - ユーザーのロール解決時に、ユーザーエントリを検索するためのフィルター。``%s`` がユーザー名に置換されます。例: ``uid=%s``
+   * - ``ldap.group.filter``
+     - （空）
+     - グループ解決時に使用する検索フィルター。``%s`` がユーザーのDNなどに置換されます。例: ``(member=%s)``
+   * - ``ldap.memberof.attribute``
+     - ``memberOf``
+     - グループメンバーシップを表す属性名。Active Directoryやこの属性を持つサーバーでロールを解決する際に使用します。
+
+設定例（``system.properties`` を直接編集する場合）:
 
 ::
 
-    # LDAP認証を有効にする
-    ldap.admin.enabled=true
-
     # LDAPサーバーのURL
     ldap.provider.url=ldap://ldap.example.com:389
-
-    # セキュア接続（LDAPS）の場合
-    # ldap.provider.url=ldaps://ldap.example.com:636
 
     # ベースDN
     ldap.base.dn=dc=example,dc=com
@@ -59,90 +113,179 @@ LDAP接続設定
     # ユーザー認証用バインドDNテンプレート（%sにユーザー名が埋め込まれる）
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # 管理用バインドDN（LDAP検索用サービスアカウント）
+    # 検索用サービスアカウントのバインドDNとパスワード
     ldap.admin.security.principal=cn=fess,ou=services,dc=example,dc=com
-
-    # 管理用バインドパスワード
     ldap.admin.security.credentials=your_password
 
-アカウントフィルター設定
-------------------------
-
-::
-
-    # アカウントフィルター（ユーザー認証時の検索フィルター）
+    # ロール解決用のフィルター
     ldap.account.filter=uid=%s
-
-    # LDAP管理画面でのユーザー検索フィルター
-    ldap.admin.user.filter=uid=%s
+    ldap.group.filter=(member=%s)
 
 .. note::
 
-   ``ldap.account.filter`` はユーザー認証時の検索フィルターで、
-   ``ldap.admin.user.filter`` はLDAP管理画面でのユーザー検索フィルターです。
-   用途が異なるため、それぞれ適切に設定してください。
+   ``%s`` プレースホルダーはJavaの ``String.format()`` で処理されます。
+   ``ldap.security.principal`` ・ ``ldap.account.filter`` ・ ``ldap.group.filter`` ・
+   各管理用フィルターはいずれも ``%s`` 形式を使用します（``{0}`` 形式ではありません）。
+   なお、フィルターに渡されるユーザー名はLDAPインジェクション対策として
+   |Fess| 内部で自動的にエスケープされます。
 
-LDAP管理用ベースDN設定
+LDAP管理機能・動作設定
+======================
+
+以下のプロパティは ``app/WEB-INF/classes/fess_config.properties`` で定義されています。
+値を変更する場合はこのファイルを編集します。
+
+管理機能の有効化
+----------------
+
+.. list-table:: 管理機能プロパティ
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - プロパティ
+     - デフォルト値
+     - 説明
+   * - ``ldap.admin.enabled``
+     - ``false``
+     - 管理画面からLDAPのユーザー／ロール／グループを作成・更新・削除する機能を有効にします。**ログイン認証には不要**で、有効にしなくてもLDAPによるログインは機能します。
+   * - ``ldap.admin.sync.password``
+     - ``true``
+     - 管理画面でユーザーを更新した際に、|Fess| 側のパスワードをLDAPと同期します。
+   * - ``ldap.auth.validation``
+     - ``true``
+     - ログイン時にLDAP認証の検証を行います。
+
+ユーザー／ロール／グループの管理用フィルターとベースDN
+------------------------------------------------------
+
+``ldap.admin.enabled=true`` の場合に、管理画面からLDAPエントリを操作するために使用します。
+
+.. list-table:: 管理用フィルター／ベースDN
+   :header-rows: 1
+   :widths: 38 47 15
+
+   * - プロパティ
+     - 説明
+     - デフォルト値
+   * - ``ldap.admin.user.filter``
+     - ユーザー検索フィルター（``%s`` がユーザー名に置換）
+     - ``uid=%s``
+   * - ``ldap.admin.user.base.dn``
+     - ユーザー検索ベースDN
+     - ``ou=People,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.user.object.classes``
+     - ユーザー作成時のobjectClass
+     - ``organizationalPerson,top,person,inetOrgPerson``
+   * - ``ldap.admin.role.filter``
+     - ロール検索フィルター
+     - ``cn=%s``
+   * - ``ldap.admin.role.base.dn``
+     - ロール検索ベースDN
+     - ``ou=Role,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.role.object.classes``
+     - ロール作成時のobjectClass
+     - ``groupOfNames``
+   * - ``ldap.admin.group.filter``
+     - グループ検索フィルター
+     - ``cn=%s``
+   * - ``ldap.admin.group.base.dn``
+     - グループ検索ベースDN
+     - ``ou=Group,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.group.object.classes``
+     - グループ作成時のobjectClass
+     - ``groupOfNames``
+
+ロール解決と動作の制御
 ----------------------
+
+ログイン後のロール／グループ解決の挙動を制御します。
+
+.. list-table:: 動作制御プロパティ
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - プロパティ
+     - デフォルト値
+     - 説明
+   * - ``ldap.role.search.user.enabled``
+     - ``true``
+     - ユーザー名に基づくロールを付与します。
+   * - ``ldap.role.search.group.enabled``
+     - ``true``
+     - グループに基づくロールを付与します。
+   * - ``ldap.role.search.role.enabled``
+     - ``true``
+     - ロールに基づくロールを付与します。
+   * - ``ldap.allow.empty.permission``
+     - ``true``
+     - グループ／ロールが空のユーザーのログインを許可します。
+   * - ``ldap.ignore.netbios.name``
+     - ``true``
+     - グループ名などからNetBIOS名（``DOMAIN\`` 形式の接頭辞）を除去します。
+   * - ``ldap.group.name.with.underscores``
+     - ``false``
+     - グループ名にアンダースコアを許可します。
+   * - ``ldap.lowercase.permission.name``
+     - ``false``
+     - パーミッション名を小文字に変換します。
+   * - ``ldap.samaccountname.group``
+     - ``false``
+     - グループ名に ``sAMAccountName`` 属性を使用します（Active Directory向け）。
+   * - ``ldap.max.username.length``
+     - ``-1``
+     - ユーザー名の最大長。``-1`` は制限なしを意味します。
+
+属性マッピング
+--------------
+
+LDAP属性と |Fess| のユーザー属性の対応は ``ldap.attr.*`` プロパティで定義されています。
+通常は変更不要ですが、スキーマが異なる場合に調整できます。代表的な例:
 
 ::
 
-    # ユーザー検索ベースDN
-    ldap.admin.user.base.dn=ou=People,dc=example,dc=com
+    ldap.attr.surname=sn
+    ldap.attr.givenName=givenName
+    ldap.attr.mail=mail
+    ldap.attr.displayName=displayName
+    ldap.attr.telephoneNumber=telephoneNumber
 
-    # ロール検索ベースDN
-    ldap.admin.role.base.dn=ou=Roles,dc=example,dc=com
+.. note::
 
-    # グループ検索ベースDN
-    ldap.admin.group.base.dn=ou=Groups,dc=example,dc=com
-
-グループフィルター設定
-----------------------
-
-::
-
-    # グループフィルター
-    ldap.group.filter=(member=%s)
-
-    # memberOf属性名
-    ldap.memberof.attribute=memberOf
+   ``ldap.attr.state`` は ``st``、``ldap.attr.city`` は ``l`` にマッピングされるなど、
+   プロパティ名とLDAP属性名が一致しないものもあります。
+   完全な一覧は ``fess_config.properties`` の ``ldap.attr.`` で始まる行を参照してください。
 
 Active Directory設定
 ====================
 
-Microsoft Active Directory向けの設定例です。
-
-基本設定
---------
+Microsoft Active Directory向けの設定例です（``system.properties`` または管理画面）。
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://ad.example.com:389
     ldap.base.dn=dc=example,dc=com
 
     # ユーザー認証用バインドDNテンプレート（UPN形式）
     ldap.security.principal=%s@example.com
 
-    # 管理用バインドDN（サービスアカウント）
+    # 検索用サービスアカウント
     ldap.admin.security.principal=cn=fess,cn=Users,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
     # アカウントフィルター
     ldap.account.filter=sAMAccountName=%s
 
-    # グループフィルター
-    ldap.group.filter=(member=%s)
-
-Active Directory固有の設定
---------------------------
-
-::
-
     # memberOf属性を使用
     ldap.memberof.attribute=memberOf
 
-    # 入れ子グループの解決（LDAP_MATCHING_RULE_IN_CHAIN）
+    # グループフィルター
+    ldap.group.filter=(member=%s)
+
+入れ子グループ（ネストグループ）を解決する場合は、Active Directory固有の
+``LDAP_MATCHING_RULE_IN_CHAIN`` を使用できます。
+
+::
+
     ldap.group.filter=(member:1.2.840.113556.1.4.1941:=%s)
 
 OpenLDAP設定
@@ -152,22 +295,27 @@ OpenLDAP向けの設定例です。
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://openldap.example.com:389
     ldap.base.dn=dc=example,dc=com
 
     # ユーザー認証用バインドDNテンプレート
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # 管理用バインドDN（サービスアカウント）
+    # 検索用サービスアカウント
     ldap.admin.security.principal=cn=admin,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
     # アカウントフィルター
     ldap.account.filter=uid=%s
 
-    # グループフィルター
+    # グループフィルター（posixGroupの場合）
     ldap.group.filter=(memberUid=%s)
+
+.. note::
+
+   標準のOpenLDAPは ``memberOf`` 属性を持たないため、
+   ``ldap.group.filter`` を使ってグループを解決します。
+   ``memberof`` オーバーレイを有効にしている場合は ``ldap.memberof.attribute`` も利用できます。
 
 セキュリティ設定
 ================
@@ -182,7 +330,7 @@ LDAPS（SSL/TLS）
     # LDAPSを使用
     ldap.provider.url=ldaps://ldap.example.com:636
 
-自己署名証明書の場合は、Java truststore に証明書をインポート:
+自己署名証明書の場合は、Java truststore に証明書をインポートします。
 
 ::
 
@@ -192,20 +340,18 @@ LDAPS（SSL/TLS）
 パスワードの保護
 ----------------
 
-パスワードを環境変数で設定:
-
-::
-
-    ldap.admin.security.credentials=${LDAP_PASSWORD}
+``ldap.admin.security.credentials`` は ``system.properties`` に保存されます。
+管理画面から設定した認証情報は内部的に暗号化されて保存されます。
+ファイルのアクセス権限を適切に制限してください。
 
 フェイルオーバー
 ================
 
-複数のLDAPサーバーへのフェイルオーバー:
+複数のLDAPサーバーへフェイルオーバーする場合は、``ldap.provider.url`` に
+スペース区切りで複数のURLを指定します。
 
 ::
 
-    # スペース区切りで複数のURLを指定
     ldap.provider.url=ldap://ldap1.example.com:389 ldap://ldap2.example.com:389
 
 トラブルシューティング
@@ -220,8 +366,8 @@ LDAPS（SSL/TLS）
 
 1. LDAPサーバーが起動しているか
 2. ファイアウォールでポートが開いているか（389または636）
-3. URLが正しいか（``ldap://`` または ``ldaps://``）
-4. バインドDNとパスワードが正しいか
+3. ``ldap.provider.url`` が正しいか（``ldap://`` または ``ldaps://``）
+4. ``ldap.admin.security.principal`` とパスワードが正しいか
 
 認証エラー
 ----------
@@ -230,27 +376,37 @@ LDAPS（SSL/TLS）
 
 **確認事項**:
 
-1. ユーザー検索フィルターが正しいか
-2. ユーザーが検索ベースDN内に存在するか
-3. ユーザー名属性が正しいか
+1. ``ldap.security.principal`` のテンプレートが正しいか（``%s`` を含むか）
+2. ユーザーが指定したベースDN内に存在するか
+3. ``ldap.account.filter`` が正しいか
 
-グループが取得できない
-----------------------
+グループ／ロールが取得できない
+------------------------------
 
-**症状**: ユーザーのグループが取得できない
+**症状**: ユーザーのグループやロールが取得できない
 
 **確認事項**:
 
-1. グループ検索フィルターが正しいか
-2. グループのメンバーシップ属性が正しいか
+1. ``ldap.group.filter`` が正しいか
+2. ``ldap.memberof.attribute`` が正しいか（Active Directoryの場合）
 3. グループが検索ベースDN内に存在するか
+4. ``ldap.role.search.*.enabled`` が有効になっているか
+
+管理画面からのユーザー管理ができない
+------------------------------------
+
+**症状**: 管理画面でLDAPユーザーを作成・編集・削除できない
+
+**確認事項**:
+
+1. ``ldap.admin.enabled`` が ``true`` になっているか
+2. ``ldap.admin.user.base.dn`` などの管理用ベースDNが正しいか
+3. ``ldap.admin.security.principal`` のサービスアカウントに書き込み権限があるか
 
 デバッグ設定
 ------------
 
-詳細なログを出力:
-
-``app/WEB-INF/classes/log4j2.xml``:
+詳細なログを出力するには、``app/WEB-INF/classes/log4j2.xml`` にロガーを追加します。
 
 ::
 

--- a/ko/15.7/config/ldap-integration.rst
+++ b/ko/15.7/config/ldap-integration.rst
@@ -5,21 +5,21 @@ LDAP 통합 가이드
 개요
 ====
 
-|Fess|는 LDAP(Lightweight Directory Access Protocol) 서버와의 통합을 지원하여
+|Fess| 는 LDAP(Lightweight Directory Access Protocol) 서버와의 통합을 지원하여
 엔터프라이즈 환경에서의 인증과 사용자 관리를 구현할 수 있습니다.
 
 LDAP 통합으로:
 
-- Active Directory나 OpenLDAP에서의 사용자 인증
-- 그룹 기반 접근 제어
-- 사용자 정보 자동 동기화
+- Active Directory나 OpenLDAP에서의 사용자 인증(로그인)
+- 그룹·역할 기반 접근 제어
+- 관리 화면에서의 LDAP 사용자／역할／그룹 관리(옵션)
 
 가 가능해집니다.
 
 지원 LDAP 서버
-================
+==============
 
-|Fess|는 다음 LDAP 서버와의 통합을 지원합니다:
+|Fess| 는 다음 LDAP 서버와의 통합을 지원합니다:
 
 - Microsoft Active Directory
 - OpenLDAP
@@ -27,170 +27,301 @@ LDAP 통합으로:
 - Apache Directory Server
 - 기타 LDAP v3 호환 서버
 
-전제조건
-========
+전제 조건
+=========
 
 - LDAP 서버로의 네트워크 접근
 - LDAP 검색용 서비스 계정(바인드 DN)
-- LDAP 구조(베이스 DN, 속성명 등) 이해
+- LDAP 구조(베이스 DN, 속성명 등)에 대한 이해
 
-기본 설정
-========
+설정 방법 개요
+==============
 
-``app/WEB-INF/conf/system.properties``에 다음 설정을 추가합니다.
+|Fess| 의 LDAP 설정은 용도에 따라 두 곳에서 관리됩니다.
 
-LDAP 연결 설정
-------------
+연결·인증 설정(관리 화면 / ``system.properties``)
+   LDAP 서버 연결 및 로그인 인증에 관한 설정입니다.
+   관리 화면의 **「시스템 > 일반」** 페이지의 「LDAP」 섹션에서 설정할 수 있으며,
+   ``app/WEB-INF/conf/system.properties`` 에 저장됩니다.
+
+LDAP 관리 기능·동작 설정(``fess_config.properties``)
+   관리 화면에서 LDAP 사용자／역할／그룹을 관리하는 기능이나,
+   역할 해석 등의 동작에 관한 설정입니다. 이 설정들은
+   ``app/WEB-INF/classes/fess_config.properties`` 에 정의되어 있으며,
+   값을 변경하려면 이 파일을 편집합니다.
+
+.. note::
+
+   로그인 인증만 사용하는 경우에는 「연결·인증 설정」만으로 동작합니다.
+   「LDAP 관리 기능」(``ldap.admin.enabled``)은 관리 화면에서 LDAP 측의
+   사용자／역할／그룹을 생성·수정·삭제하는 경우에만 필요합니다.
+
+연결·인증 설정
+==============
+
+이 설정들은 관리 화면 「시스템 > 일반」의 LDAP 섹션에서 설정할 수 있으며,
+``app/WEB-INF/conf/system.properties`` 에 저장됩니다. 직접 파일을 편집하는 것도 가능합니다.
+
+.. list-table:: 연결·인증 프로퍼티
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - 프로퍼티
+     - 기본값
+     - 설명
+   * - ``ldap.provider.url``
+     - (없음)
+     - LDAP 서버 URL. 예: ``ldap://ldap.example.com:389``. LDAPS의 경우 ``ldaps://ldap.example.com:636``. 공백으로 구분하여 여러 개를 지정하면 페일오버가 됩니다.
+   * - ``ldap.base.dn``
+     - (없음)
+     - LDAP 검색의 베이스 DN. 예: ``dc=example,dc=com``
+   * - ``ldap.security.principal``
+     - (없음)
+     - 사용자 인증(바인드)에 사용하는 DN 템플릿. ``%s`` 가 사용자 이름으로 치환됩니다. 예: ``uid=%s,ou=People,dc=example,dc=com``
+   * - ``ldap.security.authentication``
+     - ``simple``
+     - LDAP 인증 방식(JNDI의 ``java.naming.security.authentication``). 일반적으로 ``simple`` 을 사용합니다.
+   * - ``ldap.initial.context.factory``
+     - ``com.sun.jndi.ldap.LdapCtxFactory``
+     - JNDI 초기 컨텍스트 팩토리 클래스. 일반적으로 변경이 불필요합니다.
+   * - ``ldap.admin.security.principal``
+     - (없음)
+     - LDAP 검색용 서비스 계정의 바인드 DN. 예: ``cn=fess,ou=services,dc=example,dc=com``
+   * - ``ldap.admin.security.credentials``
+     - (없음)
+     - 위 서비스 계정의 비밀번호.
+   * - ``ldap.account.filter``
+     - (없음)
+     - 사용자의 역할 해석 시, 사용자 엔트리를 검색하기 위한 필터. ``%s`` 가 사용자 이름으로 치환됩니다. 예: ``uid=%s``
+   * - ``ldap.group.filter``
+     - (빈 값)
+     - 그룹 해석 시 사용하는 검색 필터. ``%s`` 가 사용자의 DN 등으로 치환됩니다. 예: ``(member=%s)``
+   * - ``ldap.memberof.attribute``
+     - ``memberOf``
+     - 그룹 멤버십을 나타내는 속성명. Active Directory나 이 속성을 가진 서버에서 역할을 해석할 때 사용합니다.
+
+설정 예(``system.properties`` 를 직접 편집하는 경우):
 
 ::
-
-    # LDAP 인증 활성화
-    ldap.admin.enabled=true
 
     # LDAP 서버 URL
     ldap.provider.url=ldap://ldap.example.com:389
 
-    # 보안 연결(LDAPS)인 경우
-    # ldap.provider.url=ldaps://ldap.example.com:636
-
     # 베이스 DN
     ldap.base.dn=dc=example,dc=com
 
-    # 사용자 인증용 바인드 DN 템플릿 (%s에 사용자 이름이 대입됨)
+    # 사용자 인증용 바인드 DN 템플릿(%s에 사용자 이름이 삽입됨)
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # 관리용 바인드 DN (LDAP 검색용 서비스 계정)
+    # 검색용 서비스 계정의 바인드 DN과 비밀번호
     ldap.admin.security.principal=cn=fess,ou=services,dc=example,dc=com
-
-    # 관리용 바인드 비밀번호
     ldap.admin.security.credentials=your_password
 
-사용자 검색 설정
-----------------
-
-::
-
-    # 사용자 검색의 베이스 DN
-    ldap.user.search.base=ou=users,dc=example,dc=com
-
-    # 사용자 검색 필터
-    ldap.account.filter=(uid=%s)
-
-    # 사용자명 속성
-    ldap.user.name.attribute=uid
-
-    # LDAP 관리 콘솔의 사용자 검색 필터
-    ldap.admin.user.filter=uid=%s
+    # 역할 해석용 필터
+    ldap.account.filter=uid=%s
+    ldap.group.filter=(member=%s)
 
 .. note::
 
-   ``ldap.account.filter``는 사용자 인증 시 검색 필터이며,
-   ``ldap.admin.user.filter``는 LDAP 관리 화면에서의 사용자 검색 필터입니다.
-   용도가 다르므로 각각 적절하게 설정하세요.
+   ``%s`` 플레이스홀더는 Java의 ``String.format()`` 으로 처리됩니다.
+   ``ldap.security.principal`` · ``ldap.account.filter`` · ``ldap.group.filter`` ·
+   각 관리용 필터는 모두 ``%s`` 형식을 사용합니다(``{0}`` 형식이 아닙니다).
+   또한 필터에 전달되는 사용자 이름은 LDAP 인젝션 대책으로
+   |Fess| 내부에서 자동으로 이스케이프됩니다.
 
-LDAP 관리용 베이스 DN 설정
-----------------------------
+LDAP 관리 기능·동작 설정
+========================
 
-::
+다음 프로퍼티들은 ``app/WEB-INF/classes/fess_config.properties`` 에 정의되어 있습니다.
+값을 변경하려면 이 파일을 편집합니다.
 
-    # 사용자 검색 베이스 DN
-    ldap.admin.user.base.dn=ou=People,dc=example,dc=com
-
-    # 역할 검색 베이스 DN
-    ldap.admin.role.base.dn=ou=Roles,dc=example,dc=com
-
-    # 그룹 검색 베이스 DN
-    ldap.admin.group.base.dn=ou=Groups,dc=example,dc=com
-
-그룹 검색 설정
+관리 기능 활성화
 ----------------
 
+.. list-table:: 관리 기능 프로퍼티
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - 프로퍼티
+     - 기본값
+     - 설명
+   * - ``ldap.admin.enabled``
+     - ``false``
+     - 관리 화면에서 LDAP의 사용자／역할／그룹을 생성·수정·삭제하는 기능을 활성화합니다. **로그인 인증에는 불필요**하며, 활성화하지 않아도 LDAP를 통한 로그인은 동작합니다.
+   * - ``ldap.admin.sync.password``
+     - ``true``
+     - 관리 화면에서 사용자를 수정했을 때, |Fess| 측의 비밀번호를 LDAP와 동기화합니다.
+   * - ``ldap.auth.validation``
+     - ``true``
+     - 로그인 시 LDAP 인증 검증을 수행합니다.
+
+사용자／역할／그룹 관리용 필터와 베이스 DN
+------------------------------------------
+
+``ldap.admin.enabled=true`` 인 경우, 관리 화면에서 LDAP 엔트리를 조작하기 위해 사용합니다.
+
+.. list-table:: 관리용 필터／베이스 DN
+   :header-rows: 1
+   :widths: 38 47 15
+
+   * - 프로퍼티
+     - 설명
+     - 기본값
+   * - ``ldap.admin.user.filter``
+     - 사용자 검색 필터(``%s`` 가 사용자 이름으로 치환)
+     - ``uid=%s``
+   * - ``ldap.admin.user.base.dn``
+     - 사용자 검색 베이스 DN
+     - ``ou=People,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.user.object.classes``
+     - 사용자 생성 시의 objectClass
+     - ``organizationalPerson,top,person,inetOrgPerson``
+   * - ``ldap.admin.role.filter``
+     - 역할 검색 필터
+     - ``cn=%s``
+   * - ``ldap.admin.role.base.dn``
+     - 역할 검색 베이스 DN
+     - ``ou=Role,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.role.object.classes``
+     - 역할 생성 시의 objectClass
+     - ``groupOfNames``
+   * - ``ldap.admin.group.filter``
+     - 그룹 검색 필터
+     - ``cn=%s``
+   * - ``ldap.admin.group.base.dn``
+     - 그룹 검색 베이스 DN
+     - ``ou=Group,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.group.object.classes``
+     - 그룹 생성 시의 objectClass
+     - ``groupOfNames``
+
+역할 해석과 동작 제어
+----------------------
+
+로그인 후의 역할／그룹 해석 동작을 제어합니다.
+
+.. list-table:: 동작 제어 프로퍼티
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - 프로퍼티
+     - 기본값
+     - 설명
+   * - ``ldap.role.search.user.enabled``
+     - ``true``
+     - 사용자 이름에 기반한 역할을 부여합니다.
+   * - ``ldap.role.search.group.enabled``
+     - ``true``
+     - 그룹에 기반한 역할을 부여합니다.
+   * - ``ldap.role.search.role.enabled``
+     - ``true``
+     - 역할에 기반한 역할을 부여합니다.
+   * - ``ldap.allow.empty.permission``
+     - ``true``
+     - 그룹／역할이 없는 사용자의 로그인을 허용합니다.
+   * - ``ldap.ignore.netbios.name``
+     - ``true``
+     - 그룹명 등에서 NetBIOS 이름(``DOMAIN\`` 형식의 접두사)을 제거합니다.
+   * - ``ldap.group.name.with.underscores``
+     - ``false``
+     - 그룹명에 언더스코어를 허용합니다.
+   * - ``ldap.lowercase.permission.name``
+     - ``false``
+     - 퍼미션 이름을 소문자로 변환합니다.
+   * - ``ldap.samaccountname.group``
+     - ``false``
+     - 그룹명에 ``sAMAccountName`` 속성을 사용합니다(Active Directory용).
+   * - ``ldap.max.username.length``
+     - ``-1``
+     - 사용자 이름의 최대 길이. ``-1`` 은 제한 없음을 의미합니다.
+
+속성 매핑
+---------
+
+LDAP 속성과 |Fess| 의 사용자 속성 간의 대응은 ``ldap.attr.*`` 프로퍼티로 정의되어 있습니다.
+일반적으로 변경이 불필요하지만, 스키마가 다를 경우에 조정할 수 있습니다. 대표적인 예:
+
 ::
 
-    # 그룹 검색의 베이스 DN
-    ldap.group.search.base=ou=groups,dc=example,dc=com
+    ldap.attr.surname=sn
+    ldap.attr.givenName=givenName
+    ldap.attr.mail=mail
+    ldap.attr.displayName=displayName
+    ldap.attr.telephoneNumber=telephoneNumber
 
-    # 그룹 검색 필터
-    ldap.group.filter=(member=%s)
+.. note::
 
-    # 그룹명 속성
-    ldap.group.name.attribute=cn
+   ``ldap.attr.state`` 는 ``st``, ``ldap.attr.city`` 는 ``l`` 에 매핑되는 등,
+   프로퍼티명과 LDAP 속성명이 일치하지 않는 것도 있습니다.
+   전체 목록은 ``fess_config.properties`` 의 ``ldap.attr.`` 로 시작하는 행을 참조하세요.
 
 Active Directory 설정
-====================
+=====================
 
-Microsoft Active Directory용 설정 예입니다.
-
-기본 설정
---------
+Microsoft Active Directory용 설정 예입니다(``system.properties`` 또는 관리 화면).
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://ad.example.com:389
     ldap.base.dn=dc=example,dc=com
 
-    # 사용자 인증용 바인드 DN 템플릿 (UPN 형식)
+    # 사용자 인증용 바인드 DN 템플릿(UPN 형식)
     ldap.security.principal=%s@example.com
 
-    # 관리용 바인드 DN (서비스 계정)
+    # 검색용 서비스 계정
     ldap.admin.security.principal=cn=fess,cn=Users,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
-    # 사용자 검색
-    ldap.user.search.base=ou=Users,dc=example,dc=com
-    ldap.account.filter=(sAMAccountName=%s)
-    ldap.user.name.attribute=sAMAccountName
+    # 계정 필터
+    ldap.account.filter=sAMAccountName=%s
 
-    # 그룹 검색
-    ldap.group.search.base=ou=Groups,dc=example,dc=com
+    # memberOf 속성 사용
+    ldap.memberof.attribute=memberOf
+
+    # 그룹 필터
     ldap.group.filter=(member=%s)
-    ldap.group.name.attribute=cn
 
-Active Directory 고유 설정
---------------------------
+중첩 그룹(네스트 그룹)을 해석하는 경우에는 Active Directory 고유의
+``LDAP_MATCHING_RULE_IN_CHAIN`` 을 사용할 수 있습니다.
 
 ::
 
-    # 중첩 그룹 해결
-    ldap.memberof.enabled=true
-
-    # memberOf 속성 사용
     ldap.group.filter=(member:1.2.840.113556.1.4.1941:=%s)
 
 OpenLDAP 설정
-============
+=============
 
 OpenLDAP용 설정 예입니다.
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://openldap.example.com:389
     ldap.base.dn=dc=example,dc=com
 
     # 사용자 인증용 바인드 DN 템플릿
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # 관리용 바인드 DN (서비스 계정)
+    # 검색용 서비스 계정
     ldap.admin.security.principal=cn=admin,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
-    # 사용자 검색
-    ldap.user.search.base=ou=people,dc=example,dc=com
-    ldap.account.filter=(uid=%s)
-    ldap.user.name.attribute=uid
+    # 계정 필터
+    ldap.account.filter=uid=%s
 
-    # 그룹 검색
-    ldap.group.search.base=ou=groups,dc=example,dc=com
+    # 그룹 필터(posixGroup의 경우)
     ldap.group.filter=(memberUid=%s)
-    ldap.group.name.attribute=cn
+
+.. note::
+
+   표준 OpenLDAP는 ``memberOf`` 속성을 가지지 않으므로,
+   ``ldap.group.filter`` 를 사용하여 그룹을 해석합니다.
+   ``memberof`` 오버레이를 활성화한 경우에는 ``ldap.memberof.attribute`` 도 이용할 수 있습니다.
 
 보안 설정
-================
+=========
 
 LDAPS(SSL/TLS)
-----------------
+--------------
 
 암호화된 연결 사용:
 
@@ -199,10 +330,7 @@ LDAPS(SSL/TLS)
     # LDAPS 사용
     ldap.provider.url=ldaps://ldap.example.com:636
 
-    # StartTLS 사용
-    ldap.start.tls=true
-
-자체 서명 인증서인 경우 Java truststore에 인증서 가져오기:
+자체 서명 인증서인 경우, Java truststore에 인증서를 가져옵니다.
 
 ::
 
@@ -210,79 +338,82 @@ LDAPS(SSL/TLS)
             -file ldap-server.crt
 
 비밀번호 보호
-----------------
+-------------
 
-비밀번호를 환경 변수로 설정:
-
-::
-
-    ldap.admin.security.credentials=${LDAP_PASSWORD}
-
-역할 매핑
-================
-
-LDAP 그룹을 |Fess| 역할에 매핑할 수 있습니다.
+``ldap.admin.security.credentials`` 는 ``system.properties`` 에 저장됩니다.
+관리 화면에서 설정한 인증 정보는 내부적으로 암호화되어 저장됩니다.
+파일의 접근 권한을 적절히 제한하세요.
 
 페일오버
-================
+========
 
-여러 LDAP 서버로의 페일오버:
+여러 LDAP 서버로 페일오버하는 경우, ``ldap.provider.url`` 에
+공백으로 구분하여 여러 URL을 지정합니다.
 
 ::
 
-    # 공백 구분으로 여러 URL 지정
     ldap.provider.url=ldap://ldap1.example.com:389 ldap://ldap2.example.com:389
 
 문제 해결
-======================
+=========
 
 연결 오류
-----------
+---------
 
-**증상**: LDAP 연결 실패
+**증상**: LDAP 연결에 실패함
 
 **확인 사항**:
 
 1. LDAP 서버가 실행 중인지
 2. 방화벽에서 포트가 열려 있는지(389 또는 636)
-3. URL이 올바른지(``ldap://`` 또는 ``ldaps://``)
-4. 바인드 DN과 비밀번호가 올바른지
+3. ``ldap.provider.url`` 이 올바른지(``ldap://`` 또는 ``ldaps://``)
+4. ``ldap.admin.security.principal`` 과 비밀번호가 올바른지
 
 인증 오류
-----------
+---------
 
-**증상**: 사용자 인증 실패
-
-**확인 사항**:
-
-1. 사용자 검색 필터가 올바른지
-2. 사용자가 검색 베이스 DN 내에 존재하는지
-3. 사용자명 속성이 올바른지
-
-그룹을 가져올 수 없음
-----------------------
-
-**증상**: 사용자의 그룹을 가져올 수 없음
+**증상**: 사용자 인증에 실패함
 
 **확인 사항**:
 
-1. 그룹 검색 필터가 올바른지
-2. 그룹 멤버십 속성이 올바른지
+1. ``ldap.security.principal`` 의 템플릿이 올바른지(``%s`` 가 포함되어 있는지)
+2. 사용자가 지정한 베이스 DN 내에 존재하는지
+3. ``ldap.account.filter`` 가 올바른지
+
+그룹／역할을 가져올 수 없음
+---------------------------
+
+**증상**: 사용자의 그룹이나 역할을 가져올 수 없음
+
+**확인 사항**:
+
+1. ``ldap.group.filter`` 가 올바른지
+2. ``ldap.memberof.attribute`` 가 올바른지(Active Directory의 경우)
 3. 그룹이 검색 베이스 DN 내에 존재하는지
+4. ``ldap.role.search.*.enabled`` 가 활성화되어 있는지
+
+관리 화면에서 사용자 관리를 할 수 없음
+--------------------------------------
+
+**증상**: 관리 화면에서 LDAP 사용자를 생성·편집·삭제할 수 없음
+
+**확인 사항**:
+
+1. ``ldap.admin.enabled`` 가 ``true`` 로 설정되어 있는지
+2. ``ldap.admin.user.base.dn`` 등의 관리용 베이스 DN이 올바른지
+3. ``ldap.admin.security.principal`` 의 서비스 계정에 쓰기 권한이 있는지
 
 디버그 설정
-------------
+-----------
 
-상세 로그 출력:
-
-``app/WEB-INF/classes/log4j2.xml``:
+상세 로그를 출력하려면, ``app/WEB-INF/classes/log4j2.xml`` 에 로거를 추가합니다.
 
 ::
 
     <Logger name="org.codelibs.fess.ldap" level="DEBUG"/>
 
 참고 정보
-========
+=========
 
 - :doc:`security-role` - 역할 기반 접근 제어
 - :doc:`sso-spnego` - SPNEGO(Kerberos) 인증

--- a/zh-cn/15.7/config/ldap-integration.rst
+++ b/zh-cn/15.7/config/ldap-integration.rst
@@ -1,6 +1,6 @@
-==================================
+==============================
 LDAP集成指南
-==================================
+==============================
 
 概述
 ====
@@ -10,9 +10,9 @@ LDAP集成指南
 
 通过LDAP集成可以实现:
 
-- 使用Active Directory或OpenLDAP进行用户认证
-- 基于组的访问控制
-- 用户信息的自动同步
+- 使用Active Directory或OpenLDAP进行用户认证（登录）
+- 基于组和角色的访问控制
+- 通过管理界面管理LDAP用户/角色/组（可选）
 
 支持的LDAP服务器
 ================
@@ -29,27 +29,81 @@ LDAP集成指南
 ========
 
 - 对LDAP服务器的网络访问
-- LDAP搜索用的服务账号（绑定DN）
+- 用于LDAP搜索的服务账号（绑定DN）
 - 对LDAP结构（基础DN、属性名等）的了解
 
-基本设置
-========
+设置方法概述
+============
 
-在 ``app/WEB-INF/conf/system.properties`` 中添加以下设置。
+|Fess| 的LDAP设置根据用途在两个地方进行管理。
 
-LDAP连接设置
-------------
+连接与认证设置（管理界面 / ``system.properties``）
+   与LDAP服务器的连接及登录认证相关的设置。
+   可通过管理界面 **"系统 > 通用"** 页面中的"LDAP"部分进行设置，
+   保存至 ``app/WEB-INF/conf/system.properties``。
+
+LDAP管理功能与行为设置（``fess_config.properties``）
+   通过管理界面管理LDAP用户/角色/组的功能，
+   以及角色解析等行为相关的设置。这些设置在
+   ``app/WEB-INF/classes/fess_config.properties`` 中定义，
+   如需更改值请编辑此文件。
+
+.. note::
+
+   仅使用登录认证时，只需"连接与认证设置"即可运行。
+   "LDAP管理功能"（``ldap.admin.enabled``）仅在需要通过管理界面
+   对LDAP端的用户/角色/组进行创建、更新、删除时才需要启用。
+
+连接与认证设置
+==============
+
+这些设置可通过管理界面"系统 > 通用"的LDAP部分进行配置，
+保存至 ``app/WEB-INF/conf/system.properties``。也可以直接编辑该文件。
+
+.. list-table:: 连接与认证属性
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - 属性
+     - 默认值
+     - 说明
+   * - ``ldap.provider.url``
+     - （无）
+     - LDAP服务器的URL。例: ``ldap://ldap.example.com:389``。使用LDAPS时为 ``ldaps://ldap.example.com:636``。用空格分隔指定多个URL时可实现故障转移。
+   * - ``ldap.base.dn``
+     - （无）
+     - LDAP搜索的基础DN。例: ``dc=example,dc=com``
+   * - ``ldap.security.principal``
+     - （无）
+     - 用户认证（绑定）所使用的DN模板。``%s`` 将被替换为用户名。例: ``uid=%s,ou=People,dc=example,dc=com``
+   * - ``ldap.security.authentication``
+     - ``simple``
+     - LDAP认证方式（JNDI的 ``java.naming.security.authentication``）。通常使用 ``simple``。
+   * - ``ldap.initial.context.factory``
+     - ``com.sun.jndi.ldap.LdapCtxFactory``
+     - JNDI初始上下文工厂类。通常无需更改。
+   * - ``ldap.admin.security.principal``
+     - （无）
+     - 用于LDAP搜索的服务账号绑定DN。例: ``cn=fess,ou=services,dc=example,dc=com``
+   * - ``ldap.admin.security.credentials``
+     - （无）
+     - 上述服务账号的密码。
+   * - ``ldap.account.filter``
+     - （无）
+     - 解析用户角色时，用于搜索用户条目的过滤器。``%s`` 将被替换为用户名。例: ``uid=%s``
+   * - ``ldap.group.filter``
+     - （空）
+     - 解析组时使用的搜索过滤器。``%s`` 将被替换为用户的DN等。例: ``(member=%s)``
+   * - ``ldap.memberof.attribute``
+     - ``memberOf``
+     - 表示组成员关系的属性名。用于在Active Directory或具有该属性的服务器上解析角色。
+
+设置示例（直接编辑 ``system.properties`` 时）:
 
 ::
 
-    # 启用LDAP认证
-    ldap.admin.enabled=true
-
     # LDAP服务器URL
     ldap.provider.url=ldap://ldap.example.com:389
-
-    # 安全连接（LDAPS）时
-    # ldap.provider.url=ldaps://ldap.example.com:636
 
     # 基础DN
     ldap.base.dn=dc=example,dc=com
@@ -57,103 +111,178 @@ LDAP连接设置
     # 用户认证绑定DN模板（%s将被替换为用户名）
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # 管理绑定DN（LDAP搜索服务账户）
+    # 搜索用服务账号的绑定DN和密码
     ldap.admin.security.principal=cn=fess,ou=services,dc=example,dc=com
-
-    # 管理绑定密码
     ldap.admin.security.credentials=your_password
 
-用户搜索设置
-----------------
-
-::
-
-    # 用户搜索的基础DN
-    ldap.user.search.base=ou=users,dc=example,dc=com
-
-    # 用户搜索过滤器
-    ldap.account.filter=(uid=%s)
-
-    # 用户名属性
-    ldap.user.name.attribute=uid
-
-    # LDAP管理控制台的用户搜索过滤器
-    ldap.admin.user.filter=uid=%s
+    # 角色解析用过滤器
+    ldap.account.filter=uid=%s
+    ldap.group.filter=(member=%s)
 
 .. note::
 
-   ``ldap.account.filter`` 是用户认证时的搜索过滤器，
-   ``ldap.admin.user.filter`` 是LDAP管理画面中的用户搜索过滤器。
-   由于用途不同，请分别进行适当设置。
+   ``%s`` 占位符由Java的 ``String.format()`` 处理。
+   ``ldap.security.principal``、``ldap.account.filter``、``ldap.group.filter`` 以及
+   各管理用过滤器均使用 ``%s`` 格式（而非 ``{0}`` 格式）。
+   另外，传递给过滤器的用户名会由 |Fess| 内部自动转义，以防止LDAP注入攻击。
 
-LDAP管理基础DN设置
---------------------
+LDAP管理功能与行为设置
+======================
+
+以下属性在 ``app/WEB-INF/classes/fess_config.properties`` 中定义。
+如需更改值请编辑此文件。
+
+管理功能的启用
+--------------
+
+.. list-table:: 管理功能属性
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - 属性
+     - 默认值
+     - 说明
+   * - ``ldap.admin.enabled``
+     - ``false``
+     - 启用通过管理界面对LDAP用户/角色/组进行创建、更新、删除的功能。**登录认证不需要此功能**，不启用也可通过LDAP进行登录。
+   * - ``ldap.admin.sync.password``
+     - ``true``
+     - 在管理界面更新用户时，将 |Fess| 端的密码与LDAP同步。
+   * - ``ldap.auth.validation``
+     - ``true``
+     - 登录时执行LDAP认证验证。
+
+用户/角色/组管理用过滤器与基础DN
+---------------------------------
+
+在 ``ldap.admin.enabled=true`` 时，用于通过管理界面操作LDAP条目。
+
+.. list-table:: 管理用过滤器/基础DN
+   :header-rows: 1
+   :widths: 38 47 15
+
+   * - 属性
+     - 说明
+     - 默认值
+   * - ``ldap.admin.user.filter``
+     - 用户搜索过滤器（``%s`` 替换为用户名）
+     - ``uid=%s``
+   * - ``ldap.admin.user.base.dn``
+     - 用户搜索基础DN
+     - ``ou=People,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.user.object.classes``
+     - 创建用户时的objectClass
+     - ``organizationalPerson,top,person,inetOrgPerson``
+   * - ``ldap.admin.role.filter``
+     - 角色搜索过滤器
+     - ``cn=%s``
+   * - ``ldap.admin.role.base.dn``
+     - 角色搜索基础DN
+     - ``ou=Role,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.role.object.classes``
+     - 创建角色时的objectClass
+     - ``groupOfNames``
+   * - ``ldap.admin.group.filter``
+     - 组搜索过滤器
+     - ``cn=%s``
+   * - ``ldap.admin.group.base.dn``
+     - 组搜索基础DN
+     - ``ou=Group,dc=fess,dc=codelibs,dc=org``
+   * - ``ldap.admin.group.object.classes``
+     - 创建组时的objectClass
+     - ``groupOfNames``
+
+角色解析与行为控制
+------------------
+
+控制登录后角色/组解析的行为。
+
+.. list-table:: 行为控制属性
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - 属性
+     - 默认值
+     - 说明
+   * - ``ldap.role.search.user.enabled``
+     - ``true``
+     - 根据用户名授予角色。
+   * - ``ldap.role.search.group.enabled``
+     - ``true``
+     - 根据组授予角色。
+   * - ``ldap.role.search.role.enabled``
+     - ``true``
+     - 根据角色授予角色。
+   * - ``ldap.allow.empty.permission``
+     - ``true``
+     - 允许组/角色为空的用户登录。
+   * - ``ldap.ignore.netbios.name``
+     - ``true``
+     - 从组名等中去除NetBIOS名（``DOMAIN\`` 格式的前缀）。
+   * - ``ldap.group.name.with.underscores``
+     - ``false``
+     - 允许组名中包含下划线。
+   * - ``ldap.lowercase.permission.name``
+     - ``false``
+     - 将权限名转换为小写。
+   * - ``ldap.samaccountname.group``
+     - ``false``
+     - 使用 ``sAMAccountName`` 属性作为组名（适用于Active Directory）。
+   * - ``ldap.max.username.length``
+     - ``-1``
+     - 用户名的最大长度。``-1`` 表示无限制。
+
+属性映射
+--------
+
+LDAP属性与 |Fess| 用户属性的对应关系通过 ``ldap.attr.*`` 属性定义。
+通常无需更改，但在模式不同时可进行调整。典型示例:
 
 ::
 
-    # 用户搜索基础DN
-    ldap.admin.user.base.dn=ou=People,dc=example,dc=com
+    ldap.attr.surname=sn
+    ldap.attr.givenName=givenName
+    ldap.attr.mail=mail
+    ldap.attr.displayName=displayName
+    ldap.attr.telephoneNumber=telephoneNumber
 
-    # 角色搜索基础DN
-    ldap.admin.role.base.dn=ou=Roles,dc=example,dc=com
+.. note::
 
-    # 组搜索基础DN
-    ldap.admin.group.base.dn=ou=Groups,dc=example,dc=com
-
-组搜索设置
-----------------
-
-::
-
-    # 组搜索的基础DN
-    ldap.group.search.base=ou=groups,dc=example,dc=com
-
-    # 组搜索过滤器
-    ldap.group.filter=(member=%s)
-
-    # 组名属性
-    ldap.group.name.attribute=cn
+   ``ldap.attr.state`` 映射到 ``st``，``ldap.attr.city`` 映射到 ``l`` 等，
+   存在属性名与LDAP属性名不一致的情况。
+   完整列表请参考 ``fess_config.properties`` 中以 ``ldap.attr.`` 开头的行。
 
 Active Directory设置
 ====================
 
-针对Microsoft Active Directory的设置示例。
-
-基本设置
---------
+针对Microsoft Active Directory的设置示例（``system.properties`` 或管理界面）。
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://ad.example.com:389
     ldap.base.dn=dc=example,dc=com
 
     # 用户认证绑定DN模板（UPN格式）
     ldap.security.principal=%s@example.com
 
-    # 管理绑定DN（服务账户）
+    # 搜索用服务账号
     ldap.admin.security.principal=cn=fess,cn=Users,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
-    # 用户搜索
-    ldap.user.search.base=ou=Users,dc=example,dc=com
-    ldap.account.filter=(sAMAccountName=%s)
-    ldap.user.name.attribute=sAMAccountName
+    # 账号过滤器
+    ldap.account.filter=sAMAccountName=%s
 
-    # 组搜索
-    ldap.group.search.base=ou=Groups,dc=example,dc=com
+    # 使用memberOf属性
+    ldap.memberof.attribute=memberOf
+
+    # 组过滤器
     ldap.group.filter=(member=%s)
-    ldap.group.name.attribute=cn
 
-Active Directory特定设置
---------------------------
+如需解析嵌套组（嵌套组），可使用Active Directory特有的
+``LDAP_MATCHING_RULE_IN_CHAIN``。
 
 ::
 
-    # 嵌套组解析
-    ldap.memberof.enabled=true
-
-    # 使用memberOf属性
     ldap.group.filter=(member:1.2.840.113556.1.4.1941:=%s)
 
 OpenLDAP设置
@@ -163,29 +292,30 @@ OpenLDAP设置
 
 ::
 
-    ldap.admin.enabled=true
     ldap.provider.url=ldap://openldap.example.com:389
     ldap.base.dn=dc=example,dc=com
 
     # 用户认证绑定DN模板
     ldap.security.principal=uid=%s,ou=People,dc=example,dc=com
 
-    # 管理绑定DN（服务账户）
+    # 搜索用服务账号
     ldap.admin.security.principal=cn=admin,dc=example,dc=com
     ldap.admin.security.credentials=your_password
 
-    # 用户搜索
-    ldap.user.search.base=ou=people,dc=example,dc=com
-    ldap.account.filter=(uid=%s)
-    ldap.user.name.attribute=uid
+    # 账号过滤器
+    ldap.account.filter=uid=%s
 
-    # 组搜索
-    ldap.group.search.base=ou=groups,dc=example,dc=com
+    # 组过滤器（posixGroup时）
     ldap.group.filter=(memberUid=%s)
-    ldap.group.name.attribute=cn
+
+.. note::
+
+   标准OpenLDAP不具有 ``memberOf`` 属性，
+   因此使用 ``ldap.group.filter`` 解析组。
+   若已启用 ``memberof`` overlay，也可使用 ``ldap.memberof.attribute``。
 
 安全设置
-================
+========
 
 LDAPS（SSL/TLS）
 ----------------
@@ -197,9 +327,6 @@ LDAPS（SSL/TLS）
     # 使用LDAPS
     ldap.provider.url=ldaps://ldap.example.com:636
 
-    # 使用StartTLS
-    ldap.start.tls=true
-
 使用自签名证书时，将证书导入Java truststore:
 
 ::
@@ -208,98 +335,27 @@ LDAPS（SSL/TLS）
             -file ldap-server.crt
 
 密码保护
-----------------
-
-使用环境变量设置密码:
-
-::
-
-    ldap.admin.security.credentials=${LDAP_PASSWORD}
-
-角色映射
-================
-
-可以将LDAP组映射到 |Fess| 的角色。
-
-自动映射
---------------
-
-组名直接用作角色名:
-
-::
-
-    # LDAP组 "fess-users" → Fess角色 "fess-users"
-    ldap.group.role.mapping.enabled=true
-
-自定义映射
-------------------
-
-::
-
-    # 组名映射到角色
-    ldap.group.role.mapping.Administrators=admin
-    ldap.group.role.mapping.PowerUsers=editor
-    ldap.group.role.mapping.Users=guest
-
-用户信息同步
-==================
-
-可以将LDAP中的用户信息同步到 |Fess|。
-
-自动同步
 --------
 
-登录时自动同步用户信息:
-
-::
-
-    ldap.user.sync.enabled=true
-
-同步的属性
-------------
-
-::
-
-    # 邮箱地址
-    ldap.user.email.attribute=mail
-
-    # 显示名
-    ldap.user.displayname.attribute=displayName
-
-连接池
-==============
-
-用于提高性能的连接池设置:
-
-::
-
-    # 启用连接池
-    ldap.connection.pool.enabled=true
-
-    # 最小连接数
-    ldap.connection.pool.min=1
-
-    # 最大连接数
-    ldap.connection.pool.max=10
-
-    # 连接超时（毫秒）
-    ldap.connection.timeout=5000
+``ldap.admin.security.credentials`` 保存在 ``system.properties`` 中。
+通过管理界面设置的认证信息会在内部加密后保存。
+请对文件访问权限进行适当限制。
 
 故障转移
-================
+========
 
-多LDAP服务器的故障转移:
+如需对多个LDAP服务器进行故障转移，在 ``ldap.provider.url`` 中
+用空格分隔指定多个URL。
 
 ::
 
-    # 用空格分隔指定多个URL
     ldap.provider.url=ldap://ldap1.example.com:389 ldap://ldap2.example.com:389
 
 故障排除
-======================
+========
 
 连接错误
-----------
+--------
 
 **症状**: LDAP连接失败
 
@@ -307,37 +363,47 @@ LDAPS（SSL/TLS）
 
 1. LDAP服务器是否已启动
 2. 防火墙是否开放端口（389或636）
-3. URL是否正确（``ldap://`` 或 ``ldaps://``）
-4. 绑定DN和密码是否正确
+3. ``ldap.provider.url`` 是否正确（``ldap://`` 或 ``ldaps://``）
+4. ``ldap.admin.security.principal`` 和密码是否正确
 
 认证错误
-----------
+--------
 
 **症状**: 用户认证失败
 
 **确认事项**:
 
-1. 用户搜索过滤器是否正确
-2. 用户是否存在于搜索基础DN内
-3. 用户名属性是否正确
+1. ``ldap.security.principal`` 的模板是否正确（是否包含 ``%s``）
+2. 用户是否存在于指定基础DN内
+3. ``ldap.account.filter`` 是否正确
 
-无法获取组
-----------------------
+无法获取组/角色
+---------------
 
-**症状**: 无法获取用户的组
+**症状**: 无法获取用户的组或角色
 
 **确认事项**:
 
-1. 组搜索过滤器是否正确
-2. 组的成员属性是否正确
+1. ``ldap.group.filter`` 是否正确
+2. ``ldap.memberof.attribute`` 是否正确（Active Directory时）
 3. 组是否存在于搜索基础DN内
+4. ``ldap.role.search.*.enabled`` 是否已启用
+
+无法通过管理界面管理用户
+------------------------
+
+**症状**: 无法通过管理界面创建、编辑、删除LDAP用户
+
+**确认事项**:
+
+1. ``ldap.admin.enabled`` 是否设置为 ``true``
+2. ``ldap.admin.user.base.dn`` 等管理用基础DN是否正确
+3. ``ldap.admin.security.principal`` 的服务账号是否具有写入权限
 
 调试设置
-------------
+--------
 
-输出详细日志:
-
-``app/WEB-INF/classes/log4j2.xml``:
+如需输出详细日志，在 ``app/WEB-INF/classes/log4j2.xml`` 中添加日志记录器。
 
 ::
 


### PR DESCRIPTION
## Summary

Revises the LDAP integration guide (`config/ldap-integration.rst`) for version 15.7 to match the actual Fess implementation, and applies the same corrections across all languages (ja, en, de, es, fr, ko, zh-cn).

The previous content had several technical inaccuracies, most importantly the meaning of `ldap.admin.enabled`, and omitted many configuration properties.

## Key corrections

- **`ldap.admin.enabled` semantics fixed.** It was documented as the switch to "enable LDAP authentication" with a sample value of `true`. In reality it enables managing LDAP users/roles/groups from the admin UI (default: `false`) and is **not** required for LDAP login authentication. Verified via `FessProp.isLdapAdminEnabled()` and its call sites in `LdapManager`, `LdapUser`, and `AdminUserAction`.
- **Configuration locations clarified.** Split settings into:
  - *Connection/authentication settings* — configured via the admin UI "System > General" (LDAP section) and stored in `system.properties` (accessed through `getSystemProperty()`).
  - *Administration/behavior settings* — defined in `fess_config.properties`.
- **Admin UI documented** as the primary way to configure connection settings (previously only file editing was mentioned).
- **Missing properties added** with correct defaults: `ldap.security.authentication` (`simple`), `ldap.initial.context.factory`, `ldap.admin.*.object.classes`, `ldap.admin.sync.password`, `ldap.auth.validation`, `ldap.role.search.*.enabled`, behavior flags (`ldap.allow.empty.permission`, `ldap.ignore.netbios.name`, etc.), `ldap.max.username.length`, and `ldap.attr.*` attribute mappings.
- **Default base DNs corrected** to the actual values (`ou=Role`, `ou=Group`, singular).
- **Placeholder format clarified** — all filter properties use the `%s` format (`String.format()`), and user input is escaped internally against LDAP injection.

## Verification

- All property keys cross-checked against `Constants.java`, `fess_config.properties`, and `FessProp.java` / `FessConfig.java`.
- All 7 language files share an identical set of 41 property keys (no fabricated or missing keys).
- RST heading underline lengths validated (East Asian width aware); no issues.
- Cross-reference targets (`security-role`, `sso-spnego`, `../admin/user-guide`) confirmed to exist.

