### PR TITLE
docs(api): correct RelatedQuery Admin API reference and update translations

### DIFF
--- a/de/15.7/api/admin/api-admin-relatedquery.rst
+++ b/de/15.7/api/admin/api-admin-relatedquery.rst
@@ -6,7 +6,12 @@ RelatedQuery API
 =========
 
 Die RelatedQuery API dient zur Verwaltung von verwandten Suchabfragen in |Fess|.
-Sie können alternative Suchbegriffe definieren, die bei bestimmten Suchanfragen vorgeschlagen werden.
+Zu einem vom Benutzer eingegebenen Suchbegriff (``term``) können verwandte Suchbegriffskandidaten
+(``queries``) registriert und verwaltet werden. Die registrierten verwandten Abfragen werden
+auf der Suchoberfläche als verwandte Suchvorschläge angezeigt.
+
+Informationen zur Authentifizierung, zum gemeinsamen Antwortformat (``version``-Feld und ``status``-Codes),
+zur Paginierung sowie zu Fehler-Responses finden Sie unter :doc:`api-admin-overview`.
 
 Basis-URL
 =========
@@ -41,8 +46,94 @@ Endpunktliste
      - /setting/{id}
      - Verwandte Abfrage löschen
 
+Verwandte Abfragen Liste abrufen
+=================================
+
+Request
+-------
+
+::
+
+    GET /api/admin/relatedquery/settings
+
+Parameter
+~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 15 50
+
+   * - Parameter
+     - Typ
+     - Erforderlich
+     - Beschreibung
+   * - ``size``
+     - Integer
+     - Nein
+     - Anzahl der Einträge pro Seite (Standard: 25; änderbar über ``paging.page.size`` in ``fess_config.properties``)
+   * - ``page``
+     - Integer
+     - Nein
+     - Seitennummer (beginnt bei 1; Standard: 1)
+
+Response
+--------
+
+.. code-block:: json
+
+    {
+      "response": {
+        "version": "15.7.0",
+        "status": 0,
+        "settings": [
+          {
+            "id": "query_id_1",
+            "term": "fess",
+            "queries": "fess tutorial\nfess installation\nfess configuration",
+            "versionNo": 1
+          }
+        ],
+        "total": 5
+      }
+    }
+
+.. note::
+
+   Jede Einstellung enthält ``versionNo`` (Versionsnummer für optimistisches Sperren). ``virtualHost``
+   und Audit-Felder (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``) werden nur dann
+   aufgenommen, wenn ein Wert gesetzt ist. Ein leerer ``virtualHost`` wird nicht in die Response aufgenommen.
+
+Verwandte Abfrage abrufen
+==========================
+
+Request
+-------
+
+::
+
+    GET /api/admin/relatedquery/setting/{id}
+
+Response
+--------
+
+.. code-block:: json
+
+    {
+      "response": {
+        "version": "15.7.0",
+        "status": 0,
+        "setting": {
+          "id": "query_id_1",
+          "term": "fess",
+          "queries": "fess tutorial\nfess installation\nfess configuration",
+          "virtualHost": "site1.example.com",
+          "versionNo": 1
+        }
+      }
+    }
+
 Verwandte Abfrage erstellen
-===========================
+============================
 
 Request
 -------
@@ -58,9 +149,9 @@ Request-Body
 .. code-block:: json
 
     {
-      "term": "install",
-      "queries": "installation\nsetup\ninstallation guide",
-      "sortOrder": 0
+      "term": "search",
+      "queries": "search tutorial\nsearch syntax\nadvanced search",
+      "virtualHost": ""
     }
 
 Feldbeschreibungen
@@ -68,23 +159,147 @@ Feldbeschreibungen
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - Feld
      - Erforderlich
      - Beschreibung
    * - ``term``
      - Ja
-     - Auslösender Suchbegriff
+     - Suchbegriff (maximal 10000 Zeichen)
    * - ``queries``
      - Ja
-     - Verwandte Abfragen (durch Zeilenumbruch getrennt)
-   * - ``sortOrder``
+     - Verwandte Abfragen. Zeilenumbruch-getrennte Zeichenkette mit einem Eintrag pro Zeile (Leerzeilen werden ignoriert; maximal 10000 Zeichen)
+   * - ``virtualHost``
      - Nein
-     - Anzeigereihenfolge
+     - Virtueller Host (maximal 1000 Zeichen)
+
+.. note::
+
+   ``crudMode`` wird serverseitig automatisch gesetzt und muss nicht im Request-Body angegeben werden.
+
+Response
+--------
+
+.. code-block:: json
+
+    {
+      "response": {
+        "version": "15.7.0",
+        "status": 0,
+        "id": "new_query_id",
+        "created": true
+      }
+    }
+
+Verwandte Abfrage aktualisieren
+================================
+
+Request
+-------
+
+::
+
+    PUT /api/admin/relatedquery/setting
+    Content-Type: application/json
+
+Request-Body
+~~~~~~~~~~~~
+
+.. code-block:: json
+
+    {
+      "id": "existing_query_id",
+      "term": "search",
+      "queries": "search tutorial\nsearch syntax\nadvanced search\nsearch tips",
+      "virtualHost": "",
+      "versionNo": 1
+    }
+
+Feldbeschreibungen
+~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 70
+
+   * - Feld
+     - Erforderlich
+     - Beschreibung
+   * - ``id``
+     - Ja
+     - ID der zu aktualisierenden verwandten Abfrage (maximal 1000 Zeichen)
+   * - ``term``
+     - Ja
+     - Suchbegriff (maximal 10000 Zeichen)
+   * - ``queries``
+     - Ja
+     - Verwandte Abfragen. Zeilenumbruch-getrennte Zeichenkette mit einem Eintrag pro Zeile (Leerzeilen werden ignoriert; maximal 10000 Zeichen)
+   * - ``virtualHost``
+     - Nein
+     - Virtueller Host (maximal 1000 Zeichen)
+   * - ``versionNo``
+     - Ja
+     - Versionsnummer für optimistisches Sperren. Geben Sie den beim Abrufen in der Response enthaltenen Wert an.
+
+Response
+--------
+
+.. code-block:: json
+
+    {
+      "response": {
+        "version": "15.7.0",
+        "status": 0,
+        "id": "existing_query_id",
+        "created": false
+      }
+    }
+
+Verwandte Abfrage löschen
+==========================
+
+Request
+-------
+
+::
+
+    DELETE /api/admin/relatedquery/setting/{id}
+
+Response
+--------
+
+.. code-block:: json
+
+    {
+      "response": {
+        "version": "15.7.0",
+        "status": 0
+      }
+    }
+
+Fehler-Response
+===============
+
+Schlägt ein Request fehl, wird in ``status`` ein von 0 verschiedener Wert gesetzt und ``message`` enthält
+eine Fehlerbeschreibung. Bei Validierungsfehlern, z. B. fehlenden Pflichtfeldern, wird ``status`` auf ``1`` gesetzt.
+Eine Übersicht der Statuscodes finden Sie unter :doc:`api-admin-overview`.
+
+.. code-block:: json
+
+    {
+      "response": {
+        "version": "15.7.0",
+        "status": 1,
+        "message": "..."
+      }
+    }
 
 Verwendungsbeispiele
 ====================
+
+Produktbezogene Abfragen
+------------------------
 
 .. code-block:: bash
 
@@ -92,9 +307,21 @@ Verwendungsbeispiele
          -H "Authorization: Bearer YOUR_TOKEN" \
          -H "Content-Type: application/json" \
          -d '{
-           "term": "download",
-           "queries": "downloads\nget started\ninstallation",
-           "sortOrder": 0
+           "term": "product",
+           "queries": "product features\nproduct pricing\nproduct comparison\nproduct reviews"
+         }'
+
+Hilfebezogene Abfragen
+-----------------------
+
+.. code-block:: bash
+
+    curl -X POST "http://localhost:8080/api/admin/relatedquery/setting" \
+         -H "Authorization: Bearer YOUR_TOKEN" \
+         -H "Content-Type: application/json" \
+         -d '{
+           "term": "help",
+           "queries": "help center\nhelp documentation\nhelp contact support"
          }'
 
 Referenzinformationen
@@ -102,4 +329,5 @@ Referenzinformationen
 
 - :doc:`api-admin-overview` - Admin API Übersicht
 - :doc:`api-admin-relatedcontent` - Verwandte Inhalte API
+- :doc:`api-admin-suggest` - Suggest-Verwaltung API
 - :doc:`../../admin/relatedquery-guide` - Verwandte Abfragen Verwaltungsanleitung

--- a/en/15.7/api/admin/api-admin-relatedquery.rst
+++ b/en/15.7/api/admin/api-admin-relatedquery.rst
@@ -5,8 +5,13 @@ RelatedQuery API
 Overview
 ========
 
-RelatedQuery API is an API for managing |Fess| related queries.
-You can suggest related search keywords for specific search queries.
+RelatedQuery API is an API for managing related queries in |Fess|.
+For a specific search keyword entered by the user (``term``), you can register and manage
+related search keyword suggestions (``queries``). Registered related queries are displayed
+as related search suggestions on the search screen.
+
+For details on authentication, the common response format (the ``version`` field and
+``status`` codes), pagination, and error responses, refer to :doc:`api-admin-overview`.
 
 Base URL
 ========
@@ -56,7 +61,7 @@ Parameters
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parameter
      - Type
@@ -65,11 +70,11 @@ Parameters
    * - ``size``
      - Integer
      - No
-     - Number of items per page (default: 20)
+     - Number of items per page (default: 25. Configurable via ``paging.page.size`` in ``fess_config.properties``)
    * - ``page``
      - Integer
      - No
-     - Page number (starts from 0)
+     - Page number (starts from 1. Default: 1)
 
 Response
 --------
@@ -78,17 +83,25 @@ Response
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
             "id": "query_id_1",
             "term": "fess",
-            "queries": "fess tutorial\nfess installation\nfess configuration"
+            "queries": "fess tutorial\nfess installation\nfess configuration",
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
+
+.. note::
+
+   Each setting includes ``versionNo`` (a version number for optimistic locking). ``virtualHost``
+   and audit fields (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``) are included
+   only when a value is set. A ``virtualHost`` with an empty value is not included in the response.
 
 Get Related Query
 =================
@@ -107,12 +120,14 @@ Response
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "setting": {
           "id": "query_id_1",
           "term": "fess",
           "queries": "fess tutorial\nfess installation\nfess configuration",
-          "virtualHost": ""
+          "virtualHost": "site1.example.com",
+          "versionNo": 1
         }
       }
     }
@@ -144,20 +159,24 @@ Field Description
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - Field
      - Required
      - Description
    * - ``term``
      - Yes
-     - Search keyword
+     - Search keyword (maximum 10,000 characters)
    * - ``queries``
      - Yes
-     - Related queries (newline-separated string, one per line)
+     - Related queries. A newline-separated string with one entry per line (empty lines are ignored. Maximum 10,000 characters)
    * - ``virtualHost``
      - No
-     - Virtual host
+     - Virtual host (maximum 1,000 characters)
+
+.. note::
+
+   ``crudMode`` is set automatically on the API side and does not need to be included in the request body.
 
 Response
 --------
@@ -166,6 +185,7 @@ Response
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "id": "new_query_id",
         "created": true
@@ -196,6 +216,32 @@ Request Body
       "versionNo": 1
     }
 
+Field Description
+~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 70
+
+   * - Field
+     - Required
+     - Description
+   * - ``id``
+     - Yes
+     - ID of the related query to update (maximum 1,000 characters)
+   * - ``term``
+     - Yes
+     - Search keyword (maximum 10,000 characters)
+   * - ``queries``
+     - Yes
+     - Related queries. A newline-separated string with one entry per line (empty lines are ignored. Maximum 10,000 characters)
+   * - ``virtualHost``
+     - No
+     - Virtual host (maximum 1,000 characters)
+   * - ``versionNo``
+     - Yes
+     - Version number for optimistic locking. Specify the value included in the response when the setting was retrieved.
+
 Response
 --------
 
@@ -203,6 +249,7 @@ Response
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "id": "existing_query_id",
         "created": false
@@ -226,7 +273,25 @@ Response
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0
+      }
+    }
+
+Error Response
+==============
+
+When a request fails, ``status`` is set to a non-zero value and ``message`` contains the
+error details. For example, a validation error such as a missing required field results in
+``status`` being ``1``. For the list of status codes, refer to :doc:`api-admin-overview`.
+
+.. code-block:: json
+
+    {
+      "response": {
+        "version": "15.7.0",
+        "status": 1,
+        "message": "..."
       }
     }
 
@@ -266,4 +331,3 @@ Reference
 - :doc:`api-admin-relatedcontent` - Related Content API
 - :doc:`api-admin-suggest` - Suggest Management API
 - :doc:`../../admin/relatedquery-guide` - Related Query Management Guide
-

--- a/es/15.7/api/admin/api-admin-relatedquery.rst
+++ b/es/15.7/api/admin/api-admin-relatedquery.rst
@@ -5,8 +5,15 @@ API de RelatedQuery
 Vision General
 ==============
 
-La API de RelatedQuery es para gestionar consultas relacionadas de |Fess|.
-Puede sugerir palabras clave de busqueda relacionadas para consultas de busqueda especificas.
+La API de RelatedQuery es una API para gestionar las consultas relacionadas de |Fess|.
+Permite registrar y administrar candidatos de palabras clave de busqueda relacionadas
+(``queries``) para las palabras clave de busqueda (``term``) que introduce el usuario.
+Las consultas relacionadas registradas se muestran como sugerencias de busqueda relacionadas
+en la pantalla de busqueda.
+
+Para obtener informacion detallada sobre la autenticacion, el formato de respuesta comun
+(el campo ``version`` y los codigos ``status``), la paginacion y las respuestas de error,
+consulte :doc:`api-admin-overview`.
 
 URL Base
 ========
@@ -56,7 +63,7 @@ Parametros
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parametro
      - Tipo
@@ -65,11 +72,11 @@ Parametros
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Numero de elementos por pagina (predeterminado: 25. Modificable mediante ``paging.page.size`` de ``fess_config.properties``)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 0)
+     - Numero de pagina (comienza en 1. Predeterminado: 1)
 
 Respuesta
 ---------
@@ -78,17 +85,26 @@ Respuesta
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
             "id": "query_id_1",
             "term": "fess",
-            "queries": "fess tutorial\nfess installation\nfess configuration"
+            "queries": "fess tutorial\nfess installation\nfess configuration",
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
+
+.. note::
+
+   Cada configuracion incluye ``versionNo`` (numero de version para el bloqueo optimista). Los campos
+   ``virtualHost`` y los campos de auditoria (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``)
+   se incluyen unicamente cuando tienen un valor asignado. Un ``virtualHost`` vacio no se incluye
+   en la respuesta.
 
 Obtener Consulta Relacionada
 ============================
@@ -107,12 +123,14 @@ Respuesta
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "setting": {
           "id": "query_id_1",
           "term": "fess",
           "queries": "fess tutorial\nfess installation\nfess configuration",
-          "virtualHost": ""
+          "virtualHost": "site1.example.com",
+          "versionNo": 1
         }
       }
     }
@@ -144,20 +162,24 @@ Descripcion de Campos
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - Campo
      - Requerido
      - Descripcion
    * - ``term``
      - Si
-     - Palabra clave de busqueda
+     - Palabra clave de busqueda (maximo 10000 caracteres)
    * - ``queries``
      - Si
-     - Consultas relacionadas (cadena separada por saltos de linea, una por linea)
+     - Consultas relacionadas. Cadena separada por saltos de linea, una por linea (las lineas vacias se ignoran; maximo 10000 caracteres)
    * - ``virtualHost``
      - No
-     - Host virtual
+     - Host virtual (maximo 1000 caracteres)
+
+.. note::
+
+   ``crudMode`` es configurado automaticamente por la API, por lo que no es necesario incluirlo en el cuerpo de la solicitud.
 
 Respuesta
 ---------
@@ -166,6 +188,7 @@ Respuesta
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "id": "new_query_id",
         "created": true
@@ -196,6 +219,32 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
+Descripcion de Campos
+~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 70
+
+   * - Campo
+     - Requerido
+     - Descripcion
+   * - ``id``
+     - Si
+     - ID de la consulta relacionada a actualizar (maximo 1000 caracteres)
+   * - ``term``
+     - Si
+     - Palabra clave de busqueda (maximo 10000 caracteres)
+   * - ``queries``
+     - Si
+     - Consultas relacionadas. Cadena separada por saltos de linea, una por linea (las lineas vacias se ignoran; maximo 10000 caracteres)
+   * - ``virtualHost``
+     - No
+     - Host virtual (maximo 1000 caracteres)
+   * - ``versionNo``
+     - Si
+     - Numero de version para el bloqueo optimista. Debe especificarse el valor incluido en la respuesta de la consulta de obtencion
+
 Respuesta
 ---------
 
@@ -203,6 +252,7 @@ Respuesta
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "id": "existing_query_id",
         "created": false
@@ -226,7 +276,26 @@ Respuesta
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0
+      }
+    }
+
+Respuesta de Error
+==================
+
+Cuando una solicitud falla, ``status`` se establece en un valor distinto de 0 y ``message``
+contiene el detalle del error. Por ejemplo, en errores de validacion como la ausencia de campos
+obligatorios, ``status`` toma el valor ``1``.
+Para consultar la lista de codigos de estado, vea :doc:`api-admin-overview`.
+
+.. code-block:: json
+
+    {
+      "response": {
+        "version": "15.7.0",
+        "status": 1,
+        "message": "..."
       }
     }
 
@@ -247,7 +316,7 @@ Consultas Relacionadas con Productos
          }'
 
 Consultas Relacionadas con Ayuda
---------------------------------
+---------------------------------
 
 .. code-block:: bash
 

--- a/fr/15.7/api/admin/api-admin-relatedquery.rst
+++ b/fr/15.7/api/admin/api-admin-relatedquery.rst
@@ -5,8 +5,13 @@ API RelatedQuery
 Vue d'ensemble
 ==============
 
-L'API RelatedQuery permet de gerer les requetes associees dans |Fess|.
-Vous pouvez suggerer des mots-cles de recherche associes pour des requetes de recherche specifiques.
+L'API RelatedQuery est une API permettant de gerer les requetes associees dans |Fess|.
+Pour un mot-cle de recherche saisi par l'utilisateur (``term``), vous pouvez enregistrer et
+gerer des suggestions de mots-cles de recherche associes (``queries``). Les requetes associees
+enregistrees sont affichees comme suggestions de recherche associees sur l'ecran de recherche.
+
+Pour les details sur l'authentification, le format de reponse commun (champ ``version`` et
+codes ``status``), la pagination et les reponses d'erreur, consultez :doc:`api-admin-overview`.
 
 URL de base
 ===========
@@ -56,7 +61,7 @@ Parametres
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parametre
      - Type
@@ -65,11 +70,11 @@ Parametres
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 20)
+     - Nombre d'elements par page (par defaut : 25 ; modifiable via ``paging.page.size`` du fichier ``fess_config.properties``)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 0)
+     - Numero de page (commence a 1 ; par defaut : 1)
 
 Reponse
 -------
@@ -78,20 +83,29 @@ Reponse
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
             "id": "query_id_1",
             "term": "fess",
-            "queries": "fess tutorial\nfess installation\nfess configuration"
+            "queries": "fess tutorial\nfess installation\nfess configuration",
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
 
+.. note::
+
+   Chaque parametre contient ``versionNo`` (numero de version utilise pour le verrouillage
+   optimiste). ``virtualHost`` et les champs d'audit (``createdBy``, ``createdTime``,
+   ``updatedBy``, ``updatedTime``) ne sont inclus que lorsqu'une valeur est definie.
+   Un ``virtualHost`` vide n'est pas inclus dans la reponse.
+
 Obtention d'une requete associee
-================================
+=================================
 
 Requete
 -------
@@ -107,18 +121,20 @@ Reponse
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "setting": {
           "id": "query_id_1",
           "term": "fess",
           "queries": "fess tutorial\nfess installation\nfess configuration",
-          "virtualHost": ""
+          "virtualHost": "site1.example.com",
+          "versionNo": 1
         }
       }
     }
 
 Creation d'une requete associee
-===============================
+================================
 
 Requete
 -------
@@ -144,20 +160,24 @@ Description des champs
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - Champ
      - Requis
      - Description
    * - ``term``
      - Oui
-     - Mot-cle de recherche
+     - Mot-cle de recherche (10 000 caracteres maximum)
    * - ``queries``
      - Oui
-     - Requetes associees (chaine separee par des sauts de ligne, une par ligne)
+     - Requetes associees. Chaine separee par des sauts de ligne, une par ligne (les lignes vides sont ignorees ; 10 000 caracteres maximum)
    * - ``virtualHost``
      - Non
-     - Hote virtuel
+     - Hote virtuel (1 000 caracteres maximum)
+
+.. note::
+
+   ``crudMode`` etant defini automatiquement cote API, il n'est pas necessaire de l'inclure dans le corps de la requete.
 
 Reponse
 -------
@@ -166,6 +186,7 @@ Reponse
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "id": "new_query_id",
         "created": true
@@ -173,7 +194,7 @@ Reponse
     }
 
 Mise a jour d'une requete associee
-==================================
+===================================
 
 Requete
 -------
@@ -196,6 +217,32 @@ Corps de la requete
       "versionNo": 1
     }
 
+Description des champs
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 70
+
+   * - Champ
+     - Requis
+     - Description
+   * - ``id``
+     - Oui
+     - ID de la requete associee a mettre a jour (1 000 caracteres maximum)
+   * - ``term``
+     - Oui
+     - Mot-cle de recherche (10 000 caracteres maximum)
+   * - ``queries``
+     - Oui
+     - Requetes associees. Chaine separee par des sauts de ligne, une par ligne (les lignes vides sont ignorees ; 10 000 caracteres maximum)
+   * - ``virtualHost``
+     - Non
+     - Hote virtuel (1 000 caracteres maximum)
+   * - ``versionNo``
+     - Oui
+     - Numero de version utilise pour le verrouillage optimiste. Specifiez la valeur incluse dans la reponse lors de l'obtention du parametre
+
 Reponse
 -------
 
@@ -203,6 +250,7 @@ Reponse
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "id": "existing_query_id",
         "created": false
@@ -210,7 +258,7 @@ Reponse
     }
 
 Suppression d'une requete associee
-==================================
+====================================
 
 Requete
 -------
@@ -226,7 +274,26 @@ Reponse
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0
+      }
+    }
+
+Reponse d'erreur
+================
+
+En cas d'echec de la requete, ``status`` est defini sur une valeur differente de 0 et
+``message`` contient le detail de l'erreur. Par exemple, pour une erreur de validation
+telle qu'un champ obligatoire manquant, ``status`` vaut ``1``. Pour la liste des codes
+de statut, consultez :doc:`api-admin-overview`.
+
+.. code-block:: json
+
+    {
+      "response": {
+        "version": "15.7.0",
+        "status": 1,
+        "message": "..."
       }
     }
 
@@ -234,7 +301,7 @@ Exemples d'utilisation
 ======================
 
 Requetes associees pour les produits
-------------------------------------
+-------------------------------------
 
 .. code-block:: bash
 
@@ -247,7 +314,7 @@ Requetes associees pour les produits
          }'
 
 Requetes associees pour l'aide
-------------------------------
+-------------------------------
 
 .. code-block:: bash
 

--- a/ja/15.7/api/admin/api-admin-relatedquery.rst
+++ b/ja/15.7/api/admin/api-admin-relatedquery.rst
@@ -6,7 +6,12 @@ RelatedQuery API
 ====
 
 RelatedQuery APIは、|Fess| の関連クエリを管理するためのAPIです。
-特定の検索クエリに対して関連する検索キーワードを提案できます。
+ユーザーが入力する検索キーワード（``term``）に対して、関連する検索キーワードの候補
+（``queries``）を登録・管理できます。登録した関連クエリは、検索画面で関連する検索候補として
+表示されます。
+
+認証方法、共通のレスポンス形式（``version`` フィールドや ``status`` コード）、
+ページネーション、エラーレスポンスの詳細は :doc:`api-admin-overview` を参照してください。
 
 ベースURL
 =========
@@ -56,7 +61,7 @@ RelatedQuery APIは、|Fess| の関連クエリを管理するためのAPIです
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - パラメーター
      - 型
@@ -65,11 +70,11 @@ RelatedQuery APIは、|Fess| の関連クエリを管理するためのAPIです
    * - ``size``
      - Integer
      - いいえ
-     - 1ページあたりの件数（デフォルト: 20）
+     - 1ページあたりの件数（デフォルト: 25。``fess_config.properties`` の ``paging.page.size`` で変更可能）
    * - ``page``
      - Integer
      - いいえ
-     - ページ番号（0から開始）
+     - ページ番号（1から開始。デフォルト: 1）
 
 レスポンス
 ----------
@@ -78,17 +83,25 @@ RelatedQuery APIは、|Fess| の関連クエリを管理するためのAPIです
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
             "id": "query_id_1",
             "term": "fess",
-            "queries": "fess tutorial\nfess installation\nfess configuration"
+            "queries": "fess tutorial\nfess installation\nfess configuration",
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
+
+.. note::
+
+   各設定には ``versionNo``（楽観的ロック用のバージョン番号）が含まれます。``virtualHost``
+   や監査用フィールド（``createdBy``、``createdTime``、``updatedBy``、``updatedTime``）は、
+   値が設定されている場合に限り含まれます。値が空の ``virtualHost`` はレスポンスに含まれません。
 
 関連クエリ取得
 ==============
@@ -107,12 +120,14 @@ RelatedQuery APIは、|Fess| の関連クエリを管理するためのAPIです
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "setting": {
           "id": "query_id_1",
           "term": "fess",
           "queries": "fess tutorial\nfess installation\nfess configuration",
-          "virtualHost": ""
+          "virtualHost": "site1.example.com",
+          "versionNo": 1
         }
       }
     }
@@ -144,20 +159,24 @@ RelatedQuery APIは、|Fess| の関連クエリを管理するためのAPIです
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - フィールド
      - 必須
      - 説明
    * - ``term``
      - はい
-     - 検索キーワード
+     - 検索キーワード（最大10000文字）
    * - ``queries``
      - はい
-     - 関連クエリ（1行に1件の改行区切り文字列）
+     - 関連クエリ。1行に1件を記述した改行区切りの文字列です（空行は無視されます。最大10000文字）
    * - ``virtualHost``
      - いいえ
-     - 仮想ホスト
+     - 仮想ホスト（最大1000文字）
+
+.. note::
+
+   ``crudMode`` はAPI側で自動的に設定されるため、リクエストボディに含める必要はありません。
 
 レスポンス
 ----------
@@ -166,6 +185,7 @@ RelatedQuery APIは、|Fess| の関連クエリを管理するためのAPIです
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "id": "new_query_id",
         "created": true
@@ -196,6 +216,32 @@ RelatedQuery APIは、|Fess| の関連クエリを管理するためのAPIです
       "versionNo": 1
     }
 
+フィールド説明
+~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 70
+
+   * - フィールド
+     - 必須
+     - 説明
+   * - ``id``
+     - はい
+     - 更新対象の関連クエリID（最大1000文字）
+   * - ``term``
+     - はい
+     - 検索キーワード（最大10000文字）
+   * - ``queries``
+     - はい
+     - 関連クエリ。1行に1件を記述した改行区切りの文字列です（空行は無視されます。最大10000文字）
+   * - ``virtualHost``
+     - いいえ
+     - 仮想ホスト（最大1000文字）
+   * - ``versionNo``
+     - はい
+     - 楽観的ロック用のバージョン番号。取得時のレスポンスに含まれる値を指定します
+
 レスポンス
 ----------
 
@@ -203,6 +249,7 @@ RelatedQuery APIは、|Fess| の関連クエリを管理するためのAPIです
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "id": "existing_query_id",
         "created": false
@@ -226,7 +273,25 @@ RelatedQuery APIは、|Fess| の関連クエリを管理するためのAPIです
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0
+      }
+    }
+
+エラーレスポンス
+================
+
+リクエストが失敗した場合、``status`` に 0 以外の値が設定され、``message`` にエラー内容が
+含まれます。たとえば、必須フィールドの不足などの検証エラーでは ``status`` が ``1`` になります。
+ステータスコードの一覧は :doc:`api-admin-overview` を参照してください。
+
+.. code-block:: json
+
+    {
+      "response": {
+        "version": "15.7.0",
+        "status": 1,
+        "message": "..."
       }
     }
 

--- a/ko/15.7/api/admin/api-admin-relatedquery.rst
+++ b/ko/15.7/api/admin/api-admin-relatedquery.rst
@@ -6,7 +6,12 @@ RelatedQuery API
 ====
 
 RelatedQuery API는 |Fess| 의 관련 쿼리를 관리하기 위한 API입니다.
-특정 검색 쿼리에 대해 관련 검색 키워드를 제안할 수 있습니다.
+사용자가 입력하는 검색 키워드(``term``)에 대해 관련 검색 키워드 후보
+(``queries``)를 등록·관리할 수 있습니다. 등록한 관련 쿼리는 검색 화면에서 관련 검색 후보로
+표시됩니다.
+
+인증 방법, 공통 응답 형식(``version`` 필드 및 ``status`` 코드),
+페이지네이션, 오류 응답의 자세한 내용은 :doc:`api-admin-overview` 를 참조하십시오.
 
 기본 URL
 =========
@@ -42,21 +47,21 @@ RelatedQuery API는 |Fess| 의 관련 쿼리를 관리하기 위한 API입니다
      - 관련 쿼리 삭제
 
 관련 쿼리 목록 조회
-==================
+====================
 
 요청
-----------
+----
 
 ::
 
     GET /api/admin/relatedquery/settings
 
 파라미터
-~~~~~~~~~~~~
+~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - 파라미터
      - 타입
@@ -65,63 +70,73 @@ RelatedQuery API는 |Fess| 의 관련 쿼리를 관리하기 위한 API입니다
    * - ``size``
      - Integer
      - 아니오
-     - 페이지당 건수 (기본값: 20)
+     - 페이지당 건수 (기본값: 25. ``fess_config.properties`` 의 ``paging.page.size`` 로 변경 가능)
    * - ``page``
      - Integer
      - 아니오
-     - 페이지 번호 (0부터 시작)
+     - 페이지 번호 (1부터 시작. 기본값: 1)
 
 응답
-----------
+----
 
 .. code-block:: json
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
             "id": "query_id_1",
             "term": "fess",
-            "queries": "fess tutorial\nfess installation\nfess configuration"
+            "queries": "fess tutorial\nfess installation\nfess configuration",
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
 
+.. note::
+
+   각 설정에는 ``versionNo`` (낙관적 잠금용 버전 번호)가 포함됩니다. ``virtualHost``
+   및 감사용 필드(``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``)는
+   값이 설정된 경우에만 포함됩니다. 값이 비어 있는 ``virtualHost`` 는 응답에 포함되지 않습니다.
+
 관련 쿼리 조회
 ==============
 
 요청
-----------
+----
 
 ::
 
     GET /api/admin/relatedquery/setting/{id}
 
 응답
-----------
+----
 
 .. code-block:: json
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "setting": {
           "id": "query_id_1",
           "term": "fess",
           "queries": "fess tutorial\nfess installation\nfess configuration",
-          "virtualHost": ""
+          "virtualHost": "site1.example.com",
+          "versionNo": 1
         }
       }
     }
 
 관련 쿼리 만들기
-==============
+================
 
 요청
-----------
+----
 
 ::
 
@@ -129,7 +144,7 @@ RelatedQuery API는 |Fess| 의 관련 쿼리를 관리하기 위한 API입니다
     Content-Type: application/json
 
 요청 본문
-~~~~~~~~~~~~~~~~
+~~~~~~~~~
 
 .. code-block:: json
 
@@ -140,32 +155,37 @@ RelatedQuery API는 |Fess| 의 관련 쿼리를 관리하기 위한 API입니다
     }
 
 필드 설명
-~~~~~~~~~~~~~~
+~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - 필드
      - 필수
      - 설명
    * - ``term``
      - 예
-     - 검색 키워드
+     - 검색 키워드 (최대 10000자)
    * - ``queries``
      - 예
-     - 관련 쿼리 (한 줄에 한 건의 줄바꿈 구분 문자열)
+     - 관련 쿼리. 한 줄에 한 건씩 작성한 줄바꿈 구분 문자열입니다 (빈 줄은 무시됩니다. 최대 10000자)
    * - ``virtualHost``
      - 아니오
-     - 가상 호스트
+     - 가상 호스트 (최대 1000자)
+
+.. note::
+
+   ``crudMode`` 는 API 측에서 자동으로 설정되므로 요청 본문에 포함할 필요가 없습니다.
 
 응답
-----------
+----
 
 .. code-block:: json
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "id": "new_query_id",
         "created": true
@@ -173,10 +193,10 @@ RelatedQuery API는 |Fess| 의 관련 쿼리를 관리하기 위한 API입니다
     }
 
 관련 쿼리 업데이트
-==============
+==================
 
 요청
-----------
+----
 
 ::
 
@@ -184,7 +204,7 @@ RelatedQuery API는 |Fess| 의 관련 쿼리를 관리하기 위한 API입니다
     Content-Type: application/json
 
 요청 본문
-~~~~~~~~~~~~~~~~
+~~~~~~~~~
 
 .. code-block:: json
 
@@ -196,13 +216,40 @@ RelatedQuery API는 |Fess| 의 관련 쿼리를 관리하기 위한 API입니다
       "versionNo": 1
     }
 
+필드 설명
+~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 70
+
+   * - 필드
+     - 필수
+     - 설명
+   * - ``id``
+     - 예
+     - 업데이트 대상 관련 쿼리 ID (최대 1000자)
+   * - ``term``
+     - 예
+     - 검색 키워드 (최대 10000자)
+   * - ``queries``
+     - 예
+     - 관련 쿼리. 한 줄에 한 건씩 작성한 줄바꿈 구분 문자열입니다 (빈 줄은 무시됩니다. 최대 10000자)
+   * - ``virtualHost``
+     - 아니오
+     - 가상 호스트 (최대 1000자)
+   * - ``versionNo``
+     - 예
+     - 낙관적 잠금용 버전 번호. 조회 시 응답에 포함된 값을 지정합니다
+
 응답
-----------
+----
 
 .. code-block:: json
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "id": "existing_query_id",
         "created": false
@@ -213,28 +260,46 @@ RelatedQuery API는 |Fess| 의 관련 쿼리를 관리하기 위한 API입니다
 ==============
 
 요청
-----------
+----
 
 ::
 
     DELETE /api/admin/relatedquery/setting/{id}
 
 응답
-----------
+----
 
 .. code-block:: json
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0
       }
     }
 
+오류 응답
+=========
+
+요청이 실패한 경우 ``status`` 에 0 이외의 값이 설정되고, ``message`` 에 오류 내용이
+포함됩니다. 예를 들어 필수 필드 누락 등의 유효성 검사 오류에서는 ``status`` 가 ``1`` 이 됩니다.
+상태 코드 목록은 :doc:`api-admin-overview` 를 참조하십시오.
+
+.. code-block:: json
+
+    {
+      "response": {
+        "version": "15.7.0",
+        "status": 1,
+        "message": "..."
+      }
+    }
+
 사용 예
-======
+=======
 
 제품 관련 쿼리
-----------------
+--------------
 
 .. code-block:: bash
 
@@ -247,7 +312,7 @@ RelatedQuery API는 |Fess| 의 관련 쿼리를 관리하기 위한 API입니다
          }'
 
 도움말 관련 쿼리
-------------------
+----------------
 
 .. code-block:: bash
 
@@ -260,7 +325,7 @@ RelatedQuery API는 |Fess| 의 관련 쿼리를 관리하기 위한 API입니다
          }'
 
 참고 정보
-========
+=========
 
 - :doc:`api-admin-overview` - Admin API 개요
 - :doc:`api-admin-relatedcontent` - 관련 콘텐츠 API

--- a/zh-cn/15.7/api/admin/api-admin-relatedquery.rst
+++ b/zh-cn/15.7/api/admin/api-admin-relatedquery.rst
@@ -6,7 +6,11 @@ RelatedQuery API
 ====
 
 RelatedQuery API是用于管理 |Fess| 相关查询的API。
-您可以为特定搜索查询推荐相关的搜索关键词。
+您可以为用户输入的搜索关键词（``term``）注册并管理相关的搜索关键词候选
+（``queries``）。注册的相关查询将在搜索界面中作为相关搜索候选显示。
+
+有关认证方式、通用响应格式（``version`` 字段和 ``status`` 状态码）、
+分页以及错误响应的详细信息，请参阅 :doc:`api-admin-overview`。
 
 基础URL
 =======
@@ -56,7 +60,7 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - 参数
      - 类型
@@ -65,11 +69,11 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
    * - ``size``
      - Integer
      - 否
-     - 每页记录数（默认：20）
+     - 每页记录数（默认：25。可通过 ``fess_config.properties`` 的 ``paging.page.size`` 更改）
    * - ``page``
      - Integer
      - 否
-     - 页码（从0开始）
+     - 页码（从1开始。默认：1）
 
 响应
 ----
@@ -78,17 +82,25 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
             "id": "query_id_1",
             "term": "fess",
-            "queries": "fess tutorial\nfess installation\nfess configuration"
+            "queries": "fess tutorial\nfess installation\nfess configuration",
+            "versionNo": 1
           }
         ],
         "total": 5
       }
     }
+
+.. note::
+
+   每条设置均包含 ``versionNo``（用于乐观锁的版本号）。``virtualHost``
+   以及审计字段（``createdBy``、``createdTime``、``updatedBy``、``updatedTime``）
+   仅在有值时才会包含在响应中。值为空的 ``virtualHost`` 不会包含在响应中。
 
 获取相关查询
 ============
@@ -107,12 +119,14 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "setting": {
           "id": "query_id_1",
           "term": "fess",
-          "queries": ["fess tutorial", "fess installation", "fess configuration"],
-          "virtualHost": ""
+          "queries": "fess tutorial\nfess installation\nfess configuration",
+          "virtualHost": "site1.example.com",
+          "versionNo": 1
         }
       }
     }
@@ -135,7 +149,7 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
 
     {
       "term": "search",
-      "queries": ["search tutorial", "search syntax", "advanced search"],
+      "queries": "search tutorial\nsearch syntax\nadvanced search",
       "virtualHost": ""
     }
 
@@ -144,20 +158,24 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 10 70
 
    * - 字段
      - 必需
      - 说明
    * - ``term``
      - 是
-     - 搜索关键词
+     - 搜索关键词（最多10000个字符）
    * - ``queries``
      - 是
-     - 相关查询数组
+     - 相关查询。每行一条，以换行符分隔的字符串（空行将被忽略。最多10000个字符）
    * - ``virtualHost``
      - 否
-     - 虚拟主机
+     - 虚拟主机（最多1000个字符）
+
+.. note::
+
+   ``crudMode`` 由API端自动设置，无需包含在请求体中。
 
 响应
 ----
@@ -166,6 +184,7 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "id": "new_query_id",
         "created": true
@@ -191,10 +210,36 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
     {
       "id": "existing_query_id",
       "term": "search",
-      "queries": ["search tutorial", "search syntax", "advanced search", "search tips"],
+      "queries": "search tutorial\nsearch syntax\nadvanced search\nsearch tips",
       "virtualHost": "",
       "versionNo": 1
     }
+
+字段说明
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 70
+
+   * - 字段
+     - 必需
+     - 说明
+   * - ``id``
+     - 是
+     - 待更新的相关查询ID（最多1000个字符）
+   * - ``term``
+     - 是
+     - 搜索关键词（最多10000个字符）
+   * - ``queries``
+     - 是
+     - 相关查询。每行一条，以换行符分隔的字符串（空行将被忽略。最多10000个字符）
+   * - ``virtualHost``
+     - 否
+     - 虚拟主机（最多1000个字符）
+   * - ``versionNo``
+     - 是
+     - 用于乐观锁的版本号。请指定获取时响应中包含的值
 
 响应
 ----
@@ -203,6 +248,7 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "id": "existing_query_id",
         "created": false
@@ -226,9 +272,25 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
 
     {
       "response": {
-        "status": 0,
-        "id": "deleted_query_id",
-        "created": false
+        "version": "15.7.0",
+        "status": 0
+      }
+    }
+
+错误响应
+========
+
+当请求失败时，``status`` 将被设置为非 0 的值，``message`` 中包含错误内容。
+例如，缺少必填字段等验证错误时，``status`` 为 ``1``。
+有关状态码的列表，请参阅 :doc:`api-admin-overview`。
+
+.. code-block:: json
+
+    {
+      "response": {
+        "version": "15.7.0",
+        "status": 1,
+        "message": "..."
       }
     }
 
@@ -245,7 +307,7 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
          -H "Content-Type: application/json" \
          -d '{
            "term": "product",
-           "queries": ["product features", "product pricing", "product comparison", "product reviews"]
+           "queries": "product features\nproduct pricing\nproduct comparison\nproduct reviews"
          }'
 
 帮助相关查询
@@ -258,7 +320,7 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
          -H "Content-Type: application/json" \
          -d '{
            "term": "help",
-           "queries": ["help center", "help documentation", "help contact support"]
+           "queries": "help center\nhelp documentation\nhelp contact support"
          }'
 
 参考信息
@@ -268,4 +330,3 @@ RelatedQuery API是用于管理 |Fess| 相关查询的API。
 - :doc:`api-admin-relatedcontent` - 相关内容API
 - :doc:`api-admin-suggest` - 建议管理API
 - :doc:`../../admin/relatedquery-guide` - 相关查询管理指南
-


### PR DESCRIPTION
## Summary

Reviewed the RelatedQuery Admin API reference (`api/admin/api-admin-relatedquery.rst`) against the current Fess implementation and corrected several inaccuracies. The Japanese source was fixed first, then propagated to all language versions.

Verified against the source implementation:
- `ApiAdminRelatedqueryAction` (REST endpoints, response builders)
- `BaseSearchBody` / `Constants` / `fess_config.properties` (pagination defaults)
- `CreateForm` / `EditForm` (request fields, required flags, length constraints)
- `ApiResult` (response envelope, status codes)

## Corrections

- **Pagination defaults**: `size` default was documented as `20`; the actual default is `25` (from `paging.page.size`). `page` was documented as starting from `0`; it actually starts from `1` (default `1`).
- **Response fields**: List/Get responses now include `versionNo` and the `version` envelope field, matching the actual JSON. Clarified that `virtualHost` and audit fields appear only when set, and that an empty `virtualHost` is omitted.
- **Update request body**: Added the previously missing field-description table for `PUT /setting` (`id`, `term`, `queries`, `virtualHost`, `versionNo`), including which fields are required and the role of `versionNo` (optimistic locking).
- **Validation constraints**: Documented maximum lengths (`term`/`queries`: 10000, `virtualHost`/`id`: 1000).
- **Error responses**: Added an error-response section and a reference to the Admin API overview for the status code list.
- **Notes**: Clarified that `crudMode` is set automatically by the API and does not need to be sent.
- **Table formatting**: Fixed `:widths:` definitions that did not match the number of columns.

## Languages updated

`ja`, `en`, `de`, `es`, `fr`, `ko`, `zh-cn`. The German version was previously incomplete and has been brought to full parity with the other languages.

All heading underline lengths were validated for the Sphinx build (including CJK width handling), and structural parity was confirmed across all seven language files.