### PR TITLE
docs(install): correct OpenSearch version to 3.7.0 in 15.7 install overview

### DIFF
--- a/de/15.7/install/install.rst
+++ b/de/15.7/install/install.rst
@@ -128,7 +128,7 @@ Der grundlegende Ablauf ist bei allen Installationsmethoden gleich.
 
    Bei anderen Versionen als der Docker-Version muss OpenSearch separat eingerichtet werden.
 
-   - Installation von OpenSearch 3.6.0
+   - Installation von OpenSearch 3.7.0
    - Installation der erforderlichen Plugins
    - Bearbeitung der Konfigurationsdateien
 
@@ -159,7 +159,7 @@ OpenSearch
 
 Verwendet OpenSearch als Suchmaschine.
 
-- **Unterstützte Version**: OpenSearch 3.6.0
+- **Unterstützte Version**: OpenSearch 3.7.0
 - **Erforderliche Plugins**:
 
   - opensearch-analysis-fess
@@ -235,7 +235,7 @@ Versionsinformationen
 Diese Dokumentation bezieht sich auf folgende Versionen:
 
 - **Fess**: 15.7.0
-- **OpenSearch**: 3.6.0
+- **OpenSearch**: 3.7.0
 - **Java**: 21 oder höher
 - **Docker**: 20.10 oder höher
 - **Docker Compose**: 2.0 oder höher

--- a/en/15.7/install/install.rst
+++ b/en/15.7/install/install.rst
@@ -128,7 +128,7 @@ The basic flow is the same for all installation methods.
 
    For non-Docker versions, OpenSearch must be set up separately.
 
-   - Install OpenSearch 3.6.0
+   - Install OpenSearch 3.7.0
    - Install required plugins
    - Edit configuration files
 
@@ -159,7 +159,7 @@ OpenSearch
 
 OpenSearch is used as the search engine.
 
-- **Supported Version**: OpenSearch 3.6.0
+- **Supported Version**: OpenSearch 3.7.0
 - **Required Plugins**:
 
   - opensearch-analysis-fess
@@ -235,7 +235,7 @@ Version Information
 This document covers the following versions:
 
 - **Fess**: 15.7.0
-- **OpenSearch**: 3.6.0
+- **OpenSearch**: 3.7.0
 - **Java**: 21 or later
 - **Docker**: 20.10 or later
 - **Docker Compose**: 2.0 or later

--- a/es/15.7/install/install.rst
+++ b/es/15.7/install/install.rst
@@ -128,7 +128,7 @@ El flujo básico es el mismo para todos los métodos de instalación.
 
    Para versiones que no sean Docker, debe configurar OpenSearch por separado.
 
-   - Instalación de OpenSearch 3.6.0
+   - Instalación de OpenSearch 3.7.0
    - Instalación de plugins requeridos
    - Edición de archivos de configuración
 
@@ -159,7 +159,7 @@ OpenSearch
 
 Se utiliza OpenSearch como motor de búsqueda.
 
-- **Versión Compatible**: OpenSearch 3.6.0
+- **Versión Compatible**: OpenSearch 3.7.0
 - **Plugins Requeridos**:
 
   - opensearch-analysis-fess
@@ -235,7 +235,7 @@ Información de Versión
 Este documento está dirigido a las siguientes versiones:
 
 - **Fess**: 15.7.0
-- **OpenSearch**: 3.6.0
+- **OpenSearch**: 3.7.0
 - **Java**: 21 o posterior
 - **Docker**: 20.10 o posterior
 - **Docker Compose**: 2.0 o posterior

--- a/fr/15.7/install/install.rst
+++ b/fr/15.7/install/install.rst
@@ -128,7 +128,7 @@ Pour toutes les méthodes d'installation, le flux de base est le même.
 
    Pour les versions autres que Docker, vous devez configurer OpenSearch séparément.
 
-   - Installation d'OpenSearch 3.6.0
+   - Installation d'OpenSearch 3.7.0
    - Installation des plugins requis
    - Modification des fichiers de configuration
 
@@ -159,7 +159,7 @@ OpenSearch
 
 OpenSearch est utilisé comme moteur de recherche.
 
-- **Version compatible** : OpenSearch 3.6.0
+- **Version compatible** : OpenSearch 3.7.0
 - **Plugins requis** :
 
   - opensearch-analysis-fess
@@ -235,7 +235,7 @@ Informations de version
 Cette documentation concerne les versions suivantes :
 
 - **Fess** : 15.7.0
-- **OpenSearch** : 3.6.0
+- **OpenSearch** : 3.7.0
 - **Java** : 21 ou ultérieur
 - **Docker** : 20.10 ou ultérieur
 - **Docker Compose** : 2.0 ou ultérieur

--- a/ja/15.7/install/install.rst
+++ b/ja/15.7/install/install.rst
@@ -128,7 +128,7 @@ Windows 版 (ZIP)
 
    Docker 版以外の場合、OpenSearch を個別にセットアップする必要があります。
 
-   - OpenSearch 3.6.0 のインストール
+   - OpenSearch 3.7.0 のインストール
    - 必須プラグインのインストール
    - 設定ファイルの編集
 
@@ -159,7 +159,7 @@ OpenSearch
 
 検索エンジンとして OpenSearch を使用します。
 
-- **対応バージョン**: OpenSearch 3.6.0
+- **対応バージョン**: OpenSearch 3.7.0
 - **必須プラグイン**:
 
   - opensearch-analysis-fess
@@ -235,7 +235,7 @@ A: はい、可能です。Fess と OpenSearch を別々のサーバーで実行
 このドキュメントは、以下のバージョンを対象としています：
 
 - **Fess**: 15.7.0
-- **OpenSearch**: 3.6.0
+- **OpenSearch**: 3.7.0
 - **Java**: 21 以降
 - **Docker**: 20.10 以降
 - **Docker Compose**: 2.0 以降

--- a/ko/15.7/install/install.rst
+++ b/ko/15.7/install/install.rst
@@ -128,7 +128,7 @@ Windows 버전 (ZIP)
 
    Docker 버전 이외의 경우 OpenSearch를 별도로 설정해야 합니다.
 
-   - OpenSearch 3.6.0 설치
+   - OpenSearch 3.7.0 설치
    - 필수 플러그인 설치
    - 설정 파일 편집
 
@@ -159,7 +159,7 @@ OpenSearch
 
 검색 엔진으로 OpenSearch를 사용합니다.
 
-- **지원 버전**: OpenSearch 3.6.0
+- **지원 버전**: OpenSearch 3.7.0
 - **필수 플러그인**:
 
   - opensearch-analysis-fess
@@ -235,7 +235,7 @@ A: 예, 가능합니다. Fess와 OpenSearch를 별도의 서버에서 실행할 
 이 문서는 다음 버전을 대상으로 합니다:
 
 - **Fess**: 15.7.0
-- **OpenSearch**: 3.6.0
+- **OpenSearch**: 3.7.0
 - **Java**: 21 이상
 - **Docker**: 20.10 이상
 - **Docker Compose**: 2.0 이상

--- a/zh-cn/15.7/install/install.rst
+++ b/zh-cn/15.7/install/install.rst
@@ -128,7 +128,7 @@ Windows 版 (ZIP)
 
    Docker 版以外的情况下，需要单独设置 OpenSearch。
 
-   - 安装 OpenSearch 3.6.0
+   - 安装 OpenSearch 3.7.0
    - 安装必需插件
    - 编辑配置文件
 
@@ -159,7 +159,7 @@ OpenSearch
 
 使用 OpenSearch 作为搜索引擎。
 
-- **支持版本**: OpenSearch 3.6.0
+- **支持版本**: OpenSearch 3.7.0
 - **必需插件**:
 
   - opensearch-analysis-fess
@@ -235,7 +235,7 @@ A: 可以。Fess 和 OpenSearch 可以在不同的服务器上运行。
 本文档适用于以下版本：
 
 - **Fess**: 15.7.0
-- **OpenSearch**: 3.6.0
+- **OpenSearch**: 3.7.0
 - **Java**: 21 或更高版本
 - **Docker**: 20.10 或更高版本
 - **Docker Compose**: 2.0 或更高版本


### PR DESCRIPTION
## Summary

Corrects the OpenSearch version in the 15.7 installation overview (`15.7/install/install.rst`) from `3.6.0` to `3.7.0` across all 7 languages (ja, en, de, fr, es, ko, zh-cn).

Fess 15.7 targets **OpenSearch 3.7.0** (`fess-parent/pom.xml`: `<opensearch.version>3.7.0</opensearch.version>`, `<opensearch.runner.version>3.7.0.0</opensearch.runner.version>`). The install overview still referenced `3.6.0`, a stale value left over from version creation. The detailed run/upgrade guides already use `3.7.0`, so the overview was internally inconsistent with the rest of the 15.7 install section.

## Changes

Each `install.rst` updates the same three lines (version references only — no other content):

1. "OpenSearch setup" step in the basic installation flow — `Install OpenSearch 3.6.0` → `3.7.0`
2. Required components / OpenSearch section — `Supported Version: OpenSearch 3.6.0` → `3.7.0`
3. Version Information section — `OpenSearch: 3.6.0` → `3.7.0`

7 files changed, 21 insertions(+), 21 deletions(-).

## Verification (confirmed against source — no change needed)

- OpenSearch `3.7.0` — `fess-parent/pom.xml`.
- Required plugins (`opensearch-analysis-fess`, `opensearch-analysis-extension`, `opensearch-minhash`, `opensearch-configsync`) — match the official OpenSearch image build for 3.7.
- Java 21+ — `fess-parent/pom.xml` (`<release>21</release>`).
- All cross-references and the install-method comparison table are accurate.

## Scope notes

- This PR intentionally changes **version numbers only**. The "recommended environments" wording in the same file is being addressed separately in #414, so it is left untouched here to avoid conflicts.
- The OpenSearch version correction for `prerequisites.rst` is handled in #415; remaining install-section files (`install-linux.rst`, `install-windows.rst`, `uninstall.rst`, `troubleshooting.rst`) still carry the stale `3.6.0` and can be corrected in a follow-up.