### PR TITLE
docs(api): correct and expand Admin Dict API reference against implementation (15.7)

### DIFF
--- a/de/15.7/api/admin/api-admin-dict.rst
+++ b/de/15.7/api/admin/api-admin-dict.rst
@@ -8,7 +8,7 @@ Dict API
 Die Dict API dient zur Verwaltung von Wörterbüchern in |Fess|.
 Über den Stamm-Endpunkt können Sie die Liste der verfügbaren Wörterbücher abrufen.
 Das Anzeigen, Erstellen, Aktualisieren und Löschen einzelner Wörterbucheinträge sowie das Hochladen und Herunterladen von Wörterbuchdateien
-erfolgen über die Sub-Endpunkte je Wörterbuchtyp (synonym, kuromoji, mapping, protwords, stopwords, stemmerOverride).
+erfolgen über die Sub-Endpunkte je Wörterbuchtyp (synonym, kuromoji, mapping, protwords, stopwords, stemmeroverride).
 
 Basis-URL
 =========
@@ -37,7 +37,8 @@ Wörterbuch-Stamm
 Endpunkte je Wörterbuchtyp
 --------------------------
 
-Für ``{type}`` wird einer der Werte ``synonym``, ``kuromoji``, ``mapping``, ``protwords``, ``stopwords``, ``stemmerOverride`` angegeben.
+Für ``{type}`` wird einer der Werte ``synonym``, ``kuromoji``, ``mapping``, ``protwords``, ``stopwords``, ``stemmeroverride`` angegeben.
+Diese Werte entsprechen dem Wert des Felds ``type``, das in der Antwort der Wörterbuchliste enthalten ist.
 ``{dictId}`` ist die ID des Wörterbuchs, die beim Auflisten der Wörterbücher zurückgegeben wird.
 
 .. list-table::
@@ -103,7 +104,8 @@ Response
             "path": "/var/lib/fess/dict/mapping.txt",
             "timestamp": "2025-01-28T15:30:00.000+0000"
           }
-        ]
+        ],
+        "total": 2
       }
     }
 
@@ -124,6 +126,8 @@ Response-Felder
      - Pfad der Wörterbuchdatei
    * - ``settings[].timestamp``
      - Zeitpunkt der Änderung der Wörterbuchdatei
+   * - ``total``
+     - Gesamtanzahl der Wörterbuchdateien
 
 Wörterbucheinträge auflisten
 ============================
@@ -155,11 +159,11 @@ Parameter
    * - ``size``
      - Integer
      - Nein
-     - Anzahl der Einträge pro Seite
+     - Anzahl der Einträge pro Seite (Standard: 25)
    * - ``page``
      - Integer
      - Nein
-     - Seitennummer
+     - Seitennummer (beginnt bei 1, Standard: 1)
 
 Response
 --------
@@ -179,9 +183,12 @@ Die Felder der einzelnen Einträge im Array ``settings`` der Antwort unterscheid
             "inputs": "検索,サーチ",
             "outputs": "検索,サーチ,リサーチ"
           }
-        ]
+        ],
+        "total": 1
       }
     }
+
+Das obige Beispiel zeigt das ``synonym``-Wörterbuch.
 
 Wörterbucheintrag abrufen
 =========================
@@ -423,7 +430,7 @@ Die Felder im Request-Body zum Erstellen/Aktualisieren von Wörterbucheinträgen
    * - ``stopwords``
      - ``input`` (erforderlich)
      - ``stopwordsFile``
-   * - ``stemmerOverride``
+   * - ``stemmeroverride``
      - ``input`` (erforderlich), ``output`` (erforderlich)
      - ``stemmerOverrideFile``
 

--- a/en/15.7/api/admin/api-admin-dict.rst
+++ b/en/15.7/api/admin/api-admin-dict.rst
@@ -8,7 +8,7 @@ Overview
 Dict API is an API for managing |Fess| dictionaries.
 The root endpoint can retrieve the list of available dictionaries.
 Reading, creating, updating, and deleting individual dictionary items, as well as uploading and downloading dictionary files,
-are performed via the sub-endpoints for each dictionary type (synonym, kuromoji, mapping, protwords, stopwords, stemmerOverride).
+are performed via the sub-endpoints for each dictionary type (synonym, kuromoji, mapping, protwords, stopwords, stemmeroverride).
 
 Base URL
 ========
@@ -37,7 +37,8 @@ Dictionary Root
 Endpoints per Dictionary Type
 -----------------------------
 
-For ``{type}``, specify one of ``synonym``, ``kuromoji``, ``mapping``, ``protwords``, ``stopwords``, or ``stemmerOverride``.
+For ``{type}``, specify one of ``synonym``, ``kuromoji``, ``mapping``, ``protwords``, ``stopwords``, or ``stemmeroverride``.
+These values match the value of the ``type`` field included in the dictionary list response.
 ``{dictId}`` is the ID of the dictionary obtained from the dictionary list.
 
 .. list-table::
@@ -103,7 +104,8 @@ Response
             "path": "/var/lib/fess/dict/mapping.txt",
             "timestamp": "2025-01-28T15:30:00.000+0000"
           }
-        ]
+        ],
+        "total": 2
       }
     }
 
@@ -124,6 +126,8 @@ Response Fields
      - Path of the dictionary file
    * - ``settings[].timestamp``
      - Update date/time of the dictionary file
+   * - ``total``
+     - Total number of dictionary files
 
 List Dictionary Items
 =====================
@@ -155,11 +159,11 @@ Parameters
    * - ``size``
      - Integer
      - No
-     - Number of items per page
+     - Number of items per page (default: 25)
    * - ``page``
      - Integer
      - No
-     - Page number
+     - Page number (starts at 1, default: 1)
 
 Response
 --------
@@ -179,9 +183,12 @@ The fields of each item in the ``settings`` array of the response differ by dict
             "inputs": "検索,サーチ",
             "outputs": "検索,サーチ,リサーチ"
           }
-        ]
+        ],
+        "total": 1
       }
     }
+
+The above is an example of the ``synonym`` dictionary.
 
 Get Dictionary Item
 ===================
@@ -423,7 +430,7 @@ The fields of the request body and response for creating and updating dictionary
    * - ``stopwords``
      - ``input`` (required)
      - ``stopwordsFile``
-   * - ``stemmerOverride``
+   * - ``stemmeroverride``
      - ``input`` (required), ``output`` (required)
      - ``stemmerOverrideFile``
 

--- a/es/15.7/api/admin/api-admin-dict.rst
+++ b/es/15.7/api/admin/api-admin-dict.rst
@@ -7,7 +7,7 @@ Vision General
 
 La API de Dict es para gestionar los diccionarios de |Fess|.
 En el endpoint raiz se puede obtener la lista de diccionarios disponibles.
-La referencia, creacion, actualizacion y eliminacion de elementos de diccionario individuales, asi como la carga y descarga de archivos de diccionario, se operan mediante los subendpoints por tipo de diccionario (synonym, kuromoji, mapping, protwords, stopwords, stemmerOverride).
+La referencia, creacion, actualizacion y eliminacion de elementos de diccionario individuales, asi como la carga y descarga de archivos de diccionario, se operan mediante los subendpoints por tipo de diccionario (synonym, kuromoji, mapping, protwords, stopwords, stemmeroverride).
 
 URL Base
 ========
@@ -36,7 +36,8 @@ Raiz del Diccionario
 Endpoints por Tipo de Diccionario
 ----------------------------------
 
-En ``{type}`` se especifica uno de ``synonym`` , ``kuromoji`` , ``mapping`` , ``protwords`` , ``stopwords`` , ``stemmerOverride`` .
+En ``{type}`` se especifica uno de ``synonym`` , ``kuromoji`` , ``mapping`` , ``protwords`` , ``stopwords`` , ``stemmeroverride`` .
+Estos valores coinciden con el valor del campo ``type`` incluido en la respuesta de la lista de diccionarios.
 ``{dictId}`` es el ID del diccionario obtenido en la lista de diccionarios.
 
 .. list-table::
@@ -102,7 +103,8 @@ Respuesta
             "path": "/var/lib/fess/dict/mapping.txt",
             "timestamp": "2025-01-28T15:30:00.000+0000"
           }
-        ]
+        ],
+        "total": 2
       }
     }
 
@@ -123,6 +125,8 @@ Campos de Respuesta
      - Ruta del archivo de diccionario
    * - ``settings[].timestamp``
      - Fecha y hora de actualizacion del archivo de diccionario
+   * - ``total``
+     - Numero total de archivos de diccionario
 
 Obtener Lista de Elementos del Diccionario
 ==========================================
@@ -154,11 +158,11 @@ Parametros
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina
+     - Numero de elementos por pagina (por defecto: 25)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina
+     - Numero de pagina (comienza en 1, por defecto: 1)
 
 Respuesta
 ---------
@@ -178,9 +182,12 @@ Los campos de cada elemento del arreglo ``settings`` de la respuesta varian segu
             "inputs": "busqueda,buscar",
             "outputs": "busqueda,buscar,investigar"
           }
-        ]
+        ],
+        "total": 1
       }
     }
+
+El ejemplo anterior corresponde al diccionario ``synonym``.
 
 Obtener Elemento del Diccionario
 ================================
@@ -422,7 +429,7 @@ Los campos del cuerpo de la solicitud de creacion y actualizacion de elementos d
    * - ``stopwords``
      - ``input`` (requerido)
      - ``stopwordsFile``
-   * - ``stemmerOverride``
+   * - ``stemmeroverride``
      - ``input`` (requerido), ``output`` (requerido)
      - ``stemmerOverrideFile``
 

--- a/fr/15.7/api/admin/api-admin-dict.rst
+++ b/fr/15.7/api/admin/api-admin-dict.rst
@@ -7,7 +7,7 @@ Vue d'ensemble
 
 L'API Dict est une API permettant de gerer les dictionnaires de |Fess|.
 L'endpoint racine permet d'obtenir la liste des dictionnaires disponibles.
-La consultation, la creation, la mise a jour et la suppression des entrees de dictionnaire individuelles, ainsi que le televersement et le telechargement des fichiers de dictionnaire, s'effectuent via les sous-endpoints propres a chaque type de dictionnaire (synonym, kuromoji, mapping, protwords, stopwords, stemmerOverride).
+La consultation, la creation, la mise a jour et la suppression des entrees de dictionnaire individuelles, ainsi que le televersement et le telechargement des fichiers de dictionnaire, s'effectuent via les sous-endpoints propres a chaque type de dictionnaire (synonym, kuromoji, mapping, protwords, stopwords, stemmeroverride).
 
 URL de base
 ===========
@@ -36,7 +36,8 @@ Racine des dictionnaires
 Endpoints propres a chaque type de dictionnaire
 -----------------------------------------------
 
-``{type}`` doit etre l'une des valeurs suivantes : ``synonym`` , ``kuromoji`` , ``mapping`` , ``protwords`` , ``stopwords`` , ``stemmerOverride`` .
+``{type}`` doit etre l'une des valeurs suivantes : ``synonym`` , ``kuromoji`` , ``mapping`` , ``protwords`` , ``stopwords`` , ``stemmeroverride`` .
+Ces valeurs correspondent a la valeur du champ ``type`` inclus dans la reponse de la liste des dictionnaires.
 ``{dictId}`` est l'ID du dictionnaire obtenu via l'obtention de la liste des dictionnaires.
 
 .. list-table::
@@ -102,7 +103,8 @@ Reponse
             "path": "/var/lib/fess/dict/mapping.txt",
             "timestamp": "2025-01-28T15:30:00.000+0000"
           }
-        ]
+        ],
+        "total": 2
       }
     }
 
@@ -123,6 +125,8 @@ Champs de la reponse
      - Chemin du fichier de dictionnaire
    * - ``settings[].timestamp``
      - Date et heure de mise a jour du fichier de dictionnaire
+   * - ``total``
+     - Nombre total de fichiers de dictionnaire
 
 Obtention de la liste des entrees de dictionnaire
 =================================================
@@ -154,11 +158,11 @@ Parametres
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page
+     - Nombre d'elements par page (defaut : 25)
    * - ``page``
      - Integer
      - Non
-     - Numero de page
+     - Numero de page (commence a 1, defaut : 1)
 
 Reponse
 -------
@@ -178,9 +182,12 @@ Les champs de chaque element du tableau ``settings`` de la reponse varient selon
             "inputs": "検索,サーチ",
             "outputs": "検索,サーチ,リサーチ"
           }
-        ]
+        ],
+        "total": 1
       }
     }
+
+L'exemple ci-dessus correspond au dictionnaire ``synonym``.
 
 Obtention d'une entree de dictionnaire
 ======================================
@@ -422,7 +429,7 @@ Les champs du corps de requete de creation/mise a jour d'une entree de dictionna
    * - ``stopwords``
      - ``input`` (requis)
      - ``stopwordsFile``
-   * - ``stemmerOverride``
+   * - ``stemmeroverride``
      - ``input`` (requis), ``output`` (requis)
      - ``stemmerOverrideFile``
 

--- a/ja/15.7/api/admin/api-admin-dict.rst
+++ b/ja/15.7/api/admin/api-admin-dict.rst
@@ -8,7 +8,7 @@ Dict API
 Dict APIは、|Fess| の辞書を管理するためのAPIです。
 ルートのエンドポイントで利用可能な辞書の一覧を取得できます。
 個々の辞書項目の参照・作成・更新・削除、辞書ファイルのアップロード・ダウンロードは、
-辞書種別ごとのサブエンドポイント（synonym、kuromoji、mapping、protwords、stopwords、stemmerOverride）で操作します。
+辞書種別ごとのサブエンドポイント（synonym、kuromoji、mapping、protwords、stopwords、stemmeroverride）で操作します。
 
 ベースURL
 =========
@@ -37,7 +37,8 @@ Dict APIは、|Fess| の辞書を管理するためのAPIです。
 辞書種別ごとのエンドポイント
 ----------------------------
 
-``{type}`` には ``synonym`` 、 ``kuromoji`` 、 ``mapping`` 、 ``protwords`` 、 ``stopwords`` 、 ``stemmerOverride`` のいずれかを指定します。
+``{type}`` には ``synonym`` 、 ``kuromoji`` 、 ``mapping`` 、 ``protwords`` 、 ``stopwords`` 、 ``stemmeroverride`` のいずれかを指定します。
+これらの値は、辞書一覧取得のレスポンスに含まれる ``type`` フィールドの値と一致します。
 ``{dictId}`` は辞書一覧取得で得られる辞書のIDです。
 
 .. list-table::
@@ -103,7 +104,8 @@ Dict APIは、|Fess| の辞書を管理するためのAPIです。
             "path": "/var/lib/fess/dict/mapping.txt",
             "timestamp": "2025-01-28T15:30:00.000+0000"
           }
-        ]
+        ],
+        "total": 2
       }
     }
 
@@ -124,6 +126,8 @@ Dict APIは、|Fess| の辞書を管理するためのAPIです。
      - 辞書ファイルのパス
    * - ``settings[].timestamp``
      - 辞書ファイルの更新日時
+   * - ``total``
+     - 辞書ファイルの総数
 
 辞書項目一覧取得
 ================
@@ -155,11 +159,11 @@ Dict APIは、|Fess| の辞書を管理するためのAPIです。
    * - ``size``
      - Integer
      - いいえ
-     - 1ページあたりの件数
+     - 1ページあたりの件数（デフォルト: 25）
    * - ``page``
      - Integer
      - いいえ
-     - ページ番号
+     - ページ番号（1から開始、デフォルト: 1）
 
 レスポンス
 ----------
@@ -179,9 +183,12 @@ Dict APIは、|Fess| の辞書を管理するためのAPIです。
             "inputs": "検索,サーチ",
             "outputs": "検索,サーチ,リサーチ"
           }
-        ]
+        ],
+        "total": 1
       }
     }
+
+上記は ``synonym`` 辞書の例です。
 
 辞書項目取得
 ============
@@ -423,7 +430,7 @@ Dict APIは、|Fess| の辞書を管理するためのAPIです。
    * - ``stopwords``
      - ``input`` （必須）
      - ``stopwordsFile``
-   * - ``stemmerOverride``
+   * - ``stemmeroverride``
      - ``input`` （必須）、 ``output`` （必須）
      - ``stemmerOverrideFile``
 

--- a/ko/15.7/api/admin/api-admin-dict.rst
+++ b/ko/15.7/api/admin/api-admin-dict.rst
@@ -8,7 +8,7 @@ Dict API
 Dict API는 |Fess| 의 사전을 관리하기 위한 API입니다.
 루트 엔드포인트에서 사용 가능한 사전 목록을 조회할 수 있습니다.
 개별 사전 항목의 참조, 생성, 업데이트, 삭제 및 사전 파일의 업로드, 다운로드는
-사전 종류별 서브 엔드포인트(synonym、kuromoji、mapping、protwords、stopwords、stemmerOverride)에서 조작합니다.
+사전 종류별 서브 엔드포인트(synonym、kuromoji、mapping、protwords、stopwords、stemmeroverride)에서 조작합니다.
 
 기본 URL
 =========
@@ -37,7 +37,8 @@ Dict API는 |Fess| 의 사전을 관리하기 위한 API입니다.
 사전 종류별 엔드포인트
 ----------------------
 
-``{type}`` 에는 ``synonym`` 、 ``kuromoji`` 、 ``mapping`` 、 ``protwords`` 、 ``stopwords`` 、 ``stemmerOverride`` 중 하나를 지정합니다.
+``{type}`` 에는 ``synonym`` 、 ``kuromoji`` 、 ``mapping`` 、 ``protwords`` 、 ``stopwords`` 、 ``stemmeroverride`` 중 하나를 지정합니다.
+이 값은 사전 목록 응답에 포함된 ``type`` 필드의 값과 일치합니다.
 ``{dictId}`` 는 사전 목록 조회에서 얻은 사전의 ID입니다.
 
 .. list-table::
@@ -103,7 +104,8 @@ Dict API는 |Fess| 의 사전을 관리하기 위한 API입니다.
             "path": "/var/lib/fess/dict/mapping.txt",
             "timestamp": "2025-01-28T15:30:00.000+0000"
           }
-        ]
+        ],
+        "total": 2
       }
     }
 
@@ -124,6 +126,8 @@ Dict API는 |Fess| 의 사전을 관리하기 위한 API입니다.
      - 사전 파일의 경로
    * - ``settings[].timestamp``
      - 사전 파일의 업데이트 일시
+   * - ``total``
+     - 사전 파일의 총 건수
 
 사전 항목 목록 조회
 ================
@@ -155,11 +159,11 @@ Dict API는 |Fess| 의 사전을 관리하기 위한 API입니다.
    * - ``size``
      - Integer
      - 아니오
-     - 페이지당 건수
+     - 페이지당 건수 (기본값: 25)
    * - ``page``
      - Integer
      - 아니오
-     - 페이지 번호
+     - 페이지 번호 (1부터 시작, 기본값: 1)
 
 응답
 ----------
@@ -179,9 +183,12 @@ Dict API는 |Fess| 의 사전을 관리하기 위한 API입니다.
             "inputs": "検索,サーチ",
             "outputs": "検索,サーチ,リサーチ"
           }
-        ]
+        ],
+        "total": 1
       }
     }
+
+위의 예는 ``synonym`` 사전의 경우입니다.
 
 사전 항목 조회
 ============
@@ -423,7 +430,7 @@ Dict API는 |Fess| 의 사전을 관리하기 위한 API입니다.
    * - ``stopwords``
      - ``input`` (필수)
      - ``stopwordsFile``
-   * - ``stemmerOverride``
+   * - ``stemmeroverride``
      - ``input`` (필수)、 ``output`` (필수)
      - ``stemmerOverrideFile``
 

--- a/zh-cn/15.7/api/admin/api-admin-dict.rst
+++ b/zh-cn/15.7/api/admin/api-admin-dict.rst
@@ -8,7 +8,7 @@ Dict API
 Dict API是用于管理 |Fess| 词典的API。
 可以通过根端点获取可用词典的列表。
 单个词典项目的查看、创建、更新、删除，以及词典文件的上传、下载，
-通过各词典类型的子端点（synonym、kuromoji、mapping、protwords、stopwords、stemmerOverride）进行操作。
+通过各词典类型的子端点（synonym、kuromoji、mapping、protwords、stopwords、stemmeroverride）进行操作。
 
 基础URL
 =======
@@ -37,7 +37,8 @@ Dict API是用于管理 |Fess| 词典的API。
 各词典类型的端点
 ----------------
 
-``{type}`` 指定 ``synonym`` 、 ``kuromoji`` 、 ``mapping`` 、 ``protwords`` 、 ``stopwords`` 、 ``stemmerOverride`` 中的任意一个。
+``{type}`` 指定 ``synonym`` 、 ``kuromoji`` 、 ``mapping`` 、 ``protwords`` 、 ``stopwords`` 、 ``stemmeroverride`` 中的任意一个。
+这些值与词典列表响应中所包含的 ``type`` 字段的值相对应。
 ``{dictId}`` 是通过获取词典列表得到的词典ID。
 
 .. list-table::
@@ -103,7 +104,8 @@ Dict API是用于管理 |Fess| 词典的API。
             "path": "/var/lib/fess/dict/mapping.txt",
             "timestamp": "2025-01-28T15:30:00.000+0000"
           }
-        ]
+        ],
+        "total": 2
       }
     }
 
@@ -124,6 +126,8 @@ Dict API是用于管理 |Fess| 词典的API。
      - 词典文件的路径
    * - ``settings[].timestamp``
      - 词典文件的更新日期时间
+   * - ``total``
+     - 词典文件的总数
 
 获取词典项目列表
 ================
@@ -155,11 +159,11 @@ Dict API是用于管理 |Fess| 词典的API。
    * - ``size``
      - Integer
      - 否
-     - 每页记录数
+     - 每页记录数（默认值：25）
    * - ``page``
      - Integer
      - 否
-     - 页码
+     - 页码（从1开始，默认值：1）
 
 响应
 ----
@@ -179,9 +183,12 @@ Dict API是用于管理 |Fess| 词典的API。
             "inputs": "検索,サーチ",
             "outputs": "検索,サーチ,リサーチ"
           }
-        ]
+        ],
+        "total": 1
       }
     }
+
+以上为 ``synonym`` 词典的示例。
 
 获取词典项目
 ============
@@ -423,7 +430,7 @@ Dict API是用于管理 |Fess| 词典的API。
    * - ``stopwords``
      - ``input`` （必需）
      - ``stopwordsFile``
-   * - ``stemmerOverride``
+   * - ``stemmeroverride``
      - ``input`` （必需）、 ``output`` （必需）
      - ``stemmerOverrideFile``
 


### PR DESCRIPTION
## Summary

Reviewed `15.7/api/admin/api-admin-dict.rst` against the actual implementation in `repos/fess` (the `ApiAdminDict*` action classes under `app/web/api/admin/dict/`, `ApiResult`, `BaseSearchBody`, and the `dict/*` entity classes) and corrected/expanded it. All changes are applied consistently across the seven languages: **ja, en, de, es, fr, ko, zh-cn**.

## Changes

### 1. Fix the `stemmerOverride` type identifier → `stemmeroverride`
The `{type}` URL segment and the `type` field value for the stemmer-override dictionary are **lowercase** `stemmeroverride`, not camelCase:

- `StemmerOverrideFile.getType()` returns `STEMMER_OVERRIDE = "stemmeroverride"`.
- The route is served by `ApiAdminDictStemmeroverrideAction` (package/action name → lowercase URL segment), matching the admin UI path `/admin/dict/stemmeroverride/`.

The camelCase `stemmerOverride` would not match the route. Fixed in the overview, the `{type}` value list, and the per-type field table.

> Note: the multipart **upload file field** is `stemmerOverrideFile` (camelCase) per `UploadForm`, and is intentionally left unchanged.

### 2. Add the `total` field to list responses
Both `GET /api/admin/dict` and `GET /{type}/settings/{dictId}` return `ApiConfigsResponse`, whose `settings(...)` setter always sets `total = settings.size()`. The `total` field was missing from both JSON examples and the dictionary-list response-field table.

### 3. Document pagination defaults
`BaseSearchBody` defines the list parameters:

- `size` defaults to `25` (`paging.page.size`).
- `page` is **1-based** with a default of `1` (`Constants.DEFAULT_ADMIN_PAGE_NUMBER = 1`).

### 4. Minor clarifications
- Note that the `{type}` URL values match the `type` field returned by the dictionary list.
- Clarify that the item-list JSON example uses the `synonym` dictionary.

## Verification
- Cross-checked every endpoint path, HTTP method, item field, required flag, and upload file-field name against source — all others were already correct (including `mapping`'s `output`, which is correctly shown as not required).
- Confirmed no bare `stemmerOverride` remains (only `stemmerOverrideFile`) and `total` is present in all seven language files.