### PR TITLE
docs(api): correct and expand v2 Auth/Session API reference against implementation (15.7)

### DIFF
--- a/de/15.7/api/api-auth.rst
+++ b/de/15.7/api/api-auth.rst
@@ -159,7 +159,8 @@ Endpunkt             ``/api/v2/auth/login``
 
 Meldet den Benutzer mit Benutzername und Passwort an.
 Bei erfolgreicher Anmeldung wird die Servlet-Sitzungs-ID rotiert, ein neues CSRF-Token ausgestellt und die Rate-Limit-Buckets der aufrufenden IP und des Zielbenutzers geleert.
-Bei Überschreitung des Rate-Limits wird ein ``Retry-After``-Header (in Sekunden) beigefügt.
+
+Das Rate-Limiting erfolgt nach zwei Dimensionen: pro aufrufender IP und pro Benutzer. Bei Überschreitung des IP-seitigen Limits wird ``429 Too Many Requests`` zusammen mit einem ``Retry-After``-Header (in Sekunden) zurückgegeben. Bei Überschreitung des benutzerseitigen Limits wird – um den Zählerzustand von außen nicht erkennbar zu machen – dieselbe ``401 Unauthorized``-Antwort wie bei ungültigen Anmeldedaten zurückgegeben (ohne ``Retry-After``-Header).
 
 Auch bei bereits authentifizierten Sitzungen wird kein Kurzschluss durchgeführt; die übermittelten Anmeldedaten werden stets überprüft.
 
@@ -174,10 +175,18 @@ Außerdem werden protokollrelative Pfade (führendes ``//``) und Pfade mit ASCII
 
    Anders als bei anderen zustandsändernden Endpunkten fasst dieser Endpunkt übermäßig große Request-Bodys und nicht unterstützte ``Content-Type``-Werte zu ``400 invalid_request`` zusammen (andere Endpunkte geben ``413`` bzw. ``415`` zurück).
 
+.. note::
+
+   Die Rate-Limits für Anmeldung und Passwortänderung können mit folgenden Eigenschaften konfiguriert werden (Standardwerte in Klammern):
+
+   - ``theme.api.login.rate.limit.per.ip.per.minute`` (``10``): Maximale Anzahl von Versuchen pro Minute und IP-Adresse. Gilt nur für ``/auth/login``.
+   - ``theme.api.login.rate.limit.per.user.per.minute`` (``5``): Maximale Anzahl von Versuchen pro Minute und Benutzer. Gilt sowohl für ``/auth/login`` als auch für ``/auth/password``.
+   - ``theme.api.login.lockout.seconds`` (``900``): Sperrungsdauer (in Sekunden) nach Überschreitung des Limits. Wird als Wert des ``Retry-After``-Headers zurückgegeben.
+
 Anfrage-Body (LoginRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Content-Type ist ``application/json``.
+Content-Type ist ``application/json`` (Zeichensatz UTF-8). Die maximale Größe des Anfrage-Bodys beträgt 4 KiB.
 
 .. tabularcolumns:: |p{3cm}|p{2cm}|p{2cm}|p{7cm}|
 .. list-table:: LoginRequest
@@ -334,6 +343,8 @@ Fehlerantwort
      - Wenn der CSRF-Token fehlt oder abgelaufen ist.
    * - 405 Method Not Allowed
      - Wenn eine andere Methode als POST angegeben wurde. Es wird ein ``Allow: POST``-Header beigefügt.
+   * - 500 Internal Server Error
+     - Wenn ein interner Serverfehler auftritt.
 
 Passwort ändern
 ===============
@@ -353,10 +364,12 @@ Da die Sitzung serverseitig zerstört wird, wird kein ``csrf_token`` zurückgege
 
 Der ``X-Fess-CSRF-Token``-Header ist erforderlich.
 
+Für diesen Endpunkt gilt ein benutzerseitiges Rate-Limit; bei Überschreitung wird ``429 Too Many Requests`` zusammen mit einem ``Retry-After``-Header zurückgegeben (die Einstellungen sind gemeinsam mit der Anmeldung).
+
 Anfrage-Body (PasswordChangeRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Content-Type ist ``application/json``.
+Content-Type ist ``application/json`` (Zeichensatz UTF-8). Die maximale Größe des Anfrage-Bodys beträgt 4 KiB.
 
 .. tabularcolumns:: |p{3.5cm}|p{2cm}|p{2cm}|p{6.5cm}|
 .. list-table:: PasswordChangeRequest
@@ -374,7 +387,7 @@ Content-Type ist ``application/json``.
    * - ``new_password``
      - string
      - Ja
-     - Neues Passwort. Muss die konfigurierte Passwortrichtlinie erfüllen. ``minLength`` ist 1.
+     - Neues Passwort. Muss die konfigurierte Passwortrichtlinie erfüllen (standardmäßig mindestens 8 Zeichen). ``minLength`` ist 1.
    * - ``confirm_password``
      - string
      - Ja

--- a/en/15.7/api/api-auth.rst
+++ b/en/15.7/api/api-auth.rst
@@ -159,7 +159,8 @@ Endpoint            ``/api/v2/auth/login``
 
 Logs in with a username and password.
 On successful login, the servlet session ID is rotated, a new CSRF token is issued, and the rate-limit buckets for the caller's IP and the target user are cleared.
-If the rate limit is exceeded, a ``Retry-After`` header (in seconds) is included.
+
+Rate limiting is applied along two axes: per caller IP and per user. When the per-IP limit is exceeded, ``429 Too Many Requests`` is returned together with a ``Retry-After`` header (in seconds). When the per-user limit is exceeded, the same ``401 Unauthorized`` as for invalid credentials is returned (without a ``Retry-After`` header), so that the state of the counter cannot be inferred from outside.
 
 Even if a session is already authenticated, no short-circuit occurs; the provided credentials are always validated.
 
@@ -174,10 +175,18 @@ Additionally, protocol-relative paths (starting with ``//``) and paths containin
 
    Unlike other state-changing endpoints, this endpoint consolidates oversized request bodies and unsupported ``Content-Type`` into ``400 invalid_request`` (other endpoints return ``413`` / ``415``).
 
+.. note::
+
+   The rate limits for login and password change can be configured with the following properties (defaults in parentheses):
+
+   - ``theme.api.login.rate.limit.per.ip.per.minute`` (``10``): Maximum number of attempts per minute per IP address. Applies only to ``/auth/login``.
+   - ``theme.api.login.rate.limit.per.user.per.minute`` (``5``): Maximum number of attempts per minute per user. Applies to both ``/auth/login`` and ``/auth/password``.
+   - ``theme.api.login.lockout.seconds`` (``900``): Lockout duration (in seconds) after the limit is exceeded. Returned as the value of the ``Retry-After`` header.
+
 Request Body (LoginRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Content-Type is ``application/json``.
+Content-Type is ``application/json`` (charset UTF-8). The maximum request body size is 4 KiB.
 
 .. tabularcolumns:: |p{3cm}|p{2cm}|p{2cm}|p{7cm}|
 .. list-table:: LoginRequest
@@ -334,6 +343,8 @@ Error Response
      - The CSRF token is missing or expired.
    * - 405 Method Not Allowed
      - A method other than POST was specified. The ``Allow: POST`` header is included.
+   * - 500 Internal Server Error
+     - An internal server error occurred.
 
 Password Change
 ===============
@@ -353,10 +364,12 @@ Since the session is destroyed server-side, ``csrf_token`` is not returned. The 
 
 The ``X-Fess-CSRF-Token`` header is required.
 
+A per-user rate limit is applied to this endpoint; when the limit is exceeded, ``429 Too Many Requests`` is returned together with a ``Retry-After`` header (the settings are shared with login).
+
 Request Body (PasswordChangeRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Content-Type is ``application/json``.
+Content-Type is ``application/json`` (charset UTF-8). The maximum request body size is 4 KiB.
 
 .. tabularcolumns:: |p{3.5cm}|p{2cm}|p{2cm}|p{6.5cm}|
 .. list-table:: PasswordChangeRequest
@@ -374,7 +387,7 @@ Content-Type is ``application/json``.
    * - ``new_password``
      - string
      - Yes
-     - New password. Must satisfy the configured password policy. ``minLength`` is 1.
+     - New password. Must satisfy the configured password policy (minimum 8 characters by default). ``minLength`` is 1.
    * - ``confirm_password``
      - string
      - Yes

--- a/es/15.7/api/api-auth.rst
+++ b/es/15.7/api/api-auth.rst
@@ -159,7 +159,8 @@ Endpoint            ``/api/v2/auth/login``
 
 Inicia sesión con nombre de usuario y contraseña.
 Cuando el inicio de sesión es exitoso, se rota el ID de sesión del servlet, se emite un nuevo token CSRF y se borran los cubos de límite de velocidad para la IP del cliente y el usuario objetivo.
-Cuando se supera el límite de velocidad, se añade la cabecera ``Retry-After`` (en segundos).
+
+El límite de velocidad se aplica en dos ejes: por IP del cliente y por usuario. Cuando se supera el límite por IP, se devuelve ``429 Too Many Requests`` junto con una cabecera ``Retry-After`` (en segundos). Cuando se supera el límite por usuario, se devuelve el mismo ``401 Unauthorized`` que para credenciales inválidas (sin cabecera ``Retry-After``), de modo que el estado del contador no pueda inferirse desde el exterior.
 
 Incluso con una sesión ya autenticada, no se realiza un cortocircuito; las credenciales proporcionadas se verifican siempre.
 
@@ -174,10 +175,18 @@ Además, las rutas relativas al protocolo (que comienzan con ``//``) y las que c
 
    A diferencia de otros endpoints que modifican el estado, este endpoint agrupa los cuerpos de solicitud excesivos y los ``Content-Type`` no admitidos como ``400 invalid_request`` (otros endpoints devuelven ``413`` / ``415``).
 
+.. note::
+
+   Los límites de velocidad para el inicio de sesión y el cambio de contraseña pueden configurarse con las siguientes propiedades (valor predeterminado entre paréntesis):
+
+   - ``theme.api.login.rate.limit.per.ip.per.minute`` (``10``): Número máximo de intentos por minuto por dirección IP. Se aplica únicamente a ``/auth/login``.
+   - ``theme.api.login.rate.limit.per.user.per.minute`` (``5``): Número máximo de intentos por minuto por usuario. Se aplica tanto a ``/auth/login`` como a ``/auth/password``.
+   - ``theme.api.login.lockout.seconds`` (``900``): Duración del bloqueo (en segundos) una vez superado el límite. Se devuelve como valor de la cabecera ``Retry-After``.
+
 Cuerpo de la solicitud (LoginRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-El Content-Type es ``application/json``.
+El Content-Type es ``application/json`` (charset ``UTF-8``). El tamaño máximo del cuerpo de la solicitud es de ``4 KiB``.
 
 .. tabularcolumns:: |p{3cm}|p{2cm}|p{2cm}|p{7cm}|
 .. list-table:: LoginRequest
@@ -334,6 +343,8 @@ Respuesta de error
      - Cuando el token CSRF está ausente o ha expirado.
    * - 405 Method Not Allowed
      - Cuando se especifica un método distinto a POST. Se añade la cabecera ``Allow: POST``.
+   * - 500 Internal Server Error
+     - Cuando se produce un error interno del servidor.
 
 Cambio de contraseña
 ====================
@@ -353,10 +364,12 @@ Dado que la sesión se destruye en el servidor, no se devuelve ``csrf_token``. L
 
 Se requiere la cabecera ``X-Fess-CSRF-Token``.
 
+Este endpoint tiene un límite de velocidad por usuario; cuando se supera, se devuelve ``429 Too Many Requests`` junto con una cabecera ``Retry-After`` (la configuración es compartida con el inicio de sesión).
+
 Cuerpo de la solicitud (PasswordChangeRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-El Content-Type es ``application/json``.
+El Content-Type es ``application/json`` (charset ``UTF-8``). El tamaño máximo del cuerpo de la solicitud es de ``4 KiB``.
 
 .. tabularcolumns:: |p{3.5cm}|p{2cm}|p{2cm}|p{6.5cm}|
 .. list-table:: PasswordChangeRequest
@@ -374,7 +387,7 @@ El Content-Type es ``application/json``.
    * - ``new_password``
      - string
      - Sí
-     - Nueva contraseña. Debe cumplir con la política de contraseñas configurada. ``minLength`` es 1.
+     - Nueva contraseña. Debe cumplir con la política de contraseñas configurada (mínimo 8 caracteres de forma predeterminada). ``minLength`` es 1.
    * - ``confirm_password``
      - string
      - Sí

--- a/fr/15.7/api/api-auth.rst
+++ b/fr/15.7/api/api-auth.rst
@@ -159,7 +159,8 @@ Point de terminaison  ``/api/v2/auth/login``
 
 Se connecte avec un nom d'utilisateur et un mot de passe.
 En cas de succès, l'identifiant de session du servlet est renouvelé, un nouveau jeton CSRF est émis, et les buckets de limite de débit de l'IP appelante et de l'utilisateur cible sont réinitialisés.
-En cas de dépassement de la limite de débit, un en-tête ``Retry-After`` (en secondes) est ajouté.
+
+La limitation de débit est appliquée selon deux axes : par IP appelante et par utilisateur. Lorsque la limite par IP est dépassée, ``429 Too Many Requests`` est retourné accompagné d'un en-tête ``Retry-After`` (en secondes). Lorsque la limite par utilisateur est dépassée, le même ``401 Unauthorized`` que pour des informations d'identification invalides est retourné (sans en-tête ``Retry-After``), afin que l'état du compteur ne puisse pas être déduit de l'extérieur.
 
 Même pour une session déjà authentifiée, aucun court-circuit n'est appliqué : les informations d'authentification transmises sont toujours vérifiées.
 
@@ -174,10 +175,18 @@ De plus, les chemins relatifs aux protocoles (commençant par ``//``) et les che
 
    Contrairement aux autres points de terminaison de modification d'état, ce point de terminaison regroupe les corps de requête trop grands et les ``Content-Type`` non pris en charge dans ``400 invalid_request`` (les autres points de terminaison retournent ``413`` / ``415``).
 
+.. note::
+
+   Les limites de débit pour la connexion et le changement de mot de passe peuvent être configurées avec les propriétés suivantes (valeurs par défaut entre parenthèses) :
+
+   - ``theme.api.login.rate.limit.per.ip.per.minute`` (``10``) : Nombre maximal de tentatives par minute par adresse IP. S'applique uniquement à ``/auth/login``.
+   - ``theme.api.login.rate.limit.per.user.per.minute`` (``5``) : Nombre maximal de tentatives par minute par utilisateur. S'applique à la fois à ``/auth/login`` et à ``/auth/password``.
+   - ``theme.api.login.lockout.seconds`` (``900``) : Durée de verrouillage (en secondes) après dépassement de la limite. Retournée comme valeur de l'en-tête ``Retry-After``.
+
 Corps de la requête (LoginRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Le Content-Type est ``application/json``.
+Le Content-Type est ``application/json`` (charset UTF-8). La taille maximale du corps de la requête est de 4 KiB.
 
 .. tabularcolumns:: |p{3cm}|p{2cm}|p{2cm}|p{7cm}|
 .. list-table:: LoginRequest
@@ -334,6 +343,8 @@ Réponse d'erreur
      - Jeton CSRF manquant ou expiré.
    * - 405 Method Not Allowed
      - Une méthode autre que POST a été spécifiée. Un en-tête ``Allow: POST`` est ajouté.
+   * - 500 Internal Server Error
+     - Une erreur interne s'est produite sur le serveur.
 
 Changement de mot de passe
 ===========================
@@ -353,10 +364,12 @@ Comme la session est détruite côté serveur, ``csrf_token`` n'est pas retourn�
 
 L'en-tête ``X-Fess-CSRF-Token`` est requis.
 
+Une limite de débit par utilisateur est appliquée à ce point de terminaison ; lorsque la limite est dépassée, ``429 Too Many Requests`` est retourné accompagné d'un en-tête ``Retry-After`` (les paramètres sont partagés avec la connexion).
+
 Corps de la requête (PasswordChangeRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Le Content-Type est ``application/json``.
+Le Content-Type est ``application/json`` (charset UTF-8). La taille maximale du corps de la requête est de 4 KiB.
 
 .. tabularcolumns:: |p{3.5cm}|p{2cm}|p{2cm}|p{6.5cm}|
 .. list-table:: PasswordChangeRequest
@@ -374,7 +387,7 @@ Le Content-Type est ``application/json``.
    * - ``new_password``
      - string
      - Oui
-     - Nouveau mot de passe. Doit satisfaire la politique de mot de passe configurée. ``minLength`` : 1.
+     - Nouveau mot de passe. Doit satisfaire la politique de mot de passe configurée (minimum 8 caractères par défaut). ``minLength`` : 1.
    * - ``confirm_password``
      - string
      - Oui

--- a/ja/15.7/api/api-auth.rst
+++ b/ja/15.7/api/api-auth.rst
@@ -159,7 +159,8 @@ HTTPメソッド         POST
 
 ユーザー名とパスワードでログインします。
 ログイン成功時には、サーブレットのセッションIDがローテーションされ、新しい CSRF トークンが発行され、呼び出し元 IP と対象ユーザーのレート制限バケットがクリアされます。
-レート制限を超えた場合は、 ``Retry-After`` ヘッダー（秒）が付与されます。
+
+レート制限は、呼び出し元 IP 単位とユーザー単位の2系統で行われます。IP 単位の上限を超えた場合は ``429 Too Many Requests`` を返し、 ``Retry-After`` ヘッダー（秒）を付与します。ユーザー単位の上限を超えた場合は、カウンターの状態が外部から推測されることを防ぐため、認証情報が不正な場合と同じ ``401 Unauthorized`` を（ ``Retry-After`` なしで）返します。
 
 既に認証済みのセッションでもショートサーキットせず、渡された資格情報は常に検証されます。
 
@@ -174,10 +175,18 @@ HTTPメソッド         POST
 
    他の状態変更エンドポイントと異なり、このエンドポイントは過大なリクエストボディや非対応の ``Content-Type`` を ``400 invalid_request`` にまとめます（他のエンドポイントは ``413`` / ``415`` を返します）。
 
+.. note::
+
+   ログインとパスワード変更のレート制限は、以下のプロパティで設定できます（かっこ内は既定値）。
+
+   - ``theme.api.login.rate.limit.per.ip.per.minute`` （ ``10`` ）: IP アドレス単位の毎分あたりの試行回数上限。 ``/auth/login`` のみに適用されます。
+   - ``theme.api.login.rate.limit.per.user.per.minute`` （ ``5`` ）: ユーザー単位の毎分あたりの試行回数上限。 ``/auth/login`` と ``/auth/password`` の両方に適用されます。
+   - ``theme.api.login.lockout.seconds`` （ ``900`` ）: 上限を超えた後のロックアウト時間（秒）。 ``Retry-After`` ヘッダーの値として返されます。
+
 リクエストボディ (LoginRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Content-Type は ``application/json`` です。
+Content-Type は ``application/json`` （文字コードは UTF-8）です。リクエストボディの上限は 4 KiB です。
 
 .. tabularcolumns:: |p{3cm}|p{2cm}|p{2cm}|p{7cm}|
 .. list-table:: LoginRequest
@@ -334,6 +343,8 @@ HTTPメソッド         POST
      - CSRF トークンが欠落・失効している場合。
    * - 405 Method Not Allowed
      - POST 以外のメソッドが指定された場合。 ``Allow: POST`` ヘッダーが付与されます。
+   * - 500 Internal Server Error
+     - サーバー内部エラーが発生した場合。
 
 パスワード変更
 ============
@@ -353,10 +364,12 @@ HTTPメソッド         POST
 
 ``X-Fess-CSRF-Token`` ヘッダーが必要です。
 
+このエンドポイントにはユーザー単位のレート制限が適用され、上限を超えた場合は ``Retry-After`` ヘッダー付きで ``429 Too Many Requests`` を返します（設定はログインと共通です）。
+
 リクエストボディ (PasswordChangeRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Content-Type は ``application/json`` です。
+Content-Type は ``application/json`` （文字コードは UTF-8）です。リクエストボディの上限は 4 KiB です。
 
 .. tabularcolumns:: |p{3.5cm}|p{2cm}|p{2cm}|p{6.5cm}|
 .. list-table:: PasswordChangeRequest
@@ -374,7 +387,7 @@ Content-Type は ``application/json`` です。
    * - ``new_password``
      - string
      - はい
-     - 新しいパスワード。設定済みのパスワードポリシーを満たす必要があります。 ``minLength`` は1です。
+     - 新しいパスワード。設定済みのパスワードポリシー（既定では最小8文字）を満たす必要があります。 ``minLength`` は1です。
    * - ``confirm_password``
      - string
      - はい

--- a/ko/15.7/api/api-auth.rst
+++ b/ko/15.7/api/api-auth.rst
@@ -159,7 +159,8 @@ HTTP 메서드          POST
 
 사용자 이름과 비밀번호로 로그인합니다.
 로그인 성공 시에는 서블릿의 세션 ID 가 교체되고, 새 CSRF 토큰이 발급되며, 호출 원 IP 와 대상 사용자의 속도 제한 버킷이 초기화됩니다.
-속도 제한을 초과한 경우 ``Retry-After`` 헤더 (초) 가 부여됩니다.
+
+속도 제한은 호출 원 IP 단위와 사용자 단위의 2계통으로 적용됩니다. IP 단위의 상한을 초과한 경우 ``429 Too Many Requests`` 를 반환하고 ``Retry-After`` 헤더 (초) 가 부여됩니다. 사용자 단위의 상한을 초과한 경우 카운터 상태가 외부에서 추측되지 않도록, 자격증명이 올바르지 않은 경우와 동일한 ``401 Unauthorized`` 가 ( ``Retry-After`` 헤더 없이) 반환됩니다.
 
 이미 인증된 세션에서도 단락 없이, 전달된 자격증명은 항상 검증됩니다.
 
@@ -174,10 +175,18 @@ HTTP 메서드          POST
 
    다른 상태 변경 엔드포인트와 달리, 이 엔드포인트는 과도한 요청 본문이나 비지원 ``Content-Type`` 을 ``400 invalid_request`` 로 통합합니다 (다른 엔드포인트는 ``413`` / ``415`` 를 반환합니다).
 
+.. note::
+
+   로그인 및 비밀번호 변경의 속도 제한은 다음 프로퍼티로 설정할 수 있습니다 (괄호 안은 기본값).
+
+   - ``theme.api.login.rate.limit.per.ip.per.minute`` (``10``): IP 주소 단위의 분당 최대 시도 횟수. ``/auth/login`` 에만 적용됩니다.
+   - ``theme.api.login.rate.limit.per.user.per.minute`` (``5``): 사용자 단위의 분당 최대 시도 횟수. ``/auth/login`` 과 ``/auth/password`` 양쪽에 적용됩니다.
+   - ``theme.api.login.lockout.seconds`` (``900``): 상한 초과 후의 잠금 시간 (초). ``Retry-After`` 헤더의 값으로 반환됩니다.
+
 요청 본문 (LoginRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Content-Type 은 ``application/json`` 입니다.
+Content-Type 은 ``application/json`` (문자 인코딩 UTF-8) 입니다. 요청 본문의 최대 크기는 4 KiB 입니다.
 
 .. tabularcolumns:: |p{3cm}|p{2cm}|p{2cm}|p{7cm}|
 .. list-table:: LoginRequest
@@ -334,6 +343,8 @@ HTTP 메서드          POST
      - CSRF 토큰이 누락·만료된 경우.
    * - 405 Method Not Allowed
      - POST 이외의 메서드가 지정된 경우. ``Allow: POST`` 헤더가 부여됩니다.
+   * - 500 Internal Server Error
+     - 서버 내부 오류가 발생한 경우.
 
 비밀번호 변경
 =============
@@ -353,10 +364,12 @@ HTTP 메서드          POST
 
 ``X-Fess-CSRF-Token`` 헤더가 필요합니다.
 
+이 엔드포인트에는 사용자 단위의 속도 제한이 적용되며, 상한을 초과한 경우 ``429 Too Many Requests`` 와 함께 ``Retry-After`` 헤더가 반환됩니다 (설정은 로그인과 공유됩니다).
+
 요청 본문 (PasswordChangeRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Content-Type 은 ``application/json`` 입니다.
+Content-Type 은 ``application/json`` (문자 인코딩 UTF-8) 입니다. 요청 본문의 최대 크기는 4 KiB 입니다.
 
 .. tabularcolumns:: |p{3.5cm}|p{2cm}|p{2cm}|p{6.5cm}|
 .. list-table:: PasswordChangeRequest
@@ -374,7 +387,7 @@ Content-Type 은 ``application/json`` 입니다.
    * - ``new_password``
      - string
      - 예
-     - 새 비밀번호. 설정된 비밀번호 정책을 충족해야 합니다. ``minLength`` 는 1입니다.
+     - 새 비밀번호. 설정된 비밀번호 정책 (기본값은 최소 8자) 을 충족해야 합니다. ``minLength`` 는 1입니다.
    * - ``confirm_password``
      - string
      - 예

--- a/zh-cn/15.7/api/api-auth.rst
+++ b/zh-cn/15.7/api/api-auth.rst
@@ -159,7 +159,8 @@ HTTP 方法            POST
 
 使用用户名和密码登录。
 登录成功时，Servlet 会话 ID 将轮换，颁发新的 CSRF 令牌，并清除调用方 IP 和目标用户的速率限制桶。
-超过速率限制时，响应中会附带 ``Retry-After`` 头（单位秒）。
+
+速率限制分为两个维度：调用方 IP 单位和用户单位。超过 IP 单位限制时，返回 ``429 Too Many Requests`` 并附带 ``Retry-After`` 头（单位秒）。超过用户单位限制时，为防止外部推测计数器状态，返回与凭据不正确相同的 ``401 Unauthorized``\ （不附带 ``Retry-After`` 头）。
 
 即使已有认证会话，也不会短路，传入的凭据始终会被验证。
 
@@ -174,10 +175,18 @@ HTTP 方法            POST
 
    与其他状态变更端点不同，本端点会将过大的请求体或不支持的 ``Content-Type`` 统一归为 ``400 invalid_request``\ （其他端点会返回 ``413`` / ``415``\ ）。
 
+.. note::
+
+   登录和密码修改的速率限制可通过以下属性进行配置（括号内为默认值）：
+
+   - ``theme.api.login.rate.limit.per.ip.per.minute`` (``10``): 每个 IP 地址每分钟的最大尝试次数。仅适用于 ``/auth/login``\ 。
+   - ``theme.api.login.rate.limit.per.user.per.minute`` (``5``): 每个用户每分钟的最大尝试次数。适用于 ``/auth/login`` 和 ``/auth/password``\ 。
+   - ``theme.api.login.lockout.seconds`` (``900``): 超过限制后的锁定时长（秒）。作为 ``Retry-After`` 头的值返回。
+
 请求体 (LoginRequest)
 ~~~~~~~~~~~~~~~~~~~~~
 
-Content-Type 为 ``application/json``\ 。
+Content-Type 为 ``application/json``\ （字符集 UTF-8）。请求体大小上限为 4 KiB。
 
 .. tabularcolumns:: |p{3cm}|p{2cm}|p{2cm}|p{7cm}|
 .. list-table:: LoginRequest
@@ -334,6 +343,8 @@ HTTP 方法            POST
      - CSRF 令牌缺失或过期时。
    * - 405 Method Not Allowed
      - 指定了 POST 以外的方法时。响应中附带 ``Allow: POST`` 头。
+   * - 500 Internal Server Error
+     - 发生服务器内部错误时。
 
 修改密码
 ========
@@ -353,10 +364,12 @@ HTTP 方法            POST
 
 需要携带 ``X-Fess-CSRF-Token`` 头。
 
+本端点应用用户单位速率限制；超过限制时，返回 ``429 Too Many Requests`` 并附带 ``Retry-After`` 头（设置与登录共用）。
+
 请求体 (PasswordChangeRequest)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Content-Type 为 ``application/json``\ 。
+Content-Type 为 ``application/json``\ （字符集 UTF-8）。请求体大小上限为 4 KiB。
 
 .. tabularcolumns:: |p{3.5cm}|p{2cm}|p{2cm}|p{6.5cm}|
 .. list-table:: PasswordChangeRequest
@@ -374,7 +387,7 @@ Content-Type 为 ``application/json``\ 。
    * - ``new_password``
      - string
      - 是
-     - 新密码。须满足已配置的密码策略。\ ``minLength`` 为 1。
+     - 新密码。须满足已配置的密码策略（默认最少 8 个字符）。\ ``minLength`` 为 1。
    * - ``confirm_password``
      - string
      - 是


### PR DESCRIPTION
## Summary

Reviewed `ja/15.7/api/api-auth.rst` (v2 Authentication / Session API) against the actual implementation in `org.codelibs.fess.api.v2` (`LoginHandler`, `LogoutHandler`, `PasswordChangeHandler`, `MeHandler`, `LoginRateLimiter`, `SearchApiV2Manager`) and corrected/expanded it. The same updates were applied across all seven languages (ja, en, de, fr, es, ko, zh-cn).

## Changes

- **Login rate limiting clarified.** The endpoint is rate limited along two axes. Exceeding the per-IP limit returns `429 Too Many Requests` with a `Retry-After` header, while exceeding the per-user limit returns a generic `401 Unauthorized` **without** `Retry-After` so the counter state cannot be inferred. Previously the page implied any rate-limit breach returned `429`.
- **Rate-limit configuration documented.** Added the controlling properties and defaults — `theme.api.login.rate.limit.per.ip.per.minute` (`10`), `theme.api.login.rate.limit.per.user.per.minute` (`5`), `theme.api.login.lockout.seconds` (`900`) — and noted they govern both `/auth/login` and `/auth/password`.
- **Request body limits documented.** Stated the 4 KiB request body cap and the `application/json` (UTF-8) requirement for the login and password-change bodies.
- **Logout error table fixed.** Added the missing `500 Internal Server Error` row, for consistency with the other three endpoints (the same manager-level error path applies).
- **Password change rate limiting.** Noted that this endpoint enforces a per-user rate limit (`429` with `Retry-After`), sharing the login settings.
- **Password policy.** Noted the default minimum password length (8 characters) for `new_password`.

## Verification

- All values verified against source (`fess_config.properties`: `theme.api.login.*`, `authentication.admin.roles`, `password.min.length`; handler logic for the IP-vs-user 429/401 behavior, 4 KiB body cap, and logout idempotency).
- RST structure checked for all seven languages: consistent note/bullet/table formatting and correct inline-literal escaping in the CJK files.