### PR TITLE
docs(api): correct and expand Admin LabelType API reference (15.7)

### DIFF
--- a/de/15.7/api/admin/api-admin-labeltype.rst
+++ b/de/15.7/api/admin/api-admin-labeltype.rst
@@ -6,7 +6,15 @@ LabelType API
 =========
 
 Die LabelType API dient zur Verwaltung von Label-Typen in |Fess|.
-Sie können Label-Typen für die Kategorisierung und Filterung von Suchergebnissen verwalten.
+Label-Typen ermöglichen die Kategorisierung von Suchergebnissen anhand von gecrawlten Pfaden und
+virtuellen Hosts und können für die Eingrenzung (Filterung) über Labels in der Suchoberfläche
+verwendet werden.
+
+Informationen zur Authentifizierung sowie zu den gemeinsamen Spezifikationen von Antworten
+(``status``-Code, ``version``-Feld, Fehlerformat, HTTP-Statuscodes usw.) finden Sie unter
+:doc:`api-admin-overview`.
+Für den Zugriff auf diese API ist ein Access Token mit Admin-API-Berechtigung (``admin-api``)
+im Header ``Authorization: Bearer <Access Token>`` erforderlich.
 
 Basis-URL
 =========
@@ -44,7 +52,7 @@ Endpunktliste
 Label-Typ-Liste abrufen
 =======================
 
-Request
+Anfrage
 -------
 
 ::
@@ -56,7 +64,7 @@ Parameter
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parameter
      - Typ
@@ -65,19 +73,28 @@ Parameter
    * - ``size``
      - Integer
      - Nein
-     - Anzahl der Einträge pro Seite (Standard: 20)
+     - Anzahl der Einträge pro Seite. Standard ist der konfigurierte Wert von ``paging.page.size`` (normalerweise ``25``).
    * - ``page``
      - Integer
      - Nein
-     - Seitennummer (beginnt bei 0)
+     - Seitennummer (beginnt bei 1). Standard ist ``1``.
+   * - ``name``
+     - String
+     - Nein
+     - Eingrenzung nach Anzeigename (Wildcard-Suche).
+   * - ``value``
+     - String
+     - Nein
+     - Eingrenzung nach Label-Wert (Wildcard-Suche).
 
-Response
---------
+Antwort
+-------
 
 .. code-block:: json
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -88,17 +105,65 @@ Response
             "excludedPaths": "",
             "permissions": "{role}admin",
             "virtualHost": "",
-            "sortOrder": 0
+            "sortOrder": 0,
+            "createdBy": "admin",
+            "createdTime": 1700000000000,
+            "updatedBy": "admin",
+            "updatedTime": 1700000000000,
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
 
+.. note::
+
+   Jedes Einstellungsobjekt enthält auch die Audit-Felder ``createdBy`` / ``createdTime`` / ``updatedBy`` /
+   ``updatedTime`` sowie ``versionNo`` für optimistisches Sperren (Felder mit dem Wert ``null``
+   werden weggelassen). Das ``response``-Objekt enthält stets ``version``, das die Produktversion
+   angibt; in den folgenden Beispielen wird es der Übersichtlichkeit halber teilweise weggelassen.
+
+Label-Typ abrufen
+=================
+
+Anfrage
+-------
+
+::
+
+    GET /api/admin/labeltype/setting/{id}
+
+Antwort
+-------
+
+.. code-block:: json
+
+    {
+      "response": {
+        "status": 0,
+        "setting": {
+          "id": "label_id_1",
+          "name": "Documentation",
+          "value": "docs",
+          "includedPaths": ".*docs\\.example\\.com.*",
+          "excludedPaths": "",
+          "permissions": "{role}admin",
+          "virtualHost": "",
+          "sortOrder": 0,
+          "createdBy": "admin",
+          "createdTime": 1700000000000,
+          "updatedBy": "admin",
+          "updatedTime": 1700000000000,
+          "versionNo": 1
+        }
+      }
+    }
+
 Label-Typ erstellen
 ===================
 
-Request
+Anfrage
 -------
 
 ::
@@ -106,8 +171,8 @@ Request
     POST /api/admin/labeltype/setting
     Content-Type: application/json
 
-Request-Body
-~~~~~~~~~~~~
+Anfragetext
+~~~~~~~~~~~
 
 .. code-block:: json
 
@@ -120,40 +185,53 @@ Request-Body
       "permissions": "{role}guest"
     }
 
-Feldbeschreibungen
-~~~~~~~~~~~~~~~~~~
+Feldbeschreibung
+~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 12 12 56
 
    * - Feld
+     - Typ
      - Erforderlich
      - Beschreibung
    * - ``name``
+     - String
      - Ja
-     - Anzeigename des Labels
+     - Anzeigename des Labels (maximal 100 Zeichen).
    * - ``value``
+     - String
      - Ja
-     - Label-Wert (verwendet bei der Suche)
+     - Label-Wert (wird bei der Suche als ``label``-Parameter verwendet). Nur alphanumerische Zeichen und Unterstriche (``_``) sind zulässig; der Wert muss dem regulären Ausdruck ``^[a-zA-Z0-9_]+$`` entsprechen (maximal 100 Zeichen).
    * - ``includedPaths``
+     - String
      - Nein
-     - Regex für Label-Zielpfade (mehrere durch Zeilenumbruch getrennt)
+     - Regulärer Ausdruck für Label-Zielpfade. Bei mehreren Angaben durch Zeilenumbruch (``\n``) trennen.
    * - ``excludedPaths``
+     - String
      - Nein
-     - Regex für ausgeschlossene Pfade (mehrere durch Zeilenumbruch getrennt)
-   * - ``sortOrder``
-     - Nein
-     - Anzeigereihenfolge
+     - Regulärer Ausdruck für ausgeschlossene Pfade. Bei mehreren Angaben durch Zeilenumbruch (``\n``) trennen.
    * - ``permissions``
+     - String
      - Nein
-     - Zugriffsberechtigte Rollen (bei mehreren durch Zeilenumbrüche getrennt)
+     - Zugriffsberechtigte Rollen/Gruppen/Benutzer (Beispiel: ``{role}admin``). Bei mehreren Angaben durch Zeilenumbruch (``\n``) trennen.
+   * - ``sortOrder``
+     - Integer
+     - Nein
+     - Anzeigereihenfolge (ganze Zahl >= 0). Standardwert ist ``0``.
    * - ``virtualHost``
+     - String
      - Nein
-     - Virtueller Host
+     - Virtueller Host (maximal 1000 Zeichen).
 
-Response
---------
+.. note::
+
+   Audit-Felder wie ``createdBy`` / ``createdTime`` werden serverseitig automatisch gesetzt
+   und müssen nicht in der Anfrage angegeben werden.
+
+Antwort
+-------
 
 .. code-block:: json
 
@@ -165,8 +243,92 @@ Response
       }
     }
 
-Verwendungsbeispiele
-====================
+Bei erfolgreicher Erstellung ist ``created`` gleich ``true``.
+
+Label-Typ aktualisieren
+=======================
+
+Anfrage
+-------
+
+::
+
+    PUT /api/admin/labeltype/setting
+    Content-Type: application/json
+
+Anfragetext
+~~~~~~~~~~~
+
+.. code-block:: json
+
+    {
+      "id": "existing_label_id",
+      "name": "News Articles",
+      "value": "news",
+      "includedPaths": ".*news\\.example\\.com.*\n.*example\\.com/(news|articles)/.*",
+      "excludedPaths": ".*/(archive|old|draft)/.*",
+      "sortOrder": 1,
+      "permissions": "{role}guest",
+      "versionNo": 1
+    }
+
+Bei der Aktualisierung sind zusätzlich zu den Feldern beim Erstellen folgende Felder erforderlich.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 12 56
+
+   * - Feld
+     - Typ
+     - Erforderlich
+     - Beschreibung
+   * - ``id``
+     - String
+     - Ja
+     - ID des zu aktualisierenden Label-Typs.
+   * - ``versionNo``
+     - Integer
+     - Ja
+     - Versionsnummer für optimistisches Sperren. Geben Sie den ``versionNo``-Wert aus der Abrufantwort an. Stimmt die angegebene Version nicht mit der aktuellen überein, schlägt die Aktualisierung fehl.
+
+Antwort
+-------
+
+.. code-block:: json
+
+    {
+      "response": {
+        "status": 0,
+        "id": "existing_label_id",
+        "created": false
+      }
+    }
+
+Bei einer Aktualisierung ist ``created`` gleich ``false``.
+
+Label-Typ löschen
+=================
+
+Anfrage
+-------
+
+::
+
+    DELETE /api/admin/labeltype/setting/{id}
+
+Antwort
+-------
+
+.. code-block:: json
+
+    {
+      "response": {
+        "status": 0
+      }
+    }
+
+Anwendungsbeispiele
+===================
 
 Dokumentations-Label erstellen
 ------------------------------
@@ -184,16 +346,24 @@ Dokumentations-Label erstellen
            "permissions": "{role}guest"
          }'
 
-Suche mit Label
----------------
+Label-Typ-Liste abrufen
+-----------------------
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/api/admin/labeltype/settings?size=50&page=1" \
+         -H "Authorization: Bearer YOUR_TOKEN"
+
+Suche mit Label-Typ
+-------------------
 
 .. code-block:: bash
 
     # Mit Label filtern
     curl "http://localhost:8080/json/?q=search&label=tech_docs"
 
-Referenzinformationen
-=====================
+Siehe auch
+==========
 
 - :doc:`api-admin-overview` - Admin API Übersicht
 - :doc:`../api-search` - Such-API

--- a/en/15.7/api/admin/api-admin-labeltype.rst
+++ b/en/15.7/api/admin/api-admin-labeltype.rst
@@ -5,8 +5,14 @@ LabelType API
 Overview
 ========
 
-LabelType API is an API for managing |Fess| label types.
-You can configure label types for search result classification and filtering.
+LabelType API is an API for managing label types in |Fess|.
+Label types allow you to classify search results based on crawled paths or virtual hosts,
+and can be used for label-based filtering on the search screen.
+
+For common specifications regarding authentication, responses (``status`` codes, ``version`` field,
+error format, HTTP status codes, etc.), refer to :doc:`api-admin-overview`.
+To access this API, you must provide an access token with admin API permission (``admin-api``)
+in the ``Authorization: Bearer <access_token>`` header.
 
 Base URL
 ========
@@ -56,7 +62,7 @@ Parameters
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parameter
      - Type
@@ -65,11 +71,19 @@ Parameters
    * - ``size``
      - Integer
      - No
-     - Number of items per page (default: 20)
+     - Number of items per page. Default is the ``paging.page.size`` setting value (``25`` by default).
    * - ``page``
      - Integer
      - No
-     - Page number (starts from 0)
+     - Page number (starts from 1). Default is ``1``.
+   * - ``name``
+     - String
+     - No
+     - Filter by display name (wildcard search).
+   * - ``value``
+     - String
+     - No
+     - Filter by label value (wildcard search).
 
 Response
 --------
@@ -78,6 +92,7 @@ Response
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -88,12 +103,24 @@ Response
             "excludedPaths": "",
             "permissions": "{role}admin",
             "virtualHost": "",
-            "sortOrder": 0
+            "sortOrder": 0,
+            "createdBy": "admin",
+            "createdTime": 1700000000000,
+            "updatedBy": "admin",
+            "updatedTime": 1700000000000,
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
+
+.. note::
+
+   Each settings object also includes ``createdBy`` / ``createdTime`` / ``updatedBy`` /
+   ``updatedTime`` for auditing, and ``versionNo`` for optimistic locking (fields with a
+   ``null`` value are omitted). The ``response`` object always includes ``version``
+   indicating the product version, but it may be omitted in subsequent examples for brevity.
 
 Get Label Type
 ==============
@@ -119,9 +146,14 @@ Response
           "value": "docs",
           "includedPaths": ".*docs\\.example\\.com.*",
           "excludedPaths": "",
-          "sortOrder": 0,
           "permissions": "{role}admin",
-          "virtualHost": ""
+          "virtualHost": "",
+          "sortOrder": 0,
+          "createdBy": "admin",
+          "createdTime": 1700000000000,
+          "updatedBy": "admin",
+          "updatedTime": 1700000000000,
+          "versionNo": 1
         }
       }
     }
@@ -151,37 +183,50 @@ Request Body
       "permissions": "{role}guest"
     }
 
-Field Description
-~~~~~~~~~~~~~~~~~
+Field Descriptions
+~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 12 12 56
 
    * - Field
+     - Type
      - Required
      - Description
    * - ``name``
+     - String
      - Yes
-     - Label display name
+     - Label display name (max 100 characters).
    * - ``value``
+     - String
      - Yes
-     - Label value (used in search)
+     - Label value (used with the ``label`` parameter in searches). Only alphanumeric characters and underscores (``_``) are allowed; must match the regex ``^[a-zA-Z0-9_]+$`` (max 100 characters).
    * - ``includedPaths``
+     - String
      - No
-     - Regex patterns for paths to label (newline-separated for multiple)
+     - Regular expressions for paths to be labelled. Separate multiple entries with a newline (``\n``).
    * - ``excludedPaths``
+     - String
      - No
-     - Regex patterns for paths to exclude from labeling (newline-separated for multiple)
-   * - ``sortOrder``
-     - No
-     - Display order
+     - Regular expressions for paths to exclude from labelling. Separate multiple entries with a newline (``\n``).
    * - ``permissions``
+     - String
      - No
-     - Access permission roles (newline-separated if multiple)
+     - Roles/groups/users permitted to access (e.g. ``{role}admin``). Separate multiple entries with a newline (``\n``).
+   * - ``sortOrder``
+     - Integer
+     - No
+     - Display order (non-negative integer). Defaults to ``0`` if not specified.
    * - ``virtualHost``
+     - String
      - No
-     - Virtual host
+     - Virtual host (max 1000 characters).
+
+.. note::
+
+   Audit fields such as ``createdBy`` / ``createdTime`` are set automatically on the server side
+   and do not need to be specified in the request.
 
 Response
 --------
@@ -195,6 +240,8 @@ Response
         "created": true
       }
     }
+
+On successful creation, ``created`` is ``true``.
 
 Update Label Type
 =================
@@ -223,6 +270,25 @@ Request Body
       "versionNo": 1
     }
 
+When updating, the following fields are required in addition to the fields used at creation time.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 12 56
+
+   * - Field
+     - Type
+     - Required
+     - Description
+   * - ``id``
+     - String
+     - Yes
+     - The ID of the label type to update.
+   * - ``versionNo``
+     - Integer
+     - Yes
+     - Version number for optimistic locking. Specify the ``versionNo`` included in the response when the setting was retrieved. If the specified version does not match the current one, the update will fail.
+
 Response
 --------
 
@@ -235,6 +301,8 @@ Response
         "created": false
       }
     }
+
+On update, ``created`` is ``false``.
 
 Delete Label Type
 =================
@@ -276,6 +344,14 @@ Create Documentation Label
            "permissions": "{role}guest"
          }'
 
+List Label Types
+----------------
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/api/admin/labeltype/settings?size=50&page=1" \
+         -H "Authorization: Bearer YOUR_TOKEN"
+
 Search with Label
 -----------------
 
@@ -284,10 +360,9 @@ Search with Label
     # Filter by label
     curl "http://localhost:8080/json/?q=search&label=tech_docs"
 
-Reference
-=========
+See Also
+========
 
 - :doc:`api-admin-overview` - Admin API Overview
 - :doc:`../api-search` - Search API
 - :doc:`../../admin/labeltype-guide` - Label Type Management Guide
-

--- a/es/15.7/api/admin/api-admin-labeltype.rst
+++ b/es/15.7/api/admin/api-admin-labeltype.rst
@@ -2,29 +2,36 @@
 API de LabelType
 ==========================
 
-Vision General
-==============
+Descripción general
+===================
 
-La API de LabelType es para gestionar tipos de etiqueta de |Fess|.
-Puede operar tipos de etiqueta para clasificacion y filtrado de resultados de busqueda.
+La API de LabelType es una API para gestionar los tipos de etiqueta de |Fess|.
+Los tipos de etiqueta permiten clasificar los resultados de búsqueda según las rutas rastreadas
+o el host virtual, y utilizarlos para filtrar (refinar) los resultados en la pantalla de búsqueda por etiqueta.
 
-URL Base
+Para conocer el método de autenticación y las especificaciones comunes de la Respuesta
+(código ``status``, campo ``version``, formato de errores, códigos de estado HTTP, etc.),
+consulte :doc:`api-admin-overview`.
+Para acceder a esta API, es necesario especificar un token de acceso con el permiso de Admin API
+(``admin-api``) en el encabezado ``Authorization: Bearer <token de acceso>``.
+
+URL base
 ========
 
 ::
 
     /api/admin/labeltype
 
-Lista de Endpoints
+Lista de endpoints
 ==================
 
 .. list-table::
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de tipos de etiqueta
@@ -41,8 +48,8 @@ Lista de Endpoints
      - /setting/{id}
      - Eliminar tipo de etiqueta
 
-Obtener Lista de Tipos de Etiqueta
-==================================
+Obtener lista de tipos de etiqueta
+===================================
 
 Solicitud
 ---------
@@ -51,25 +58,33 @@ Solicitud
 
     GET /api/admin/labeltype/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
-     - Requerido
-     - Descripcion
+     - Obligatorio
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Número de elementos por página. El valor predeterminado es el configurado en ``paging.page.size`` (normalmente ``25``).
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 0)
+     - Número de página (comienza en 1). El valor predeterminado es ``1``.
+   * - ``name``
+     - String
+     - No
+     - Filtrar por nombre de visualización (búsqueda con comodines).
+   * - ``value``
+     - String
+     - No
+     - Filtrar por valor de etiqueta (búsqueda con comodines).
 
 Respuesta
 ---------
@@ -78,6 +93,7 @@ Respuesta
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -88,14 +104,26 @@ Respuesta
             "excludedPaths": "",
             "permissions": "{role}admin",
             "virtualHost": "",
-            "sortOrder": 0
+            "sortOrder": 0,
+            "createdBy": "admin",
+            "createdTime": 1700000000000,
+            "updatedBy": "admin",
+            "updatedTime": 1700000000000,
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
 
-Obtener Tipo de Etiqueta
+.. note::
+
+   Cada objeto de configuración también incluye ``createdBy`` / ``createdTime`` / ``updatedBy`` /
+   ``updatedTime`` para auditoría, y ``versionNo`` para bloqueo optimista (los campos con valor
+   ``null`` se omiten). El objeto ``response`` siempre contiene ``version``, que indica la versión
+   del producto, aunque en los ejemplos siguientes puede omitirse por brevedad.
+
+Obtener tipo de etiqueta
 ========================
 
 Solicitud
@@ -119,14 +147,19 @@ Respuesta
           "value": "docs",
           "includedPaths": ".*docs\\.example\\.com.*",
           "excludedPaths": "",
-          "sortOrder": 0,
           "permissions": "{role}admin",
-          "virtualHost": ""
+          "virtualHost": "",
+          "sortOrder": 0,
+          "createdBy": "admin",
+          "createdTime": 1700000000000,
+          "updatedBy": "admin",
+          "updatedTime": 1700000000000,
+          "versionNo": 1
         }
       }
     }
 
-Crear Tipo de Etiqueta
+Crear tipo de etiqueta
 ======================
 
 Solicitud
@@ -137,7 +170,7 @@ Solicitud
     POST /api/admin/labeltype/setting
     Content-Type: application/json
 
-Cuerpo de la Solicitud
+Cuerpo de la solicitud
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -151,37 +184,50 @@ Cuerpo de la Solicitud
       "permissions": "{role}guest"
     }
 
-Descripcion de Campos
+Descripción de campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 12 12 56
 
    * - Campo
-     - Requerido
-     - Descripcion
+     - Tipo
+     - Obligatorio
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre de visualizacion de la etiqueta
+     - String
+     - Sí
+     - Nombre de visualización de la etiqueta (máximo 100 caracteres).
    * - ``value``
-     - Si
-     - Valor de la etiqueta (usado en busquedas)
+     - String
+     - Sí
+     - Valor de la etiqueta (utilizado con el parámetro ``label`` en las búsquedas). Solo se permiten caracteres alfanuméricos ASCII y guión bajo (``_``), y debe coincidir con la expresión regular ``^[a-zA-Z0-9_]+$`` (máximo 100 caracteres).
    * - ``includedPaths``
+     - String
      - No
-     - Expresion regular para rutas con etiqueta (separadas por salto de linea si son multiples)
+     - Expresión regular de las rutas a las que se aplica la etiqueta. Si se especifican varias, sepárelas con salto de línea (``\n``).
    * - ``excludedPaths``
+     - String
      - No
-     - Expresion regular para rutas excluidas de etiqueta (separadas por salto de linea si son multiples)
-   * - ``sortOrder``
-     - No
-     - Orden de visualizacion
+     - Expresión regular de las rutas excluidas de la etiqueta. Si se especifican varias, sepárelas con salto de línea (``\n``).
    * - ``permissions``
+     - String
      - No
-     - Roles con permiso de acceso (separados por saltos de linea si son varios)
+     - Roles, grupos o usuarios con permiso de acceso (por ejemplo: ``{role}admin``). Si se especifican varios, sepárelos con salto de línea (``\n``).
+   * - ``sortOrder``
+     - Integer
+     - No
+     - Orden de visualización (entero mayor o igual a 0). El valor predeterminado es ``0``.
    * - ``virtualHost``
+     - String
      - No
-     - Host virtual
+     - Host virtual (máximo 1000 caracteres).
+
+.. note::
+
+   Los campos de auditoría como ``createdBy`` / ``createdTime`` son establecidos automáticamente
+   por el servidor, por lo que no es necesario especificarlos en la solicitud.
 
 Respuesta
 ---------
@@ -196,7 +242,9 @@ Respuesta
       }
     }
 
-Actualizar Tipo de Etiqueta
+Si la creación es exitosa, ``created`` será ``true``.
+
+Actualizar tipo de etiqueta
 ===========================
 
 Solicitud
@@ -207,7 +255,7 @@ Solicitud
     PUT /api/admin/labeltype/setting
     Content-Type: application/json
 
-Cuerpo de la Solicitud
+Cuerpo de la solicitud
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -223,6 +271,25 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
+En la actualización, además de los campos de creación, los siguientes campos son obligatorios.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 12 56
+
+   * - Campo
+     - Tipo
+     - Obligatorio
+     - Descripción
+   * - ``id``
+     - String
+     - Sí
+     - ID del tipo de etiqueta a actualizar.
+   * - ``versionNo``
+     - Integer
+     - Sí
+     - Número de versión para bloqueo optimista. Especifique el valor de ``versionNo`` incluido en la respuesta al obtener el registro. Si la versión especificada no coincide con la actual, la actualización fallará.
+
 Respuesta
 ---------
 
@@ -236,7 +303,9 @@ Respuesta
       }
     }
 
-Eliminar Tipo de Etiqueta
+En caso de actualización, ``created`` será ``false``.
+
+Eliminar tipo de etiqueta
 =========================
 
 Solicitud
@@ -257,11 +326,11 @@ Respuesta
       }
     }
 
-Ejemplos de Uso
+Ejemplos de uso
 ===============
 
-Crear Etiqueta para Documentacion
----------------------------------
+Crear etiqueta para documentación
+----------------------------------
 
 .. code-block:: bash
 
@@ -276,7 +345,15 @@ Crear Etiqueta para Documentacion
            "permissions": "{role}guest"
          }'
 
-Busqueda Usando Etiqueta
+Obtener lista de tipos de etiqueta
+-----------------------------------
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/api/admin/labeltype/settings?size=50&page=1" \
+         -H "Authorization: Bearer YOUR_TOKEN"
+
+Búsqueda usando etiqueta
 ------------------------
 
 .. code-block:: bash
@@ -284,9 +361,9 @@ Busqueda Usando Etiqueta
     # Filtrar por etiqueta
     curl "http://localhost:8080/json/?q=search&label=tech_docs"
 
-Informacion de Referencia
-=========================
+Véase también
+=============
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`../api-search` - API de busqueda
-- :doc:`../../admin/labeltype-guide` - Guia de gestion de tipos de etiqueta
+- :doc:`api-admin-overview` - Descripción general de Admin API
+- :doc:`../api-search` - API de búsqueda
+- :doc:`../../admin/labeltype-guide` - Guía de gestión de tipos de etiqueta

--- a/fr/15.7/api/admin/api-admin-labeltype.rst
+++ b/fr/15.7/api/admin/api-admin-labeltype.rst
@@ -1,12 +1,20 @@
 ==========================
-API LabelType
+LabelType API
 ==========================
 
-Vue d'ensemble
-==============
+Apercu
+======
 
 L'API LabelType permet de gerer les types de labels de |Fess|.
-Vous pouvez manipuler les types de labels utilises pour la classification et le filtrage des resultats de recherche.
+Les types de labels permettent de classer les resultats de recherche en fonction des chemins
+cibles du crawl et des hotes virtuels, et peuvent etre utilises pour le filtrage
+(restriction) par label dans l'interface de recherche.
+
+Pour les methodes d'authentification et les specifications communes des reponses
+(code ``status``, champ ``version``, format des erreurs, codes de statut HTTP, etc.),
+consultez :doc:`api-admin-overview`.
+Pour acceder a cette API, un jeton d'acces disposant de la permission d'API d'administration
+(``admin-api``) doit etre specifie dans l'en-tete ``Authorization: Bearer <jeton d'acces>``.
 
 URL de base
 ===========
@@ -15,8 +23,8 @@ URL de base
 
     /api/admin/labeltype
 
-Liste des endpoints
-===================
+Liste des points de terminaison
+================================
 
 .. list-table::
    :header-rows: 1
@@ -42,7 +50,7 @@ Liste des endpoints
      - Suppression d'un type de label
 
 Obtention de la liste des types de labels
-=========================================
+==========================================
 
 Requete
 -------
@@ -56,20 +64,28 @@ Parametres
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parametre
      - Type
-     - Requis
+     - Obligatoire
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 20)
+     - Nombre d'elements par page. La valeur par defaut est celle du parametre ``paging.page.size`` (``25`` par defaut).
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 0)
+     - Numero de page (commence a ``1``). La valeur par defaut est ``1``.
+   * - ``name``
+     - String
+     - Non
+     - Filtrage par nom d'affichage (recherche avec caracteres generiques).
+   * - ``value``
+     - String
+     - Non
+     - Filtrage par valeur de label (recherche avec caracteres generiques).
 
 Reponse
 -------
@@ -78,6 +94,7 @@ Reponse
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -88,15 +105,28 @@ Reponse
             "excludedPaths": "",
             "permissions": "{role}admin",
             "virtualHost": "",
-            "sortOrder": 0
+            "sortOrder": 0,
+            "createdBy": "admin",
+            "createdTime": 1700000000000,
+            "updatedBy": "admin",
+            "updatedTime": 1700000000000,
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
 
+.. note::
+
+   Chaque objet de configuration inclut egalement ``createdBy`` / ``createdTime`` /
+   ``updatedBy`` / ``updatedTime`` a des fins d'audit, ainsi que ``versionNo`` pour le
+   verrouillage optimiste (les champs dont la valeur est ``null`` sont omis). L'objet
+   ``response`` contient toujours ``version``, indiquant la version du produit, mais
+   celui-ci peut etre omis dans les exemples suivants par souci de concision.
+
 Obtention d'un type de label
-============================
+=============================
 
 Requete
 -------
@@ -119,15 +149,20 @@ Reponse
           "value": "docs",
           "includedPaths": ".*docs\\.example\\.com.*",
           "excludedPaths": "",
-          "sortOrder": 0,
           "permissions": "{role}admin",
-          "virtualHost": ""
+          "virtualHost": "",
+          "sortOrder": 0,
+          "createdBy": "admin",
+          "createdTime": 1700000000000,
+          "updatedBy": "admin",
+          "updatedTime": 1700000000000,
+          "versionNo": 1
         }
       }
     }
 
 Creation d'un type de label
-===========================
+============================
 
 Requete
 -------
@@ -152,36 +187,49 @@ Corps de la requete
     }
 
 Description des champs
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 12 12 56
 
    * - Champ
-     - Requis
+     - Type
+     - Obligatoire
      - Description
    * - ``name``
+     - String
      - Oui
-     - Nom d'affichage du label
+     - Nom d'affichage du label (100 caracteres maximum).
    * - ``value``
+     - String
      - Oui
-     - Valeur du label (utilisee dans les recherches)
+     - Valeur du label (utilisee avec le parametre ``label`` lors des recherches). Seuls les caracteres alphanumeriques et les tirets bas (``_``) sont autorises ; la valeur doit correspondre a l'expression reguliere ``^[a-zA-Z0-9_]+$`` (100 caracteres maximum).
    * - ``includedPaths``
+     - String
      - Non
-     - Regex des chemins cibles (separes par des sauts de ligne si multiples)
+     - Expression reguliere des chemins cibles du label. Si plusieurs valeurs sont specifees, elles sont separees par un saut de ligne (``\n``).
    * - ``excludedPaths``
+     - String
      - Non
-     - Regex des chemins a exclure (separes par des sauts de ligne si multiples)
-   * - ``sortOrder``
-     - Non
-     - Ordre d'affichage
+     - Expression reguliere des chemins a exclure du label. Si plusieurs valeurs sont specifees, elles sont separees par un saut de ligne (``\n``).
    * - ``permissions``
+     - String
      - Non
-     - Roles autorises (separes par des sauts de ligne si plusieurs)
+     - Roles, groupes ou utilisateurs autorises a acceder (ex. : ``{role}admin``). Si plusieurs valeurs sont specifees, elles sont separees par un saut de ligne (``\n``).
+   * - ``sortOrder``
+     - Integer
+     - Non
+     - Ordre d'affichage (entier superieur ou egal a 0). La valeur par defaut est ``0``.
    * - ``virtualHost``
+     - String
      - Non
-     - Hote virtuel
+     - Hote virtuel (1000 caracteres maximum).
+
+.. note::
+
+   Les champs d'audit tels que ``createdBy`` / ``createdTime`` sont definis
+   automatiquement cote serveur et n'ont pas besoin d'etre specifies dans la requete.
 
 Reponse
 -------
@@ -196,8 +244,10 @@ Reponse
       }
     }
 
+En cas de creation reussie, ``created`` prend la valeur ``true``.
+
 Mise a jour d'un type de label
-==============================
+================================
 
 Requete
 -------
@@ -223,6 +273,25 @@ Corps de la requete
       "versionNo": 1
     }
 
+Lors d'une mise a jour, les champs suivants sont obligatoires en plus de ceux utilises lors de la creation.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 12 56
+
+   * - Champ
+     - Type
+     - Obligatoire
+     - Description
+   * - ``id``
+     - String
+     - Oui
+     - ID du type de label a mettre a jour.
+   * - ``versionNo``
+     - Integer
+     - Oui
+     - Numero de version pour le verrouillage optimiste. Specifiez la valeur ``versionNo`` presente dans la reponse obtenue lors de la lecture. Si la version specifiee ne correspond pas a la version actuelle, la mise a jour echoue.
+
 Reponse
 -------
 
@@ -236,8 +305,10 @@ Reponse
       }
     }
 
+Dans le cas d'une mise a jour, ``created`` prend la valeur ``false``.
+
 Suppression d'un type de label
-==============================
+================================
 
 Requete
 -------
@@ -258,10 +329,10 @@ Reponse
     }
 
 Exemples d'utilisation
-======================
+=======================
 
 Creation d'un label pour la documentation
------------------------------------------
+------------------------------------------
 
 .. code-block:: bash
 
@@ -276,16 +347,24 @@ Creation d'un label pour la documentation
            "permissions": "{role}guest"
          }'
 
+Obtention de la liste des types de labels
+------------------------------------------
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/api/admin/labeltype/settings?size=50&page=1" \
+         -H "Authorization: Bearer YOUR_TOKEN"
+
 Recherche avec un label
------------------------
+------------------------
 
 .. code-block:: bash
 
     # Filtrage par label
     curl "http://localhost:8080/json/?q=search&label=tech_docs"
 
-Informations complementaires
-============================
+Voir aussi
+===========
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
 - :doc:`../api-search` - API de recherche

--- a/ja/15.7/api/admin/api-admin-labeltype.rst
+++ b/ja/15.7/api/admin/api-admin-labeltype.rst
@@ -6,7 +6,13 @@ LabelType API
 ====
 
 LabelType APIは、|Fess| のラベルタイプを管理するためのAPIです。
-検索結果のラベル分類、フィルタリング用のラベルタイプを操作できます。
+ラベルタイプを使用すると、クロール対象のパスや仮想ホストに基づいて検索結果を分類し、
+検索画面でのラベルによる絞り込み（フィルタリング）に利用できます。
+
+認証方法やレスポンスの共通仕様（``status`` コード、``version`` フィールド、エラー形式、
+HTTPステータスコードなど）については :doc:`api-admin-overview` を参照してください。
+本APIにアクセスするには、管理API権限（``admin-api``）を持つアクセストークンを
+``Authorization: Bearer <アクセストークン>`` ヘッダーで指定する必要があります。
 
 ベースURL
 =========
@@ -56,7 +62,7 @@ LabelType APIは、|Fess| のラベルタイプを管理するためのAPIです
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - パラメーター
      - 型
@@ -65,11 +71,19 @@ LabelType APIは、|Fess| のラベルタイプを管理するためのAPIです
    * - ``size``
      - Integer
      - いいえ
-     - 1ページあたりの件数（デフォルト: 20）
+     - 1ページあたりの件数。デフォルトは ``paging.page.size`` の設定値（標準では ``25``）です。
    * - ``page``
      - Integer
      - いいえ
-     - ページ番号（0から開始）
+     - ページ番号（1から開始）。デフォルトは ``1`` です。
+   * - ``name``
+     - String
+     - いいえ
+     - 表示名による絞り込み（ワイルドカード検索）。
+   * - ``value``
+     - String
+     - いいえ
+     - ラベル値による絞り込み（ワイルドカード検索）。
 
 レスポンス
 ----------
@@ -78,6 +92,7 @@ LabelType APIは、|Fess| のラベルタイプを管理するためのAPIです
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -88,12 +103,24 @@ LabelType APIは、|Fess| のラベルタイプを管理するためのAPIです
             "excludedPaths": "",
             "permissions": "{role}admin",
             "virtualHost": "",
-            "sortOrder": 0
+            "sortOrder": 0,
+            "createdBy": "admin",
+            "createdTime": 1700000000000,
+            "updatedBy": "admin",
+            "updatedTime": 1700000000000,
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
+
+.. note::
+
+   各設定オブジェクトには、監査用の ``createdBy`` / ``createdTime`` / ``updatedBy`` /
+   ``updatedTime`` と、楽観的ロック用の ``versionNo`` も含まれます（値が ``null`` の
+   フィールドは省略されます）。``response`` オブジェクトには製品バージョンを示す
+   ``version`` が常に含まれますが、以降の例では簡潔さのために省略している場合があります。
 
 ラベルタイプ取得
 ================
@@ -119,9 +146,14 @@ LabelType APIは、|Fess| のラベルタイプを管理するためのAPIです
           "value": "docs",
           "includedPaths": ".*docs\\.example\\.com.*",
           "excludedPaths": "",
-          "sortOrder": 0,
           "permissions": "{role}admin",
-          "virtualHost": ""
+          "virtualHost": "",
+          "sortOrder": 0,
+          "createdBy": "admin",
+          "createdTime": 1700000000000,
+          "updatedBy": "admin",
+          "updatedTime": 1700000000000,
+          "versionNo": 1
         }
       }
     }
@@ -156,32 +188,45 @@ LabelType APIは、|Fess| のラベルタイプを管理するためのAPIです
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 12 12 56
 
    * - フィールド
+     - 型
      - 必須
      - 説明
    * - ``name``
+     - String
      - はい
-     - ラベル表示名
+     - ラベル表示名（最大100文字）。
    * - ``value``
+     - String
      - はい
-     - ラベル値（検索時に使用）
+     - ラベル値（検索時に ``label`` パラメーターで使用）。半角英数字とアンダースコア（``_``）のみ使用可能で、正規表現 ``^[a-zA-Z0-9_]+$`` に一致する必要があります（最大100文字）。
    * - ``includedPaths``
+     - String
      - いいえ
-     - ラベル対象パスの正規表現（複数の場合は改行区切り）
+     - ラベル対象とするパスの正規表現。複数指定する場合は改行（``\n``）で区切ります。
    * - ``excludedPaths``
+     - String
      - いいえ
-     - ラベル除外パスの正規表現（複数の場合は改行区切り）
-   * - ``sortOrder``
-     - いいえ
-     - 表示順序
+     - ラベル対象から除外するパスの正規表現。複数指定する場合は改行（``\n``）で区切ります。
    * - ``permissions``
+     - String
      - いいえ
-     - アクセス許可ロール（複数の場合は改行区切り）
+     - アクセスを許可するロール／グループ／ユーザー（例: ``{role}admin``）。複数指定する場合は改行（``\n``）で区切ります。
+   * - ``sortOrder``
+     - Integer
+     - いいえ
+     - 表示順序（0以上の整数）。指定しない場合は ``0`` です。
    * - ``virtualHost``
+     - String
      - いいえ
-     - 仮想ホスト
+     - 仮想ホスト（最大1000文字）。
+
+.. note::
+
+   ``createdBy`` / ``createdTime`` などの監査フィールドはサーバー側で自動的に設定される
+   ため、リクエストでの指定は不要です。
 
 レスポンス
 ----------
@@ -195,6 +240,8 @@ LabelType APIは、|Fess| のラベルタイプを管理するためのAPIです
         "created": true
       }
     }
+
+作成に成功すると ``created`` は ``true`` になります。
 
 ラベルタイプ更新
 ================
@@ -223,6 +270,25 @@ LabelType APIは、|Fess| のラベルタイプを管理するためのAPIです
       "versionNo": 1
     }
 
+更新時は、作成時のフィールドに加えて以下のフィールドが必須です。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 12 56
+
+   * - フィールド
+     - 型
+     - 必須
+     - 説明
+   * - ``id``
+     - String
+     - はい
+     - 更新対象のラベルタイプID。
+   * - ``versionNo``
+     - Integer
+     - はい
+     - 楽観的ロック用のバージョン番号。取得時のレスポンスに含まれる ``versionNo`` を指定します。指定したバージョンが現在のものと一致しない場合、更新は失敗します。
+
 レスポンス
 ----------
 
@@ -235,6 +301,8 @@ LabelType APIは、|Fess| のラベルタイプを管理するためのAPIです
         "created": false
       }
     }
+
+更新の場合、``created`` は ``false`` になります。
 
 ラベルタイプ削除
 ================
@@ -275,6 +343,14 @@ LabelType APIは、|Fess| のラベルタイプを管理するためのAPIです
            "sortOrder": 0,
            "permissions": "{role}guest"
          }'
+
+ラベルタイプ一覧取得
+--------------------
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/api/admin/labeltype/settings?size=50&page=1" \
+         -H "Authorization: Bearer YOUR_TOKEN"
 
 ラベルを使用した検索
 --------------------

--- a/ko/15.7/api/admin/api-admin-labeltype.rst
+++ b/ko/15.7/api/admin/api-admin-labeltype.rst
@@ -6,7 +6,13 @@ LabelType API
 ====
 
 LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
-검색 결과의 라벨 분류, 필터링용 라벨 타입을 조작할 수 있습니다.
+라벨 타입을 사용하면 크롤링 대상 경로나 가상 호스트를 기반으로 검색 결과를 분류하고,
+검색 화면에서 라벨을 이용한 필터링에 활용할 수 있습니다.
+
+인증 방법 및 응답의 공통 사양(``status`` 코드, ``version`` 필드, 오류 형식,
+HTTP 상태 코드 등)에 대해서는 :doc:`api-admin-overview` 를 참조하십시오.
+이 API에 접근하려면 관리 API 권한(``admin-api``)을 가진 액세스 토큰을
+``Authorization: Bearer <액세스 토큰>`` 헤더로 지정해야 합니다.
 
 기본 URL
 =========
@@ -33,7 +39,7 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
      - 라벨 타입 조회
    * - POST
      - /setting
-     - 라벨 타입 만들기
+     - 라벨 타입 생성
    * - PUT
      - /setting
      - 라벨 타입 업데이트
@@ -56,7 +62,7 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - 파라미터
      - 타입
@@ -64,12 +70,20 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
      - 설명
    * - ``size``
      - Integer
-     - 아니오
-     - 페이지당 건수 (기본값: 20)
+     - 아니요
+     - 페이지당 건수. 기본값은 ``paging.page.size`` 의 설정값(기본 ``25``)입니다.
    * - ``page``
      - Integer
-     - 아니오
-     - 페이지 번호 (0부터 시작)
+     - 아니요
+     - 페이지 번호(1부터 시작). 기본값은 ``1`` 입니다.
+   * - ``name``
+     - String
+     - 아니요
+     - 표시 이름으로 필터링(와일드카드 검색).
+   * - ``value``
+     - String
+     - 아니요
+     - 라벨 값으로 필터링(와일드카드 검색).
 
 응답
 ----------
@@ -78,6 +92,7 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -88,12 +103,24 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
             "excludedPaths": "",
             "permissions": "{role}admin",
             "virtualHost": "",
-            "sortOrder": 0
+            "sortOrder": 0,
+            "createdBy": "admin",
+            "createdTime": 1700000000000,
+            "updatedBy": "admin",
+            "updatedTime": 1700000000000,
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
+
+.. note::
+
+   각 설정 객체에는 감사용 ``createdBy`` / ``createdTime`` / ``updatedBy`` /
+   ``updatedTime`` 과 낙관적 잠금용 ``versionNo`` 도 포함됩니다(값이 ``null`` 인
+   필드는 생략됩니다). ``response`` 객체에는 제품 버전을 나타내는
+   ``version`` 이 항상 포함되지만, 이후 예시에서는 간결함을 위해 생략하는 경우가 있습니다.
 
 라벨 타입 조회
 ================
@@ -119,14 +146,19 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
           "value": "docs",
           "includedPaths": ".*docs\\.example\\.com.*",
           "excludedPaths": "",
-          "sortOrder": 0,
           "permissions": "{role}admin",
-          "virtualHost": ""
+          "virtualHost": "",
+          "sortOrder": 0,
+          "createdBy": "admin",
+          "createdTime": 1700000000000,
+          "updatedBy": "admin",
+          "updatedTime": 1700000000000,
+          "versionNo": 1
         }
       }
     }
 
-라벨 타입 만들기
+라벨 타입 생성
 ================
 
 요청
@@ -156,32 +188,45 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 12 12 56
 
    * - 필드
+     - 타입
      - 필수
      - 설명
    * - ``name``
+     - String
      - 예
-     - 라벨 표시 이름
+     - 라벨 표시 이름(최대 100자).
    * - ``value``
+     - String
      - 예
-     - 라벨 값 (검색 시 사용)
+     - 라벨 값(검색 시 ``label`` 파라미터로 사용). 영숫자와 언더스코어(``_``)만 사용 가능하며, 정규 표현식 ``^[a-zA-Z0-9_]+$`` 에 일치해야 합니다(최대 100자).
    * - ``includedPaths``
-     - 아니오
-     - 라벨 대상 경로의 정규 표현식 (여러 개인 경우 줄바꿈으로 구분)
+     - String
+     - 아니요
+     - 라벨 대상 경로의 정규 표현식. 여러 개 지정 시 줄바꿈(``\n``)으로 구분합니다.
    * - ``excludedPaths``
-     - 아니오
-     - 라벨 제외 경로의 정규 표현식 (여러 개인 경우 줄바꿈으로 구분)
-   * - ``sortOrder``
-     - 아니오
-     - 표시 순서
+     - String
+     - 아니요
+     - 라벨 대상에서 제외할 경로의 정규 표현식. 여러 개 지정 시 줄바꿈(``\n``)으로 구분합니다.
    * - ``permissions``
-     - 아니오
-     - 접근 허용 역할 (여러 개인 경우 줄바꿈으로 구분)
+     - String
+     - 아니요
+     - 접근을 허용할 역할/그룹/사용자(예: ``{role}admin``). 여러 개 지정 시 줄바꿈(``\n``)으로 구분합니다.
+   * - ``sortOrder``
+     - Integer
+     - 아니요
+     - 표시 순서(0 이상의 정수). 지정하지 않으면 ``0`` 입니다.
    * - ``virtualHost``
-     - 아니오
-     - 가상 호스트
+     - String
+     - 아니요
+     - 가상 호스트(최대 1000자).
+
+.. note::
+
+   ``createdBy`` / ``createdTime`` 등의 감사 필드는 서버 측에서 자동으로 설정되므로
+   요청에서 지정할 필요가 없습니다.
 
 응답
 ----------
@@ -196,8 +241,10 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
       }
     }
 
+생성에 성공하면 ``created`` 는 ``true`` 가 됩니다.
+
 라벨 타입 업데이트
-================
+====================
 
 요청
 ----------
@@ -223,6 +270,25 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
       "versionNo": 1
     }
 
+업데이트 시에는 생성 시의 필드에 더해 다음 필드가 필수입니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 12 56
+
+   * - 필드
+     - 타입
+     - 필수
+     - 설명
+   * - ``id``
+     - String
+     - 예
+     - 업데이트 대상 라벨 타입 ID.
+   * - ``versionNo``
+     - Integer
+     - 예
+     - 낙관적 잠금용 버전 번호. 조회 시 응답에 포함된 ``versionNo`` 를 지정합니다. 지정한 버전이 현재 버전과 일치하지 않으면 업데이트가 실패합니다.
+
 응답
 ----------
 
@@ -235,6 +301,8 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
         "created": false
       }
     }
+
+업데이트의 경우 ``created`` 는 ``false`` 가 됩니다.
 
 라벨 타입 삭제
 ================
@@ -257,10 +325,10 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
       }
     }
 
-사용 예
-======
+사용 예시
+==========
 
-문서용 라벨 만들기
+문서용 라벨 생성
 ------------------------
 
 .. code-block:: bash
@@ -276,6 +344,14 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
            "permissions": "{role}guest"
          }'
 
+라벨 타입 목록 조회
+--------------------
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/api/admin/labeltype/settings?size=50&page=1" \
+         -H "Authorization: Bearer YOUR_TOKEN"
+
 라벨을 사용한 검색
 --------------------
 
@@ -285,7 +361,7 @@ LabelType API는 |Fess| 의 라벨 타입을 관리하기 위한 API입니다.
     curl "http://localhost:8080/json/?q=search&label=tech_docs"
 
 참고 정보
-========
+==========
 
 - :doc:`api-admin-overview` - Admin API 개요
 - :doc:`../api-search` - 검색 API

--- a/zh-cn/15.7/api/admin/api-admin-labeltype.rst
+++ b/zh-cn/15.7/api/admin/api-admin-labeltype.rst
@@ -6,10 +6,16 @@ LabelType API
 ====
 
 LabelType API是用于管理 |Fess| 标签类型的API。
-您可以操作用于搜索结果标签分类和过滤的标签类型。
+使用标签类型，可以根据爬取目标的路径或虚拟主机对搜索结果进行分类，
+并在搜索界面中通过标签进行筛选（过滤）。
 
-基础URL
-=======
+关于认证方式及响应的通用规范（``status`` 状态码、``version`` 字段、错误格式、
+HTTP状态码等），请参阅 :doc:`api-admin-overview`。
+访问本API需要使用具有管理API权限（``admin-api``）的访问令牌，
+并通过 ``Authorization: Bearer <访问令牌>`` 请求头指定。
+
+基础 URL
+========
 
 ::
 
@@ -56,20 +62,28 @@ LabelType API是用于管理 |Fess| 标签类型的API。
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - 参数
      - 类型
-     - 必需
+     - 必填
      - 说明
    * - ``size``
      - Integer
      - 否
-     - 每页记录数（默认：20）
+     - 每页记录数。默认值为 ``paging.page.size`` 的设置值（标准为 ``25``）。
    * - ``page``
      - Integer
      - 否
-     - 页码（从0开始）
+     - 页码（从1开始）。默认值为 ``1``。
+   * - ``name``
+     - String
+     - 否
+     - 按显示名称筛选（通配符搜索）。
+   * - ``value``
+     - String
+     - 否
+     - 按标签值筛选（通配符搜索）。
 
 响应
 ----
@@ -78,6 +92,7 @@ LabelType API是用于管理 |Fess| 标签类型的API。
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -88,12 +103,24 @@ LabelType API是用于管理 |Fess| 标签类型的API。
             "excludedPaths": "",
             "permissions": "{role}admin",
             "virtualHost": "",
-            "sortOrder": 0
+            "sortOrder": 0,
+            "createdBy": "admin",
+            "createdTime": 1700000000000,
+            "updatedBy": "admin",
+            "updatedTime": 1700000000000,
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
+
+.. note::
+
+   每个设置对象中还包含用于审计的 ``createdBy`` / ``createdTime`` / ``updatedBy`` /
+   ``updatedTime``，以及用于乐观锁的 ``versionNo``（值为 ``null`` 的
+   字段将被省略）。``response`` 对象中始终包含表示产品版本的
+   ``version``，但为简洁起见，后续示例中可能省略该字段。
 
 获取标签类型
 ============
@@ -119,9 +146,14 @@ LabelType API是用于管理 |Fess| 标签类型的API。
           "value": "docs",
           "includedPaths": ".*docs\\.example\\.com.*",
           "excludedPaths": "",
-          "sortOrder": 0,
           "permissions": "{role}admin",
-          "virtualHost": ""
+          "virtualHost": "",
+          "sortOrder": 0,
+          "createdBy": "admin",
+          "createdTime": 1700000000000,
+          "updatedBy": "admin",
+          "updatedTime": 1700000000000,
+          "versionNo": 1
         }
       }
     }
@@ -156,32 +188,45 @@ LabelType API是用于管理 |Fess| 标签类型的API。
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 12 12 56
 
    * - 字段
-     - 必需
+     - 类型
+     - 必填
      - 说明
    * - ``name``
+     - String
      - 是
-     - 标签显示名称
+     - 标签显示名称（最多100个字符）。
    * - ``value``
+     - String
      - 是
-     - 标签值（搜索时使用）
+     - 标签值（搜索时通过 ``label`` 参数使用）。只能使用半角英数字和下划线（``_``），且须符合正则表达式 ``^[a-zA-Z0-9_]+$``（最多100个字符）。
    * - ``includedPaths``
+     - String
      - 否
-     - 标签目标路径的正则表达式（多个用换行符分隔）
+     - 作为标签目标的路径正则表达式。指定多个时用换行符（``\n``）分隔。
    * - ``excludedPaths``
+     - String
      - 否
-     - 标签排除路径的正则表达式（多个用换行符分隔）
-   * - ``sortOrder``
-     - 否
-     - 显示顺序
+     - 从标签目标中排除的路径正则表达式。指定多个时用换行符（``\n``）分隔。
    * - ``permissions``
+     - String
      - 否
-     - 访问权限角色（多个时用换行符分隔）
+     - 允许访问的角色/组/用户（例如：``{role}admin``）。指定多个时用换行符（``\n``）分隔。
+   * - ``sortOrder``
+     - Integer
+     - 否
+     - 显示顺序（0以上的整数）。未指定时默认为 ``0``。
    * - ``virtualHost``
+     - String
      - 否
-     - 虚拟主机
+     - 虚拟主机（最多1000个字符）。
+
+.. note::
+
+   ``createdBy`` / ``createdTime`` 等审计字段由服务器端自动设置，
+   无需在请求中指定。
 
 响应
 ----
@@ -195,6 +240,8 @@ LabelType API是用于管理 |Fess| 标签类型的API。
         "created": true
       }
     }
+
+创建成功时，``created`` 的值为 ``true``。
 
 更新标签类型
 ============
@@ -223,6 +270,25 @@ LabelType API是用于管理 |Fess| 标签类型的API。
       "versionNo": 1
     }
 
+更新时，除创建时的字段外，还需要以下必填字段。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 12 56
+
+   * - 字段
+     - 类型
+     - 必填
+     - 说明
+   * - ``id``
+     - String
+     - 是
+     - 要更新的标签类型ID。
+   * - ``versionNo``
+     - Integer
+     - 是
+     - 用于乐观锁的版本号。请指定获取时响应中包含的 ``versionNo``。若指定的版本与当前版本不一致，更新将失败。
+
 响应
 ----
 
@@ -235,6 +301,8 @@ LabelType API是用于管理 |Fess| 标签类型的API。
         "created": false
       }
     }
+
+更新时，``created`` 的值为 ``false``。
 
 删除标签类型
 ============
@@ -276,8 +344,16 @@ LabelType API是用于管理 |Fess| 标签类型的API。
            "permissions": "{role}guest"
          }'
 
-使用标签搜索
-------------
+获取标签类型列表
+----------------
+
+.. code-block:: bash
+
+    curl "http://localhost:8080/api/admin/labeltype/settings?size=50&page=1" \
+         -H "Authorization: Bearer YOUR_TOKEN"
+
+使用标签进行搜索
+----------------
 
 .. code-block:: bash
 
@@ -290,4 +366,3 @@ LabelType API是用于管理 |Fess| 标签类型的API。
 - :doc:`api-admin-overview` - Admin API概述
 - :doc:`../api-search` - 搜索API
 - :doc:`../../admin/labeltype-guide` - 标签类型管理指南
-


### PR DESCRIPTION
## Summary

Reviewed the **LabelType Admin API** documentation (`15.7/api/admin/api-admin-labeltype.rst`) against the current implementation and corrected several inaccuracies, then added missing information. The same corrections are applied across all languages (ja, en, de, es, fr, ko, zh-cn).

Verified against:
- `app/web/api/admin/labeltype/ApiAdminLabeltypeAction.java`, `SearchBody`, `CreateBody`, `EditBody`
- `app/web/admin/labeltype/CreateForm.java`, `EditForm.java`
- `app/web/api/admin/BaseSearchBody.java`, `app/web/api/ApiResult.java`
- `fess_config.properties` (`paging.page.size`, `api.admin.access.permissions`), `Constants.java`

## Corrections

- **List pagination** — default page size follows `paging.page.size` (**25**), not 20; page numbering is **1-based** (default **1**), not 0-based.
- **Missing list filters** — added the `name` and `value` query parameters (wildcard search).
- **Validation constraints** — documented that `value` must match `^[a-zA-Z0-9_]+$` (alphanumeric + underscore, max 100), plus max lengths for `name`/`virtualHost` and the `sortOrder` range.
- **Update requirements** — `id` and `versionNo` are required for `PUT /setting`; `versionNo` is used for optimistic locking.
- **Response shape** — examples now include the always-present `version` field and the audit/system fields (`createdBy`, `createdTime`, `updatedBy`, `updatedTime`, `versionNo`).
- **Authentication** — added a note that an access token with the `admin-api` permission must be supplied via `Authorization: Bearer <token>`, with a reference to the Admin API overview for common conventions (status codes, error format).

## Notes

- Technical content (JSON bodies, curl examples, URLs, property names, regex, defaults) is identical across all 7 languages; only prose differs.
- RST heading underline lengths were validated (including CJK double-width handling) and all code blocks/tables parse cleanly.