### PR TITLE
docs(api): correct DataConfig admin API reference (all languages)

### DIFF
--- a/de/15.7/api/admin/api-admin-dataconfig.rst
+++ b/de/15.7/api/admin/api-admin-dataconfig.rst
@@ -56,7 +56,7 @@ Parameter
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parameter
      - Typ
@@ -65,11 +65,23 @@ Parameter
    * - ``size``
      - Integer
      - Nein
-     - Anzahl der Einträge pro Seite (Standard: 20)
+     - Anzahl der Einträge pro Seite (Standard: 25)
    * - ``page``
      - Integer
      - Nein
-     - Seitennummer (beginnt bei 0)
+     - Seitennummer (beginnt bei 1, Standard: 1)
+   * - ``name``
+     - String
+     - Nein
+     - Filtern nach Konfigurationsname
+   * - ``handlerName``
+     - String
+     - Nein
+     - Filtern nach Handler-Name
+   * - ``description``
+     - String
+     - Nein
+     - Filtern nach Beschreibung
 
 Response
 --------
@@ -152,7 +164,7 @@ Request-Body
       "name": "Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=pass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description",
       "boost": 1.0,
       "available": "true",
       "sortOrder": 0,
@@ -164,7 +176,7 @@ Feldbeschreibungen
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - Feld
      - Erforderlich
@@ -234,12 +246,28 @@ Request-Body
       "name": "Updated Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=newpass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description + \" \" + data.features",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description + \" \" + features",
       "boost": 1.5,
       "available": "true",
       "sortOrder": 0,
       "versionNo": 1
     }
+
+Aktualisierungsanfragen erfordern dieselben Pflichtfelder wie beim Erstellen (``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``) sowie zusätzlich die folgenden Felder:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Feld
+     - Erforderlich
+     - Beschreibung
+   * - ``id``
+     - Ja
+     - ID der zu aktualisierenden Konfiguration
+   * - ``versionNo``
+     - Ja
+     - Versionsnummer für optimistisches Sperren (den beim Abrufen erhaltenen Wert angeben)
 
 Response
 --------
@@ -287,9 +315,18 @@ Handler-Typen
    * - ``DatabaseDataStore``
      - Verbindung zur Datenbank über JDBC
    * - ``CsvDataStore``
-     - Daten aus CSV-Dateien lesen
+     - Daten aus CSV-Dateien lesen (jede Zeile wird als ein Dokument verarbeitet)
+   * - ``CsvListDataStore``
+     - CSV-Dateien lesen und verarbeitete Dateien automatisch löschen (eine Erweiterung von ``CsvDataStore`` mit zeitstempelbasierter Filterung)
    * - ``JsonDataStore``
      - Daten aus JSON-Dateien oder JSON-APIs lesen
+
+.. note::
+
+   Die verfügbaren Handler-Typen hängen von den installierten Datenspeicher-Plugins ab.
+   Die oben genannten Handler sind standardmäßig enthalten. Durch die Installation von
+   Datenspeicher-Plugins wie SharePoint, Slack oder Salesforce werden die entsprechenden
+   Handler-Namen verfügbar.
 
 Verwendungsbeispiele
 ====================
@@ -306,7 +343,7 @@ Datenbank-Crawl-Konfiguration
            "name": "User Database",
            "handlerName": "DatabaseDataStore",
            "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/userdb\nusername=dbuser\npassword=dbpass\nsql=SELECT * FROM users WHERE active=true",
-           "handlerScript": "url=\"https://example.com/user/\" + data.user_id\ntitle=data.username\ncontent=data.profile",
+           "handlerScript": "url=\"https://example.com/user/\" + user_id\ntitle=username\ncontent=profile",
            "boost": 1.0,
            "available": "true",
            "sortOrder": 0

--- a/en/15.7/api/admin/api-admin-dataconfig.rst
+++ b/en/15.7/api/admin/api-admin-dataconfig.rst
@@ -56,7 +56,7 @@ Parameters
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parameter
      - Type
@@ -65,11 +65,23 @@ Parameters
    * - ``size``
      - Integer
      - No
-     - Number of items per page (default: 20)
+     - Number of items per page (default: 25)
    * - ``page``
      - Integer
      - No
-     - Page number (starts from 0)
+     - Page number (starts from 1, default: 1)
+   * - ``name``
+     - String
+     - No
+     - Filter by configuration name
+   * - ``handlerName``
+     - String
+     - No
+     - Filter by handler name
+   * - ``description``
+     - String
+     - No
+     - Filter by description
 
 Response
 --------
@@ -152,7 +164,7 @@ Request Body
       "name": "Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=pass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description",
       "boost": 1.0,
       "available": "true",
       "sortOrder": 0,
@@ -164,7 +176,7 @@ Field Description
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - Field
      - Required
@@ -234,12 +246,28 @@ Request Body
       "name": "Updated Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=newpass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description + \" \" + data.features",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description + \" \" + features",
       "boost": 1.5,
       "available": "true",
       "sortOrder": 0,
       "versionNo": 1
     }
+
+Update requests require the same required fields as creation (``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``), plus the following fields:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Field
+     - Required
+     - Description
+   * - ``id``
+     - Yes
+     - ID of the configuration to update
+   * - ``versionNo``
+     - Yes
+     - Version number for optimistic locking (specify the value returned when the setting was retrieved)
 
 Response
 --------
@@ -287,9 +315,15 @@ Handler Types
    * - ``DatabaseDataStore``
      - Connect to databases via JDBC
    * - ``CsvDataStore``
-     - Read data from CSV files
+     - Reads data from a CSV file (processes each row as one document)
+   * - ``CsvListDataStore``
+     - Reads CSV files and automatically deletes processed files (an extension of ``CsvDataStore`` with timestamp-based filtering)
    * - ``JsonDataStore``
      - Read data from JSON files or JSON APIs
+
+.. note::
+
+   The available handler types depend on the installed data store plugins. The handlers above are included by default. Installing data store plugins such as SharePoint, Slack, or Salesforce makes their corresponding handler names available.
 
 Usage Examples
 ==============
@@ -306,7 +340,7 @@ Database Crawl Configuration
            "name": "User Database",
            "handlerName": "DatabaseDataStore",
            "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/userdb\nusername=dbuser\npassword=dbpass\nsql=SELECT * FROM users WHERE active=true",
-           "handlerScript": "url=\"https://example.com/user/\" + data.user_id\ntitle=data.username\ncontent=data.profile",
+           "handlerScript": "url=\"https://example.com/user/\" + user_id\ntitle=username\ncontent=profile",
            "boost": 1.0,
            "available": "true",
            "sortOrder": 0

--- a/es/15.7/api/admin/api-admin-dataconfig.rst
+++ b/es/15.7/api/admin/api-admin-dataconfig.rst
@@ -56,7 +56,7 @@ Parametros
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parametro
      - Tipo
@@ -65,11 +65,23 @@ Parametros
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Numero de elementos por pagina (predeterminado: 25)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 0)
+     - Numero de pagina (comienza en 1, predeterminado: 1)
+   * - ``name``
+     - String
+     - No
+     - Filtrar por nombre de configuracion
+   * - ``handlerName``
+     - String
+     - No
+     - Filtrar por nombre de manejador
+   * - ``description``
+     - String
+     - No
+     - Filtrar por descripcion
 
 Respuesta
 ---------
@@ -152,7 +164,7 @@ Cuerpo de la Solicitud
       "name": "Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=pass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description",
       "boost": 1.0,
       "available": "true",
       "sortOrder": 0,
@@ -164,7 +176,7 @@ Descripcion de Campos
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - Campo
      - Requerido
@@ -234,12 +246,28 @@ Cuerpo de la Solicitud
       "name": "Updated Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=newpass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description + \" \" + data.features",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description + \" \" + features",
       "boost": 1.5,
       "available": "true",
       "sortOrder": 0,
       "versionNo": 1
     }
+
+Las solicitudes de actualizacion requieren los mismos campos obligatorios que la creacion (``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``), ademas de los siguientes campos:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Campo
+     - Requerido
+     - Descripcion
+   * - ``id``
+     - Si
+     - ID de la configuracion a actualizar
+   * - ``versionNo``
+     - Si
+     - Numero de version para el bloqueo optimista (especifique el valor obtenido al recuperar la configuracion)
 
 Respuesta
 ---------
@@ -287,9 +315,18 @@ Tipos de Manejador
    * - ``DatabaseDataStore``
      - Conecta a base de datos via JDBC
    * - ``CsvDataStore``
-     - Lee datos de archivos CSV
+     - Lee datos de un archivo CSV (procesa cada fila como un documento)
+   * - ``CsvListDataStore``
+     - Lee archivos CSV y elimina automaticamente los archivos procesados (una extension de ``CsvDataStore`` con filtrado basado en marcas de tiempo)
    * - ``JsonDataStore``
      - Lee datos de archivos JSON o API JSON
+
+.. note::
+
+   Los tipos de manejador disponibles dependen de los plugins de almacen de datos instalados.
+   Los manejadores indicados arriba se incluyen de forma predeterminada. Al instalar plugins de
+   almacen de datos como SharePoint, Slack o Salesforce, los nombres de manejador correspondientes
+   quedan disponibles.
 
 Ejemplos de Uso
 ===============
@@ -306,7 +343,7 @@ Configuracion de Rastreo de Base de Datos
            "name": "User Database",
            "handlerName": "DatabaseDataStore",
            "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/userdb\nusername=dbuser\npassword=dbpass\nsql=SELECT * FROM users WHERE active=true",
-           "handlerScript": "url=\"https://example.com/user/\" + data.user_id\ntitle=data.username\ncontent=data.profile",
+           "handlerScript": "url=\"https://example.com/user/\" + user_id\ntitle=username\ncontent=profile",
            "boost": 1.0,
            "available": "true",
            "sortOrder": 0

--- a/fr/15.7/api/admin/api-admin-dataconfig.rst
+++ b/fr/15.7/api/admin/api-admin-dataconfig.rst
@@ -56,7 +56,7 @@ Parametres
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parametre
      - Type
@@ -65,11 +65,23 @@ Parametres
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 20)
+     - Nombre d'elements par page (par defaut : 25)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 0)
+     - Numero de page (commence a 1, par defaut : 1)
+   * - ``name``
+     - String
+     - Non
+     - Filtrer par nom de configuration
+   * - ``handlerName``
+     - String
+     - Non
+     - Filtrer par nom de gestionnaire
+   * - ``description``
+     - String
+     - Non
+     - Filtrer par description
 
 Reponse
 -------
@@ -83,7 +95,7 @@ Reponse
           {
             "id": "dataconfig_id_1",
             "name": "Database Crawler",
-            "description": "データベースクローラー",
+            "description": "Crawler de base de donnees",
             "handlerName": "DatabaseDataStore",
             "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/mydb",
             "handlerScript": "...",
@@ -119,7 +131,7 @@ Reponse
         "setting": {
           "id": "dataconfig_id_1",
           "name": "Database Crawler",
-          "description": "データベースクローラー",
+          "description": "Crawler de base de donnees",
           "handlerName": "DatabaseDataStore",
           "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/mydb\nusername=dbuser\npassword=dbpass",
           "handlerScript": "...",
@@ -152,7 +164,7 @@ Corps de la requete
       "name": "Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=pass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description",
       "boost": 1.0,
       "available": "true",
       "sortOrder": 0,
@@ -164,7 +176,7 @@ Description des champs
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - Champ
      - Requis
@@ -234,12 +246,28 @@ Corps de la requete
       "name": "Updated Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=newpass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description + \" \" + data.features",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description + \" \" + features",
       "boost": 1.5,
       "available": "true",
       "sortOrder": 0,
       "versionNo": 1
     }
+
+Les requetes de mise a jour necessitent les memes champs obligatoires que la creation (``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``), ainsi que les champs suivants :
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Champ
+     - Requis
+     - Description
+   * - ``id``
+     - Oui
+     - ID de la configuration a mettre a jour
+   * - ``versionNo``
+     - Oui
+     - Numero de version pour le verrouillage optimiste (indiquer la valeur obtenue lors de la recuperation du parametre)
 
 Reponse
 -------
@@ -287,9 +315,17 @@ Types de gestionnaires
    * - ``DatabaseDataStore``
      - Connexion a une base de donnees via JDBC
    * - ``CsvDataStore``
-     - Lecture des donnees depuis un fichier CSV
+     - Lecture des donnees depuis un fichier CSV (traitement de chaque ligne comme un document)
+   * - ``CsvListDataStore``
+     - Lecture des fichiers CSV avec suppression automatique des fichiers traites (extension de ``CsvDataStore`` avec filtrage par horodatage)
    * - ``JsonDataStore``
      - Lecture des donnees depuis un fichier JSON ou une API JSON
+
+.. note::
+
+   Les types de gestionnaires disponibles dependent des plugins de datastore installes.
+   Les gestionnaires ci-dessus sont inclus par defaut. L'installation de plugins de datastore
+   tels que SharePoint, Slack ou Salesforce rend disponibles leurs noms de gestionnaire respectifs.
 
 Exemples d'utilisation
 ======================
@@ -306,7 +342,7 @@ Configuration de crawl de base de donnees
            "name": "User Database",
            "handlerName": "DatabaseDataStore",
            "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/userdb\nusername=dbuser\npassword=dbpass\nsql=SELECT * FROM users WHERE active=true",
-           "handlerScript": "url=\"https://example.com/user/\" + data.user_id\ntitle=data.username\ncontent=data.profile",
+           "handlerScript": "url=\"https://example.com/user/\" + user_id\ntitle=username\ncontent=profile",
            "boost": 1.0,
            "available": "true",
            "sortOrder": 0

--- a/ja/15.7/api/admin/api-admin-dataconfig.rst
+++ b/ja/15.7/api/admin/api-admin-dataconfig.rst
@@ -56,7 +56,7 @@ DataConfig APIは、|Fess| のデータストア設定を管理するためのAP
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - パラメーター
      - 型
@@ -65,11 +65,23 @@ DataConfig APIは、|Fess| のデータストア設定を管理するためのAP
    * - ``size``
      - Integer
      - いいえ
-     - 1ページあたりの件数（デフォルト: 20）
+     - 1ページあたりの件数（デフォルト: 25）
    * - ``page``
      - Integer
      - いいえ
-     - ページ番号（0から開始）
+     - ページ番号（1から開始、デフォルト: 1）
+   * - ``name``
+     - String
+     - いいえ
+     - 設定名による絞り込み
+   * - ``handlerName``
+     - String
+     - いいえ
+     - ハンドラー名による絞り込み
+   * - ``description``
+     - String
+     - いいえ
+     - 説明による絞り込み
 
 レスポンス
 ----------
@@ -152,7 +164,7 @@ DataConfig APIは、|Fess| のデータストア設定を管理するためのAP
       "name": "Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=pass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description",
       "boost": 1.0,
       "available": "true",
       "sortOrder": 0,
@@ -164,7 +176,7 @@ DataConfig APIは、|Fess| のデータストア設定を管理するためのAP
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - フィールド
      - 必須
@@ -234,12 +246,29 @@ DataConfig APIは、|Fess| のデータストア設定を管理するためのAP
       "name": "Updated Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=newpass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description + \" \" + data.features",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description + \" \" + features",
       "boost": 1.5,
       "available": "true",
       "sortOrder": 0,
       "versionNo": 1
     }
+
+更新リクエストでは、作成時と同じ必須フィールド（``name`` 、 ``handlerName`` 、 ``boost`` 、
+``available`` 、 ``sortOrder`` ）に加えて、以下のフィールドが必須です。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - フィールド
+     - 必須
+     - 説明
+   * - ``id``
+     - はい
+     - 更新対象の設定ID
+   * - ``versionNo``
+     - はい
+     - 楽観ロック用のバージョン番号（取得時の値を指定）
 
 レスポンス
 ----------
@@ -287,9 +316,17 @@ DataConfig APIは、|Fess| のデータストア設定を管理するためのAP
    * - ``DatabaseDataStore``
      - JDBC経由でデータベースに接続
    * - ``CsvDataStore``
-     - CSVファイルからデータを読み込み
+     - CSVファイルからデータを読み込み（1行を1ドキュメントとして処理）
+   * - ``CsvListDataStore``
+     - CSVファイルを読み込み、処理済みファイルを自動削除（タイムスタンプによるフィルタリングに対応した ``CsvDataStore`` の拡張）
    * - ``JsonDataStore``
      - JSONファイルまたはJSON APIからデータを読み込み
+
+.. note::
+
+   利用可能なハンドラータイプは、インストールされているデータストアプラグインによって異なります。
+   上記は標準で含まれるハンドラーです。SharePoint、Slack、Salesforce などのデータストア
+   プラグインを追加すると、それぞれに対応するハンドラー名が利用可能になります。
 
 使用例
 ======
@@ -306,7 +343,7 @@ DataConfig APIは、|Fess| のデータストア設定を管理するためのAP
            "name": "User Database",
            "handlerName": "DatabaseDataStore",
            "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/userdb\nusername=dbuser\npassword=dbpass\nsql=SELECT * FROM users WHERE active=true",
-           "handlerScript": "url=\"https://example.com/user/\" + data.user_id\ntitle=data.username\ncontent=data.profile",
+           "handlerScript": "url=\"https://example.com/user/\" + user_id\ntitle=username\ncontent=profile",
            "boost": 1.0,
            "available": "true",
            "sortOrder": 0

--- a/ko/15.7/api/admin/api-admin-dataconfig.rst
+++ b/ko/15.7/api/admin/api-admin-dataconfig.rst
@@ -56,7 +56,7 @@ DataConfig API는 |Fess| 의 데이터스토어 설정을 관리하기 위한 AP
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - 파라미터
      - 타입
@@ -65,11 +65,23 @@ DataConfig API는 |Fess| 의 데이터스토어 설정을 관리하기 위한 AP
    * - ``size``
      - Integer
      - 아니오
-     - 페이지당 건수 (기본값: 20)
+     - 페이지당 건수 (기본값: 25)
    * - ``page``
      - Integer
      - 아니오
-     - 페이지 번호 (0부터 시작)
+     - 페이지 번호 (1부터 시작, 기본값: 1)
+   * - ``name``
+     - String
+     - 아니오
+     - 설정 이름으로 필터링
+   * - ``handlerName``
+     - String
+     - 아니오
+     - 핸들러 이름으로 필터링
+   * - ``description``
+     - String
+     - 아니오
+     - 설명으로 필터링
 
 응답
 ----------
@@ -152,7 +164,7 @@ DataConfig API는 |Fess| 의 데이터스토어 설정을 관리하기 위한 AP
       "name": "Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=pass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description",
       "boost": 1.0,
       "available": "true",
       "sortOrder": 0,
@@ -164,7 +176,7 @@ DataConfig API는 |Fess| 의 데이터스토어 설정을 관리하기 위한 AP
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - 필드
      - 필수
@@ -234,12 +246,28 @@ DataConfig API는 |Fess| 의 데이터스토어 설정을 관리하기 위한 AP
       "name": "Updated Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=newpass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description + \" \" + data.features",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description + \" \" + features",
       "boost": 1.5,
       "available": "true",
       "sortOrder": 0,
       "versionNo": 1
     }
+
+업데이트 요청에는 생성 시와 동일한 필수 필드(``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``)에 더해 다음 필드가 필수입니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - 필드
+     - 필수
+     - 설명
+   * - ``id``
+     - 예
+     - 업데이트할 설정 ID
+   * - ``versionNo``
+     - 예
+     - 낙관적 잠금을 위한 버전 번호(조회 시 얻은 값을 지정)
 
 응답
 ----------
@@ -287,9 +315,17 @@ DataConfig API는 |Fess| 의 데이터스토어 설정을 관리하기 위한 AP
    * - ``DatabaseDataStore``
      - JDBC를 통해 데이터베이스에 연결
    * - ``CsvDataStore``
-     - CSV 파일에서 데이터 읽기
+     - CSV 파일에서 데이터를 읽어 들임 (각 행을 하나의 문서로 처리)
+   * - ``CsvListDataStore``
+     - CSV 파일을 읽어 들이고 처리된 파일을 자동 삭제 (타임스탬프 기반 필터링을 지원하는 ``CsvDataStore`` 의 확장)
    * - ``JsonDataStore``
      - JSON 파일 또는 JSON API에서 데이터 읽기
+
+.. note::
+
+   이용 가능한 핸들러 타입은 설치된 데이터스토어 플러그인에 따라 다릅니다.
+   위 목록은 기본으로 포함된 핸들러입니다. SharePoint, Slack, Salesforce 등의 데이터스토어
+   플러그인을 추가로 설치하면 각각에 해당하는 핸들러 이름을 사용할 수 있게 됩니다.
 
 사용 예
 ======
@@ -306,7 +342,7 @@ DataConfig API는 |Fess| 의 데이터스토어 설정을 관리하기 위한 AP
            "name": "User Database",
            "handlerName": "DatabaseDataStore",
            "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/userdb\nusername=dbuser\npassword=dbpass\nsql=SELECT * FROM users WHERE active=true",
-           "handlerScript": "url=\"https://example.com/user/\" + data.user_id\ntitle=data.username\ncontent=data.profile",
+           "handlerScript": "url=\"https://example.com/user/\" + user_id\ntitle=username\ncontent=profile",
            "boost": 1.0,
            "available": "true",
            "sortOrder": 0

--- a/zh-cn/15.7/api/admin/api-admin-dataconfig.rst
+++ b/zh-cn/15.7/api/admin/api-admin-dataconfig.rst
@@ -56,7 +56,7 @@ DataConfig API是用于管理 |Fess| 数据存储设置的API。
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - 参数
      - 类型
@@ -65,11 +65,23 @@ DataConfig API是用于管理 |Fess| 数据存储设置的API。
    * - ``size``
      - Integer
      - 否
-     - 每页记录数（默认：20）
+     - 每页记录数（默认：25）
    * - ``page``
      - Integer
      - 否
-     - 页码（从0开始）
+     - 页码（从 1 开始，默认值：1）
+   * - ``name``
+     - String
+     - 否
+     - 按配置名称过滤
+   * - ``handlerName``
+     - String
+     - 否
+     - 按处理器名称过滤
+   * - ``description``
+     - String
+     - 否
+     - 按描述过滤
 
 响应
 ----
@@ -83,7 +95,7 @@ DataConfig API是用于管理 |Fess| 数据存储设置的API。
           {
             "id": "dataconfig_id_1",
             "name": "Database Crawler",
-            "description": "データベースクローラー",
+            "description": "数据库爬虫",
             "handlerName": "DatabaseDataStore",
             "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/mydb",
             "handlerScript": "...",
@@ -119,7 +131,7 @@ DataConfig API是用于管理 |Fess| 数据存储设置的API。
         "setting": {
           "id": "dataconfig_id_1",
           "name": "Database Crawler",
-          "description": "データベースクローラー",
+          "description": "数据库爬虫",
           "handlerName": "DatabaseDataStore",
           "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/mydb\nusername=dbuser\npassword=dbpass",
           "handlerScript": "...",
@@ -152,7 +164,7 @@ DataConfig API是用于管理 |Fess| 数据存储设置的API。
       "name": "Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=pass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description",
       "boost": 1.0,
       "available": "true",
       "sortOrder": 0,
@@ -164,7 +176,7 @@ DataConfig API是用于管理 |Fess| 数据存储设置的API。
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 25 15 60
 
    * - 字段
      - 必需
@@ -234,12 +246,28 @@ DataConfig API是用于管理 |Fess| 数据存储设置的API。
       "name": "Updated Product Database",
       "handlerName": "DatabaseDataStore",
       "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/products\nusername=user\npassword=newpass",
-      "handlerScript": "url=\"https://example.com/product/\" + data.product_id\ntitle=data.product_name\ncontent=data.description + \" \" + data.features",
+      "handlerScript": "url=\"https://example.com/product/\" + product_id\ntitle=product_name\ncontent=description + \" \" + features",
       "boost": 1.5,
       "available": "true",
       "sortOrder": 0,
       "versionNo": 1
     }
+
+更新请求需要与创建时相同的必填字段（``name``、``handlerName``、``boost``、``available``、``sortOrder``），以及以下字段：
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - 字段
+     - 必需
+     - 说明
+   * - ``id``
+     - 是
+     - 要更新的配置 ID
+   * - ``versionNo``
+     - 是
+     - 用于乐观锁的版本号（指定获取设置时返回的值）
 
 响应
 ----
@@ -287,9 +315,17 @@ DataConfig API是用于管理 |Fess| 数据存储设置的API。
    * - ``DatabaseDataStore``
      - 通过JDBC连接数据库
    * - ``CsvDataStore``
-     - 从CSV文件读取数据
+     - 从CSV文件读取数据（将每一行作为一个文档处理）
+   * - ``CsvListDataStore``
+     - 读取CSV文件并自动删除已处理的文件（支持基于时间戳过滤的 ``CsvDataStore`` 扩展）
    * - ``JsonDataStore``
      - 从JSON文件或JSON API读取数据
+
+.. note::
+
+   可用的处理器类型取决于已安装的数据存储插件。
+   上述处理器为默认包含的类型。安装 SharePoint、Slack、Salesforce 等数据存储
+   插件后，相应的处理器名称将变为可用。
 
 使用示例
 ========
@@ -306,7 +342,7 @@ DataConfig API是用于管理 |Fess| 数据存储设置的API。
            "name": "User Database",
            "handlerName": "DatabaseDataStore",
            "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/userdb\nusername=dbuser\npassword=dbpass\nsql=SELECT * FROM users WHERE active=true",
-           "handlerScript": "url=\"https://example.com/user/\" + data.user_id\ntitle=data.username\ncontent=data.profile",
+           "handlerScript": "url=\"https://example.com/user/\" + user_id\ntitle=username\ncontent=profile",
            "boost": 1.0,
            "available": "true",
            "sortOrder": 0
@@ -319,4 +355,3 @@ DataConfig API是用于管理 |Fess| 数据存储设置的API。
 - :doc:`api-admin-webconfig` - Web爬虫设置API
 - :doc:`api-admin-fileconfig` - 文件爬虫设置API
 - :doc:`../../admin/dataconfig-guide` - 数据存储设置指南
-


### PR DESCRIPTION
## Summary

Reviewed `ja/15.7/api/admin/api-admin-dataconfig.rst` against the current implementation and corrected several inaccuracies, then propagated the fixes to all seven languages (ja, en, de, es, fr, ko, zh-cn).

Source of truth verified: `ApiAdminDataconfigAction`, `BaseSearchBody`/`SearchBody`, `DataConfigPager`, `CreateForm`/`EditForm`, `fess_config.properties`, and the DB/CSV/JSON data store plugins (`DatabaseDataStore`, `CsvDataStore`, `CsvListDataStore`, `JsonDataStore`) including the Groovy script binding in `GroovyEngine`.

## Corrections

| Area | Before (incorrect) | After (verified) |
|------|--------------------|------------------|
| List `page` param | "starts from 0" | 1-based, default `1` (`Constants.DEFAULT_ADMIN_PAGE_NUMBER = 1`) |
| List `size` param | default `20` | default `25` (`paging.page.size`) |
| `handlerScript` field access | `data.product_id`, `data.product_name`, … | bare field names `product_id`, `product_name`, … (DB/CSV/JSON bind each column/field as a top-level Groovy variable; there is no `data.` namespace) |

## Additions (previously missing)

- **List filter parameters**: `name`, `handlerName`, `description` (accepted by `SearchBody` and applied via the pager).
- **Update-only required fields**: `id` and `versionNo` (optimistic locking), documented in a dedicated table in the Update section.
- **`CsvListDataStore`** handler type, plus a note that the available handler types depend on the installed data store plugins.

## Fixes

- Corrected `list-table` `:widths:` directives that declared fewer columns than the table actually had (the parameter table had 4 columns but 3 widths; the field-description table had 3 columns but 2 widths).

## Verification

- All claims checked against source code (file:line) before editing.
- All 7 language files cross-checked for structural parity (identical section order, `:widths:`, code blocks).
- Validated that every `list-table`'s `:widths:` count matches its actual per-row cell count, and that no Japanese text remains in the non-ja files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)