### PR TITLE
docs(api): correct and expand Admin Group API reference against implementation (15.7)

### DIFF
--- a/de/15.7/api/admin/api-admin-group.rst
+++ b/de/15.7/api/admin/api-admin-group.rst
@@ -56,7 +56,7 @@ Parameter
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parameter
      - Typ
@@ -65,11 +65,15 @@ Parameter
    * - ``size``
      - Integer
      - Nein
-     - Anzahl der Einträge pro Seite (Standard: 20)
+     - Anzahl der Einträge pro Seite (Standard: 25)
    * - ``page``
      - Integer
      - Nein
-     - Seitennummer (beginnt bei 0)
+     - Seitennummer (beginnt bei 1, Standard: 1)
+   * - ``id``
+     - String
+     - Nein
+     - Filtert anhand der exakten Übereinstimmung mit der angegebenen Gruppen-ID
 
 Response
 --------
@@ -85,14 +89,16 @@ Response
             "name": "Engineering",
             "attributes": {
               "gidNumber": "1000"
-            }
+            },
+            "versionNo": 1
           },
           {
             "id": "group_id_2",
             "name": "Sales",
             "attributes": {
               "gidNumber": "1001"
-            }
+            },
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -122,7 +128,8 @@ Response
           "name": "Engineering",
           "attributes": {
             "gidNumber": "1000"
-          }
+          },
+          "versionNo": 1
         }
       }
     }
@@ -155,14 +162,14 @@ Feldbeschreibungen
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - Feld
      - Erforderlich
      - Beschreibung
    * - ``name``
      - Ja
-     - Gruppenname
+     - Gruppenname (maximal 100 Zeichen)
    * - ``attributes``
      - Nein
      - Attribut-Map (enthält LDAP-Attribute wie ``gidNumber``). Werte werden als Zeichenketten angegeben
@@ -204,6 +211,29 @@ Request-Body
       },
       "versionNo": 1
     }
+
+Feldbeschreibungen
+~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Feld
+     - Erforderlich
+     - Beschreibung
+   * - ``id``
+     - Ja
+     - Zu aktualisierende Gruppen-ID
+   * - ``name``
+     - Ja
+     - Gruppenname (maximal 100 Zeichen)
+   * - ``attributes``
+     - Nein
+     - Attribut-Map (enthält LDAP-Attribute wie ``gidNumber``). Werte werden als Zeichenketten angegeben
+   * - ``versionNo``
+     - Ja
+     - Versionsnummer für optimistisches Sperren. Geben Sie den Wert von ``versionNo`` an, der beim Abrufen der Gruppe ermittelt wurde
 
 Response
 --------

--- a/en/15.7/api/admin/api-admin-group.rst
+++ b/en/15.7/api/admin/api-admin-group.rst
@@ -56,7 +56,7 @@ Parameters
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parameter
      - Type
@@ -65,11 +65,15 @@ Parameters
    * - ``size``
      - Integer
      - No
-     - Number of items per page (default: 20)
+     - Number of items per page (default: 25)
    * - ``page``
      - Integer
      - No
-     - Page number (starts from 0)
+     - Page number (starts from 1, default: 1)
+   * - ``id``
+     - String
+     - No
+     - Filters by exact match on the specified group ID
 
 Response
 --------
@@ -85,14 +89,16 @@ Response
             "name": "Engineering",
             "attributes": {
               "gidNumber": "1000"
-            }
+            },
+            "versionNo": 1
           },
           {
             "id": "group_id_2",
             "name": "Sales",
             "attributes": {
               "gidNumber": "1001"
-            }
+            },
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -122,7 +128,8 @@ Response
           "name": "Engineering",
           "attributes": {
             "gidNumber": "1000"
-          }
+          },
+          "versionNo": 1
         }
       }
     }
@@ -155,14 +162,14 @@ Field Description
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - Field
      - Required
      - Description
    * - ``name``
      - Yes
-     - Group name
+     - Group name (max 100 characters)
    * - ``attributes``
      - No
      - Map of attributes (includes LDAP attributes such as ``gidNumber``). Values are specified as strings
@@ -204,6 +211,29 @@ Request Body
       },
       "versionNo": 1
     }
+
+Field Description
+~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Field
+     - Required
+     - Description
+   * - ``id``
+     - Yes
+     - Group ID to update
+   * - ``name``
+     - Yes
+     - Group name (max 100 characters)
+   * - ``attributes``
+     - No
+     - Map of attributes (includes LDAP attributes such as ``gidNumber``). Values are specified as strings
+   * - ``versionNo``
+     - Yes
+     - Version number for optimistic locking. Specify the ``versionNo`` value obtained from Get Group
 
 Response
 --------

--- a/es/15.7/api/admin/api-admin-group.rst
+++ b/es/15.7/api/admin/api-admin-group.rst
@@ -56,7 +56,7 @@ Parametros
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parametro
      - Tipo
@@ -65,11 +65,15 @@ Parametros
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Numero de elementos por pagina (predeterminado: 25)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 0)
+     - Numero de pagina (comienza en 1, predeterminado: 1)
+   * - ``id``
+     - String
+     - No
+     - Filtra por coincidencia exacta con el ID de grupo especificado
 
 Respuesta
 ---------
@@ -85,14 +89,16 @@ Respuesta
             "name": "Engineering",
             "attributes": {
               "gidNumber": "1000"
-            }
+            },
+            "versionNo": 1
           },
           {
             "id": "group_id_2",
             "name": "Sales",
             "attributes": {
               "gidNumber": "1001"
-            }
+            },
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -122,7 +128,8 @@ Respuesta
           "name": "Engineering",
           "attributes": {
             "gidNumber": "1000"
-          }
+          },
+          "versionNo": 1
         }
       }
     }
@@ -155,14 +162,14 @@ Descripcion de Campos
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - Campo
      - Requerido
      - Descripcion
    * - ``name``
      - Si
-     - Nombre del grupo
+     - Nombre del grupo (maximo 100 caracteres)
    * - ``attributes``
      - No
      - Mapa de atributos (incluye atributos LDAP como ``gidNumber``). Los valores se especifican como cadenas
@@ -204,6 +211,29 @@ Cuerpo de la Solicitud
       },
       "versionNo": 1
     }
+
+Descripcion de Campos
+~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Campo
+     - Requerido
+     - Descripcion
+   * - ``id``
+     - Si
+     - ID del grupo a actualizar
+   * - ``name``
+     - Si
+     - Nombre del grupo (maximo 100 caracteres)
+   * - ``attributes``
+     - No
+     - Mapa de atributos (incluye atributos LDAP como ``gidNumber``). Los valores se especifican como cadenas
+   * - ``versionNo``
+     - Si
+     - Numero de version para el bloqueo optimista. Especifique el valor de ``versionNo`` obtenido al obtener el grupo
 
 Respuesta
 ---------

--- a/fr/15.7/api/admin/api-admin-group.rst
+++ b/fr/15.7/api/admin/api-admin-group.rst
@@ -56,7 +56,7 @@ Parametres
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parametre
      - Type
@@ -65,11 +65,15 @@ Parametres
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 20)
+     - Nombre d'elements par page (par defaut : 25)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 0)
+     - Numero de page (commence a 1, par defaut : 1)
+   * - ``id``
+     - String
+     - Non
+     - Filtre par correspondance exacte sur l'ID de groupe specifie
 
 Reponse
 -------
@@ -85,14 +89,16 @@ Reponse
             "name": "Engineering",
             "attributes": {
               "gidNumber": "1000"
-            }
+            },
+            "versionNo": 1
           },
           {
             "id": "group_id_2",
             "name": "Sales",
             "attributes": {
               "gidNumber": "1001"
-            }
+            },
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -122,7 +128,8 @@ Reponse
           "name": "Engineering",
           "attributes": {
             "gidNumber": "1000"
-          }
+          },
+          "versionNo": 1
         }
       }
     }
@@ -155,14 +162,14 @@ Description des champs
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - Champ
      - Requis
      - Description
    * - ``name``
      - Oui
-     - Nom du groupe
+     - Nom du groupe (maximum 100 caracteres)
    * - ``attributes``
      - Non
      - Map d'attributs (contenant des attributs LDAP comme ``gidNumber``). Les valeurs sont specifiees sous forme de chaines de caracteres
@@ -204,6 +211,29 @@ Corps de la requete
       },
       "versionNo": 1
     }
+
+Description des champs
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Champ
+     - Requis
+     - Description
+   * - ``id``
+     - Oui
+     - ID du groupe a mettre a jour
+   * - ``name``
+     - Oui
+     - Nom du groupe (maximum 100 caracteres)
+   * - ``attributes``
+     - Non
+     - Map d'attributs (contenant des attributs LDAP comme ``gidNumber``). Les valeurs sont specifiees sous forme de chaines de caracteres
+   * - ``versionNo``
+     - Oui
+     - Numero de version pour le verrouillage optimiste. Specifiez la valeur de ``versionNo`` obtenue lors de l'obtention du groupe
 
 Reponse
 -------

--- a/ja/15.7/api/admin/api-admin-group.rst
+++ b/ja/15.7/api/admin/api-admin-group.rst
@@ -56,7 +56,7 @@ Group APIは、|Fess| のグループを管理するためのAPIです。
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - パラメーター
      - 型
@@ -65,11 +65,15 @@ Group APIは、|Fess| のグループを管理するためのAPIです。
    * - ``size``
      - Integer
      - いいえ
-     - 1ページあたりの件数（デフォルト: 20）
+     - 1ページあたりの件数（デフォルト: 25）
    * - ``page``
      - Integer
      - いいえ
-     - ページ番号（0から開始）
+     - ページ番号（1から開始、デフォルト: 1）
+   * - ``id``
+     - String
+     - いいえ
+     - 指定したグループIDで完全一致フィルタリングします
 
 レスポンス
 ----------
@@ -85,14 +89,16 @@ Group APIは、|Fess| のグループを管理するためのAPIです。
             "name": "Engineering",
             "attributes": {
               "gidNumber": "1000"
-            }
+            },
+            "versionNo": 1
           },
           {
             "id": "group_id_2",
             "name": "Sales",
             "attributes": {
               "gidNumber": "1001"
-            }
+            },
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -122,7 +128,8 @@ Group APIは、|Fess| のグループを管理するためのAPIです。
           "name": "Engineering",
           "attributes": {
             "gidNumber": "1000"
-          }
+          },
+          "versionNo": 1
         }
       }
     }
@@ -155,14 +162,14 @@ Group APIは、|Fess| のグループを管理するためのAPIです。
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - フィールド
      - 必須
      - 説明
    * - ``name``
      - はい
-     - グループ名
+     - グループ名（最大100文字）
    * - ``attributes``
      - いいえ
      - 属性のマップ（``gidNumber`` などのLDAP属性を含む）。値は文字列で指定します
@@ -204,6 +211,29 @@ Group APIは、|Fess| のグループを管理するためのAPIです。
       },
       "versionNo": 1
     }
+
+フィールド説明
+~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - フィールド
+     - 必須
+     - 説明
+   * - ``id``
+     - はい
+     - 更新対象のグループID
+   * - ``name``
+     - はい
+     - グループ名（最大100文字）
+   * - ``attributes``
+     - いいえ
+     - 属性のマップ（``gidNumber`` などのLDAP属性を含む）。値は文字列で指定します
+   * - ``versionNo``
+     - はい
+     - 楽観的ロック用のバージョン番号。グループ取得で得た ``versionNo`` の値を指定します
 
 レスポンス
 ----------

--- a/ko/15.7/api/admin/api-admin-group.rst
+++ b/ko/15.7/api/admin/api-admin-group.rst
@@ -56,7 +56,7 @@ Group API는 |Fess| 의 그룹을 관리하기 위한 API입니다.
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - 파라미터
      - 타입
@@ -65,11 +65,15 @@ Group API는 |Fess| 의 그룹을 관리하기 위한 API입니다.
    * - ``size``
      - Integer
      - 아니오
-     - 페이지당 건수 (기본값: 20)
+     - 페이지당 건수 (기본값: 25)
    * - ``page``
      - Integer
      - 아니오
-     - 페이지 번호 (0부터 시작)
+     - 페이지 번호 (1부터 시작, 기본값: 1)
+   * - ``id``
+     - String
+     - 아니오
+     - 지정한 그룹 ID로 완전 일치 필터링합니다
 
 응답
 ----------
@@ -85,14 +89,16 @@ Group API는 |Fess| 의 그룹을 관리하기 위한 API입니다.
             "name": "Engineering",
             "attributes": {
               "gidNumber": "1000"
-            }
+            },
+            "versionNo": 1
           },
           {
             "id": "group_id_2",
             "name": "Sales",
             "attributes": {
               "gidNumber": "1001"
-            }
+            },
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -122,7 +128,8 @@ Group API는 |Fess| 의 그룹을 관리하기 위한 API입니다.
           "name": "Engineering",
           "attributes": {
             "gidNumber": "1000"
-          }
+          },
+          "versionNo": 1
         }
       }
     }
@@ -155,14 +162,14 @@ Group API는 |Fess| 의 그룹을 관리하기 위한 API입니다.
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - 필드
      - 필수
      - 설명
    * - ``name``
      - 예
-     - 그룹 이름
+     - 그룹 이름 (최대 100자)
    * - ``attributes``
      - 아니오
      - 속성의 맵 (``gidNumber`` 등의 LDAP 속성을 포함). 값은 문자열로 지정합니다
@@ -204,6 +211,29 @@ Group API는 |Fess| 의 그룹을 관리하기 위한 API입니다.
       },
       "versionNo": 1
     }
+
+필드 설명
+~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - 필드
+     - 필수
+     - 설명
+   * - ``id``
+     - 예
+     - 업데이트 대상 그룹 ID
+   * - ``name``
+     - 예
+     - 그룹 이름 (최대 100자)
+   * - ``attributes``
+     - 아니오
+     - 속성의 맵 (``gidNumber`` 등의 LDAP 속성을 포함). 값은 문자열로 지정합니다
+   * - ``versionNo``
+     - 예
+     - 낙관적 잠금을 위한 버전 번호. 그룹 조회에서 얻은 ``versionNo`` 값을 지정합니다
 
 응답
 ----------

--- a/zh-cn/15.7/api/admin/api-admin-group.rst
+++ b/zh-cn/15.7/api/admin/api-admin-group.rst
@@ -56,7 +56,7 @@ Group API是用于管理 |Fess| 组的API。
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - 参数
      - 类型
@@ -65,11 +65,15 @@ Group API是用于管理 |Fess| 组的API。
    * - ``size``
      - Integer
      - 否
-     - 每页记录数（默认：20）
+     - 每页记录数（默认：25）
    * - ``page``
      - Integer
      - 否
-     - 页码（从0开始）
+     - 页码（从1开始，默认：1）
+   * - ``id``
+     - String
+     - 否
+     - 按指定的组ID进行完全匹配过滤
 
 响应
 ----
@@ -85,14 +89,16 @@ Group API是用于管理 |Fess| 组的API。
             "name": "Engineering",
             "attributes": {
               "gidNumber": "1000"
-            }
+            },
+            "versionNo": 1
           },
           {
             "id": "group_id_2",
             "name": "Sales",
             "attributes": {
               "gidNumber": "1001"
-            }
+            },
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -122,7 +128,8 @@ Group API是用于管理 |Fess| 组的API。
           "name": "Engineering",
           "attributes": {
             "gidNumber": "1000"
-          }
+          },
+          "versionNo": 1
         }
       }
     }
@@ -155,14 +162,14 @@ Group API是用于管理 |Fess| 组的API。
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - 字段
      - 必需
      - 说明
    * - ``name``
      - 是
-     - 组名称
+     - 组名称（最大100个字符）
    * - ``attributes``
      - 否
      - 属性的映射（包含 ``gidNumber`` 等LDAP属性）。值以字符串指定
@@ -204,6 +211,29 @@ Group API是用于管理 |Fess| 组的API。
       },
       "versionNo": 1
     }
+
+字段说明
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - 字段
+     - 必需
+     - 说明
+   * - ``id``
+     - 是
+     - 要更新的组ID
+   * - ``name``
+     - 是
+     - 组名称（最大100个字符）
+   * - ``attributes``
+     - 否
+     - 属性的映射（包含 ``gidNumber`` 等LDAP属性）。值以字符串指定
+   * - ``versionNo``
+     - 是
+     - 乐观锁的版本号。指定从获取组获得的 ``versionNo`` 值
 
 响应
 ----


### PR DESCRIPTION
## Summary

Reviewed the Admin Group API documentation (`api/admin/api-admin-group.rst`) against the `ApiAdminGroupAction` implementation and corrected several inaccuracies. The same fixes were applied consistently across all seven languages (ja, en, de, fr, es, ko, zh-cn), with Japanese as the source of truth.

## Changes

- **List parameters — default page size**: corrected the `size` default from `20` to `25` (it derives from the `paging.page.size` configuration property).
- **List parameters — page numbering**: clarified that `page` is **1-based with a default of `1`** (it was incorrectly documented as starting from `0`).
- **List parameters — missing `id` parameter**: documented the `id` query parameter, which filters the list by an exact group ID match.
- **Responses — `versionNo`**: added the `versionNo` field that is actually returned for each group in the list and single-get responses.
- **Create field table — `name` constraint**: noted the 100-character maximum length for `name`.
- **Update — field description table**: added a field description table for the update request, documenting that `id`, `name`, and `versionNo` are required and that `versionNo` is used for optimistic locking.
- **RST formatting**: fixed `list-table` `:widths:` directives so the number of widths matches the number of columns (the parameter and field tables previously had a mismatched count).

## Verification

- Verified every documented endpoint, parameter, request/response field, and default value against the source implementation (`ApiAdminGroupAction`, `BaseSearchBody`, `CreateForm`/`EditForm`, the `Group` entity/behavior, and `GroupService`).
- Confirmed all seven files have valid JSON examples, `:widths:` counts matching their column counts, and consistent field names/values across languages.