### PR TITLE
docs(api): correct and expand Admin Scheduler API reference against implementation (15.7)

### DIFF
--- a/de/15.7/api/admin/api-admin-scheduler.rst
+++ b/de/15.7/api/admin/api-admin-scheduler.rst
@@ -71,11 +71,11 @@ Parameter
    * - ``size``
      - Integer
      - Nein
-     - Anzahl der Einträge pro Seite
+     - Anzahl der Einträge pro Seite (Standard: 25; konfigurierbar über ``paging.page.size`` in ``fess_config.properties``)
    * - ``page``
      - Integer
      - Nein
-     - Seitennummer
+     - Seitennummer (1-basiert; Standard: 1)
 
 Response
 --------
@@ -84,6 +84,7 @@ Response
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -97,6 +98,7 @@ Response
             "crawler": "true",
             "available": "true",
             "sortOrder": 0,
+            "versionNo": 1,
             "running": false
           }
         ],
@@ -106,7 +108,11 @@ Response
 
 .. note::
 
-   ``jobLogging`` / ``crawler`` / ``available`` werden als Zeichenketten (``"true"`` / ``"false"``) behandelt. ``running`` ist ein boolescher Wert und gibt den Ausführungsstatus des Jobs an.
+   Das ``response``-Objekt enthält stets ``version`` (Produktversion) und ``status`` (Ergebniscode). Die gemeinsame Antwortstruktur ist in :doc:`api-admin-overview` beschrieben. In späteren Beispielen kann ``version`` der Übersichtlichkeit halber weggelassen werden.
+
+.. note::
+
+   Im Response werden ``jobLogging`` / ``crawler`` / ``available`` als Zeichenketten (``"true"`` / ``"false"``) zurückgegeben. ``running`` ist ein boolescher Wert und ein reines Response-Feld, das anzeigt, ob der Job gerade ausgeführt wird (kann im Request nicht gesetzt werden). ``total`` ist die Gesamtanzahl der zur Abfrage passenden Jobs.
 
 Geplanten Job abrufen
 =====================
@@ -137,6 +143,7 @@ Response
           "crawler": "true",
           "available": "true",
           "sortOrder": 0,
+          "versionNo": 1,
           "running": false
         }
       }
@@ -182,31 +189,39 @@ Feldbeschreibungen
      - Beschreibung
    * - ``name``
      - Ja
-     - Job-Name
+     - Job-Name (max. 100 Zeichen)
    * - ``target``
      - Ja
-     - Ausführungsziel ("all" oder ein bestimmtes Ziel)
+     - Ausführungsziel (max. 100 Zeichen). ``all`` oder einen bestimmten Zielnamen angeben
    * - ``cronExpression``
      - Nein
-     - Cron-Ausdruck (Sekunden Minuten Stunden Tag Monat Wochentag)
+     - Cron-Ausdruck (Sekunde Minute Stunde Tag Monat Wochentag). Max. 100 Zeichen, wird als Cron-Ausdruck validiert. Ist das Feld leer, wird der Job nicht geplant und kann nur manuell gestartet werden
    * - ``scriptType``
      - Ja
-     - Skript-Typ ("groovy")
+     - Skript-Typ (max. 100 Zeichen). Derzeit wird nur ``groovy`` unterstützt
    * - ``scriptData``
      - Nein
-     - Ausführungsskript
+     - Ausführungsskript. Die maximale Größe richtet sich nach ``form.admin.max.input.size`` in ``fess_config.properties``
    * - ``jobLogging``
      - Nein
-     - Protokollierung aktivieren (Zeichenkette ``"true"`` / ``"false"``)
+     - Job-Protokollierung aktivieren (Zeichenkette)
    * - ``crawler``
      - Nein
-     - Ob es ein Crawler-Job ist (Zeichenkette ``"true"`` / ``"false"``)
+     - Ob es ein Crawler-Job ist (Zeichenkette)
    * - ``available``
      - Nein
-     - Aktiviert/Deaktiviert (Zeichenkette ``"true"`` / ``"false"``)
+     - Aktiviert/Deaktiviert (Zeichenkette)
    * - ``sortOrder``
      - Ja
-     - Anzeigereihenfolge
+     - Anzeigereihenfolge (Ganzzahl zwischen 0 und 2147483647)
+
+.. note::
+
+   ``jobLogging`` / ``crawler`` / ``available`` sind Zeichenkettenfelder. Im Request aktiviert die Angabe von ``"on"`` oder ``"true"`` (Groß-/Kleinschreibung wird nicht berücksichtigt) das jeweilige Feld; jeder andere Wert (``"false"``, leere Zeichenkette oder nicht angegeben) wird als deaktiviert behandelt. Im Response werden die Werte als ``"true"`` / ``"false"`` zurückgegeben.
+
+.. note::
+
+   ``crudMode`` wird serverseitig automatisch gesetzt und muss im Request nicht angegeben werden. Audit-Felder wie ``createdBy`` / ``createdTime`` werden ebenfalls serverseitig gesetzt.
 
 Response
 --------
@@ -268,6 +283,10 @@ Request-Body
       "sortOrder": 1,
       "versionNo": 1
     }
+
+.. note::
+
+   Für Aktualisierungen sind ``id`` (max. 1000 Zeichen) und ``versionNo`` Pflichtfelder. ``versionNo`` wird für optimistisches Sperren verwendet; geben Sie den Wert an, der im GET-Response zurückgegeben wurde. Stimmt der Wert nicht überein, schlägt die Aktualisierung fehl. Die weiteren Pflichtfelder (``name`` / ``target`` / ``scriptType`` / ``sortOrder``) sind dieselben wie beim Erstellen.
 
 Response
 --------
@@ -342,8 +361,9 @@ Response-Felder
 Hinweise
 --------
 
-- Wenn der Job bereits läuft, wird ein Fehler zurückgegeben
-- Wenn der Job deaktiviert ist (``available`` ist ``"false"``), wird ein Fehler zurückgegeben
+- Wenn der Job bereits läuft, schlägt der Start fehl und es wird ein Fehler zurückgegeben (``status`` ungleich ``0``).
+- Wenn der Job deaktiviert ist (``available`` ist nicht aktiviert), schlägt der Start ebenfalls fehl und es wird ein Fehler zurückgegeben.
+- ``jobLogId`` wird nur ausgegeben, wenn die Job-Protokollierung aktiviert ist (``jobLogging`` ist aktiviert).
 
 Job stoppen
 ===========
@@ -388,7 +408,8 @@ Crawl-Job erstellen und ausführen
            "scriptData": "return container.getComponent(\"crawlJob\").execute();",
            "jobLogging": "true",
            "crawler": "true",
-           "available": "true"
+           "available": "true",
+           "sortOrder": 1
          }'
 
     # Job sofort ausführen

--- a/en/15.7/api/admin/api-admin-scheduler.rst
+++ b/en/15.7/api/admin/api-admin-scheduler.rst
@@ -71,11 +71,11 @@ Parameters
    * - ``size``
      - Integer
      - No
-     - Number of items per page
+     - Number of items per page (default: 25; configurable via ``paging.page.size`` in ``fess_config.properties``)
    * - ``page``
      - Integer
      - No
-     - Page number
+     - Page number (1-based; default: 1)
 
 Response
 --------
@@ -84,6 +84,7 @@ Response
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -97,6 +98,7 @@ Response
             "crawler": "true",
             "available": "true",
             "sortOrder": 0,
+            "versionNo": 1,
             "running": false
           }
         ],
@@ -106,7 +108,11 @@ Response
 
 .. note::
 
-   ``jobLogging`` / ``crawler`` / ``available`` are treated as strings (``"true"`` / ``"false"``). ``running`` is a boolean value indicating the execution status of the job.
+   The ``response`` object always includes ``version`` (product version) and ``status`` (result code). See :doc:`api-admin-overview` for the common response format. Later examples may omit ``version`` for brevity.
+
+.. note::
+
+   In responses, ``jobLogging`` / ``crawler`` / ``available`` are returned as strings (``"true"`` / ``"false"``). ``running`` is a boolean, response-only field indicating whether the job is currently running (it cannot be set in requests). ``total`` is the total number of jobs matching the query.
 
 Get Scheduled Job
 =================
@@ -137,6 +143,7 @@ Response
           "crawler": "true",
           "available": "true",
           "sortOrder": 0,
+          "versionNo": 1,
           "running": false
         }
       }
@@ -182,31 +189,39 @@ Field Description
      - Description
    * - ``name``
      - Yes
-     - Job name
+     - Job name (max 100 characters)
    * - ``target``
      - Yes
-     - Execution target ("all" or specific target)
+     - Execution target (max 100 characters). Specify ``all`` or a specific target name
    * - ``cronExpression``
      - No
-     - Cron expression (seconds minutes hours day month weekday)
+     - Cron expression (second minute hour day month day-of-week). Max 100 characters, validated as a cron expression. If empty, the job is not scheduled and can only be started manually
    * - ``scriptType``
      - Yes
-     - Script type ("groovy")
+     - Script type (max 100 characters). Currently only ``groovy`` is supported
    * - ``scriptData``
      - No
-     - Execution script
+     - Execution script. The maximum size follows ``form.admin.max.input.size`` in ``fess_config.properties``
    * - ``jobLogging``
      - No
-     - Enable logging (string ``"true"`` / ``"false"``)
+     - Enable job logging (string)
    * - ``crawler``
      - No
-     - Whether this is a crawler job (string ``"true"`` / ``"false"``)
+     - Whether this is a crawler job (string)
    * - ``available``
      - No
-     - Enable/disable (string ``"true"`` / ``"false"``)
+     - Enabled/disabled (string)
    * - ``sortOrder``
      - Yes
-     - Display order
+     - Display order (integer between 0 and 2147483647)
+
+.. note::
+
+   ``jobLogging`` / ``crawler`` / ``available`` are string fields. In requests, specifying ``"on"`` or ``"true"`` (case-insensitive) enables them; any other value (``"false"``, empty string, or unset) is treated as disabled. In responses they are returned as ``"true"`` / ``"false"``.
+
+.. note::
+
+   ``crudMode`` is set automatically on the server side and does not need to be specified in requests. Audit fields such as ``createdBy`` / ``createdTime`` are also set on the server side.
 
 Response
 --------
@@ -268,6 +283,10 @@ Request Body
       "sortOrder": 1,
       "versionNo": 1
     }
+
+.. note::
+
+   For updates, ``id`` (max 1000 characters) and ``versionNo`` are required. ``versionNo`` is used for optimistic locking; specify the value returned in the get response. If the value does not match, the update fails. Other required fields (``name`` / ``target`` / ``scriptType`` / ``sortOrder``) are the same as for creation.
 
 Response
 --------
@@ -344,8 +363,9 @@ Response Fields
 Notes
 -----
 
-- Returns an error if the job is already running
-- Returns an error if the job is disabled (``available`` is ``"false"``)
+- If the job is already running, the start fails and an error is returned (``status`` other than ``0``).
+- If the job is disabled (``available`` is not enabled), the start likewise fails with an error.
+- ``jobLogId`` is issued only when job logging is enabled (``jobLogging`` is enabled).
 
 Stop Job
 ========
@@ -390,7 +410,8 @@ Create and Run a Crawl Job
            "scriptData": "return container.getComponent(\"crawlJob\").execute();",
            "jobLogging": "true",
            "crawler": "true",
-           "available": "true"
+           "available": "true",
+           "sortOrder": 1
          }'
 
     # Run job immediately

--- a/es/15.7/api/admin/api-admin-scheduler.rst
+++ b/es/15.7/api/admin/api-admin-scheduler.rst
@@ -71,11 +71,11 @@ Parametros
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina
+     - Numero de elementos por pagina (por defecto: 25; configurable mediante ``paging.page.size`` en ``fess_config.properties``)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina
+     - Numero de pagina (a partir de 1; por defecto: 1)
 
 Respuesta
 ---------
@@ -84,6 +84,7 @@ Respuesta
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -97,6 +98,7 @@ Respuesta
             "crawler": "true",
             "available": "true",
             "sortOrder": 0,
+            "versionNo": 1,
             "running": false
           }
         ],
@@ -106,7 +108,11 @@ Respuesta
 
 .. note::
 
-   ``jobLogging`` / ``crawler`` / ``available`` se tratan como cadenas (``"true"`` / ``"false"``). ``running`` es un valor booleano que indica el estado de ejecucion del trabajo.
+   El objeto ``response`` siempre incluye ``version`` (version del producto) y ``status`` (codigo de resultado). Consulte la descripcion general de Admin API (:doc:`api-admin-overview`) para conocer el formato de respuesta comun. Los ejemplos posteriores pueden omitir ``version`` por brevedad.
+
+.. note::
+
+   En las respuestas, ``jobLogging`` / ``crawler`` / ``available`` se devuelven como cadenas (``"true"`` / ``"false"``). ``running`` es un campo booleano exclusivo de respuesta que indica si el trabajo se esta ejecutando en ese momento (no puede especificarse en las solicitudes). ``total`` es el numero total de trabajos que coinciden con la consulta.
 
 Obtener Trabajo Programado
 ==========================
@@ -137,6 +143,7 @@ Respuesta
           "crawler": "true",
           "available": "true",
           "sortOrder": 0,
+          "versionNo": 1,
           "running": false
         }
       }
@@ -182,31 +189,39 @@ Descripcion de Campos
      - Descripcion
    * - ``name``
      - Si
-     - Nombre del trabajo
+     - Nombre del trabajo (max. 100 caracteres)
    * - ``target``
      - Si
-     - Objetivo de ejecucion ("all" u objetivo especifico)
+     - Objetivo de ejecucion (max. 100 caracteres). Especifique ``all`` o un nombre de objetivo especifico
    * - ``cronExpression``
      - No
-     - Expresion Cron (segundos minutos horas dia mes dia-semana)
+     - Expresion Cron (segundo minuto hora dia mes dia-semana). Max. 100 caracteres, validada como expresion cron. Si esta vacia, el trabajo no se ejecuta de forma programada y solo puede iniciarse manualmente
    * - ``scriptType``
      - Si
-     - Tipo de script ("groovy")
+     - Tipo de script (max. 100 caracteres). Actualmente solo se admite ``groovy``
    * - ``scriptData``
      - No
-     - Script de ejecucion
+     - Script de ejecucion. El tamano maximo sigue ``form.admin.max.input.size`` en ``fess_config.properties``
    * - ``jobLogging``
      - No
-     - Habilitar registro (cadena ``"true"`` / ``"false"``)
+     - Habilitar registro de trabajos (cadena)
    * - ``crawler``
      - No
-     - Es trabajo de rastreo (cadena ``"true"`` / ``"false"``)
+     - Si es un trabajo de rastreo (cadena)
    * - ``available``
      - No
-     - Habilitado/Deshabilitado (cadena ``"true"`` / ``"false"``)
+     - Habilitado/Deshabilitado (cadena)
    * - ``sortOrder``
      - Si
-     - Orden de visualizacion
+     - Orden de visualizacion (entero entre 0 y 2147483647)
+
+.. note::
+
+   ``jobLogging`` / ``crawler`` / ``available`` son campos de cadena. En las solicitudes, especificar ``"on"`` o ``"true"`` (sin distincion de mayusculas y minusculas) los habilita; cualquier otro valor (``"false"``, cadena vacia o no especificado) se trata como deshabilitado. En las respuestas se devuelven como ``"true"`` / ``"false"``.
+
+.. note::
+
+   ``crudMode`` se establece automaticamente en el servidor y no es necesario especificarlo en las solicitudes. Los campos de auditoria como ``createdBy`` / ``createdTime`` tambien se establecen en el servidor.
 
 Respuesta
 ---------
@@ -268,6 +283,10 @@ Cuerpo de la Solicitud
       "sortOrder": 1,
       "versionNo": 1
     }
+
+.. note::
+
+   Para las actualizaciones, ``id`` (max. 1000 caracteres) y ``versionNo`` son obligatorios. ``versionNo`` se utiliza para el bloqueo optimista; especifique el valor devuelto en la respuesta de obtencion. Si el valor no coincide, la actualizacion falla. Los demas campos obligatorios (``name`` / ``target`` / ``scriptType`` / ``sortOrder``) son los mismos que para la creacion.
 
 Respuesta
 ---------
@@ -344,8 +363,9 @@ Campos de Respuesta
 Notas
 -----
 
-- Se devuelve un error si el trabajo ya esta en ejecucion
-- Se devuelve un error si el trabajo esta deshabilitado (``available`` es ``"false"``)
+- Si el trabajo ya esta en ejecucion, el inicio falla y se devuelve un error (``status`` distinto de ``0``).
+- Si el trabajo esta deshabilitado (``available`` no esta habilitado), el inicio tambien falla con un error.
+- ``jobLogId`` solo se emite cuando el registro de trabajos esta habilitado (``jobLogging`` esta habilitado).
 
 Detener Trabajo
 ===============
@@ -390,7 +410,8 @@ Crear y Ejecutar Trabajo de Rastreo
            "scriptData": "return container.getComponent(\"crawlJob\").execute();",
            "jobLogging": "true",
            "crawler": "true",
-           "available": "true"
+           "available": "true",
+           "sortOrder": 1
          }'
 
     # Ejecutar trabajo inmediatamente

--- a/fr/15.7/api/admin/api-admin-scheduler.rst
+++ b/fr/15.7/api/admin/api-admin-scheduler.rst
@@ -71,11 +71,11 @@ Parametres
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page
+     - Nombre d'elements par page (defaut : 25 ; configurable via ``paging.page.size`` dans ``fess_config.properties``)
    * - ``page``
      - Integer
      - Non
-     - Numero de page
+     - Numero de page (base 1 ; defaut : 1)
 
 Reponse
 -------
@@ -84,6 +84,7 @@ Reponse
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -97,6 +98,7 @@ Reponse
             "crawler": "true",
             "available": "true",
             "sortOrder": 0,
+            "versionNo": 1,
             "running": false
           }
         ],
@@ -106,7 +108,11 @@ Reponse
 
 .. note::
 
-   ``jobLogging`` / ``crawler`` / ``available`` sont traites comme des chaines de caracteres (``"true"`` / ``"false"``). ``running`` est une valeur booleenne indiquant l'etat d'execution de la tache.
+   L'objet ``response`` contient toujours ``version`` (version du produit) et ``status`` (code de resultat). Consultez :doc:`api-admin-overview` pour le format de reponse commun. Les exemples suivants peuvent omettre ``version`` par souci de concision.
+
+.. note::
+
+   Dans les reponses, ``jobLogging`` / ``crawler`` / ``available`` sont retournes sous forme de chaines de caracteres (``"true"`` / ``"false"``). ``running`` est un champ booleen, specifique aux reponses, indiquant si la tache est en cours d'execution (ne peut pas etre specifie dans les requetes). ``total`` est le nombre total de taches correspondant a la requete.
 
 Obtention d'une tache planifiee
 ===============================
@@ -137,6 +143,7 @@ Reponse
           "crawler": "true",
           "available": "true",
           "sortOrder": 0,
+          "versionNo": 1,
           "running": false
         }
       }
@@ -182,31 +189,39 @@ Description des champs
      - Description
    * - ``name``
      - Oui
-     - Nom de la tache
+     - Nom de la tache (max 100 caracteres)
    * - ``target``
      - Oui
-     - Cible d'execution ("all" ou cible specifique)
+     - Cible d'execution (max 100 caracteres). Specifier ``all`` ou un nom de cible specifique
    * - ``cronExpression``
      - Non
-     - Expression Cron (secondes minutes heures jour mois jour-semaine)
+     - Expression Cron (seconde minute heure jour mois jour-semaine). Max 100 caracteres, validee en tant qu'expression cron. Si vide, la tache n'est pas planifiee et ne peut etre demarree que manuellement
    * - ``scriptType``
      - Oui
-     - Type de script ("groovy")
+     - Type de script (max 100 caracteres). Actuellement seul ``groovy`` est supporte
    * - ``scriptData``
      - Non
-     - Script a executer
+     - Script a executer. La taille maximale est definie par ``form.admin.max.input.size`` dans ``fess_config.properties``
    * - ``jobLogging``
      - Non
-     - Activer la journalisation (chaine ``"true"`` / ``"false"``)
+     - Activer la journalisation des taches (chaine)
    * - ``crawler``
      - Non
-     - S'il s'agit d'une tache de crawl (chaine ``"true"`` / ``"false"``)
+     - S'il s'agit d'une tache de crawl (chaine)
    * - ``available``
      - Non
-     - Active/Desactive (chaine ``"true"`` / ``"false"``)
+     - Active/Desactive (chaine)
    * - ``sortOrder``
      - Oui
-     - Ordre d'affichage
+     - Ordre d'affichage (entier entre 0 et 2147483647)
+
+.. note::
+
+   ``jobLogging`` / ``crawler`` / ``available`` sont des champs de type chaine. Dans les requetes, specifier ``"on"`` ou ``"true"`` (insensible a la casse) les active ; toute autre valeur (``"false"``, chaine vide ou non specifie) est traitee comme desactivee. Dans les reponses, ils sont retournes sous la forme ``"true"`` / ``"false"``.
+
+.. note::
+
+   ``crudMode`` est defini automatiquement cote serveur et n'a pas besoin d'etre specifie dans les requetes. Les champs d'audit tels que ``createdBy`` / ``createdTime`` sont egalement definis cote serveur.
 
 Reponse
 -------
@@ -268,6 +283,10 @@ Corps de la requete
       "sortOrder": 1,
       "versionNo": 1
     }
+
+.. note::
+
+   Pour les mises a jour, ``id`` (max 1000 caracteres) et ``versionNo`` sont obligatoires. ``versionNo`` est utilise pour le verrouillage optimiste ; specifier la valeur retournee dans la reponse de recuperation. Si la valeur ne correspond pas, la mise a jour echoue. Les autres champs obligatoires (``name`` / ``target`` / ``scriptType`` / ``sortOrder``) sont identiques a ceux de la creation.
 
 Reponse
 -------
@@ -344,8 +363,9 @@ Champs de la reponse
 Notes
 -----
 
-- Une erreur est retournee si la tache est deja en cours d'execution
-- Une erreur est retournee si la tache est desactivee (``available`` vaut ``"false"``)
+- Si la tache est deja en cours d'execution, le demarrage echoue et une erreur est retournee (``status`` different de ``0``).
+- Si la tache est desactivee (``available`` n'est pas active), le demarrage echoue egalement avec une erreur.
+- ``jobLogId`` est emis uniquement lorsque la journalisation des taches est activee (``jobLogging`` est active).
 
 Arret d'une tache
 =================
@@ -390,7 +410,8 @@ Creation et execution d'une tache de crawl
            "scriptData": "return container.getComponent(\"crawlJob\").execute();",
            "jobLogging": "true",
            "crawler": "true",
-           "available": "true"
+           "available": "true",
+           "sortOrder": 1
          }'
 
     # Executer la tache immediatement

--- a/ja/15.7/api/admin/api-admin-scheduler.rst
+++ b/ja/15.7/api/admin/api-admin-scheduler.rst
@@ -71,11 +71,11 @@ Scheduler APIは、|Fess| のスケジュールジョブを管理するための
    * - ``size``
      - Integer
      - いいえ
-     - 1ページあたりの件数
+     - 1ページあたりの件数（デフォルト: 25。``fess_config.properties`` の ``paging.page.size`` で変更可能）
    * - ``page``
      - Integer
      - いいえ
-     - ページ番号
+     - ページ番号（1から開始。デフォルト: 1）
 
 レスポンス
 ----------
@@ -84,6 +84,7 @@ Scheduler APIは、|Fess| のスケジュールジョブを管理するための
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -97,6 +98,7 @@ Scheduler APIは、|Fess| のスケジュールジョブを管理するための
             "crawler": "true",
             "available": "true",
             "sortOrder": 0,
+            "versionNo": 1,
             "running": false
           }
         ],
@@ -106,7 +108,11 @@ Scheduler APIは、|Fess| のスケジュールジョブを管理するための
 
 .. note::
 
-   ``jobLogging`` / ``crawler`` / ``available`` は文字列（``"true"`` / ``"false"``）として扱われます。``running`` はブール値で、ジョブの実行状態を示します。
+   レスポンスの ``response`` オブジェクトには、製品バージョンを示す ``version`` と処理結果を示す ``status`` が常に含まれます（共通仕様は :doc:`api-admin-overview` を参照）。以降の例では簡潔さのために ``version`` を省略する場合があります。
+
+.. note::
+
+   レスポンス内の ``jobLogging`` / ``crawler`` / ``available`` は文字列（``"true"`` / ``"false"``）として返されます。``running`` はブール値で、ジョブが現在実行中かどうかを示すレスポンス専用フィールドです（リクエストでは指定できません）。``total`` は条件に一致する全ジョブ数です。
 
 スケジュールジョブ取得
 ======================
@@ -137,6 +143,7 @@ Scheduler APIは、|Fess| のスケジュールジョブを管理するための
           "crawler": "true",
           "available": "true",
           "sortOrder": 0,
+          "versionNo": 1,
           "running": false
         }
       }
@@ -182,31 +189,39 @@ Scheduler APIは、|Fess| のスケジュールジョブを管理するための
      - 説明
    * - ``name``
      - はい
-     - ジョブ名
+     - ジョブ名（最大100文字）
    * - ``target``
      - はい
-     - 実行対象（"all" または特定のターゲット）
+     - 実行対象（最大100文字）。``all`` または特定のターゲット名を指定します
    * - ``cronExpression``
      - いいえ
-     - Cron式（秒 分 時 日 月 曜日）
+     - Cron式（秒 分 時 日 月 曜日）。最大100文字で、Cron式として検証されます。空の場合はスケジュール実行されず、手動でのみ起動できます
    * - ``scriptType``
      - はい
-     - スクリプトタイプ（"groovy"）
+     - スクリプトタイプ（最大100文字）。現在は ``groovy`` のみがサポートされています
    * - ``scriptData``
      - いいえ
-     - 実行スクリプト
+     - 実行スクリプト。最大サイズは ``fess_config.properties`` の ``form.admin.max.input.size`` に従います
    * - ``jobLogging``
      - いいえ
-     - ログ記録を有効化（文字列 ``"true"`` / ``"false"``）
+     - ジョブログの記録を有効化（文字列）
    * - ``crawler``
      - いいえ
-     - クローラージョブかどうか（文字列 ``"true"`` / ``"false"``）
+     - クローラージョブかどうか（文字列）
    * - ``available``
      - いいえ
-     - 有効/無効（文字列 ``"true"`` / ``"false"``）
+     - 有効/無効（文字列）
    * - ``sortOrder``
      - はい
-     - 表示順序
+     - 表示順序（0〜2147483647の整数）
+
+.. note::
+
+   ``jobLogging`` / ``crawler`` / ``available`` は文字列フィールドです。リクエストでは ``"on"`` または ``"true"``（大文字小文字を区別しない）を指定すると有効になり、それ以外の値（``"false"``、空文字列、未指定など）は無効として扱われます。レスポンスでは ``"true"`` / ``"false"`` として返されます。
+
+.. note::
+
+   ``crudMode`` はサーバー側で自動的に設定されるため、リクエストで指定する必要はありません。``createdBy`` / ``createdTime`` などの監査フィールドもサーバー側で設定されます。
 
 レスポンス
 ----------
@@ -268,6 +283,10 @@ Cron式の例
       "sortOrder": 1,
       "versionNo": 1
     }
+
+.. note::
+
+   更新では ``id``（最大1000文字）と ``versionNo`` が必須です。``versionNo`` は楽観的ロックに使用され、取得時のレスポンスに含まれる値を指定します。値が一致しない場合は更新が失敗します。そのほかの必須フィールド（``name`` / ``target`` / ``scriptType`` / ``sortOrder``）は作成時と同様です。
 
 レスポンス
 ----------
@@ -344,8 +363,9 @@ Cron式の例
 注意事項
 --------
 
-- ジョブが既に実行中の場合、エラーが返されます
-- ジョブが無効（``available`` が ``"false"``）の場合、エラーが返されます
+- ジョブが既に実行中の場合、起動に失敗しエラー（``status`` が ``0`` 以外）が返されます
+- ジョブが無効（``available`` が有効でない）の場合も、同様に起動に失敗しエラーが返されます
+- ``jobLogId`` は、ジョブログが有効（``jobLogging`` が有効）な場合にのみ発行されます
 
 ジョブ停止
 ==========
@@ -390,7 +410,8 @@ Cron式の例
            "scriptData": "return container.getComponent(\"crawlJob\").execute();",
            "jobLogging": "true",
            "crawler": "true",
-           "available": "true"
+           "available": "true",
+           "sortOrder": 1
          }'
 
     # ジョブを即座に実行

--- a/ko/15.7/api/admin/api-admin-scheduler.rst
+++ b/ko/15.7/api/admin/api-admin-scheduler.rst
@@ -71,11 +71,11 @@ Scheduler API는 |Fess| 의 스케줄 작업을 관리하기 위한 API입니다
    * - ``size``
      - Integer
      - 아니오
-     - 페이지당 건수
+     - 페이지당 건수（기본값: 25。``fess_config.properties`` 의 ``paging.page.size`` 로 변경 가능）
    * - ``page``
      - Integer
      - 아니오
-     - 페이지 번호
+     - 페이지 번호（1부터 시작。기본값: 1）
 
 응답
 ----------
@@ -84,6 +84,7 @@ Scheduler API는 |Fess| 의 스케줄 작업을 관리하기 위한 API입니다
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -97,6 +98,7 @@ Scheduler API는 |Fess| 의 스케줄 작업을 관리하기 위한 API입니다
             "crawler": "true",
             "available": "true",
             "sortOrder": 0,
+            "versionNo": 1,
             "running": false
           }
         ],
@@ -106,7 +108,11 @@ Scheduler API는 |Fess| 의 스케줄 작업을 관리하기 위한 API입니다
 
 .. note::
 
-   ``jobLogging`` / ``crawler`` / ``available`` 은 문자열 (``"true"`` / ``"false"``) 로 처리됩니다. ``running`` 은 불리언 값으로, 작업의 실행 상태를 나타냅니다.
+   ``response`` 오브젝트에는 제품 버전을 나타내는 ``version`` 과 처리 결과를 나타내는 ``status`` 가 항상 포함됩니다（공통 사양은 :doc:`api-admin-overview` 를 참조）。이후 예시에서는 간결함을 위해 ``version`` 을 생략하는 경우가 있습니다.
+
+.. note::
+
+   응답의 ``jobLogging`` / ``crawler`` / ``available`` 은 문자열（``"true"`` / ``"false"``）로 반환됩니다. ``running`` 은 불리언 값으로, 작업이 현재 실행 중인지 여부를 나타내는 응답 전용 필드입니다（요청에서는 지정할 수 없습니다）。``total`` 은 조건에 일치하는 전체 작업 수입니다.
 
 스케줄 작업 조회
 ======================
@@ -137,6 +143,7 @@ Scheduler API는 |Fess| 의 스케줄 작업을 관리하기 위한 API입니다
           "crawler": "true",
           "available": "true",
           "sortOrder": 0,
+          "versionNo": 1,
           "running": false
         }
       }
@@ -182,31 +189,39 @@ Scheduler API는 |Fess| 의 스케줄 작업을 관리하기 위한 API입니다
      - 설명
    * - ``name``
      - 예
-     - 작업 이름
+     - 작업 이름（최대 100자）
    * - ``target``
      - 예
-     - 실행 대상 ("all" 또는 특정 대상)
+     - 실행 대상（최대 100자）。``all`` 또는 특정 대상 이름을 지정합니다
    * - ``cronExpression``
      - 아니오
-     - Cron 표현식 (초 분 시 일 월 요일)
+     - Cron 표현식（초 분 시 일 월 요일）。최대 100자이며 Cron 표현식으로 검증됩니다. 비어 있으면 스케줄 실행되지 않고 수동으로만 시작할 수 있습니다
    * - ``scriptType``
      - 예
-     - 스크립트 타입 ("groovy")
+     - 스크립트 타입（최대 100자）。현재는 ``groovy`` 만 지원됩니다
    * - ``scriptData``
      - 아니오
-     - 실행 스크립트
+     - 실행 스크립트。최대 크기는 ``fess_config.properties`` 의 ``form.admin.max.input.size`` 에 따릅니다
    * - ``jobLogging``
      - 아니오
-     - 로그 기록 활성화 (문자열 ``"true"`` / ``"false"``)
+     - 작업 로그 기록 활성화（문자열）
    * - ``crawler``
      - 아니오
-     - 크롤러 작업인지 여부 (문자열 ``"true"`` / ``"false"``)
+     - 크롤러 작업인지 여부（문자열）
    * - ``available``
      - 아니오
-     - 활성화/비활성화 (문자열 ``"true"`` / ``"false"``)
+     - 활성화/비활성화（문자열）
    * - ``sortOrder``
      - 예
-     - 표시 순서
+     - 표시 순서（0〜2147483647의 정수）
+
+.. note::
+
+   ``jobLogging`` / ``crawler`` / ``available`` 은 문자열 필드입니다. 요청에서 ``"on"`` 또는 ``"true"``（대소문자 구분 없음）를 지정하면 활성화되며, 그 외의 값（``"false"``, 빈 문자열, 미지정 등）은 비활성화로 처리됩니다. 응답에서는 ``"true"`` / ``"false"`` 로 반환됩니다.
+
+.. note::
+
+   ``crudMode`` 는 서버 측에서 자동으로 설정되므로 요청에서 지정할 필요가 없습니다. ``createdBy`` / ``createdTime`` 등의 감사 필드도 서버 측에서 설정됩니다.
 
 응답
 ----------
@@ -268,6 +283,10 @@ Cron 표현식 예시
       "sortOrder": 1,
       "versionNo": 1
     }
+
+.. note::
+
+   업데이트 시 ``id``（최대 1000자）와 ``versionNo`` 는 필수입니다. ``versionNo`` 는 낙관적 잠금에 사용되며, 조회 시 응답에 포함된 값을 지정합니다. 값이 일치하지 않으면 업데이트가 실패합니다. 그 밖의 필수 필드（``name`` / ``target`` / ``scriptType`` / ``sortOrder``）는 작성 시와 동일합니다.
 
 응답
 ----------
@@ -344,8 +363,9 @@ Cron 표현식 예시
 주의 사항
 --------
 
-- 작업이 이미 실행 중인 경우 오류가 반환됩니다
-- 작업이 비활성화 (``available`` 이 ``"false"``) 된 경우 오류가 반환됩니다
+- 작업이 이미 실행 중인 경우 시작에 실패하고 오류（``status`` 가 ``0`` 이 아닌 값）가 반환됩니다
+- 작업이 비활성화（``available`` 이 활성화되지 않은）된 경우에도 마찬가지로 시작에 실패하고 오류가 반환됩니다
+- ``jobLogId`` 는 작업 로그가 활성화（``jobLogging`` 이 활성화）된 경우에만 발행됩니다
 
 작업 중지
 ==========
@@ -390,7 +410,8 @@ Cron 표현식 예시
            "scriptData": "return container.getComponent(\"crawlJob\").execute();",
            "jobLogging": "true",
            "crawler": "true",
-           "available": "true"
+           "available": "true",
+           "sortOrder": 1
          }'
 
     # 작업을 즉시 실행

--- a/zh-cn/15.7/api/admin/api-admin-scheduler.rst
+++ b/zh-cn/15.7/api/admin/api-admin-scheduler.rst
@@ -71,11 +71,11 @@ Scheduler API是用于管理 |Fess| 计划任务的API。
    * - ``size``
      - Integer
      - 否
-     - 每页记录数
+     - 每页记录数（默认：25；可通过 ``fess_config.properties`` 中的 ``paging.page.size`` 修改）
    * - ``page``
      - Integer
      - 否
-     - 页码
+     - 页码（从1开始；默认：1）
 
 响应
 ----
@@ -84,6 +84,7 @@ Scheduler API是用于管理 |Fess| 计划任务的API。
 
     {
       "response": {
+        "version": "15.7.0",
         "status": 0,
         "settings": [
           {
@@ -97,6 +98,7 @@ Scheduler API是用于管理 |Fess| 计划任务的API。
             "crawler": "true",
             "available": "true",
             "sortOrder": 0,
+            "versionNo": 1,
             "running": false
           }
         ],
@@ -106,7 +108,11 @@ Scheduler API是用于管理 |Fess| 计划任务的API。
 
 .. note::
 
-   ``jobLogging`` / ``crawler`` / ``available`` 作为字符串（``"true"`` / ``"false"``）处理。``running`` 为布尔值，表示任务的运行状态。
+   响应的 ``response`` 对象中始终包含表示产品版本的 ``version`` 和表示处理结果的 ``status``（公共规范请参阅 :doc:`api-admin-overview`）。后续示例中可能省略 ``version`` 以保持简洁。
+
+.. note::
+
+   响应中的 ``jobLogging`` / ``crawler`` / ``available`` 以字符串（``"true"`` / ``"false"``）形式返回。``running`` 为布尔值，是仅响应中包含的字段，表示任务当前是否正在运行（不可在请求中指定）。``total`` 为符合查询条件的任务总数。
 
 获取计划任务
 ============
@@ -137,6 +143,7 @@ Scheduler API是用于管理 |Fess| 计划任务的API。
           "crawler": "true",
           "available": "true",
           "sortOrder": 0,
+          "versionNo": 1,
           "running": false
         }
       }
@@ -182,31 +189,39 @@ Scheduler API是用于管理 |Fess| 计划任务的API。
      - 说明
    * - ``name``
      - 是
-     - 任务名称
+     - 任务名称（最大100字符）
    * - ``target``
      - 是
-     - 执行目标（"all"或特定目标）
+     - 执行目标（最大100字符）。指定 ``all`` 或特定目标名称
    * - ``cronExpression``
      - 否
-     - Cron表达式（秒 分 时 日 月 星期）
+     - Cron表达式（秒 分 时 日 月 星期）。最大100字符，将作为Cron表达式进行验证。若为空，则不进行定时执行，只能手动启动
    * - ``scriptType``
      - 是
-     - 脚本类型（"groovy"）
+     - 脚本类型（最大100字符）。目前仅支持 ``groovy``
    * - ``scriptData``
      - 否
-     - 执行脚本
+     - 执行脚本。最大大小遵循 ``fess_config.properties`` 中的 ``form.admin.max.input.size``
    * - ``jobLogging``
      - 否
-     - 启用日志记录（字符串 ``"true"`` / ``"false"``）
+     - 启用任务日志记录（字符串）
    * - ``crawler``
      - 否
-     - 是否为爬虫任务（字符串 ``"true"`` / ``"false"``）
+     - 是否为爬虫任务（字符串）
    * - ``available``
      - 否
-     - 启用/禁用（字符串 ``"true"`` / ``"false"``）
+     - 启用/禁用（字符串）
    * - ``sortOrder``
      - 是
-     - 显示顺序
+     - 显示顺序（0～2147483647之间的整数）
+
+.. note::
+
+   ``jobLogging`` / ``crawler`` / ``available`` 为字符串字段。在请求中，指定 ``"on"`` 或 ``"true"``（不区分大小写）时启用；其他值（``"false"``、空字符串或未指定）均视为禁用。在响应中以 ``"true"`` / ``"false"`` 形式返回。
+
+.. note::
+
+   ``crudMode`` 由服务器端自动设置，无需在请求中指定。``createdBy`` / ``createdTime`` 等审计字段也由服务器端设置。
 
 响应
 ----
@@ -268,6 +283,10 @@ Cron表达式示例
       "sortOrder": 1,
       "versionNo": 1
     }
+
+.. note::
+
+   更新时，``id``（最大1000字符）和 ``versionNo`` 为必填项。``versionNo`` 用于乐观锁，需指定获取响应中返回的值。若值不匹配，更新将失败。其他必填字段（``name`` / ``target`` / ``scriptType`` / ``sortOrder``）与创建时相同。
 
 响应
 ----
@@ -344,8 +363,9 @@ Cron表达式示例
 注意事项
 --------
 
-- 如果任务已在运行中，将返回错误
-- 如果任务已禁用（``available`` 为 ``"false"``），将返回错误
+- 如果任务已在运行中，启动将失败并返回错误（``status`` 非 ``0``）。
+- 如果任务已禁用（``available`` 未启用），同样将启动失败并返回错误。
+- ``jobLogId`` 仅在任务日志已启用（``jobLogging`` 已启用）时才会发行。
 
 停止任务
 ========
@@ -390,7 +410,8 @@ Cron表达式示例
            "scriptData": "return container.getComponent(\"crawlJob\").execute();",
            "jobLogging": "true",
            "crawler": "true",
-           "available": "true"
+           "available": "true",
+           "sortOrder": 1
          }'
 
     # 立即执行任务


### PR DESCRIPTION
## Summary

Reviewed the Scheduler Admin API documentation (`api/admin/api-admin-scheduler.rst`) against the actual implementation (`ApiAdminSchedulerAction`, `CreateForm`/`EditForm`, `BaseSearchBody`, `ScheduledJob`) and corrected inaccuracies and filled gaps. Changes are applied consistently across all languages: `ja`, `en`, `de`, `fr`, `es`, `ko`, `zh-cn`.

## Changes

- **Fix incorrect example**: add the required `sortOrder` field to the "create and run a crawl job" curl example. `sortOrder` is validated as required, so the previous example would fail validation.
- **Document validation constraints**: max lengths for `name`, `target`, `scriptType`, `cronExpression` (100) and `id` (1000); integer range for `sortOrder` (0–2147483647); `cronExpression` is validated as a cron expression and, when empty, the job runs manually only; `scriptData` size is bounded by `form.admin.max.input.size`.
- **Update semantics**: clarify that `id` and `versionNo` are required for updates and that `versionNo` provides optimistic locking.
- **String-field semantics**: `jobLogging` / `crawler` / `available` accept `on` or `true` (case-insensitive) on input and are returned as `true` / `false`; `running` is a response-only boolean.
- **Response completeness**: add `versionNo` to the list/get response examples, add `version` to the response envelope, and note pagination defaults (`paging.page.size`, 1-based `page`).
- **Server-controlled fields**: note that `crudMode` and audit fields (`createdBy` / `createdTime`) are set server-side.
- **Start-job notes**: make precise — both an already-running job and a disabled job fail to start, and `jobLogId` is issued only when job logging is enabled.

## Verification

- Each documented field, type, default, and constraint was checked against the source implementation.
- RST structure validated; the same set of edits was applied uniformly across all seven language versions.