### PR TITLE
docs(install): correct OpenSearch version to 3.7.0 in 15.7 prerequisites

### DIFF
--- a/de/15.7/install/prerequisites.rst
+++ b/de/15.7/install/prerequisites.rst
@@ -74,9 +74,9 @@ TAR.GZ/ZIP/RPM/DEB Version
   - OpenJDK 21 oder höher
   - Eclipse Temurin 21 oder höher
 
-- **OpenSearch 3.6.0**: Erforderlich für Produktionsumgebungen (eingebettete Version nicht empfohlen)
+- **OpenSearch 3.7.0**: Erforderlich für Produktionsumgebungen (eingebettete Version nicht empfohlen)
 
-  - Unterstützte Version: OpenSearch 3.6.0
+  - Unterstützte Version: OpenSearch 3.7.0
   - Bei anderen Versionen ist auf Plugin-Kompatibilität zu achten
 
 Docker Version
@@ -95,7 +95,7 @@ Die Hauptports, die von |Fess| verwendet werden, sind wie folgt:
 
 .. list-table::
    :header-rows: 1
-   :widths: 15 15.70
+   :widths: 15 15 70
 
    * - Port
      - Protokoll

--- a/en/15.7/install/prerequisites.rst
+++ b/en/15.7/install/prerequisites.rst
@@ -74,9 +74,9 @@ TAR.GZ/ZIP/RPM/DEB Versions
   - OpenJDK 21 or later
   - Eclipse Temurin 21 or later
 
-- **OpenSearch 3.6.0**: Required for production environments (embedded version not recommended)
+- **OpenSearch 3.7.0**: Required for production environments (embedded version not recommended)
 
-  - Supported Version: OpenSearch 3.6.0
+  - Supported Version: OpenSearch 3.7.0
   - Compatibility with plugins must be considered for other versions
 
 Docker Version
@@ -95,7 +95,7 @@ The main ports used by |Fess| are as follows:
 
 .. list-table::
    :header-rows: 1
-   :widths: 15 15.70
+   :widths: 15 15 70
 
    * - Port
      - Protocol

--- a/es/15.7/install/prerequisites.rst
+++ b/es/15.7/install/prerequisites.rst
@@ -74,9 +74,9 @@ Versión TAR.GZ/ZIP/RPM/DEB
   - OpenJDK 21 o posterior
   - Eclipse Temurin 21 o posterior
 
-- **OpenSearch 3.6.0**: Obligatorio para entornos de producción (la versión integrada no es recomendada)
+- **OpenSearch 3.7.0**: Obligatorio para entornos de producción (la versión integrada no es recomendada)
 
-  - Versión compatible: OpenSearch 3.6.0
+  - Versión compatible: OpenSearch 3.7.0
   - Tenga cuidado con la compatibilidad de plugins en otras versiones
 
 Versión Docker
@@ -95,7 +95,7 @@ Los puertos principales utilizados por |Fess| son los siguientes:
 
 .. list-table::
    :header-rows: 1
-   :widths: 15 15.70
+   :widths: 15 15 70
 
    * - Puerto
      - Protocolo

--- a/fr/15.7/install/prerequisites.rst
+++ b/fr/15.7/install/prerequisites.rst
@@ -74,9 +74,9 @@ Version TAR.GZ/ZIP/RPM/DEB
   - OpenJDK 21 ou ultérieur
   - Eclipse Temurin 21 ou ultérieur
 
-- **OpenSearch 3.6.0** : Obligatoire pour les environnements de production (la version intégrée est déconseillée)
+- **OpenSearch 3.7.0** : Obligatoire pour les environnements de production (la version intégrée est déconseillée)
 
-  - Version compatible : OpenSearch 3.6.0
+  - Version compatible : OpenSearch 3.7.0
   - Attention à la compatibilité des plugins avec les autres versions
 
 Version Docker
@@ -95,7 +95,7 @@ Les ports principaux utilisés par |Fess| sont les suivants :
 
 .. list-table::
    :header-rows: 1
-   :widths: 15 15.70
+   :widths: 15 15 70
 
    * - Port
      - Protocole

--- a/ja/15.7/install/prerequisites.rst
+++ b/ja/15.7/install/prerequisites.rst
@@ -74,9 +74,9 @@ TAR.GZ/ZIP/RPM/DEB 版
   - OpenJDK 21 以降
   - Eclipse Temurin 21 以降
 
-- **OpenSearch 3.6.0**: 本番環境では必須（組み込み版は非推奨）
+- **OpenSearch 3.7.0**: 本番環境では必須（組み込み版は非推奨）
 
-  - 対応バージョン: OpenSearch 3.6.0
+  - 対応バージョン: OpenSearch 3.7.0
   - その他のバージョンではプラグインの互換性に注意が必要
 
 Docker 版
@@ -95,7 +95,7 @@ Docker 版
 
 .. list-table::
    :header-rows: 1
-   :widths: 15 15.70
+   :widths: 15 15 70
 
    * - ポート
      - プロトコル

--- a/ko/15.7/install/prerequisites.rst
+++ b/ko/15.7/install/prerequisites.rst
@@ -74,9 +74,9 @@ TAR.GZ/ZIP/RPM/DEB 버전
   - OpenJDK 21 이상
   - Eclipse Temurin 21 이상
 
-- **OpenSearch 3.6.0**: 운영 환경에서는 필수(내장 버전은 비권장)
+- **OpenSearch 3.7.0**: 운영 환경에서는 필수(내장 버전은 비권장)
 
-  - 지원 버전: OpenSearch 3.6.0
+  - 지원 버전: OpenSearch 3.7.0
   - 기타 버전에서는 플러그인 호환성에 주의 필요
 
 Docker 버전
@@ -95,7 +95,7 @@ Docker 버전
 
 .. list-table::
    :header-rows: 1
-   :widths: 15 15.70
+   :widths: 15 15 70
 
    * - 포트
      - 프로토콜

--- a/zh-cn/15.7/install/prerequisites.rst
+++ b/zh-cn/15.7/install/prerequisites.rst
@@ -73,9 +73,9 @@ TAR.GZ/ZIP/RPM/DEB 版
   - OpenJDK 21 或更高版本
   - Eclipse Temurin 21 或更高版本
 
-- **OpenSearch 3.6.0**: 生产环境必需（不推荐使用内嵌版本）
+- **OpenSearch 3.7.0**: 生产环境必需（不推荐使用内嵌版本）
 
-  - 支持版本: OpenSearch 3.6.0
+  - 支持版本: OpenSearch 3.7.0
   - 其他版本需要注意插件兼容性
 
 Docker 版
@@ -94,7 +94,7 @@ Docker 版
 
 .. list-table::
    :header-rows: 1
-   :widths: 15 15.70
+   :widths: 15 15 70
 
    * - 端口
      - 协议


### PR DESCRIPTION
## Summary

The 15.7 **System Requirements** (`install/prerequisites.rst`) page listed **OpenSearch 3.6.0**, but Fess 15.7.0 ships with **OpenSearch 3.7.0**. The stale value was carried over when the docs were copied from 15.6. This PR corrects it across all seven languages and fixes one RST table issue.

### Changes (per language: ja, en, de, es, fr, ko, zh-cn)

1. **OpenSearch version `3.6.0` → `3.7.0`** (2 occurrences each): the "Required Software" heading/value and the "Supported Version" line.
2. **RST `list-table` `:widths:` fix** on the Required Ports table: `15 15.70` → `15 15 70`. The table has three columns (Port / Protocol / Purpose) but the directive supplied only two width values, causing an RST column-count mismatch. (The `15.70` was a typo for two separate values.)

### Verification

- `fess-parent` 15.7.0 sets `opensearch.version=3.7.0` (`pom.xml`). The bump to 3.7.0 landed before the `fess-parent-15.7.0` release tag, confirming 3.7.0 is the version that ships with Fess 15.7.0.
- The matching OpenSearch plugins (`analysis-fess`, `analysis-extension`, `minhash`, `configsync`) are published at 3.7.0 as well.
- Java 21, default ports (8080 / 9200 / 9300), and other content on the page were checked against source and are accurate, so they are left unchanged.

### Follow-up (out of scope for this PR)

The same stale `OpenSearch 3.6.0` value still appears throughout the rest of the 15.7 install documentation set — including copy-paste download URLs, `opensearch-plugin install` commands, and directory paths in `install-linux.rst`, `install-windows.rst`, `install.rst`, `run.rst`, `upgrade.rst`, `uninstall.rst`, and `troubleshooting.rst` (all seven languages). These should be updated to 3.7.0 in a follow-up so the install instructions stay consistent and functional.