### PR TITLE
docs(api): correct Role API reference against implementation (15.7)

### DIFF
--- a/de/15.7/api/admin/api-admin-role.rst
+++ b/de/15.7/api/admin/api-admin-role.rst
@@ -56,7 +56,7 @@ Parameter
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parameter
      - Typ
@@ -65,11 +65,15 @@ Parameter
    * - ``size``
      - Integer
      - Nein
-     - Anzahl der Einträge pro Seite (Standard: 20)
+     - Anzahl der Einträge pro Seite (Standard: 25, konfigurierbar über ``paging.page.size`` in ``fess_config.properties``)
    * - ``page``
      - Integer
      - Nein
-     - Seitennummer (beginnt bei 0)
+     - Seitennummer (beginnt bei 1, Standard: 1; Werte von 0 oder kleiner werden als 1 behandelt)
+   * - ``id``
+     - String
+     - Nein
+     - Filtert anhand der exakten Übereinstimmung mit der angegebenen Rollen-ID
 
 Response
 --------
@@ -82,11 +86,13 @@ Response
         "settings": [
           {
             "id": "role_id_1",
-            "name": "admin"
+            "name": "admin",
+            "versionNo": 1
           },
           {
             "id": "role_id_2",
-            "name": "user"
+            "name": "user",
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -113,7 +119,8 @@ Response
         "status": 0,
         "setting": {
           "id": "role_id_1",
-          "name": "admin"
+          "name": "admin",
+          "versionNo": 1
         }
       }
     }
@@ -143,14 +150,17 @@ Feldbeschreibungen
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - Feld
      - Erforderlich
      - Beschreibung
    * - ``name``
      - Ja
-     - Rollenname
+     - Rollenname (maximal 100 Zeichen)
+   * - ``attributes``
+     - Nein
+     - Attribut-Map. Werte werden als Zeichenketten angegeben
 
 Response
 --------
@@ -186,6 +196,29 @@ Request-Body
       "name": "editor_updated",
       "versionNo": 1
     }
+
+Feldbeschreibungen
+~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Feld
+     - Erforderlich
+     - Beschreibung
+   * - ``id``
+     - Ja
+     - Zu aktualisierende Rollen-ID
+   * - ``name``
+     - Ja
+     - Rollenname (maximal 100 Zeichen)
+   * - ``attributes``
+     - Nein
+     - Attribut-Map. Werte werden als Zeichenketten angegeben
+   * - ``versionNo``
+     - Ja
+     - Versionsnummer für optimistisches Sperren. Geben Sie den Wert von ``versionNo`` an, der beim Abrufen der Rolle ermittelt wurde
 
 Response
 --------
@@ -243,7 +276,7 @@ Rollenliste abrufen
 
 .. code-block:: bash
 
-    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50" \
+    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
 Referenzinformationen

--- a/en/15.7/api/admin/api-admin-role.rst
+++ b/en/15.7/api/admin/api-admin-role.rst
@@ -56,7 +56,7 @@ Parameters
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parameter
      - Type
@@ -65,11 +65,15 @@ Parameters
    * - ``size``
      - Integer
      - No
-     - Number of items per page (default: 20)
+     - Number of items per page (default: 25, configurable via ``paging.page.size`` in ``fess_config.properties``)
    * - ``page``
      - Integer
      - No
-     - Page number (starts from 0)
+     - Page number (starts from 1, default: 1; values of 0 or less are treated as 1)
+   * - ``id``
+     - String
+     - No
+     - Filters by exact match on the specified role ID
 
 Response
 --------
@@ -82,11 +86,13 @@ Response
         "settings": [
           {
             "id": "role_id_1",
-            "name": "admin"
+            "name": "admin",
+            "versionNo": 1
           },
           {
             "id": "role_id_2",
-            "name": "user"
+            "name": "user",
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -113,7 +119,8 @@ Response
         "status": 0,
         "setting": {
           "id": "role_id_1",
-          "name": "admin"
+          "name": "admin",
+          "versionNo": 1
         }
       }
     }
@@ -143,14 +150,17 @@ Field Description
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - Field
      - Required
      - Description
    * - ``name``
      - Yes
-     - Role name
+     - Role name (max 100 characters)
+   * - ``attributes``
+     - No
+     - Map of attributes. Values are specified as strings
 
 Response
 --------
@@ -186,6 +196,29 @@ Request Body
       "name": "editor_updated",
       "versionNo": 1
     }
+
+Field Description
+~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Field
+     - Required
+     - Description
+   * - ``id``
+     - Yes
+     - Role ID to update
+   * - ``name``
+     - Yes
+     - Role name (max 100 characters)
+   * - ``attributes``
+     - No
+     - Map of attributes. Values are specified as strings
+   * - ``versionNo``
+     - Yes
+     - Version number for optimistic locking. Specify the ``versionNo`` value obtained from Get Role
 
 Response
 --------
@@ -243,7 +276,7 @@ List Roles
 
 .. code-block:: bash
 
-    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50" \
+    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
 Reference
@@ -253,4 +286,3 @@ Reference
 - :doc:`api-admin-user` - User Management API
 - :doc:`api-admin-group` - Group Management API
 - :doc:`../../admin/role-guide` - Role Management Guide
-

--- a/es/15.7/api/admin/api-admin-role.rst
+++ b/es/15.7/api/admin/api-admin-role.rst
@@ -56,7 +56,7 @@ Parametros
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parametro
      - Tipo
@@ -65,11 +65,15 @@ Parametros
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Numero de elementos por pagina (predeterminado: 25. Configurable mediante ``paging.page.size`` en ``fess_config.properties``)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 0)
+     - Numero de pagina (comienza en 1, predeterminado: 1. Los valores de 0 o menos se tratan como 1)
+   * - ``id``
+     - String
+     - No
+     - Filtra por coincidencia exacta con el ID de rol especificado
 
 Respuesta
 ---------
@@ -82,11 +86,13 @@ Respuesta
         "settings": [
           {
             "id": "role_id_1",
-            "name": "admin"
+            "name": "admin",
+            "versionNo": 1
           },
           {
             "id": "role_id_2",
-            "name": "user"
+            "name": "user",
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -113,7 +119,8 @@ Respuesta
         "status": 0,
         "setting": {
           "id": "role_id_1",
-          "name": "admin"
+          "name": "admin",
+          "versionNo": 1
         }
       }
     }
@@ -143,14 +150,17 @@ Descripcion de Campos
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - Campo
      - Requerido
      - Descripcion
    * - ``name``
      - Si
-     - Nombre del rol
+     - Nombre del rol (maximo 100 caracteres)
+   * - ``attributes``
+     - No
+     - Mapa de atributos. Los valores se especifican como cadenas
 
 Respuesta
 ---------
@@ -186,6 +196,29 @@ Cuerpo de la Solicitud
       "name": "editor_updated",
       "versionNo": 1
     }
+
+Descripcion de Campos
+~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Campo
+     - Requerido
+     - Descripcion
+   * - ``id``
+     - Si
+     - ID del rol a actualizar
+   * - ``name``
+     - Si
+     - Nombre del rol (maximo 100 caracteres)
+   * - ``attributes``
+     - No
+     - Mapa de atributos. Los valores se especifican como cadenas
+   * - ``versionNo``
+     - Si
+     - Numero de version para el bloqueo optimista. Especifique el valor de ``versionNo`` obtenido al obtener el rol
 
 Respuesta
 ---------
@@ -243,7 +276,7 @@ Obtener Lista de Roles
 
 .. code-block:: bash
 
-    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50" \
+    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
 Informacion de Referencia

--- a/fr/15.7/api/admin/api-admin-role.rst
+++ b/fr/15.7/api/admin/api-admin-role.rst
@@ -42,7 +42,7 @@ Liste des endpoints
      - Suppression d'un role
 
 Obtention de la liste des roles
-===============================
+================================
 
 Requete
 -------
@@ -56,7 +56,7 @@ Parametres
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - Parametre
      - Type
@@ -65,11 +65,15 @@ Parametres
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 20)
+     - Nombre d'elements par page (par defaut : 25. Modifiable via la propriete ``paging.page.size`` dans ``fess_config.properties``)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 0)
+     - Numero de page (commence a 1, par defaut : 1. Les valeurs de 0 ou moins sont traitees comme 1)
+   * - ``id``
+     - String
+     - Non
+     - Filtre par correspondance exacte sur l'ID de role specifie
 
 Reponse
 -------
@@ -82,11 +86,13 @@ Reponse
         "settings": [
           {
             "id": "role_id_1",
-            "name": "admin"
+            "name": "admin",
+            "versionNo": 1
           },
           {
             "id": "role_id_2",
-            "name": "user"
+            "name": "user",
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -113,7 +119,8 @@ Reponse
         "status": 0,
         "setting": {
           "id": "role_id_1",
-          "name": "admin"
+          "name": "admin",
+          "versionNo": 1
         }
       }
     }
@@ -143,14 +150,17 @@ Description des champs
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - Champ
      - Requis
      - Description
    * - ``name``
      - Oui
-     - Nom du role
+     - Nom du role (maximum 100 caracteres)
+   * - ``attributes``
+     - Non
+     - Map d'attributs. Les valeurs sont specifiees sous forme de chaines de caracteres
 
 Reponse
 -------
@@ -186,6 +196,29 @@ Corps de la requete
       "name": "editor_updated",
       "versionNo": 1
     }
+
+Description des champs
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Champ
+     - Requis
+     - Description
+   * - ``id``
+     - Oui
+     - ID du role a mettre a jour
+   * - ``name``
+     - Oui
+     - Nom du role (maximum 100 caracteres)
+   * - ``attributes``
+     - Non
+     - Map d'attributs. Les valeurs sont specifiees sous forme de chaines de caracteres
+   * - ``versionNo``
+     - Oui
+     - Numero de version pour le verrouillage optimiste. Specifiez la valeur de ``versionNo`` obtenue lors de l'obtention du role
 
 Reponse
 -------
@@ -239,11 +272,11 @@ Creation d'un nouveau role
          }'
 
 Obtention de la liste des roles
--------------------------------
+--------------------------------
 
 .. code-block:: bash
 
-    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50" \
+    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
 Informations complementaires

--- a/ja/15.7/api/admin/api-admin-role.rst
+++ b/ja/15.7/api/admin/api-admin-role.rst
@@ -56,7 +56,7 @@ Role APIは、|Fess| のロールを管理するためのAPIです。
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - パラメーター
      - 型
@@ -65,11 +65,15 @@ Role APIは、|Fess| のロールを管理するためのAPIです。
    * - ``size``
      - Integer
      - いいえ
-     - 1ページあたりの件数（デフォルト: 20）
+     - 1ページあたりの件数（デフォルト: 25。``fess_config.properties`` の ``paging.page.size`` で変更可能）
    * - ``page``
      - Integer
      - いいえ
-     - ページ番号（0から開始）
+     - ページ番号（1から開始、デフォルト: 1。0以下を指定した場合は1として扱われます）
+   * - ``id``
+     - String
+     - いいえ
+     - 指定したロールIDで完全一致フィルタリングします
 
 レスポンス
 ----------
@@ -82,11 +86,13 @@ Role APIは、|Fess| のロールを管理するためのAPIです。
         "settings": [
           {
             "id": "role_id_1",
-            "name": "admin"
+            "name": "admin",
+            "versionNo": 1
           },
           {
             "id": "role_id_2",
-            "name": "user"
+            "name": "user",
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -113,7 +119,8 @@ Role APIは、|Fess| のロールを管理するためのAPIです。
         "status": 0,
         "setting": {
           "id": "role_id_1",
-          "name": "admin"
+          "name": "admin",
+          "versionNo": 1
         }
       }
     }
@@ -143,14 +150,17 @@ Role APIは、|Fess| のロールを管理するためのAPIです。
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - フィールド
      - 必須
      - 説明
    * - ``name``
      - はい
-     - ロール名
+     - ロール名（最大100文字）
+   * - ``attributes``
+     - いいえ
+     - 属性のマップ。値は文字列で指定します
 
 レスポンス
 ----------
@@ -186,6 +196,29 @@ Role APIは、|Fess| のロールを管理するためのAPIです。
       "name": "editor_updated",
       "versionNo": 1
     }
+
+フィールド説明
+~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - フィールド
+     - 必須
+     - 説明
+   * - ``id``
+     - はい
+     - 更新対象のロールID
+   * - ``name``
+     - はい
+     - ロール名（最大100文字）
+   * - ``attributes``
+     - いいえ
+     - 属性のマップ。値は文字列で指定します
+   * - ``versionNo``
+     - はい
+     - 楽観的ロック用のバージョン番号。ロール取得で得た ``versionNo`` の値を指定します
 
 レスポンス
 ----------
@@ -243,7 +276,7 @@ Role APIは、|Fess| のロールを管理するためのAPIです。
 
 .. code-block:: bash
 
-    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50" \
+    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
 参考情報

--- a/ko/15.7/api/admin/api-admin-role.rst
+++ b/ko/15.7/api/admin/api-admin-role.rst
@@ -42,7 +42,7 @@ Role API는 |Fess| 의 역할을 관리하기 위한 API입니다.
      - 역할 삭제
 
 역할 목록 조회
-==============
+================
 
 요청
 ----------
@@ -56,7 +56,7 @@ Role API는 |Fess| 의 역할을 관리하기 위한 API입니다.
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - 파라미터
      - 타입
@@ -65,11 +65,15 @@ Role API는 |Fess| 의 역할을 관리하기 위한 API입니다.
    * - ``size``
      - Integer
      - 아니오
-     - 페이지당 건수 (기본값: 20)
+     - 페이지당 건수 (기본값: 25。``fess_config.properties`` 의 ``paging.page.size`` 로 변경 가능)
    * - ``page``
      - Integer
      - 아니오
-     - 페이지 번호 (0부터 시작)
+     - 페이지 번호 (1부터 시작, 기본값: 1。0 이하를 지정한 경우 1로 처리됩니다)
+   * - ``id``
+     - String
+     - 아니오
+     - 지정한 역할 ID로 완전 일치 필터링합니다
 
 응답
 ----------
@@ -82,11 +86,13 @@ Role API는 |Fess| 의 역할을 관리하기 위한 API입니다.
         "settings": [
           {
             "id": "role_id_1",
-            "name": "admin"
+            "name": "admin",
+            "versionNo": 1
           },
           {
             "id": "role_id_2",
-            "name": "user"
+            "name": "user",
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -94,7 +100,7 @@ Role API는 |Fess| 의 역할을 관리하기 위한 API입니다.
     }
 
 역할 조회
-==========
+============
 
 요청
 ----------
@@ -113,13 +119,14 @@ Role API는 |Fess| 의 역할을 관리하기 위한 API입니다.
         "status": 0,
         "setting": {
           "id": "role_id_1",
-          "name": "admin"
+          "name": "admin",
+          "versionNo": 1
         }
       }
     }
 
 역할 만들기
-==========
+============
 
 요청
 ----------
@@ -143,14 +150,17 @@ Role API는 |Fess| 의 역할을 관리하기 위한 API입니다.
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - 필드
      - 필수
      - 설명
    * - ``name``
      - 예
-     - 역할 이름
+     - 역할 이름 (최대 100자)
+   * - ``attributes``
+     - 아니오
+     - 속성의 맵. 값은 문자열로 지정합니다
 
 응답
 ----------
@@ -166,7 +176,7 @@ Role API는 |Fess| 의 역할을 관리하기 위한 API입니다.
     }
 
 역할 업데이트
-==========
+============
 
 요청
 ----------
@@ -187,6 +197,29 @@ Role API는 |Fess| 의 역할을 관리하기 위한 API입니다.
       "versionNo": 1
     }
 
+필드 설명
+~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - 필드
+     - 필수
+     - 설명
+   * - ``id``
+     - 예
+     - 업데이트 대상 역할 ID
+   * - ``name``
+     - 예
+     - 역할 이름 (최대 100자)
+   * - ``attributes``
+     - 아니오
+     - 속성의 맵. 값은 문자열로 지정합니다
+   * - ``versionNo``
+     - 예
+     - 낙관적 잠금을 위한 버전 번호. 역할 조회에서 얻은 ``versionNo`` 값을 지정합니다
+
 응답
 ----------
 
@@ -201,7 +234,7 @@ Role API는 |Fess| 의 역할을 관리하기 위한 API입니다.
     }
 
 역할 삭제
-==========
+============
 
 요청
 ----------
@@ -227,7 +260,7 @@ Role API는 |Fess| 의 역할을 관리하기 위한 API입니다.
 ======
 
 새 역할 만들기
---------------
+----------------
 
 .. code-block:: bash
 
@@ -239,11 +272,11 @@ Role API는 |Fess| 의 역할을 관리하기 위한 API입니다.
          }'
 
 역할 목록 조회
---------------
+----------------
 
 .. code-block:: bash
 
-    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50" \
+    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
 참고 정보

--- a/zh-cn/15.7/api/admin/api-admin-role.rst
+++ b/zh-cn/15.7/api/admin/api-admin-role.rst
@@ -56,7 +56,7 @@ Role API是用于管理 |Fess| 角色的API。
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 15.70
+   :widths: 20 15 15 50
 
    * - 参数
      - 类型
@@ -65,11 +65,15 @@ Role API是用于管理 |Fess| 角色的API。
    * - ``size``
      - Integer
      - 否
-     - 每页记录数（默认：20）
+     - 每页记录数（默认：25。可通过 ``fess_config.properties`` 的 ``paging.page.size`` 修改）
    * - ``page``
      - Integer
      - 否
-     - 页码（从0开始）
+     - 页码（从1开始，默认：1。指定0或以下时视为1）
+   * - ``id``
+     - String
+     - 否
+     - 按指定的角色ID进行完全匹配过滤
 
 响应
 ----
@@ -82,11 +86,13 @@ Role API是用于管理 |Fess| 角色的API。
         "settings": [
           {
             "id": "role_id_1",
-            "name": "admin"
+            "name": "admin",
+            "versionNo": 1
           },
           {
             "id": "role_id_2",
-            "name": "user"
+            "name": "user",
+            "versionNo": 1
           }
         ],
         "total": 5
@@ -113,7 +119,8 @@ Role API是用于管理 |Fess| 角色的API。
         "status": 0,
         "setting": {
           "id": "role_id_1",
-          "name": "admin"
+          "name": "admin",
+          "versionNo": 1
         }
       }
     }
@@ -143,14 +150,17 @@ Role API是用于管理 |Fess| 角色的API。
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15.70
+   :widths: 20 15 65
 
    * - 字段
      - 必需
      - 说明
    * - ``name``
      - 是
-     - 角色名称
+     - 角色名称（最大100个字符）
+   * - ``attributes``
+     - 否
+     - 属性的映射。值以字符串指定
 
 响应
 ----
@@ -186,6 +196,29 @@ Role API是用于管理 |Fess| 角色的API。
       "name": "editor_updated",
       "versionNo": 1
     }
+
+字段说明
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - 字段
+     - 必需
+     - 说明
+   * - ``id``
+     - 是
+     - 要更新的角色ID
+   * - ``name``
+     - 是
+     - 角色名称（最大100个字符）
+   * - ``attributes``
+     - 否
+     - 属性的映射。值以字符串指定
+   * - ``versionNo``
+     - 是
+     - 乐观锁的版本号。指定从获取角色获得的 ``versionNo`` 值
 
 响应
 ----
@@ -243,7 +276,7 @@ Role API是用于管理 |Fess| 角色的API。
 
 .. code-block:: bash
 
-    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50" \
+    curl -X GET "http://localhost:8080/api/admin/role/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
 参考信息
@@ -253,4 +286,3 @@ Role API是用于管理 |Fess| 角色的API。
 - :doc:`api-admin-user` - 用户管理API
 - :doc:`api-admin-group` - 组管理API
 - :doc:`../../admin/role-guide` - 角色管理指南
-


### PR DESCRIPTION
## Summary

Reviewed the Admin **Role API** documentation (`15.7/api/admin/api-admin-role.rst`) against the actual implementation (`ApiAdminRoleAction`, `BaseSearchBody`, `CreateBody`/`EditBody`, `ApiResult`) and corrected several inaccuracies. The Japanese source was fixed first, then the corrections were propagated to all languages (en, de, es, fr, ko, zh-cn).

This brings the Role API page in line with the already-corrected Group API page, which shares the same CRUD framework.

## Changes

- **Default page size**: `20` → `25`, and note that it is configurable via `paging.page.size` in `fess_config.properties` (`BaseSearchBody.size` resolves to `getPagingPageSizeAsInteger()`, default `25`).
- **Page numbering**: was described as starting from `0`; it is actually 1-based (`Constants.DEFAULT_ADMIN_PAGE_NUMBER = 1`), default `1`, and values of `0` or less are treated as `1`.
- **`id` query parameter**: added to the list endpoint (exact-match filtering on role ID; `SearchBody.id`).
- **`versionNo` in responses**: the list and get responses return `EditBody` objects that always include `versionNo`; added it to the response examples.
- **`attributes` field**: documented the optional `attributes` map accepted by create/update (`CreateForm.attributes`, merged into the role document).
- **Update field table**: added the previously missing field description table for the update request body (`id`, `name`, `attributes`, `versionNo`, with `name` ≤ 100 chars and `versionNo` required for optimistic locking).
- **RST fixes**: corrected malformed `list-table` `:widths:` values.

## Verification

- All technical values (JSON keys, defaults, paths, property names, table widths) verified identical across all 7 languages.
- RST title underline widths validated (East-Asian width aware); CJK files consistent with their existing sibling docs.
- No leftover untranslated text in the non-Japanese versions.