### PR TITLE
docs(api): fix Popular Words API property name to web.api.popularword

### DIFF
--- a/de/15.7/api/api-popularword.rst
+++ b/de/15.7/api/api-popularword.rst
@@ -15,7 +15,7 @@ Endpunkt             ``/api/v2/popular-words``
 
 Durch Senden einer Anfrage wie ``http://<Server Name>/api/v2/popular-words?seed=123`` an |Fess| können Sie eine Liste beliebter Suchbegriffe im JSON-Format erhalten.
 
-Wenn ``web.api.popular.word=false`` gesetzt ist, gibt diese API ``invalid_request`` (HTTP 400) zurück (entspricht dem Verhalten „unsupported operation" in v1).
+Wenn ``web.api.popularword=false`` gesetzt ist, gibt diese API ``invalid_request`` (HTTP 400) zurück (entspricht dem Verhalten „unsupported operation" in v1).
 
 Informationen zum gemeinsamen Antwort-Envelope und zum Fehlermodell finden Sie unter :doc:`api-overview`.
 
@@ -87,7 +87,7 @@ Wenn die Beliebte-Wörter-API fehlschlägt, wird der gemeinsame Fehler-Envelope 
    * - Statuscode
      - Beschreibung
    * - 400 Bad Request
-     - Wenn die Anfrage ungültig ist (einschließlich des Falls, dass die Funktion durch ``web.api.popular.word=false`` deaktiviert ist). ``error.code`` ist ``invalid_request``.
+     - Wenn die Anfrage ungültig ist (einschließlich des Falls, dass die Funktion durch ``web.api.popularword=false`` deaktiviert ist). ``error.code`` ist ``invalid_request``.
    * - 405 Method Not Allowed
      - Wenn eine nicht unterstützte HTTP-Methode angegeben wurde.
    * - 500 Internal Server Error

--- a/en/15.7/api/api-popularword.rst
+++ b/en/15.7/api/api-popularword.rst
@@ -15,7 +15,7 @@ Endpoint            ``/api/v2/popular-words``
 
 By sending a request to |Fess| such as ``http://<Server Name>/api/v2/popular-words?seed=123``, you can receive a list of popular search words in JSON format.
 
-If ``web.api.popular.word=false``, this API returns ``invalid_request`` (HTTP 400) (equivalent to the "unsupported operation" behavior in v1).
+If ``web.api.popularword=false``, this API returns ``invalid_request`` (HTTP 400) (equivalent to the "unsupported operation" behavior in v1).
 
 For the common response envelope and error model, see :doc:`api-overview`.
 
@@ -87,7 +87,7 @@ When the Popular Words API fails, a common error envelope is returned. For detai
    * - Status Code
      - Description
    * - 400 Bad Request
-     - The request is invalid (including when the feature is disabled with ``web.api.popular.word=false``). The ``error.code`` is ``invalid_request``.
+     - The request is invalid (including when the feature is disabled with ``web.api.popularword=false``). The ``error.code`` is ``invalid_request``.
    * - 405 Method Not Allowed
      - An unsupported HTTP method was specified.
    * - 500 Internal Server Error

--- a/es/15.7/api/api-popularword.rst
+++ b/es/15.7/api/api-popularword.rst
@@ -15,7 +15,7 @@ Endpoint            ``/api/v2/popular-words``
 
 Al enviar a |Fess| una solicitud como ``http://<Server Name>/api/v2/popular-words?seed=123``, puede recibir en formato JSON una lista de palabras de búsqueda populares.
 
-Cuando ``web.api.popular.word=false``, esta API devuelve ``invalid_request`` (HTTP 400) (comportamiento equivalente a "unsupported operation" de v1).
+Cuando ``web.api.popularword=false``, esta API devuelve ``invalid_request`` (HTTP 400) (comportamiento equivalente a "unsupported operation" de v1).
 
 Para el sobre de respuesta común y el modelo de errores, consulte :doc:`api-overview`.
 
@@ -87,7 +87,7 @@ Si la API de palabras populares falla, se devuelve el sobre de error común. Con
    * - Código de estado
      - Descripción
    * - 400 Bad Request
-     - Cuando la solicitud no es válida (incluye el caso en que la funcionalidad está deshabilitada con ``web.api.popular.word=false``). El ``error.code`` es ``invalid_request``.
+     - Cuando la solicitud no es válida (incluye el caso en que la funcionalidad está deshabilitada con ``web.api.popularword=false``). El ``error.code`` es ``invalid_request``.
    * - 405 Method Not Allowed
      - Cuando se especifica un método HTTP no admitido.
    * - 500 Internal Server Error

--- a/fr/15.7/api/api-popularword.rst
+++ b/fr/15.7/api/api-popularword.rst
@@ -15,7 +15,7 @@ Point de terminaison  ``/api/v2/popular-words``
 
 En envoyant une requête à |Fess| de type ``http://<Server Name>/api/v2/popular-words?seed=123``, vous pouvez recevoir au format JSON la liste des mots de recherche populaires.
 
-Lorsque ``web.api.popular.word=false``, cette API retourne ``invalid_request`` (HTTP 400) (comportement équivalent à « unsupported operation » en v1).
+Lorsque ``web.api.popularword=false``, cette API retourne ``invalid_request`` (HTTP 400) (comportement équivalent à « unsupported operation » en v1).
 
 Pour l'enveloppe de réponse commune et le modèle d'erreur, voir :doc:`api-overview`.
 
@@ -87,7 +87,7 @@ En cas d'échec de l'API des mots populaires, l'enveloppe d'erreur commune est r
    * - Code de statut
      - Description
    * - 400 Bad Request
-     - La requête est incorrecte (y compris lorsque la fonctionnalité est désactivée via ``web.api.popular.word=false``). ``error.code`` vaut ``invalid_request``.
+     - La requête est incorrecte (y compris lorsque la fonctionnalité est désactivée via ``web.api.popularword=false``). ``error.code`` vaut ``invalid_request``.
    * - 405 Method Not Allowed
      - Une méthode HTTP non prise en charge a été spécifiée.
    * - 500 Internal Server Error

--- a/ja/15.7/api/api-popularword.rst
+++ b/ja/15.7/api/api-popularword.rst
@@ -15,7 +15,7 @@ HTTPメソッド         GET
 
 |Fess| に、 ``http://<Server Name>/api/v2/popular-words?seed=123`` のようなリクエストを送ることで、人気検索ワードの一覧をJSON形式で受け取ることができます。
 
-``web.api.popular.word=false`` の場合、このAPIは ``invalid_request`` （HTTP 400）を返します（v1 の「unsupported operation」相当の挙動です）。
+``web.api.popularword=false`` の場合、このAPIは ``invalid_request`` （HTTP 400）を返します（v1 の「unsupported operation」相当の挙動です）。
 
 レスポンスの共通エンベロープおよびエラーモデルについては :doc:`api-overview` を参照してください。
 
@@ -87,7 +87,7 @@ curlコマンドでのリクエスト例:
    * - ステータスコード
      - 説明
    * - 400 Bad Request
-     - リクエストが不正な場合（ ``web.api.popular.word=false`` で機能が無効な場合を含む）。 ``error.code`` は ``invalid_request`` です。
+     - リクエストが不正な場合（ ``web.api.popularword=false`` で機能が無効な場合を含む）。 ``error.code`` は ``invalid_request`` です。
    * - 405 Method Not Allowed
      - サポートされていない HTTP メソッドが指定された場合。
    * - 500 Internal Server Error

--- a/ko/15.7/api/api-popularword.rst
+++ b/ko/15.7/api/api-popularword.rst
@@ -15,7 +15,7 @@ HTTP 메서드          GET
 
 |Fess| 에 ``http://<Server Name>/api/v2/popular-words?seed=123`` 와 같은 요청을 전송하면 인기 검색어 목록을 JSON 형식으로 받을 수 있습니다.
 
-``web.api.popular.word=false`` 인 경우 이 API 는 ``invalid_request`` (HTTP 400) 를 반환합니다 (v1 의 "unsupported operation" 에 해당하는 동작입니다).
+``web.api.popularword=false`` 인 경우 이 API 는 ``invalid_request`` (HTTP 400) 를 반환합니다 (v1 의 "unsupported operation" 에 해당하는 동작입니다).
 
 응답 공통 엔벨로프 및 오류 모델에 대해서는 :doc:`api-overview` 를 참조하십시오.
 
@@ -87,7 +87,7 @@ curl 명령으로 요청 예:
    * - 상태 코드
      - 설명
    * - 400 Bad Request
-     - 요청이 잘못된 경우 ( ``web.api.popular.word=false`` 로 기능이 비활성화된 경우 포함). ``error.code`` 는 ``invalid_request`` 입니다.
+     - 요청이 잘못된 경우 ( ``web.api.popularword=false`` 로 기능이 비활성화된 경우 포함). ``error.code`` 는 ``invalid_request`` 입니다.
    * - 405 Method Not Allowed
      - 지원되지 않는 HTTP 메서드가 지정된 경우.
    * - 500 Internal Server Error

--- a/zh-cn/15.7/api/api-popularword.rst
+++ b/zh-cn/15.7/api/api-popularword.rst
@@ -15,7 +15,7 @@ HTTP 方法            GET
 
 向 |Fess| 发送 ``http://<Server Name>/api/v2/popular-words?seed=123`` 等形式的请求，可以获取热门搜索词列表（JSON 格式）。
 
-若 ``web.api.popular.word=false``\ ，则此 API 返回 ``invalid_request``\ （HTTP 400）（相当于 v1 中"unsupported operation"的行为）。
+若 ``web.api.popularword=false``\ ，则此 API 返回 ``invalid_request``\ （HTTP 400）（相当于 v1 中"unsupported operation"的行为）。
 
 有关公共响应信封及错误模型，请参阅 :doc:`api-overview`。
 
@@ -87,7 +87,7 @@ HTTP 方法            GET
    * - 状态码
      - 说明
    * - 400 Bad Request
-     - 请求不合法时（包括 ``web.api.popular.word=false`` 导致功能禁用的情形）。\ ``error.code`` 为 ``invalid_request``\ 。
+     - 请求不合法时（包括 ``web.api.popularword=false`` 导致功能禁用的情形）。\ ``error.code`` 为 ``invalid_request``\ 。
    * - 405 Method Not Allowed
      - 指定了不支持的 HTTP 方法时。
    * - 500 Internal Server Error


### PR DESCRIPTION
## Summary

The 15.7 **Popular Words API** docs (`/api/v2/popular-words`) referenced the controlling config property as `web.api.popular.word`, but the actual property name in the Fess source is **`web.api.popularword`** (no dot before "word").

- Source of truth: `Constants.WEB_API_POPULAR_WORD_PROPERTY = "web.api.popularword"` (`repos/fess`, `org/codelibs/fess/Constants.java`), used by `FessProp.isWebApiPopularWord()` and checked in `SearchApiV2Manager.handlePopularWords()`.

Each language doc had two occurrences (the "feature disabled" note and the 400 error-table row); both are corrected.

## Changes

- Fixed `web.api.popular.word` → `web.api.popularword` in `15.7/api/api-popularword.rst` for all seven languages: `de`, `en`, `es`, `fr`, `ja`, `ko`, `zh-cn`.

## Verification

The rest of each document was reviewed against the v2 implementation (`SearchApiV2Manager.handlePopularWords`, `V2EnvelopeWriter`, `PopularWordHelper`) and confirmed accurate:

- **Endpoint / method**: `GET /api/v2/popular-words` ✓
- **Parameters**: `seed` (string), `label` (repeatable), `field` (repeatable) ✓
- **Response envelope**: `response.status` / `record_count` / `popular_words` (array of strings) ✓
- **Disabled behavior**: returns `invalid_request` (HTTP 400) ✓
- **Error table**: 400 / 405 / 500 ✓ (403/CSRF does not apply — GET is always CSRF-exempt)

No content changes other than the property-name correction.