### PR TITLE
docs(api): correct ping_status in v2 Health API (15.7)

### DIFF
--- a/de/15.7/api/api-health.rst
+++ b/de/15.7/api/api-health.rst
@@ -36,7 +36,7 @@ Die einzelnen Felder von ``engine`` sind wie folgt:
    * - ``status``
      - Clusterstatus. Einer der Werte ``green`` / ``yellow`` / ``red``.
    * - ``ping_status``
-     - Ping-Statuscode (int).
+     - Ping-Statuscode (int). Der Wert ist ``1``, wenn der Cluster ``red`` ist, und ``0`` andernfalls (``green`` / ``yellow``).
 
 Tabelle: engine-Felder
 
@@ -77,7 +77,7 @@ Wenn der Cluster ``red`` ist (503), wird ein Fehler-Envelope zurückgegeben, und
             "engine": {
               "cluster_name": "fess-es",
               "status": "red",
-              "ping_status": 2
+              "ping_status": 1
             }
           }
         }

--- a/en/15.7/api/api-health.rst
+++ b/en/15.7/api/api-health.rst
@@ -36,7 +36,7 @@ The fields of ``engine`` are as follows:
    * - ``status``
      - Cluster status. One of ``green``, ``yellow``, or ``red``.
    * - ``ping_status``
-     - Ping status (int).
+     - Ping status (int). It is ``1`` when the cluster status is ``red``, and ``0`` otherwise (``green`` or ``yellow``).
 
 Table: engine Fields
 
@@ -77,7 +77,7 @@ When the cluster is ``red`` (503), an error envelope is returned with the engine
             "engine": {
               "cluster_name": "fess-es",
               "status": "red",
-              "ping_status": 2
+              "ping_status": 1
             }
           }
         }

--- a/es/15.7/api/api-health.rst
+++ b/es/15.7/api/api-health.rst
@@ -36,7 +36,7 @@ Los campos de ``engine`` son los siguientes:
    * - ``status``
      - Estado del clúster. Uno de ``green`` / ``yellow`` / ``red``.
    * - ``ping_status``
-     - Estado del ping (int).
+     - Estado del ping (int). Es ``1`` cuando el clúster está en ``red``, y ``0`` en caso contrario (``green`` / ``yellow``).
 
 Tabla: Campos de engine
 
@@ -77,7 +77,7 @@ Cuando el clúster está en estado ``red`` (503), se devuelve el sobre de error 
             "engine": {
               "cluster_name": "fess-es",
               "status": "red",
-              "ping_status": 2
+              "ping_status": 1
             }
           }
         }

--- a/fr/15.7/api/api-health.rst
+++ b/fr/15.7/api/api-health.rst
@@ -36,7 +36,7 @@ Les champs de ``engine`` sont les suivants.
    * - ``status``
      - État du cluster. L'une des valeurs ``green`` / ``yellow`` / ``red``.
    * - ``ping_status``
-     - Statut du ping (int).
+     - Statut du ping (int). La valeur est ``1`` lorsque le cluster est ``red``, et ``0`` dans les autres cas (``green`` / ``yellow``).
 
 Tableau : Champs de engine
 
@@ -77,7 +77,7 @@ Lorsque le cluster est ``red`` (503), l'enveloppe d'erreur est retournée, avec 
             "engine": {
               "cluster_name": "fess-es",
               "status": "red",
-              "ping_status": 2
+              "ping_status": 1
             }
           }
         }

--- a/ja/15.7/api/api-health.rst
+++ b/ja/15.7/api/api-health.rst
@@ -36,7 +36,7 @@ HTTP ステータスは、クラスターの状態が ``green`` / ``yellow`` の
    * - ``status``
      - クラスターの状態。 ``green`` / ``yellow`` / ``red`` のいずれか。
    * - ``ping_status``
-     - ping のステータス（int）。
+     - ping のステータス（int）。クラスターが ``red`` の場合は ``1`` 、それ以外（ ``green`` / ``yellow`` ）の場合は ``0`` になります。
 
 表: engine フィールド
 
@@ -77,7 +77,7 @@ HTTP ステータスは、クラスターの状態が ``green`` / ``yellow`` の
             "engine": {
               "cluster_name": "fess-es",
               "status": "red",
-              "ping_status": 2
+              "ping_status": 1
             }
           }
         }

--- a/ko/15.7/api/api-health.rst
+++ b/ko/15.7/api/api-health.rst
@@ -36,7 +36,7 @@ HTTP 상태는 클러스터 상태가 ``green`` / ``yellow`` 인 경우 200, ``r
    * - ``status``
      - 클러스터 상태. ``green`` / ``yellow`` / ``red`` 중 하나.
    * - ``ping_status``
-     - ping 상태 (int).
+     - ping 상태 (int). 클러스터가 ``red`` 인 경우 ``1`` , 그 외 ( ``green`` / ``yellow`` ) 인 경우 ``0`` 이 됩니다.
 
 표: engine 필드
 
@@ -77,7 +77,7 @@ HTTP 상태는 클러스터 상태가 ``green`` / ``yellow`` 인 경우 200, ``r
             "engine": {
               "cluster_name": "fess-es",
               "status": "red",
-              "ping_status": 2
+              "ping_status": 1
             }
           }
         }

--- a/zh-cn/15.7/api/api-health.rst
+++ b/zh-cn/15.7/api/api-health.rst
@@ -36,7 +36,7 @@ HTTP 方法            GET
    * - ``status``
      - 集群状态。为 ``green`` / ``yellow`` / ``red`` 之一。
    * - ``ping_status``
-     - ping 的状态码（int）。
+     - ping 的状态码（int）。集群为 ``red`` 时值为 ``1``\ ，其他情况（\ ``green`` / ``yellow``\ ）值为 ``0``\ 。
 
 表: engine 字段
 
@@ -77,7 +77,7 @@ HTTP 方法            GET
             "engine": {
               "cluster_name": "fess-es",
               "status": "red",
-              "ping_status": 2
+              "ping_status": 1
             }
           }
         }


### PR DESCRIPTION
## Summary

Corrects the `ping_status` field documentation for the **v2 Health API** (`GET /api/v2/health`) in the 15.7 docs, verified against the Fess source code.

`engine.ping_status` is a **binary integer flag**, not an arbitrary status code. In `PingResponse`, it is derived as `status = (clusterStatus == RED) ? 1 : 0`, so it can only ever be `1` (cluster is `red`) or `0` (cluster is `green`/`yellow`).

The documentation had two issues:

1. **Incorrect example value** — the red-cluster (503) response example showed `"ping_status": 2`, which the code never emits. Corrected to `1`.
2. **Missing semantics** — the `engine` field table only said "Ping status (int)" without explaining the `0`/`1` meaning. Added a sentence documenting it.

## Source of truth

- `repos/fess/src/main/java/org/codelibs/fess/entity/PingResponse.java` — `status = response.getStatus() == ClusterHealthStatus.RED ? 1 : 0;`
- `repos/fess/src/main/java/org/codelibs/fess/api/v2/SearchApiV2Manager.java` — `handleHealth(...)` builds `engine` with `cluster_name`, `status`, `ping_status` only.

## Verification of the rest of the page

The remaining content was checked against the implementation and is accurate: base URL and `GET /api/v2/health` endpoint, GET-only with 405 on other methods, green/yellow → 200 success envelope, red → 503 error envelope (`error.code: service_unavailable`, message `search engine cluster is red`) with the engine snapshot under `error.details.engine`, the three `engine` fields, and no request parameters.

## Languages

Applied consistently across all 7 languages (ja, en, de, es, fr, ko, zh-cn), matching each file's existing inline-literal punctuation conventions.