### PR TITLE
docs(api): fix paging defaults and add cross-references in 15.7 API quickstart

### DIFF
--- a/de/15.7/api/api-quickstart.rst
+++ b/de/15.7/api/api-quickstart.rst
@@ -24,10 +24,10 @@ Der v2-Such-Endpunkt ist ``GET /api/v2/search``.
     # Einfache Suche
     curl "http://localhost:8080/api/v2/search?q=fess"
 
-    # 20 Suchergebnisse abrufen
+    # 20 Suchergebnisse abrufen (num ist die Seitengröße; Standard ist 10)
     curl "http://localhost:8080/api/v2/search?q=fess&num=20"
 
-    # Seite 2 abrufen (ab Ergebnis 21)
+    # Die ersten 20 Ergebnisse überspringen (start ist die 0-basierte Startposition)
     curl "http://localhost:8080/api/v2/search?q=fess&start=20"
 
     # Suche mit Label-Filter
@@ -50,7 +50,7 @@ v2-Antworten werden im ``response``-Envelope zurückgegeben.
         "status": 0,
         "q": "fess",
         "record_count": 125,
-        "page_size": 20,
+        "page_size": 10,
         "page_number": 1,
         "data": [
           {
@@ -63,6 +63,13 @@ v2-Antworten werden im ``response``-Envelope zurückgegeben.
         ]
       }
     }
+
+.. note::
+
+   Das obige Beispiel ist repräsentativ. Die in ``data`` enthaltenen Dokumentfelder hängen von
+   der Serverkonfiguration ab (der Allowlist für Antwortfelder). Eine vollständige Liste der
+   verfügbaren Anfrageparameter und Antwortfelder finden Sie unter :doc:`api-search`. Für den
+   gemeinsamen Antwort-Envelope, das Fehlermodell und CSRF siehe :doc:`api-overview`.
 
 Die Vorschlags-API ausprobieren
 ---------------------------------
@@ -301,6 +308,9 @@ API funktioniert nicht
 Nächste Schritte
 ================
 
+- :doc:`api-overview` - Allgemeine API-Spezifikationen (Antwort-Envelope, Fehlermodell, Authentifizierung/CSRF)
 - :doc:`api-search` - Details zur Such-API
 - :doc:`api-suggest` - Details zur Vorschlags-API
+- :doc:`api-label` - Details zur Label-API
+- :doc:`api-health` - Details zur Health-Check-API
 - :doc:`admin/index` - Verwendung der Verwaltungs-API

--- a/en/15.7/api/api-quickstart.rst
+++ b/en/15.7/api/api-quickstart.rst
@@ -24,10 +24,10 @@ The v2 search endpoint is ``GET /api/v2/search``.
     # Basic search
     curl "http://localhost:8080/api/v2/search?q=fess"
 
-    # Get 20 search results
+    # Get 20 search results (num is the page size; default is 10)
     curl "http://localhost:8080/api/v2/search?q=fess&num=20"
 
-    # Get page 2 (starting from result 21)
+    # Skip the first 20 results (start is the 0-based start position)
     curl "http://localhost:8080/api/v2/search?q=fess&start=20"
 
     # Search with label filter
@@ -50,7 +50,7 @@ v2 responses are returned in the ``response`` envelope.
         "status": 0,
         "q": "fess",
         "record_count": 125,
-        "page_size": 20,
+        "page_size": 10,
         "page_number": 1,
         "data": [
           {
@@ -63,6 +63,13 @@ v2 responses are returned in the ``response`` envelope.
         ]
       }
     }
+
+.. note::
+
+   The example above is representative. The document fields included in ``data`` depend on
+   the server configuration (the response-field allowlist). For the full list of available
+   request parameters and response fields, see :doc:`api-search`. For the common response
+   envelope, error model, and CSRF, see :doc:`api-overview`.
 
 Try the Suggest API
 -------------------
@@ -301,6 +308,9 @@ API Not Working
 Next Steps
 ==========
 
+- :doc:`api-overview` - Common API specifications (response envelope, error model, authentication/CSRF)
 - :doc:`api-search` - Search API details
 - :doc:`api-suggest` - Suggest API details
+- :doc:`api-label` - Label API details
+- :doc:`api-health` - Health Check API details
 - :doc:`admin/index` - Admin API usage

--- a/es/15.7/api/api-quickstart.rst
+++ b/es/15.7/api/api-quickstart.rst
@@ -24,10 +24,10 @@ El endpoint de búsqueda v2 es ``GET /api/v2/search``.
     # Búsqueda básica
     curl "http://localhost:8080/api/v2/search?q=fess"
 
-    # Obtener 20 resultados de búsqueda
+    # Obtener 20 resultados de búsqueda (num es el tamaño de página; el valor predeterminado es 10)
     curl "http://localhost:8080/api/v2/search?q=fess&num=20"
 
-    # Obtener la página 2 (comenzando desde el resultado 21)
+    # Omitir los primeros 20 resultados (start es la posición inicial basada en 0)
     curl "http://localhost:8080/api/v2/search?q=fess&start=20"
 
     # Búsqueda con filtro de etiquetas
@@ -50,7 +50,7 @@ La respuesta de v2 se devuelve en el sobre ``response``.
         "status": 0,
         "q": "fess",
         "record_count": 125,
-        "page_size": 20,
+        "page_size": 10,
         "page_number": 1,
         "data": [
           {
@@ -63,6 +63,13 @@ La respuesta de v2 se devuelve en el sobre ``response``.
         ]
       }
     }
+
+.. note::
+
+   El ejemplo anterior es representativo. Los campos de documento incluidos en ``data`` dependen
+   de la configuración del servidor (la lista de campos de respuesta permitidos). Para la lista
+   completa de parámetros de solicitud y campos de respuesta disponibles, consulte :doc:`api-search`.
+   Para el sobre de respuesta común, el modelo de error y CSRF, consulte :doc:`api-overview`.
 
 Pruebe la API de sugerencias
 -----------------------------
@@ -301,6 +308,9 @@ La API no funciona
 Próximos pasos
 ==============
 
+- :doc:`api-overview` - Especificaciones comunes de la API (sobre de respuesta, modelo de error, autenticación/CSRF)
 - :doc:`api-search` - Detalles de la API de búsqueda
 - :doc:`api-suggest` - Detalles de la API de sugerencias
+- :doc:`api-label` - Detalles de la API de etiquetas
+- :doc:`api-health` - Detalles de la API de verificación de estado
 - :doc:`admin/index` - Uso de la API de administración

--- a/fr/15.7/api/api-quickstart.rst
+++ b/fr/15.7/api/api-quickstart.rst
@@ -24,10 +24,10 @@ Le point de terminaison de recherche v2 est ``GET /api/v2/search``.
     # Recherche simple
     curl "http://localhost:8080/api/v2/search?q=fess"
 
-    # Obtenir 20 résultats de recherche
+    # Obtenir 20 résultats de recherche (num est la taille de page ; la valeur par défaut est 10)
     curl "http://localhost:8080/api/v2/search?q=fess&num=20"
 
-    # Obtenir la page 2 (à partir du résultat 21)
+    # Ignorer les 20 premiers résultats (start est la position de départ, indexée à partir de 0)
     curl "http://localhost:8080/api/v2/search?q=fess&start=20"
 
     # Recherche avec filtre par étiquette
@@ -50,7 +50,7 @@ Les réponses v2 sont encapsulées dans l'enveloppe ``response``.
         "status": 0,
         "q": "fess",
         "record_count": 125,
-        "page_size": 20,
+        "page_size": 10,
         "page_number": 1,
         "data": [
           {
@@ -63,6 +63,13 @@ Les réponses v2 sont encapsulées dans l'enveloppe ``response``.
         ]
       }
     }
+
+.. note::
+
+   L'exemple ci-dessus est représentatif. Les champs de document inclus dans ``data`` dépendent
+   de la configuration du serveur (la liste d'autorisation des champs de réponse). Pour la liste
+   complète des paramètres de requête et des champs de réponse disponibles, voir :doc:`api-search`.
+   Pour l'enveloppe de réponse commune, le modèle d'erreur et le CSRF, voir :doc:`api-overview`.
 
 Essayer l'API de suggestions
 ------------------------------
@@ -301,6 +308,9 @@ L'API ne fonctionne pas
 Prochaines étapes
 ==================
 
+- :doc:`api-overview` - Spécifications communes de l'API (enveloppe de réponse, modèle d'erreur, authentification/CSRF)
 - :doc:`api-search` - Détails de l'API de recherche
 - :doc:`api-suggest` - Détails de l'API de suggestions
+- :doc:`api-label` - Détails de l'API des étiquettes
+- :doc:`api-health` - Détails de l'API de contrôle de santé
 - :doc:`admin/index` - Utilisation de l'API d'administration

--- a/ja/15.7/api/api-quickstart.rst
+++ b/ja/15.7/api/api-quickstart.rst
@@ -24,10 +24,10 @@ v2 の検索エンドポイントは ``GET /api/v2/search`` です。
     # 基本的な検索
     curl "http://localhost:8080/api/v2/search?q=fess"
 
-    # 検索結果を20件取得
+    # 検索結果を20件取得（num はページサイズ。既定値は 10）
     curl "http://localhost:8080/api/v2/search?q=fess&num=20"
 
-    # 2ページ目を取得（21件目から）
+    # 先頭20件をスキップして取得（start は0始まりの開始位置）
     curl "http://localhost:8080/api/v2/search?q=fess&start=20"
 
     # ラベルを指定して検索
@@ -50,7 +50,7 @@ v2 のレスポンスは ``response`` エンベロープで返されます。
         "status": 0,
         "q": "fess",
         "record_count": 125,
-        "page_size": 20,
+        "page_size": 10,
         "page_number": 1,
         "data": [
           {
@@ -63,6 +63,13 @@ v2 のレスポンスは ``response`` エンベロープで返されます。
         ]
       }
     }
+
+.. note::
+
+   上記は代表的な例です。 ``data`` に含まれるドキュメントのフィールドは、サーバーの設定
+   （応答フィールドの許可リスト）に依存します。利用可能なリクエストパラメーターと
+   レスポンスフィールドの全一覧は :doc:`api-search` を、共通のレスポンスエンベロープ・
+   エラーモデル・CSRF については :doc:`api-overview` を参照してください。
 
 サジェストAPIを試す
 ----------------
@@ -301,6 +308,9 @@ APIが動作しない場合
 次のステップ
 ==========
 
+- :doc:`api-overview` - APIの共通仕様（レスポンスエンベロープ、エラーモデル、認証/CSRF）
 - :doc:`api-search` - 検索APIの詳細
 - :doc:`api-suggest` - サジェストAPIの詳細
+- :doc:`api-label` - ラベルAPIの詳細
+- :doc:`api-health` - ヘルスチェックAPIの詳細
 - :doc:`admin/index` - 管理APIの利用方法

--- a/ko/15.7/api/api-quickstart.rst
+++ b/ko/15.7/api/api-quickstart.rst
@@ -24,10 +24,10 @@ v2 의 검색 엔드포인트는 ``GET /api/v2/search`` 입니다.
     # 기본 검색
     curl "http://localhost:8080/api/v2/search?q=fess"
 
-    # 검색 결과를 20건 취득
+    # 검색 결과를 20건 취득 (num 은 페이지 크기; 기본값은 10)
     curl "http://localhost:8080/api/v2/search?q=fess&num=20"
 
-    # 2페이지 취득 (21번째부터)
+    # 처음 20건을 건너뜀 (start 는 0부터 시작하는 시작 위치)
     curl "http://localhost:8080/api/v2/search?q=fess&start=20"
 
     # 레이블을 지정하여 검색
@@ -50,7 +50,7 @@ v2 의 응답은 ``response`` 엔벨로프로 반환됩니다.
         "status": 0,
         "q": "fess",
         "record_count": 125,
-        "page_size": 20,
+        "page_size": 10,
         "page_number": 1,
         "data": [
           {
@@ -63,6 +63,10 @@ v2 의 응답은 ``response`` 엔벨로프로 반환됩니다.
         ]
       }
     }
+
+.. note::
+
+   위의 예는 대표적인 예시입니다. ``data`` 에 포함되는 문서 필드는 서버 설정 (응답 필드 허용 목록) 에 따라 다릅니다. 사용 가능한 요청 파라미터 및 응답 필드의 전체 목록은 :doc:`api-search` 를 참조하십시오. 공통 응답 엔벨로프, 오류 모델, CSRF 에 대해서는 :doc:`api-overview` 를 참조하십시오.
 
 자동완성 API 시험하기
 ---------------------
@@ -301,6 +305,9 @@ API 가 동작하지 않는 경우
 다음 단계
 =========
 
+- :doc:`api-overview` - 공통 API 사양 (응답 엔벨로프, 오류 모델, 인증/CSRF)
 - :doc:`api-search` - 검색 API 상세
 - :doc:`api-suggest` - 자동완성 API 상세
+- :doc:`api-label` - 레이블 API 상세
+- :doc:`api-health` - 헬스 체크 API 상세
 - :doc:`admin/index` - 관리 API 사용법

--- a/zh-cn/15.7/api/api-quickstart.rst
+++ b/zh-cn/15.7/api/api-quickstart.rst
@@ -24,10 +24,10 @@ v2 的搜索端点为 ``GET /api/v2/search``\ 。
     # 基本搜索
     curl "http://localhost:8080/api/v2/search?q=fess"
 
-    # 获取 20 条搜索结果
+    # 获取 20 条搜索结果（num 为每页条数，默认值为 10）
     curl "http://localhost:8080/api/v2/search?q=fess&num=20"
 
-    # 获取第 2 页（从第 21 条开始）
+    # 跳过前 20 条结果（start 为从 0 开始的起始位置）
     curl "http://localhost:8080/api/v2/search?q=fess&start=20"
 
     # 使用标签过滤搜索
@@ -50,7 +50,7 @@ v2 的响应以 ``response`` 信封返回。
         "status": 0,
         "q": "fess",
         "record_count": 125,
-        "page_size": 20,
+        "page_size": 10,
         "page_number": 1,
         "data": [
           {
@@ -63,6 +63,12 @@ v2 的响应以 ``response`` 信封返回。
         ]
       }
     }
+
+.. note::
+
+   上述示例仅供参考。``data`` 中包含的文档字段取决于服务器配置（响应字段白名单）。
+   完整的请求参数和响应字段列表，请参阅 :doc:`api-search`。
+   公共响应信封、错误模型及 CSRF 的说明，请参阅 :doc:`api-overview`。
 
 尝试建议词 API
 --------------
@@ -301,6 +307,9 @@ API 无法正常工作
 下一步
 ======
 
+- :doc:`api-overview` - 通用 API 规范（响应信封、错误模型、认证/CSRF）
 - :doc:`api-search` - 搜索 API 详细说明
 - :doc:`api-suggest` - 建议词 API 详细说明
+- :doc:`api-label` - 标签 API 详细说明
+- :doc:`api-health` - 健康检查 API 详细说明
 - :doc:`admin/index` - 管理 API 的使用方法


### PR DESCRIPTION
## Summary

Reviewed `15.7/api/api-quickstart.rst` against the actual Fess 15.7 `/api/v2` implementation (`SearchApiV2Manager`, `V2JsonRequestParams`, `SearchHandler`) and fixed a few accuracy issues, then added cross-references for clarity. The documented v2 endpoints, parameters, and response envelope were otherwise confirmed correct.

## Changes

- **Default page size**: the search response example showed `page_size: 20` with no `num` parameter, but the actual default page size is `10` (`paging.search.page.size`). Corrected to `10`.
- **Paging comment**: the `start=20` example was commented as "get page 2 (from result 21)", which conflates the 0-based record offset with a page number (with the default page size of 10, `start=20` is page 3). Reworded to describe `start` as the 0-based start position that skips the first 20 results.
- **`num` clarification**: noted that `num` is the page size and its default is `10`.
- **Response fields note**: added a note that the document fields in `data` depend on the server's response-field allowlist (`QueryFieldConfig#isApiResponseField`), with links to `api-search` (full parameter/field reference) and `api-overview` (common envelope, error model, CSRF).
- **Next Steps**: added `api-overview`, `api-label`, and `api-health` links.

## Languages

Applied consistently across all 7 languages: `ja`, `en`, `de`, `es`, `fr`, `ko`, `zh-cn`.