### PR TITLE
docs(15.7): correct uninstall procedure (Docker images, volumes, OpenSearch version)

### DIFF
--- a/de/15.7/install/uninstall.rst
+++ b/de/15.7/install/uninstall.rst
@@ -1,6 +1,6 @@
-==================
+========================
 Deinstallationsverfahren
-==================
+========================
 
 Diese Seite beschreibt die Verfahren zur vollständigen Deinstallation von |Fess|.
 
@@ -13,22 +13,19 @@ Diese Seite beschreibt die Verfahren zur vollständigen Deinstallation von |Fess
    - Backup-Verfahren finden Sie unter :doc:`upgrade`
 
 Vorbereitung vor der Deinstallation
-====================================
+===================================
 
 Erstellung eines Backups
--------------------------
+------------------------
 
 Erstellen Sie Backups der benötigten Daten:
 
 1. **Konfigurationsdaten**
 
-   Download über die Verwaltungsseite unter „System" → „Backup"
+   Download über die Verwaltungsseite unter „System" → „Sicherung".
+   Mit diesem Vorgang können Sie verschiedene Einstellungen (einschließlich der Crawl-Einstellungen) sowie Suchprotokolle gesammelt exportieren.
 
-2. **Crawl-Konfiguration**
-
-   Exportieren Sie bei Bedarf die Crawl-Konfiguration
-
-3. **Angepasste Konfigurationsdateien**
+2. **Angepasste Konfigurationsdateien**
 
    TAR.GZ/ZIP-Version::
 
@@ -39,6 +36,12 @@ Erstellen Sie Backups der benötigten Daten:
 
        $ sudo cp -r /etc/fess /backup/
 
+.. note::
+
+   Der Großteil der Indizes und Einstellungen von |Fess| wird in OpenSearch gespeichert.
+   Wenn Sie die Indexdaten sichern möchten, verwenden Sie die Snapshot-Funktion von OpenSearch.
+   Ausführliche Anweisungen finden Sie unter :doc:`upgrade`.
+
 Stopp der Dienste
 -----------------
 
@@ -46,7 +49,7 @@ Stoppen Sie vor der Deinstallation alle Dienste.
 
 TAR.GZ/ZIP-Version::
 
-    $ ps aux | grep fess
+    $ ps aux | grep -E 'fess|opensearch'
     $ kill <fess_pid>
     $ kill <opensearch_pid>
 
@@ -60,62 +63,67 @@ Docker-Version::
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
 Deinstallation der TAR.GZ/ZIP-Version
-======================================
+=====================================
 
 Schritt 1: Löschen von Fess
-----------------------------
+---------------------------
 
 Löschen Sie das Installationsverzeichnis::
 
     $ rm -rf /path/to/fess-15.7.0
 
 Schritt 2: Löschen von OpenSearch
-----------------------------------
+---------------------------------
 
 Löschen Sie das OpenSearch-Installationsverzeichnis::
 
-    $ rm -rf /path/to/opensearch-3.6.0
+    $ rm -rf /path/to/opensearch-3.7.0
 
 Schritt 3: Löschen des Datenverzeichnisses (Optional)
-------------------------------------------------------
+-----------------------------------------------------
 
-Standardmäßig befindet sich das Datenverzeichnis im Fess-Installationsverzeichnis.
-Falls Sie einen anderen Speicherort angegeben haben, löschen Sie auch dieses Verzeichnis::
+Die Indexdaten von |Fess| werden in OpenSearch gespeichert.
+Standardmäßig werden sie innerhalb des OpenSearch-Installationsverzeichnisses gespeichert (z. B. ``opensearch-3.7.0/data``).
+Falls Sie mit ``path.data`` einen anderen Speicherort angegeben haben, löschen Sie auch dieses Verzeichnis::
 
     $ rm -rf /path/to/data
 
 Schritt 4: Löschen des Protokollverzeichnisses (Optional)
-----------------------------------------------------------
+---------------------------------------------------------
 
 Löschen Sie die Protokolldateien::
 
-    $ rm -rf /path/to/fess/logs
-    $ rm -rf /path/to/opensearch/logs
+    $ rm -rf /path/to/fess-15.7.0/logs
+    $ rm -rf /path/to/opensearch-3.7.0/logs
 
 Deinstallation der RPM-Version
-===============================
+==============================
 
 Schritt 1: Deinstallation von Fess
------------------------------------
+----------------------------------
 
 Deinstallieren Sie das RPM-Paket::
 
     $ sudo rpm -e fess
 
+.. note::
+
+   Bei der Deinstallation des |Fess|-Pakets werden durch das Löschskript des Pakets
+   der ``fess``-Dienst gestoppt und deaktiviert sowie der Benutzer ``fess`` und die Gruppe ``fess`` automatisch gelöscht.
+   Die folgenden Schritte werden ausgeführt, um sicherzustellen, dass diese zuverlässig gelöscht wurden, oder
+   um Daten und Konfigurationsdateien manuell zu löschen.
+
 Schritt 2: Deinstallation von OpenSearch
------------------------------------------
+----------------------------------------
 
 ::
 
     $ sudo rpm -e opensearch
 
-Schritt 3: Deaktivierung und Löschung der Dienste
---------------------------------------------------
+Schritt 3: Überprüfung der Deaktivierung der Dienste
+----------------------------------------------------
 
-Bei chkconfig::
-
-    $ sudo /sbin/chkconfig --del fess
-    $ sudo /sbin/chkconfig --del opensearch
+Normalerweise werden die Dienste beim Löschen des Pakets deaktiviert. Um sie sicherheitshalber zu überprüfen bzw. zu deaktivieren, führen Sie Folgendes aus.
 
 Bei systemd::
 
@@ -123,38 +131,57 @@ Bei systemd::
     $ sudo systemctl disable opensearch.service
     $ sudo systemctl daemon-reload
 
+Bei einer älteren SysV-init-Umgebung (chkconfig)::
+
+    $ sudo /sbin/chkconfig --del fess
+    $ sudo /sbin/chkconfig --del opensearch
+
 Schritt 4: Löschen des Datenverzeichnisses
--------------------------------------------
+------------------------------------------
 
 .. warning::
 
-   Diese Operation löscht alle Indexdaten und Konfigurationen vollständig.
+   Bei Ausführung dieser Operation werden alle Indexdaten vollständig gelöscht.
 
-::
+Da das Datenverzeichnis bei der Deinstallation des Pakets nicht gelöscht wird, löschen Sie es manuell::
 
     $ sudo rm -rf /var/lib/fess
     $ sudo rm -rf /var/lib/opensearch
 
 Schritt 5: Löschen der Konfigurationsdateien
----------------------------------------------
+--------------------------------------------
 
-::
+Löschen Sie die Konfigurationsdateien und die Umgebungseinstellungsdateien::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/sysconfig/fess
     $ sudo rm -rf /etc/opensearch
 
+.. note::
+
+   Bei RPM können die Konfigurationsdateien in ``/etc/fess`` unter dem Namen ``.rpmsave`` zurückbleiben.
+   Um sie vollständig zu löschen, löschen Sie sie wie oben gezeigt manuell.
+
 Schritt 6: Löschen der Protokolldateien
-----------------------------------------
+---------------------------------------
 
 ::
 
     $ sudo rm -rf /var/log/fess
     $ sudo rm -rf /var/log/opensearch
 
-Schritt 7: Löschen von Benutzer und Gruppe (Optional)
-------------------------------------------------------
+Schritt 7: Löschen des temporären Verzeichnisses (Optional)
+-----------------------------------------------------------
 
-Falls Sie Systembenutzer und -gruppen löschen möchten::
+::
+
+    $ sudo rm -rf /var/tmp/fess
+
+Schritt 8: Löschen von Benutzer und Gruppe (Optional)
+-----------------------------------------------------
+
+Normalerweise werden der Benutzer ``fess`` und die Gruppe ``fess`` beim Löschen des Pakets gelöscht.
+Falls sie zurückgeblieben sind oder Sie den Benutzer und die Gruppe für OpenSearch löschen möchten, führen Sie Folgendes aus::
 
     $ sudo userdel fess
     $ sudo groupdel fess
@@ -162,45 +189,50 @@ Falls Sie Systembenutzer und -gruppen löschen möchten::
     $ sudo groupdel opensearch
 
 Deinstallation der DEB-Version
-===============================
+==============================
 
 Schritt 1: Deinstallation von Fess
------------------------------------
+----------------------------------
 
 Deinstallieren Sie das DEB-Paket::
 
     $ sudo dpkg -r fess
 
-Zum vollständigen Löschen einschließlich Konfigurationsdateien::
+Um es einschließlich der Konfigurationsdateien und der Umgebungseinstellungsdateien vollständig zu löschen, verwenden Sie purge::
 
     $ sudo dpkg -P fess
 
+.. note::
+
+   Bei ``dpkg -r`` (remove) bleiben die Konfigurationsdateien (conffile) wie ``/etc/default/fess`` zurück.
+   Wenn Sie ``dpkg -P`` (purge) verwenden, werden diese Konfigurationsdateien sowie der Benutzer ``fess`` und die Gruppe ``fess`` ebenfalls gelöscht.
+
 Schritt 2: Deinstallation von OpenSearch
------------------------------------------
+----------------------------------------
 
 ::
 
     $ sudo dpkg -r opensearch
 
-Oder vollständiges Löschen einschließlich Konfigurationsdateien::
+Oder vollständiges Löschen einschließlich der Konfigurationsdateien::
 
     $ sudo dpkg -P opensearch
 
-Schritt 3: Deaktivierung der Dienste
--------------------------------------
+Schritt 3: Überprüfung der Deaktivierung der Dienste
+----------------------------------------------------
 
-::
+Normalerweise werden die Dienste beim Löschen des Pakets deaktiviert. Um sie sicherheitshalber zu überprüfen bzw. zu deaktivieren, führen Sie Folgendes aus::
 
     $ sudo systemctl disable fess.service
     $ sudo systemctl disable opensearch.service
     $ sudo systemctl daemon-reload
 
 Schritt 4: Löschen des Datenverzeichnisses
--------------------------------------------
+------------------------------------------
 
 .. warning::
 
-   Diese Operation löscht alle Indexdaten und Konfigurationen vollständig.
+   Bei Ausführung dieser Operation werden alle Indexdaten vollständig gelöscht.
 
 ::
 
@@ -208,15 +240,16 @@ Schritt 4: Löschen des Datenverzeichnisses
     $ sudo rm -rf /var/lib/opensearch
 
 Schritt 5: Löschen der Konfigurationsdateien (bei Nicht-Verwendung von dpkg -P)
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 
 ::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/default/fess
     $ sudo rm -rf /etc/opensearch
 
 Schritt 6: Löschen der Protokolldateien
-----------------------------------------
+---------------------------------------
 
 ::
 
@@ -224,9 +257,10 @@ Schritt 6: Löschen der Protokolldateien
     $ sudo rm -rf /var/log/opensearch
 
 Schritt 7: Löschen von Benutzer und Gruppe (Optional)
-------------------------------------------------------
+-----------------------------------------------------
 
-Falls Sie Systembenutzer und -gruppen löschen möchten::
+Falls Sie ``dpkg -P`` nicht verwendet haben, bleiben der Benutzer ``fess`` und die Gruppe ``fess`` zurück.
+Um sie zu löschen, führen Sie Folgendes aus::
 
     $ sudo userdel fess
     $ sudo groupdel fess
@@ -234,68 +268,64 @@ Falls Sie Systembenutzer und -gruppen löschen möchten::
     $ sudo groupdel opensearch
 
 Deinstallation der Docker-Version
-==================================
+=================================
 
 Schritt 1: Löschen von Containern und Netzwerken
--------------------------------------------------
+------------------------------------------------
 
-::
+Löschen Sie die Container sowie das von Docker Compose erstellte Netzwerk (``search_net``)::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
 Schritt 2: Löschen der Volumes
--------------------------------
+------------------------------
 
 .. warning::
 
-   Diese Operation löscht alle Daten vollständig.
+   Bei Ausführung dieser Operation werden alle Daten vollständig gelöscht.
 
-Liste der Volumes überprüfen::
+Die Daten von |Fess| (Indizes, Wörterbücher usw.) werden in den Volumes von OpenSearch gespeichert.
+Überprüfen Sie zunächst die Liste der Volumes::
 
     $ docker volume ls
 
-Fess-bezogene Volumes löschen::
+Löschen Sie die OpenSearch-bezogenen Volumes::
 
-    $ docker volume rm fess-es-data
-    $ docker volume rm fess-data
+    $ docker volume rm <project>_search01_data
+    $ docker volume rm <project>_search01_dictionary
 
-Oder alle Volumes auf einmal löschen::
+.. note::
+
+   Den Volume-Namen wird der Projektname von Docker Compose (normalerweise der Name des
+   Verzeichnisses, in dem die Compose-Dateien abgelegt sind) als Präfix vorangestellt. Überprüfen Sie die tatsächlichen Namen mit ``docker volume ls``.
+
+Um Container und Volumes auf einmal zu löschen, fügen Sie ``down`` die Option ``-v`` hinzu::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down -v
 
 Schritt 3: Löschen der Images (Optional)
------------------------------------------
+----------------------------------------
 
-Falls Sie Docker-Images löschen und Festplattenplatz freigeben möchten::
+Wenn Sie Docker-Images löschen und Festplattenplatz freigeben möchten::
 
     $ docker images | grep fess
-    $ docker rmi codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess-opensearch:3.7.0
 
-    $ docker images | grep opensearch
-    $ docker rmi opensearchproject/opensearch:3.6.0
-
-Schritt 4: Löschen der Netzwerke (Optional)
---------------------------------------------
-
-Löschen Sie von Docker Compose erstellte Netzwerke::
-
-    $ docker network ls
-    $ docker network rm <network_name>
-
-Schritt 5: Löschen der Compose-Dateien
----------------------------------------
+Schritt 4: Löschen der Compose-Dateien
+--------------------------------------
 
 ::
 
     $ rm compose.yaml compose-opensearch3.yaml
 
 Überprüfung der Deinstallation
-===============================
+==============================
 
 Überprüfen Sie, dass alle Komponenten gelöscht wurden.
 
 Überprüfung der Prozesse
--------------------------
+------------------------
 
 ::
 
@@ -315,7 +345,7 @@ Wenn nichts angezeigt wird, sind die Prozesse gestoppt.
 Überprüfen Sie, dass keine Ports verwendet werden.
 
 Überprüfung der Dateien
-------------------------
+-----------------------
 
 TAR.GZ/ZIP-Version::
 
@@ -328,11 +358,11 @@ RPM/DEB-Version::
 
 Docker-Version::
 
-    $ docker ps -a | grep fess  # Überprüfen, dass Container nicht existieren
-    $ docker volume ls | grep fess  # Überprüfen, dass Volumes nicht existieren
+    $ docker ps -a | grep -E 'fess01|search01'  # Überprüfen, dass Container nicht existieren
+    $ docker volume ls | grep search01           # Überprüfen, dass Volumes nicht existieren
 
 Überprüfung der Pakete
------------------------
+----------------------
 
 RPM-Version::
 
@@ -350,17 +380,18 @@ Teilweise Deinstallation
 ========================
 
 Nur Fess löschen und OpenSearch behalten
------------------------------------------
+----------------------------------------
 
 Falls Sie OpenSearch auch für andere Anwendungen verwenden, können Sie nur Fess löschen.
 
 1. Fess stoppen
 2. Fess-Paket oder -Verzeichnis löschen
 3. Fess-Datenverzeichnis löschen (``/var/lib/fess`` usw.)
-4. OpenSearch nicht löschen
+4. Die in OpenSearch erstellten |Fess|-Indizes (``fess.*``, ``.fess_*`` usw.) löschen
+5. OpenSearch nicht löschen
 
 Nur OpenSearch löschen und Fess behalten
------------------------------------------
+----------------------------------------
 
 .. warning::
 
@@ -376,7 +407,7 @@ Fehlerbehebung
 ==============
 
 Paket kann nicht gelöscht werden
----------------------------------
+--------------------------------
 
 **Symptom:**
 
@@ -399,7 +430,7 @@ Fehler bei ``rpm -e`` oder ``dpkg -r``.
        $ sudo dpkg -r --force-all fess
 
 Verzeichnis kann nicht gelöscht werden
----------------------------------------
+--------------------------------------
 
 **Symptom:**
 
@@ -420,7 +451,7 @@ Verzeichnis kann mit ``rm -rf`` nicht gelöscht werden.
        $ sudo lsof | grep /path/to/directory
 
 Vorbereitung für Neuinstallation
-=================================
+================================
 
 Bei Neuinstallation nach der Deinstallation überprüfen Sie Folgendes:
 

--- a/en/15.7/install/uninstall.rst
+++ b/en/15.7/install/uninstall.rst
@@ -1,51 +1,46 @@
-=====================
+========================
 Uninstallation Procedure
-=====================
+========================
 
-This page describes the procedures for complete uninstallation of |Fess|.
+This page describes the procedures for completely uninstalling |Fess|.
 
 .. warning::
 
    **Important Notes Before Uninstallation**
 
    - Uninstalling will delete all data
-   - If you have important data, create a backup first
+   - If you have important data, be sure to create a backup first
    - For backup procedures, refer to :doc:`upgrade`
 
-Pre-Uninstallation Preparation
-===============================
+Preparation Before Uninstallation
+=================================
 
 Create Backup
 -------------
 
-Back up necessary data:
+Back up the necessary data:
 
-1. **Configuration Data Backup**
+1. **Configuration Data**
 
-   Download from the admin screen at "System" → "Backup".
+   Download it from "System" → "Backup" in the admin screen.
+   This operation lets you export various settings (including crawl settings), search logs, and more all at once.
 
-   Download the following files:
-
-   - ``fess_basic_config.bulk``
-   - ``fess_user.bulk``
-
-2. **Configuration File Backup**
+2. **Customized Configuration Files**
 
    TAR.GZ/ZIP version::
 
-       $ cp /path/to/fess/app/WEB-INF/conf/system.properties /backup/
-       $ cp /path/to/fess/app/WEB-INF/classes/fess_config.properties /backup/
+       $ cp -r /path/to/fess/app/WEB-INF/conf /backup/
+       $ cp -r /path/to/fess/app/WEB-INF/classes /backup/
 
    RPM/DEB version::
 
-       $ sudo cp /etc/fess/system.properties /backup/
-       $ sudo cp /etc/fess/fess_config.properties /backup/
+       $ sudo cp -r /etc/fess /backup/
 
-3. **Customized Configuration Files**
+.. note::
 
-   If you have customized configuration files, back up those as well::
-
-       $ cp /path/to/fess/app/WEB-INF/classes/log4j2.xml /backup/
+   Most of |Fess|'s indexes and settings are stored in OpenSearch.
+   To back up index data, use OpenSearch's snapshot feature.
+   For detailed procedures, refer to :doc:`upgrade`.
 
 Stop Services
 -------------
@@ -54,7 +49,7 @@ Before uninstallation, stop all services.
 
 TAR.GZ/ZIP version::
 
-    $ ps aux | grep fess
+    $ ps aux | grep -E 'fess|opensearch'
     $ kill <fess_pid>
     $ kill <opensearch_pid>
 
@@ -67,8 +62,8 @@ Docker version::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
-Uninstall TAR.GZ/ZIP Version
-=============================
+Uninstalling the TAR.GZ/ZIP Version
+===================================
 
 Step 1: Remove Fess
 -------------------
@@ -78,29 +73,31 @@ Delete the installation directory::
     $ rm -rf /path/to/fess-15.7.0
 
 Step 2: Remove OpenSearch
---------------------------
+-------------------------
 
 Delete the OpenSearch installation directory::
 
-    $ rm -rf /path/to/opensearch-3.6.0
+    $ rm -rf /path/to/opensearch-3.7.0
 
-Step 3: Delete Data Directory (Optional)
------------------------------------------
+Step 3: Delete the Data Directory (Optional)
+--------------------------------------------
 
-By default, the data directory is within the Fess installation directory, but if you specified a different location, delete that directory as well::
+|Fess|'s index data is stored in OpenSearch.
+By default it is stored inside the OpenSearch installation directory (such as ``opensearch-3.7.0/data``),
+but if you have specified a different location with ``path.data``, delete that directory as well::
 
     $ rm -rf /path/to/data
 
-Step 4: Delete Log Directory (Optional)
-----------------------------------------
+Step 4: Delete the Log Directory (Optional)
+-------------------------------------------
 
-Delete log files::
+Delete the log files::
 
-    $ rm -rf /path/to/fess/logs
-    $ rm -rf /path/to/opensearch/logs
+    $ rm -rf /path/to/fess-15.7.0/logs
+    $ rm -rf /path/to/opensearch-3.7.0/logs
 
-Uninstall RPM Version
-=====================
+Uninstalling the RPM Version
+============================
 
 Step 1: Uninstall Fess
 ----------------------
@@ -109,20 +106,24 @@ Uninstall the RPM package::
 
     $ sudo rpm -e fess
 
+.. note::
+
+   When the |Fess| package is uninstalled, the package's removal script automatically
+   stops and disables the ``fess`` service and removes the ``fess`` user and group.
+   The following steps are performed to confirm that these have been reliably removed, or
+   to manually delete data and configuration files.
+
 Step 2: Uninstall OpenSearch
------------------------------
+----------------------------
 
 ::
 
     $ sudo rpm -e opensearch
 
-Step 3: Disable and Remove Service
------------------------------------
+Step 3: Confirm the Service Is Disabled
+---------------------------------------
 
-For chkconfig::
-
-    $ sudo /sbin/chkconfig --del fess
-    $ sudo /sbin/chkconfig --del opensearch
+The service is usually disabled when the package is removed, but to confirm or disable it just in case, run the following.
 
 For systemd::
 
@@ -130,46 +131,65 @@ For systemd::
     $ sudo systemctl disable opensearch.service
     $ sudo systemctl daemon-reload
 
-Step 4: Delete Data Directory
-------------------------------
+For older SysV init (chkconfig) environments::
+
+    $ sudo /sbin/chkconfig --del fess
+    $ sudo /sbin/chkconfig --del opensearch
+
+Step 4: Delete the Data Directory
+---------------------------------
 
 .. warning::
 
-   This operation will completely delete all index data and configuration.
+   Performing this operation completely deletes all index data.
 
-::
+The data directory is not removed when the package is uninstalled, so delete it manually::
 
     $ sudo rm -rf /var/lib/fess
     $ sudo rm -rf /var/lib/opensearch
 
-Step 5: Delete Configuration Files
------------------------------------
+Step 5: Delete the Configuration Files
+--------------------------------------
 
-::
+Delete the configuration files and environment settings files::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/sysconfig/fess
     $ sudo rm -rf /etc/opensearch
 
-Step 6: Delete Log Files
--------------------------
+.. note::
+
+   With RPM, configuration files in ``/etc/fess`` may remain with a name like ``.rpmsave``.
+   To delete them completely, remove them manually as shown above.
+
+Step 6: Delete the Log Files
+----------------------------
 
 ::
 
     $ sudo rm -rf /var/log/fess
     $ sudo rm -rf /var/log/opensearch
 
-Step 7: Delete Users and Groups (Optional)
--------------------------------------------
+Step 7: Delete the Temporary Directory (Optional)
+-------------------------------------------------
 
-To delete system users and groups::
+::
+
+    $ sudo rm -rf /var/tmp/fess
+
+Step 8: Delete the User and Group (Optional)
+--------------------------------------------
+
+The ``fess`` user and group are usually removed when the package is deleted.
+If they remain, or to remove the user and group for OpenSearch, run the following::
 
     $ sudo userdel fess
     $ sudo groupdel fess
     $ sudo userdel opensearch
     $ sudo groupdel opensearch
 
-Uninstall DEB Version
-======================
+Uninstalling the DEB Version
+============================
 
 Step 1: Uninstall Fess
 ----------------------
@@ -178,126 +198,129 @@ Uninstall the DEB package::
 
     $ sudo dpkg -r fess
 
-To completely remove including configuration files::
+To completely remove it including configuration files and environment settings files, use purge::
 
     $ sudo dpkg -P fess
 
+.. note::
+
+   With ``dpkg -r`` (remove), configuration files (conffiles) such as ``/etc/default/fess`` remain.
+   Using ``dpkg -P`` (purge) also deletes these configuration files and the ``fess`` user and group.
+
 Step 2: Uninstall OpenSearch
------------------------------
+----------------------------
 
 ::
 
     $ sudo dpkg -r opensearch
 
-Or to remove including configuration files::
+Or remove it including configuration files::
 
     $ sudo dpkg -P opensearch
 
-Step 3: Disable Service
------------------------
+Step 3: Confirm the Service Is Disabled
+---------------------------------------
 
-::
+The service is usually disabled when the package is removed. To confirm or disable it just in case, run the following::
 
     $ sudo systemctl disable fess.service
     $ sudo systemctl disable opensearch.service
     $ sudo systemctl daemon-reload
 
-Step 4: Delete Data Directory
-------------------------------
+Step 4: Delete the Data Directory
+---------------------------------
 
 .. warning::
 
-   This operation will completely delete all index data and configuration.
+   Performing this operation completely deletes all index data.
 
 ::
 
     $ sudo rm -rf /var/lib/fess
     $ sudo rm -rf /var/lib/opensearch
 
-Step 5: Delete Configuration Files (if dpkg -P was not used)
--------------------------------------------------------------
+Step 5: Delete the Configuration Files (if dpkg -P was not used)
+----------------------------------------------------------------
 
 ::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/default/fess
     $ sudo rm -rf /etc/opensearch
 
-Step 6: Delete Log Files
--------------------------
+Step 6: Delete the Log Files
+----------------------------
 
 ::
 
     $ sudo rm -rf /var/log/fess
     $ sudo rm -rf /var/log/opensearch
 
-Step 7: Delete Users and Groups (Optional)
--------------------------------------------
+Step 7: Delete the User and Group (Optional)
+--------------------------------------------
 
-To delete system users and groups::
+If you did not use ``dpkg -P``, the ``fess`` user and group remain.
+To remove them, run the following::
 
     $ sudo userdel fess
     $ sudo groupdel fess
     $ sudo userdel opensearch
     $ sudo groupdel opensearch
 
-Uninstall Docker Version
-=========================
+Uninstalling the Docker Version
+===============================
 
 Step 1: Remove Containers and Networks
----------------------------------------
+--------------------------------------
 
-::
+Remove the containers and the network created by Docker Compose (``search_net``)::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
 Step 2: Remove Volumes
------------------------
+----------------------
 
 .. warning::
 
-   This operation will completely delete all data.
+   Performing this operation completely deletes all data.
 
-Verify volume list::
+|Fess|'s data (such as indexes and dictionaries) is stored in OpenSearch volumes.
+First, check the list of volumes::
 
     $ docker volume ls
 
-Remove Fess-related volumes::
+Remove the OpenSearch-related volumes::
 
-    $ docker volume rm fess-es-data
-    $ docker volume rm fess-data
+    $ docker volume rm <project>_search01_data
+    $ docker volume rm <project>_search01_dictionary
 
-Or remove all volumes at once::
+.. note::
+
+   Volume names are prefixed with the Docker Compose project name (usually the name of the
+   directory where the Compose files are located). Check the actual names with ``docker volume ls``.
+
+To remove the containers and volumes all at once, add the ``-v`` option to ``down``::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down -v
 
 Step 3: Remove Images (Optional)
----------------------------------
+--------------------------------
 
-To remove Docker images to free up disk space::
+To remove the Docker images and free up disk space::
 
     $ docker images | grep fess
-    $ docker rmi codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess-opensearch:3.7.0
 
-    $ docker images | grep opensearch
-    $ docker rmi opensearchproject/opensearch:3.6.0
-
-Step 4: Remove Networks (Optional)
------------------------------------
-
-Remove networks created by Docker Compose::
-
-    $ docker network ls
-    $ docker network rm <network_name>
-
-Step 5: Remove Compose Files
------------------------------
+Step 4: Remove Compose Files
+----------------------------
 
 ::
 
     $ rm compose.yaml compose-opensearch3.yaml
 
-Verify Uninstallation
-======================
+Verifying the Uninstallation
+============================
 
 Verify that all components have been removed.
 
@@ -309,7 +332,7 @@ Verify Processes
     $ ps aux | grep fess
     $ ps aux | grep opensearch
 
-If nothing is displayed, processes are stopped.
+If nothing is displayed, the processes are stopped.
 
 Verify Ports
 ------------
@@ -319,24 +342,24 @@ Verify Ports
     $ sudo netstat -tuln | grep 8080
     $ sudo netstat -tuln | grep 9200
 
-Verify ports are not in use.
+Verify that the ports are not in use.
 
 Verify Files
 ------------
 
 TAR.GZ/ZIP version::
 
-    $ ls /path/to/fess-15.7.0  # Verify directory does not exist
+    $ ls /path/to/fess-15.7.0  # Verify that the directory does not exist
 
 RPM/DEB version::
 
-    $ ls /var/lib/fess  # Verify directory does not exist
-    $ ls /etc/fess      # Verify directory does not exist
+    $ ls /var/lib/fess  # Verify that the directory does not exist
+    $ ls /etc/fess      # Verify that the directory does not exist
 
 Docker version::
 
-    $ docker ps -a | grep fess  # Verify containers do not exist
-    $ docker volume ls | grep fess  # Verify volumes do not exist
+    $ docker ps -a | grep -E 'fess01|search01'  # Verify that the containers do not exist
+    $ docker volume ls | grep search01           # Verify that the volumes do not exist
 
 Verify Packages
 ---------------
@@ -351,47 +374,48 @@ DEB version::
     $ dpkg -l | grep fess
     $ dpkg -l | grep opensearch
 
-If nothing is displayed, packages have been removed.
+If nothing is displayed, the packages have been removed.
 
 Partial Uninstallation
-=======================
+======================
 
-Remove Only Fess, Keep OpenSearch
-----------------------------------
+Remove Only Fess, Keeping OpenSearch
+------------------------------------
 
 If OpenSearch is also used by other applications, you can remove only Fess.
 
 1. Stop Fess
-2. Remove Fess package or directory
-3. Remove Fess data directory (e.g., ``/var/lib/fess``)
-4. Do not remove OpenSearch
+2. Remove the Fess package or directory
+3. Remove the Fess data directory (such as ``/var/lib/fess``)
+4. Delete the |Fess| indexes created in OpenSearch (such as ``fess.*`` and ``.fess_*``)
+5. Do not remove OpenSearch
 
-Remove Only OpenSearch, Keep Fess
-----------------------------------
+Remove Only OpenSearch, Keeping Fess
+------------------------------------
 
 .. warning::
 
    Removing OpenSearch will cause Fess to stop functioning.
-   Change configuration to connect to a different OpenSearch cluster.
+   Change the configuration to connect to a different OpenSearch cluster.
 
 1. Stop OpenSearch
-2. Remove OpenSearch package or directory
-3. Remove OpenSearch data directory (e.g., ``/var/lib/opensearch``)
-4. Update Fess configuration to specify a different OpenSearch cluster
+2. Remove the OpenSearch package or directory
+3. Remove the OpenSearch data directory (such as ``/var/lib/opensearch``)
+4. Update the Fess configuration to specify a different OpenSearch cluster
 
 Troubleshooting
 ===============
 
-Cannot Remove Package
----------------------
+Cannot Remove the Package
+-------------------------
 
 **Symptoms:**
 
-Error occurs with ``rpm -e`` or ``dpkg -r``.
+An error occurs with ``rpm -e`` or ``dpkg -r``.
 
 **Solution:**
 
-1. Verify service is stopped::
+1. Verify that the service is stopped::
 
        $ sudo systemctl stop fess.service
 
@@ -405,16 +429,16 @@ Error occurs with ``rpm -e`` or ``dpkg -r``.
        $ sudo rpm -e --nodeps fess
        $ sudo dpkg -r --force-all fess
 
-Cannot Delete Directory
-------------------------
+Cannot Delete the Directory
+---------------------------
 
 **Symptoms:**
 
-Cannot delete directory with ``rm -rf``.
+Cannot delete a directory with ``rm -rf``.
 
 **Solution:**
 
-1. Verify permissions::
+1. Check permissions::
 
        $ ls -ld /path/to/directory
 
@@ -422,14 +446,14 @@ Cannot delete directory with ``rm -rf``.
 
        $ sudo rm -rf /path/to/directory
 
-3. Verify no processes are using files::
+3. Verify that no process is using the files::
 
        $ sudo lsof | grep /path/to/directory
 
 Preparing for Reinstallation
-=============================
+============================
 
-Before reinstalling after uninstallation, verify the following:
+When reinstalling after uninstallation, verify the following:
 
 1. All processes are stopped
 2. All files and directories are deleted
@@ -441,8 +465,8 @@ For reinstallation procedures, refer to :doc:`install`.
 Next Steps
 ==========
 
-After uninstallation is complete:
+Once uninstallation is complete:
 
 - To install a new version, refer to :doc:`install`
 - To migrate data, refer to :doc:`upgrade`
-- For alternative search solutions, refer to the official Fess website
+- To consider an alternative search solution, refer to the official Fess website

--- a/es/15.7/install/uninstall.rst
+++ b/es/15.7/install/uninstall.rst
@@ -1,6 +1,6 @@
-==========================
+================================
 Procedimientos de Desinstalación
-==========================
+================================
 
 Esta página describe los procedimientos para desinstalar completamente |Fess|.
 
@@ -13,22 +13,19 @@ Esta página describe los procedimientos para desinstalar completamente |Fess|.
    - Para los procedimientos de respaldo, consulte :doc:`upgrade`
 
 Preparación Antes de la Desinstalación
-=======================================
+======================================
 
 Obtención de Respaldo
-----------------------
+---------------------
 
 Haga un respaldo de los datos necesarios:
 
 1. **Datos de configuración**
 
-   Descargue desde la pantalla de administración en "Sistema" → "Respaldo"
+   Descargue desde la pantalla de administración en "Sistema" → "Copia de seguridad".
+   Con esta operación puede exportar de forma conjunta las distintas configuraciones (incluida la configuración de rastreo) y los registros de búsqueda, entre otros.
 
-2. **Configuración de rastreo**
-
-   Exporte la configuración de rastreo según sea necesario
-
-3. **Archivos de configuración personalizados**
+2. **Archivos de configuración personalizados**
 
    Versión TAR.GZ/ZIP::
 
@@ -39,14 +36,20 @@ Haga un respaldo de los datos necesarios:
 
        $ sudo cp -r /etc/fess /backup/
 
+.. note::
+
+   La mayor parte del índice y de la configuración de |Fess| se almacena en OpenSearch.
+   Para hacer un respaldo de los datos del índice, utilice la función de instantáneas (snapshot) de OpenSearch.
+   Para conocer el procedimiento detallado, consulte :doc:`upgrade`.
+
 Detención del Servicio
------------------------
+----------------------
 
 Antes de desinstalar, detenga todos los servicios.
 
 Versión TAR.GZ/ZIP::
 
-    $ ps aux | grep fess
+    $ ps aux | grep -E 'fess|opensearch'
     $ kill <fess_pid>
     $ kill <opensearch_pid>
 
@@ -60,62 +63,67 @@ Versión Docker::
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
 Desinstalación de Versión TAR.GZ/ZIP
-=====================================
+====================================
 
 Paso 1: Eliminación de Fess
-----------------------------
+---------------------------
 
 Elimine el directorio de instalación::
 
     $ rm -rf /path/to/fess-15.7.0
 
 Paso 2: Eliminación de OpenSearch
-----------------------------------
+---------------------------------
 
 Elimine el directorio de instalación de OpenSearch::
 
-    $ rm -rf /path/to/opensearch-3.6.0
+    $ rm -rf /path/to/opensearch-3.7.0
 
 Paso 3: Eliminación del Directorio de Datos (Opcional)
--------------------------------------------------------
+------------------------------------------------------
 
-Por defecto, el directorio de datos está dentro del directorio de instalación de Fess,
-pero si especificó otra ubicación, elimine también ese directorio::
+Los datos del índice de |Fess| se almacenan en OpenSearch.
+Por defecto se guardan dentro del directorio de instalación de OpenSearch (por ejemplo, ``opensearch-3.7.0/data``),
+pero si ha especificado otra ubicación con ``path.data``, elimine también ese directorio::
 
     $ rm -rf /path/to/data
 
 Paso 4: Eliminación del Directorio de Registros (Opcional)
------------------------------------------------------------
+----------------------------------------------------------
 
 Elimine los archivos de registro::
 
-    $ rm -rf /path/to/fess/logs
-    $ rm -rf /path/to/opensearch/logs
+    $ rm -rf /path/to/fess-15.7.0/logs
+    $ rm -rf /path/to/opensearch-3.7.0/logs
 
 Desinstalación de Versión RPM
-==============================
+=============================
 
 Paso 1: Desinstalación de Fess
--------------------------------
+------------------------------
 
 Desinstale el paquete RPM::
 
     $ sudo rpm -e fess
 
+.. note::
+
+   Durante la desinstalación del paquete de |Fess|, el script de eliminación del paquete
+   detiene y deshabilita automáticamente el servicio ``fess`` y elimina el usuario y el grupo ``fess``.
+   Los pasos siguientes se realizan para confirmar que estos se hayan eliminado correctamente o para
+   eliminar manualmente los datos y los archivos de configuración.
+
 Paso 2: Desinstalación de OpenSearch
--------------------------------------
+------------------------------------
 
 ::
 
     $ sudo rpm -e opensearch
 
-Paso 3: Deshabilitación y Eliminación del Servicio
----------------------------------------------------
+Paso 3: Confirmación de la Deshabilitación del Servicio
+-------------------------------------------------------
 
-En caso de chkconfig::
-
-    $ sudo /sbin/chkconfig --del fess
-    $ sudo /sbin/chkconfig --del opensearch
+Normalmente el servicio se deshabilita al eliminar el paquete, pero, por si acaso, para confirmar o deshabilitar ejecute lo siguiente.
 
 En caso de systemd::
 
@@ -123,38 +131,57 @@ En caso de systemd::
     $ sudo systemctl disable opensearch.service
     $ sudo systemctl daemon-reload
 
+En el caso de un entorno antiguo con SysV init (chkconfig)::
+
+    $ sudo /sbin/chkconfig --del fess
+    $ sudo /sbin/chkconfig --del opensearch
+
 Paso 4: Eliminación del Directorio de Datos
---------------------------------------------
+-------------------------------------------
 
 .. warning::
 
-   Ejecutar esta operación eliminará completamente todos los datos de índice y configuración.
+   Al ejecutar esta operación se eliminarán por completo todos los datos del índice.
 
-::
+Dado que el directorio de datos no se elimina al desinstalar el paquete, elimínelo manualmente::
 
     $ sudo rm -rf /var/lib/fess
     $ sudo rm -rf /var/lib/opensearch
 
 Paso 5: Eliminación de Archivos de Configuración
--------------------------------------------------
+------------------------------------------------
 
-::
+Elimine los archivos de configuración y los archivos de configuración de entorno::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/sysconfig/fess
     $ sudo rm -rf /etc/opensearch
 
+.. note::
+
+   En RPM, los archivos de configuración dentro de ``/etc/fess`` pueden quedar con el nombre ``.rpmsave``.
+   Para eliminarlos por completo, elimínelos manualmente como se indica arriba.
+
 Paso 6: Eliminación de Archivos de Registro
---------------------------------------------
+-------------------------------------------
 
 ::
 
     $ sudo rm -rf /var/log/fess
     $ sudo rm -rf /var/log/opensearch
 
-Paso 7: Eliminación de Usuario y Grupo (Opcional)
---------------------------------------------------
+Paso 7: Eliminación del Directorio Temporal (Opcional)
+------------------------------------------------------
 
-Si desea eliminar el usuario y grupo del sistema::
+::
+
+    $ sudo rm -rf /var/tmp/fess
+
+Paso 8: Eliminación de Usuario y Grupo (Opcional)
+-------------------------------------------------
+
+Normalmente, el usuario y el grupo ``fess`` se eliminan al eliminar el paquete.
+Si permanecen, o si desea eliminar el usuario y el grupo de OpenSearch, ejecute lo siguiente::
 
     $ sudo userdel fess
     $ sudo groupdel fess
@@ -162,45 +189,50 @@ Si desea eliminar el usuario y grupo del sistema::
     $ sudo groupdel opensearch
 
 Desinstalación de Versión DEB
-==============================
+=============================
 
 Paso 1: Desinstalación de Fess
--------------------------------
+------------------------------
 
 Desinstale el paquete DEB::
 
     $ sudo dpkg -r fess
 
-Para eliminar completamente incluyendo archivos de configuración::
+Para eliminar completamente incluyendo los archivos de configuración y los archivos de configuración de entorno, utilice purge::
 
     $ sudo dpkg -P fess
 
+.. note::
+
+   Con ``dpkg -r`` (remove), los archivos de configuración (conffile) como ``/etc/default/fess`` permanecen.
+   Si utiliza ``dpkg -P`` (purge), se eliminan estos archivos de configuración junto con el usuario y el grupo ``fess``.
+
 Paso 2: Desinstalación de OpenSearch
--------------------------------------
+------------------------------------
 
 ::
 
     $ sudo dpkg -r opensearch
 
-O para eliminar incluyendo archivos de configuración::
+O bien, para eliminar incluyendo los archivos de configuración::
 
     $ sudo dpkg -P opensearch
 
-Paso 3: Deshabilitación del Servicio
--------------------------------------
+Paso 3: Confirmación de la Deshabilitación del Servicio
+-------------------------------------------------------
 
-::
+Normalmente el servicio se deshabilita al eliminar el paquete. Por si acaso, para confirmar o deshabilitar ejecute lo siguiente::
 
     $ sudo systemctl disable fess.service
     $ sudo systemctl disable opensearch.service
     $ sudo systemctl daemon-reload
 
 Paso 4: Eliminación del Directorio de Datos
---------------------------------------------
+-------------------------------------------
 
 .. warning::
 
-   Ejecutar esta operación eliminará completamente todos los datos de índice y configuración.
+   Al ejecutar esta operación se eliminarán por completo todos los datos del índice.
 
 ::
 
@@ -208,15 +240,16 @@ Paso 4: Eliminación del Directorio de Datos
     $ sudo rm -rf /var/lib/opensearch
 
 Paso 5: Eliminación de Archivos de Configuración (Si no usó dpkg -P)
----------------------------------------------------------------------
+--------------------------------------------------------------------
 
 ::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/default/fess
     $ sudo rm -rf /etc/opensearch
 
 Paso 6: Eliminación de Archivos de Registro
---------------------------------------------
+-------------------------------------------
 
 ::
 
@@ -224,9 +257,10 @@ Paso 6: Eliminación de Archivos de Registro
     $ sudo rm -rf /var/log/opensearch
 
 Paso 7: Eliminación de Usuario y Grupo (Opcional)
---------------------------------------------------
+-------------------------------------------------
 
-Si desea eliminar el usuario y grupo del sistema::
+Si no utilizó ``dpkg -P``, el usuario y el grupo ``fess`` permanecen.
+Si desea eliminarlos, ejecute lo siguiente::
 
     $ sudo userdel fess
     $ sudo groupdel fess
@@ -234,68 +268,64 @@ Si desea eliminar el usuario y grupo del sistema::
     $ sudo groupdel opensearch
 
 Desinstalación de Versión Docker
-=================================
+================================
 
 Paso 1: Eliminación de Contenedores y Red
-------------------------------------------
+-----------------------------------------
 
-::
+Elimine los contenedores y la red creada por Docker Compose (``search_net``)::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
 Paso 2: Eliminación de Volúmenes
----------------------------------
+--------------------------------
 
 .. warning::
 
-   Ejecutar esta operación eliminará completamente todos los datos.
+   Al ejecutar esta operación se eliminarán por completo todos los datos.
 
-Verificar lista de volúmenes::
+Los datos de |Fess| (índices, diccionarios, etc.) se almacenan en los volúmenes de OpenSearch.
+Primero, verifique la lista de volúmenes::
 
     $ docker volume ls
 
-Eliminar volúmenes relacionados con Fess::
+Elimine los volúmenes relacionados con OpenSearch::
 
-    $ docker volume rm fess-es-data
-    $ docker volume rm fess-data
+    $ docker volume rm <project>_search01_data
+    $ docker volume rm <project>_search01_dictionary
 
-O eliminar todos los volúmenes en lote::
+.. note::
+
+   Los nombres de los volúmenes llevan como prefijo el nombre del proyecto de Docker Compose (normalmente el nombre
+   del directorio en el que se ubicó el archivo Compose). Verifique el nombre real con ``docker volume ls``.
+
+Para eliminar los contenedores y los volúmenes de una sola vez, añada la opción ``-v`` a ``down``::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down -v
 
 Paso 3: Eliminación de Imágenes (Opcional)
--------------------------------------------
+------------------------------------------
 
 Si desea eliminar las imágenes Docker para liberar espacio en disco::
 
     $ docker images | grep fess
-    $ docker rmi codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess-opensearch:3.7.0
 
-    $ docker images | grep opensearch
-    $ docker rmi opensearchproject/opensearch:3.6.0
-
-Paso 4: Eliminación de Red (Opcional)
---------------------------------------
-
-Elimine la red creada por Docker Compose::
-
-    $ docker network ls
-    $ docker network rm <network_name>
-
-Paso 5: Eliminación de Archivos Compose
-----------------------------------------
+Paso 4: Eliminación de Archivos Compose
+---------------------------------------
 
 ::
 
     $ rm compose.yaml compose-opensearch3.yaml
 
 Verificación de la Desinstalación
-==================================
+=================================
 
 Verifique que se hayan eliminado todos los componentes.
 
 Verificación de Procesos
--------------------------
+------------------------
 
 ::
 
@@ -305,7 +335,7 @@ Verificación de Procesos
 Si no se muestra nada, los procesos están detenidos.
 
 Verificación de Puertos
-------------------------
+-----------------------
 
 ::
 
@@ -315,7 +345,7 @@ Verificación de Puertos
 Verifique que los puertos no estén en uso.
 
 Verificación de Archivos
--------------------------
+------------------------
 
 Versión TAR.GZ/ZIP::
 
@@ -328,11 +358,11 @@ Versión RPM/DEB::
 
 Versión Docker::
 
-    $ docker ps -a | grep fess  # Verifique que no existan contenedores
-    $ docker volume ls | grep fess  # Verifique que no existan volúmenes
+    $ docker ps -a | grep -E 'fess01|search01'  # Verifique que no existan contenedores
+    $ docker volume ls | grep search01           # Verifique que no existan volúmenes
 
 Verificación de Paquetes
--------------------------
+------------------------
 
 Versión RPM::
 
@@ -347,20 +377,21 @@ Versión DEB::
 Si no se muestra nada, los paquetes están eliminados.
 
 Desinstalación Parcial
-=======================
+======================
 
 Eliminar Solo Fess y Mantener OpenSearch
------------------------------------------
+----------------------------------------
 
 Si OpenSearch se utiliza también en otras aplicaciones, puede eliminar solo Fess.
 
 1. Detenga Fess
-2. Elimine el paquete o directorio de Fess
+2. Elimine el paquete o el directorio de Fess
 3. Elimine el directorio de datos de Fess (``/var/lib/fess``, etc.)
-4. No elimine OpenSearch
+4. Elimine los índices de |Fess| creados dentro de OpenSearch (``fess.*``, ``.fess_*``, etc.)
+5. No elimine OpenSearch
 
 Eliminar Solo OpenSearch y Mantener Fess
------------------------------------------
+----------------------------------------
 
 .. warning::
 
@@ -368,15 +399,15 @@ Eliminar Solo OpenSearch y Mantener Fess
    Cambie la configuración para conectarse a otro clúster de OpenSearch.
 
 1. Detenga OpenSearch
-2. Elimine el paquete o directorio de OpenSearch
+2. Elimine el paquete o el directorio de OpenSearch
 3. Elimine el directorio de datos de OpenSearch (``/var/lib/opensearch``, etc.)
 4. Actualice la configuración de Fess para especificar otro clúster de OpenSearch
 
 Solución de Problemas
-======================
+=====================
 
 No se Puede Eliminar el Paquete
---------------------------------
+-------------------------------
 
 **Síntoma:**
 
@@ -388,7 +419,7 @@ Se produce un error con ``rpm -e`` o ``dpkg -r``.
 
        $ sudo systemctl stop fess.service
 
-2. Verifique dependencias::
+2. Verifique las dependencias::
 
        $ rpm -qa | grep fess
        $ dpkg -l | grep fess
@@ -399,7 +430,7 @@ Se produce un error con ``rpm -e`` o ``dpkg -r``.
        $ sudo dpkg -r --force-all fess
 
 No se Puede Eliminar el Directorio
------------------------------------
+----------------------------------
 
 **Síntoma:**
 
@@ -407,20 +438,20 @@ No se puede eliminar el directorio con ``rm -rf``.
 
 **Solución:**
 
-1. Verificar permisos::
+1. Verifique los permisos::
 
        $ ls -ld /path/to/directory
 
-2. Eliminar con sudo::
+2. Elimine con sudo::
 
        $ sudo rm -rf /path/to/directory
 
-3. Verificar que ningún proceso esté usando archivos::
+3. Verifique que ningún proceso esté usando archivos::
 
        $ sudo lsof | grep /path/to/directory
 
-Preparación para Reinstalación
-===============================
+Preparación para la Reinstalación
+=================================
 
 Si va a reinstalar después de desinstalar, verifique lo siguiente:
 

--- a/fr/15.7/install/uninstall.rst
+++ b/fr/15.7/install/uninstall.rst
@@ -1,6 +1,6 @@
-==========================
+============================
 Procédure de désinstallation
-==========================
+============================
 
 Cette page décrit la procédure de désinstallation complète de |Fess|.
 
@@ -13,22 +13,19 @@ Cette page décrit la procédure de désinstallation complète de |Fess|.
    - Pour les procédures de sauvegarde, consultez :doc:`upgrade`
 
 Préparation avant la désinstallation
-=====================================
+====================================
 
 Récupération de la sauvegarde
-------------------------------
+-----------------------------
 
 Veuillez sauvegarder les données nécessaires :
 
 1. **Données de configuration**
 
-   Téléchargez depuis « Système » → « Sauvegarde » dans l'écran d'administration
+   Téléchargez depuis « Système » → « Sauvegarde » dans l'écran d'administration.
+   Cette opération permet d'exporter en bloc les différents paramètres (y compris la configuration d'exploration), les journaux de recherche, etc.
 
-2. **Configuration d'exploration**
-
-   Si nécessaire, exportez la configuration d'exploration
-
-3. **Fichiers de configuration personnalisés**
+2. **Fichiers de configuration personnalisés**
 
    Version TAR.GZ/ZIP ::
 
@@ -39,14 +36,20 @@ Veuillez sauvegarder les données nécessaires :
 
        $ sudo cp -r /etc/fess /backup/
 
+.. note::
+
+   La majeure partie des index et de la configuration de |Fess| est stockée dans OpenSearch.
+   Pour sauvegarder les données d'index, utilisez la fonction de snapshot d'OpenSearch.
+   Pour la procédure détaillée, consultez :doc:`upgrade`.
+
 Arrêt des services
--------------------
+------------------
 
 Avant la désinstallation, arrêtez tous les services.
 
 Version TAR.GZ/ZIP ::
 
-    $ ps aux | grep fess
+    $ ps aux | grep -E 'fess|opensearch'
     $ kill <fess_pid>
     $ kill <opensearch_pid>
 
@@ -60,62 +63,68 @@ Version Docker ::
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
 Désinstallation de la version TAR.GZ/ZIP
-=========================================
+========================================
 
 Étape 1 : Suppression de Fess
-------------------------------
+-----------------------------
 
 Supprimez le répertoire d'installation ::
 
     $ rm -rf /path/to/fess-15.7.0
 
 Étape 2 : Suppression d'OpenSearch
------------------------------------
+----------------------------------
 
 Supprimez le répertoire d'installation d'OpenSearch ::
 
-    $ rm -rf /path/to/opensearch-3.6.0
+    $ rm -rf /path/to/opensearch-3.7.0
 
 Étape 3 : Suppression du répertoire de données (optionnel)
------------------------------------------------------------
+----------------------------------------------------------
 
-Par défaut, le répertoire de données se trouve dans le répertoire d'installation de Fess,
-mais si vous avez spécifié un emplacement différent, supprimez également ce répertoire ::
+Les données d'index de |Fess| sont stockées dans OpenSearch.
+Par défaut, elles sont stockées dans le répertoire d'installation d'OpenSearch (``opensearch-3.7.0/data``, etc.),
+mais si vous avez spécifié un autre emplacement avec ``path.data``, supprimez également ce répertoire ::
 
     $ rm -rf /path/to/data
 
 Étape 4 : Suppression du répertoire de journaux (optionnel)
-------------------------------------------------------------
+-----------------------------------------------------------
 
 Supprimez les fichiers journaux ::
 
-    $ rm -rf /path/to/fess/logs
-    $ rm -rf /path/to/opensearch/logs
+    $ rm -rf /path/to/fess-15.7.0/logs
+    $ rm -rf /path/to/opensearch-3.7.0/logs
 
 Désinstallation de la version RPM
-==================================
+=================================
 
 Étape 1 : Désinstallation de Fess
-----------------------------------
+---------------------------------
 
 Désinstallez le package RPM ::
 
     $ sudo rpm -e fess
 
+.. note::
+
+   Lors de la désinstallation du package |Fess|, le script de suppression du package exécute
+   automatiquement l'arrêt et la désactivation du service ``fess``, ainsi que la suppression de
+   l'utilisateur et du groupe ``fess``.
+   Les étapes suivantes servent à vérifier que ces éléments ont bien été supprimés, ou à
+   supprimer manuellement les données et les fichiers de configuration.
+
 Étape 2 : Désinstallation d'OpenSearch
----------------------------------------
+--------------------------------------
 
 ::
 
     $ sudo rpm -e opensearch
 
-Étape 3 : Désactivation et suppression des services
-----------------------------------------------------
+Étape 3 : Vérification de la désactivation des services
+-------------------------------------------------------
 
-Avec chkconfig ::
-
-    $ sudo /sbin/chkconfig --del fess
-    $ sudo /sbin/chkconfig --del opensearch
+Normalement, le service est désactivé lors de la suppression du package, mais pour vérifier ou désactiver par précaution, exécutez ce qui suit.
 
 Avec systemd ::
 
@@ -123,38 +132,57 @@ Avec systemd ::
     $ sudo systemctl disable opensearch.service
     $ sudo systemctl daemon-reload
 
+Dans un ancien environnement SysV init (chkconfig) ::
+
+    $ sudo /sbin/chkconfig --del fess
+    $ sudo /sbin/chkconfig --del opensearch
+
 Étape 4 : Suppression du répertoire de données
------------------------------------------------
+----------------------------------------------
 
 .. warning::
 
-   L'exécution de cette opération supprimera complètement toutes les données d'index et la configuration.
+   L'exécution de cette opération supprimera complètement toutes les données d'index.
 
-::
+Le répertoire de données n'étant pas supprimé lors de la désinstallation du package, supprimez-le manuellement ::
 
     $ sudo rm -rf /var/lib/fess
     $ sudo rm -rf /var/lib/opensearch
 
 Étape 5 : Suppression des fichiers de configuration
-----------------------------------------------------
+---------------------------------------------------
 
-::
+Supprimez les fichiers de configuration et les fichiers de configuration d'environnement ::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/sysconfig/fess
     $ sudo rm -rf /etc/opensearch
 
+.. note::
+
+   Avec RPM, les fichiers de configuration dans ``/etc/fess`` peuvent subsister sous le nom ``.rpmsave``.
+   Pour les supprimer complètement, supprimez-les manuellement comme indiqué ci-dessus.
+
 Étape 6 : Suppression des fichiers journaux
---------------------------------------------
+-------------------------------------------
 
 ::
 
     $ sudo rm -rf /var/log/fess
     $ sudo rm -rf /var/log/opensearch
 
-Étape 7 : Suppression des utilisateurs et groupes (optionnel)
---------------------------------------------------------------
+Étape 7 : Suppression du répertoire temporaire (optionnel)
+----------------------------------------------------------
 
-Pour supprimer les utilisateurs et groupes système ::
+::
+
+    $ sudo rm -rf /var/tmp/fess
+
+Étape 8 : Suppression des utilisateurs et groupes (optionnel)
+-------------------------------------------------------------
+
+Normalement, l'utilisateur et le groupe ``fess`` sont supprimés lors de la suppression du package.
+S'ils subsistent, ou pour supprimer l'utilisateur et le groupe d'OpenSearch, exécutez ce qui suit ::
 
     $ sudo userdel fess
     $ sudo groupdel fess
@@ -162,45 +190,50 @@ Pour supprimer les utilisateurs et groupes système ::
     $ sudo groupdel opensearch
 
 Désinstallation de la version DEB
-==================================
+=================================
 
 Étape 1 : Désinstallation de Fess
-----------------------------------
+---------------------------------
 
 Désinstallez le package DEB ::
 
     $ sudo dpkg -r fess
 
-Pour supprimer complètement y compris les fichiers de configuration ::
+Pour supprimer complètement, y compris les fichiers de configuration et les fichiers de configuration d'environnement, utilisez purge ::
 
     $ sudo dpkg -P fess
 
+.. note::
+
+   Avec ``dpkg -r`` (remove), les fichiers de configuration (conffile) tels que ``/etc/default/fess`` subsistent.
+   Avec ``dpkg -P`` (purge), ces fichiers de configuration ainsi que l'utilisateur et le groupe ``fess`` sont également supprimés.
+
 Étape 2 : Désinstallation d'OpenSearch
----------------------------------------
+--------------------------------------
 
 ::
 
     $ sudo dpkg -r opensearch
 
-Ou pour supprimer y compris les fichiers de configuration ::
+Ou, pour supprimer y compris les fichiers de configuration ::
 
     $ sudo dpkg -P opensearch
 
-Étape 3 : Désactivation des services
--------------------------------------
+Étape 3 : Vérification de la désactivation des services
+-------------------------------------------------------
 
-::
+Normalement, le service est désactivé lors de la suppression du package. Pour vérifier ou désactiver par précaution, exécutez ce qui suit ::
 
     $ sudo systemctl disable fess.service
     $ sudo systemctl disable opensearch.service
     $ sudo systemctl daemon-reload
 
 Étape 4 : Suppression du répertoire de données
------------------------------------------------
+----------------------------------------------
 
 .. warning::
 
-   L'exécution de cette opération supprimera complètement toutes les données d'index et la configuration.
+   L'exécution de cette opération supprimera complètement toutes les données d'index.
 
 ::
 
@@ -208,15 +241,16 @@ Ou pour supprimer y compris les fichiers de configuration ::
     $ sudo rm -rf /var/lib/opensearch
 
 Étape 5 : Suppression des fichiers de configuration (si dpkg -P n'a pas été utilisé)
--------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------
 
 ::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/default/fess
     $ sudo rm -rf /etc/opensearch
 
 Étape 6 : Suppression des fichiers journaux
---------------------------------------------
+-------------------------------------------
 
 ::
 
@@ -224,9 +258,10 @@ Ou pour supprimer y compris les fichiers de configuration ::
     $ sudo rm -rf /var/log/opensearch
 
 Étape 7 : Suppression des utilisateurs et groupes (optionnel)
---------------------------------------------------------------
+-------------------------------------------------------------
 
-Pour supprimer les utilisateurs et groupes système ::
+Si vous n'avez pas utilisé ``dpkg -P``, l'utilisateur et le groupe ``fess`` subsistent.
+Pour les supprimer, exécutez ce qui suit ::
 
     $ sudo userdel fess
     $ sudo groupdel fess
@@ -234,68 +269,64 @@ Pour supprimer les utilisateurs et groupes système ::
     $ sudo groupdel opensearch
 
 Désinstallation de la version Docker
-=====================================
+====================================
 
 Étape 1 : Suppression des conteneurs et réseaux
-------------------------------------------------
+-----------------------------------------------
 
-::
+Supprimez les conteneurs ainsi que le réseau créé par Docker Compose (``search_net``) ::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
 Étape 2 : Suppression des volumes
-----------------------------------
+---------------------------------
 
 .. warning::
 
    L'exécution de cette opération supprimera complètement toutes les données.
 
-Vérification de la liste des volumes ::
+Les données de |Fess| (index, dictionnaires, etc.) sont stockées dans les volumes d'OpenSearch.
+Vérifiez d'abord la liste des volumes ::
 
     $ docker volume ls
 
-Suppression des volumes liés à Fess ::
+Supprimez les volumes liés à OpenSearch ::
 
-    $ docker volume rm fess-es-data
-    $ docker volume rm fess-data
+    $ docker volume rm <project>_search01_data
+    $ docker volume rm <project>_search01_dictionary
 
-Ou suppression groupée de tous les volumes ::
+.. note::
+
+   Les noms de volumes sont préfixés par le nom du projet Docker Compose (généralement le nom du
+   répertoire dans lequel se trouve le fichier Compose). Vérifiez les noms réels avec ``docker volume ls``.
+
+Pour supprimer en bloc les conteneurs et les volumes, ajoutez l'option ``-v`` à ``down`` ::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down -v
 
 Étape 3 : Suppression des images (optionnel)
----------------------------------------------
+--------------------------------------------
 
 Pour supprimer les images Docker et libérer de l'espace disque ::
 
     $ docker images | grep fess
-    $ docker rmi codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess-opensearch:3.7.0
 
-    $ docker images | grep opensearch
-    $ docker rmi opensearchproject/opensearch:3.6.0
-
-Étape 4 : Suppression du réseau (optionnel)
---------------------------------------------
-
-Suppression du réseau créé par Docker Compose ::
-
-    $ docker network ls
-    $ docker network rm <network_name>
-
-Étape 5 : Suppression des fichiers Compose
--------------------------------------------
+Étape 4 : Suppression des fichiers Compose
+------------------------------------------
 
 ::
 
     $ rm compose.yaml compose-opensearch3.yaml
 
 Vérification de la désinstallation
-===================================
+==================================
 
 Vérifiez que tous les composants ont été supprimés.
 
 Vérification des processus
----------------------------
+--------------------------
 
 ::
 
@@ -305,7 +336,7 @@ Vérification des processus
 Si rien ne s'affiche, les processus sont arrêtés.
 
 Vérification des ports
------------------------
+----------------------
 
 ::
 
@@ -315,7 +346,7 @@ Vérification des ports
 Vérifiez que les ports ne sont pas utilisés.
 
 Vérification des fichiers
---------------------------
+-------------------------
 
 Version TAR.GZ/ZIP ::
 
@@ -328,11 +359,11 @@ Version RPM/DEB ::
 
 Version Docker ::
 
-    $ docker ps -a | grep fess  # Vérifiez que le conteneur n'existe pas
-    $ docker volume ls | grep fess  # Vérifiez que le volume n'existe pas
+    $ docker ps -a | grep -E 'fess01|search01'  # Vérifiez que le conteneur n'existe pas
+    $ docker volume ls | grep search01           # Vérifiez que le volume n'existe pas
 
 Vérification des packages
---------------------------
+-------------------------
 
 Version RPM ::
 
@@ -347,36 +378,37 @@ Version DEB ::
 Si rien ne s'affiche, les packages ont été supprimés.
 
 Désinstallation partielle
-==========================
+=========================
 
 Supprimer uniquement Fess en conservant OpenSearch
----------------------------------------------------
+--------------------------------------------------
 
 Si vous utilisez également OpenSearch pour d'autres applications, vous pouvez supprimer uniquement Fess.
 
-1. Arrêt de Fess
-2. Suppression du package ou du répertoire de Fess
-3. Suppression du répertoire de données de Fess (``/var/lib/fess``, etc.)
-4. Ne pas supprimer OpenSearch
+1. Arrêter Fess
+2. Supprimer le package ou le répertoire de Fess
+3. Supprimer le répertoire de données de Fess (``/var/lib/fess``, etc.)
+4. Supprimer les index de |Fess| créés dans OpenSearch (``fess.*``, ``.fess_*``, etc.)
+5. Ne pas supprimer OpenSearch
 
 Supprimer uniquement OpenSearch en conservant Fess
----------------------------------------------------
+--------------------------------------------------
 
 .. warning::
 
    Si vous supprimez OpenSearch, Fess ne fonctionnera plus.
    Veuillez modifier la configuration pour vous connecter à un autre cluster OpenSearch.
 
-1. Arrêt d'OpenSearch
-2. Suppression du package ou du répertoire d'OpenSearch
-3. Suppression du répertoire de données d'OpenSearch (``/var/lib/opensearch``, etc.)
-4. Mise à jour de la configuration de Fess pour spécifier un autre cluster OpenSearch
+1. Arrêter OpenSearch
+2. Supprimer le package ou le répertoire d'OpenSearch
+3. Supprimer le répertoire de données d'OpenSearch (``/var/lib/opensearch``, etc.)
+4. Mettre à jour la configuration de Fess pour spécifier un autre cluster OpenSearch
 
 Dépannage
 =========
 
 Impossible de supprimer le package
------------------------------------
+----------------------------------
 
 **Symptôme :**
 
@@ -399,7 +431,7 @@ Erreur avec ``rpm -e`` ou ``dpkg -r``.
        $ sudo dpkg -r --force-all fess
 
 Impossible de supprimer le répertoire
---------------------------------------
+-------------------------------------
 
 **Symptôme :**
 
@@ -420,7 +452,7 @@ Impossible de supprimer le répertoire avec ``rm -rf``.
        $ sudo lsof | grep /path/to/directory
 
 Préparation pour la réinstallation
-===================================
+==================================
 
 Si vous réinstallez après la désinstallation, vérifiez les points suivants :
 
@@ -434,7 +466,7 @@ Pour les procédures de réinstallation, consultez :doc:`install`.
 Étapes suivantes
 ================
 
-Après la désinstallation :
+Une fois la désinstallation terminée :
 
 - Pour installer une nouvelle version, consultez :doc:`install`
 - Pour migrer des données, consultez :doc:`upgrade`

--- a/ja/15.7/install/uninstall.rst
+++ b/ja/15.7/install/uninstall.rst
@@ -22,13 +22,10 @@
 
 1. **設定データ**
 
-   管理画面から「システム」→「バックアップ」でダウンロード
+   管理画面の「システム」→「バックアップ」からダウンロードします。
+   この操作で、各種設定（クロール設定を含む）や検索ログなどをまとめてエクスポートできます。
 
-2. **クロール設定**
-
-   必要に応じて、クロール設定をエクスポート
-
-3. **カスタマイズした設定ファイル**
+2. **カスタマイズした設定ファイル**
 
    TAR.GZ/ZIP 版::
 
@@ -39,6 +36,12 @@
 
        $ sudo cp -r /etc/fess /backup/
 
+.. note::
+
+   |Fess| のインデックスや設定の大部分は OpenSearch に保存されます。
+   インデックスデータをバックアップする場合は、OpenSearch のスナップショット機能を使用します。
+   詳細な手順は :doc:`upgrade` を参照してください。
+
 サービスの停止
 ------------
 
@@ -46,7 +49,7 @@
 
 TAR.GZ/ZIP 版::
 
-    $ ps aux | grep fess
+    $ ps aux | grep -E 'fess|opensearch'
     $ kill <fess_pid>
     $ kill <opensearch_pid>
 
@@ -74,13 +77,14 @@ TAR.GZ/ZIP 版のアンインストール
 
 OpenSearch のインストールディレクトリを削除します::
 
-    $ rm -rf /path/to/opensearch-3.6.0
+    $ rm -rf /path/to/opensearch-3.7.0
 
 ステップ 3: データディレクトリの削除（オプション）
 -------------------------------------------
 
-デフォルトでは、データディレクトリは Fess のインストールディレクトリ内にありますが、
-別の場所を指定している場合は、そのディレクトリも削除してください::
+|Fess| のインデックスデータは OpenSearch に保存されます。
+デフォルトでは OpenSearch のインストールディレクトリ内（``opensearch-3.7.0/data`` など）に保存されますが、
+``path.data`` で別の場所を指定している場合は、そのディレクトリも削除してください::
 
     $ rm -rf /path/to/data
 
@@ -89,8 +93,8 @@ OpenSearch のインストールディレクトリを削除します::
 
 ログファイルを削除します::
 
-    $ rm -rf /path/to/fess/logs
-    $ rm -rf /path/to/opensearch/logs
+    $ rm -rf /path/to/fess-15.7.0/logs
+    $ rm -rf /path/to/opensearch-3.7.0/logs
 
 RPM 版のアンインストール
 ======================
@@ -102,6 +106,13 @@ RPM パッケージをアンインストールします::
 
     $ sudo rpm -e fess
 
+.. note::
+
+   |Fess| パッケージのアンインストール時には、パッケージの削除スクリプトによって
+   ``fess`` サービスの停止・無効化と、``fess`` ユーザーおよびグループの削除が自動的に実行されます。
+   以降のステップは、これらが確実に削除されたことを確認するため、または
+   データや設定ファイルを手動で削除するために実施します。
+
 ステップ 2: OpenSearch のアンインストール
 --------------------------------------
 
@@ -109,13 +120,10 @@ RPM パッケージをアンインストールします::
 
     $ sudo rpm -e opensearch
 
-ステップ 3: サービスの無効化と削除
---------------------------------
+ステップ 3: サービスの無効化の確認
+-------------------------------
 
-chkconfig の場合::
-
-    $ sudo /sbin/chkconfig --del fess
-    $ sudo /sbin/chkconfig --del opensearch
+通常はパッケージ削除時にサービスが無効化されますが、念のため確認・無効化する場合は以下を実行します。
 
 systemd の場合::
 
@@ -123,14 +131,19 @@ systemd の場合::
     $ sudo systemctl disable opensearch.service
     $ sudo systemctl daemon-reload
 
+古い SysV init（chkconfig）環境の場合::
+
+    $ sudo /sbin/chkconfig --del fess
+    $ sudo /sbin/chkconfig --del opensearch
+
 ステップ 4: データディレクトリの削除
 ----------------------------------
 
 .. warning::
 
-   この操作を実行すると、すべてのインデックスデータと設定が完全に削除されます。
+   この操作を実行すると、すべてのインデックスデータが完全に削除されます。
 
-::
+データディレクトリはパッケージのアンインストールでは削除されないため、手動で削除します::
 
     $ sudo rm -rf /var/lib/fess
     $ sudo rm -rf /var/lib/opensearch
@@ -138,10 +151,16 @@ systemd の場合::
 ステップ 5: 設定ファイルの削除
 ----------------------------
 
-::
+設定ファイルと環境設定ファイルを削除します::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/sysconfig/fess
     $ sudo rm -rf /etc/opensearch
+
+.. note::
+
+   RPM では ``/etc/fess`` 内の設定ファイルが ``.rpmsave`` という名前で残る場合があります。
+   完全に削除するには、上記のように手動で削除してください。
 
 ステップ 6: ログファイルの削除
 ----------------------------
@@ -151,10 +170,18 @@ systemd の場合::
     $ sudo rm -rf /var/log/fess
     $ sudo rm -rf /var/log/opensearch
 
-ステップ 7: ユーザーとグループの削除（オプション）
+ステップ 7: 一時ディレクトリの削除（オプション）
+-----------------------------------------
+
+::
+
+    $ sudo rm -rf /var/tmp/fess
+
+ステップ 8: ユーザーとグループの削除（オプション）
 -------------------------------------------
 
-システムユーザーとグループを削除する場合::
+通常はパッケージ削除時に ``fess`` ユーザー・グループは削除されます。
+残っている場合や、OpenSearch 用のユーザー・グループを削除する場合は、以下を実行します::
 
     $ sudo userdel fess
     $ sudo groupdel fess
@@ -171,9 +198,14 @@ DEB パッケージをアンインストールします::
 
     $ sudo dpkg -r fess
 
-設定ファイルも含めて完全に削除する場合::
+設定ファイルや環境設定ファイルも含めて完全に削除する場合は、purge を使用します::
 
     $ sudo dpkg -P fess
+
+.. note::
+
+   ``dpkg -r``（remove）では、設定ファイル（conffile）である ``/etc/default/fess`` などは残ります。
+   ``dpkg -P``（purge）を使用すると、これらの設定ファイルと ``fess`` ユーザー・グループも削除されます。
 
 ステップ 2: OpenSearch のアンインストール
 --------------------------------------
@@ -186,10 +218,10 @@ DEB パッケージをアンインストールします::
 
     $ sudo dpkg -P opensearch
 
-ステップ 3: サービスの無効化
---------------------------
+ステップ 3: サービスの無効化の確認
+-------------------------------
 
-::
+通常はパッケージ削除時にサービスが無効化されます。念のため確認・無効化する場合は以下を実行します::
 
     $ sudo systemctl disable fess.service
     $ sudo systemctl disable opensearch.service
@@ -200,7 +232,7 @@ DEB パッケージをアンインストールします::
 
 .. warning::
 
-   この操作を実行すると、すべてのインデックスデータと設定が完全に削除されます。
+   この操作を実行すると、すべてのインデックスデータが完全に削除されます。
 
 ::
 
@@ -213,6 +245,7 @@ DEB パッケージをアンインストールします::
 ::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/default/fess
     $ sudo rm -rf /etc/opensearch
 
 ステップ 6: ログファイルの削除
@@ -226,7 +259,8 @@ DEB パッケージをアンインストールします::
 ステップ 7: ユーザーとグループの削除（オプション）
 -------------------------------------------
 
-システムユーザーとグループを削除する場合::
+``dpkg -P`` を使用しなかった場合、``fess`` ユーザー・グループが残ります。
+削除する場合は以下を実行します::
 
     $ sudo userdel fess
     $ sudo groupdel fess
@@ -239,7 +273,7 @@ Docker 版のアンインストール
 ステップ 1: コンテナとネットワークの削除
 ------------------------------------
 
-::
+コンテナ、および Docker Compose が作成したネットワーク（``search_net``）を削除します::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
@@ -250,16 +284,22 @@ Docker 版のアンインストール
 
    この操作を実行すると、すべてのデータが完全に削除されます。
 
-ボリューム一覧を確認::
+|Fess| のデータ（インデックスや辞書など）は OpenSearch のボリュームに保存されます。
+まず、ボリューム一覧を確認します::
 
     $ docker volume ls
 
-Fess 関連のボリュームを削除::
+OpenSearch 関連のボリュームを削除します::
 
-    $ docker volume rm fess-es-data
-    $ docker volume rm fess-data
+    $ docker volume rm <project>_search01_data
+    $ docker volume rm <project>_search01_dictionary
 
-または、すべてのボリュームを一括削除::
+.. note::
+
+   ボリューム名には、Docker Compose のプロジェクト名（通常は Compose ファイルを配置した
+   ディレクトリ名）が接頭辞として付きます。``docker volume ls`` で実際の名前を確認してください。
+
+コンテナとボリュームを一括で削除する場合は、``down`` に ``-v`` オプションを付けます::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down -v
 
@@ -269,20 +309,10 @@ Fess 関連のボリュームを削除::
 Docker イメージを削除してディスクスペースを解放する場合::
 
     $ docker images | grep fess
-    $ docker rmi codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess-opensearch:3.7.0
 
-    $ docker images | grep opensearch
-    $ docker rmi opensearchproject/opensearch:3.6.0
-
-ステップ 4: ネットワークの削除（オプション）
-----------------------------------------
-
-Docker Compose が作成したネットワークを削除::
-
-    $ docker network ls
-    $ docker network rm <network_name>
-
-ステップ 5: Compose ファイルの削除
+ステップ 4: Compose ファイルの削除
 --------------------------------
 
 ::
@@ -328,8 +358,8 @@ RPM/DEB 版::
 
 Docker 版::
 
-    $ docker ps -a | grep fess  # コンテナが存在しないことを確認
-    $ docker volume ls | grep fess  # ボリュームが存在しないことを確認
+    $ docker ps -a | grep -E 'fess01|search01'  # コンテナが存在しないことを確認
+    $ docker volume ls | grep search01           # ボリュームが存在しないことを確認
 
 パッケージの確認
 --------------
@@ -357,7 +387,8 @@ OpenSearch を他のアプリケーションでも使用している場合、Fes
 1. Fess を停止
 2. Fess のパッケージまたはディレクトリを削除
 3. Fess のデータディレクトリを削除（``/var/lib/fess`` など）
-4. OpenSearch は削除しない
+4. OpenSearch 内に作成された |Fess| のインデックス（``fess.*``、``.fess_*`` など）を削除
+5. OpenSearch は削除しない
 
 OpenSearch のみを削除して Fess を残す
 -----------------------------------
@@ -439,4 +470,3 @@ OpenSearch のみを削除して Fess を残す
 - 新しいバージョンをインストールする場合は :doc:`install` を参照
 - データを移行する場合は :doc:`upgrade` を参照
 - 代替の検索ソリューションを検討する場合は、Fess の公式サイトを参照
-

--- a/ko/15.7/install/uninstall.rst
+++ b/ko/15.7/install/uninstall.rst
@@ -22,13 +22,10 @@
 
 1. **설정 데이터**
 
-   관리 화면에서 "시스템"→"백업"으로 다운로드
+   관리 화면의 "시스템" → "백업" 에서 다운로드합니다.
+   이 작업으로 각종 설정(크롤 설정 포함)이나 검색 로그 등을 한꺼번에 내보낼 수 있습니다.
 
-2. **크롤 설정**
-
-   필요에 따라 크롤 설정을 내보내기
-
-3. **커스터마이징한 설정 파일**
+2. **커스터마이징한 설정 파일**
 
    TAR.GZ/ZIP 버전::
 
@@ -39,6 +36,12 @@
 
        $ sudo cp -r /etc/fess /backup/
 
+.. note::
+
+   |Fess| 의 인덱스나 설정의 대부분은 OpenSearch 에 저장됩니다.
+   인덱스 데이터를 백업하는 경우 OpenSearch 의 스냅샷 기능을 사용합니다.
+   자세한 절차는 :doc:`upgrade` 를 참조하십시오.
+
 서비스 중지
 ------------
 
@@ -46,7 +49,7 @@
 
 TAR.GZ/ZIP 버전::
 
-    $ ps aux | grep fess
+    $ ps aux | grep -E 'fess|opensearch'
     $ kill <fess_pid>
     $ kill <opensearch_pid>
 
@@ -74,13 +77,14 @@ TAR.GZ/ZIP 버전 제거
 
 OpenSearch 설치 디렉터리를 삭제합니다::
 
-    $ rm -rf /path/to/opensearch-3.6.0
+    $ rm -rf /path/to/opensearch-3.7.0
 
 단계 3: 데이터 디렉터리 삭제(옵션)
 -------------------------------------------
 
-기본적으로 데이터 디렉터리는 Fess의 설치 디렉터리 내에 있지만
-다른 위치를 지정한 경우 해당 디렉터리도 삭제하십시오::
+|Fess| 의 인덱스 데이터는 OpenSearch 에 저장됩니다.
+기본적으로 OpenSearch 의 설치 디렉터리 내(``opensearch-3.7.0/data`` 등)에 저장되지만,
+``path.data`` 로 다른 위치를 지정한 경우 해당 디렉터리도 삭제하십시오::
 
     $ rm -rf /path/to/data
 
@@ -89,8 +93,8 @@ OpenSearch 설치 디렉터리를 삭제합니다::
 
 로그 파일을 삭제합니다::
 
-    $ rm -rf /path/to/fess/logs
-    $ rm -rf /path/to/opensearch/logs
+    $ rm -rf /path/to/fess-15.7.0/logs
+    $ rm -rf /path/to/opensearch-3.7.0/logs
 
 RPM 버전 제거
 ======================
@@ -102,6 +106,13 @@ RPM 패키지를 제거합니다::
 
     $ sudo rpm -e fess
 
+.. note::
+
+   |Fess| 패키지를 제거할 때에는 패키지의 삭제 스크립트에 의해
+   ``fess`` 서비스의 중지·비활성화와 ``fess`` 사용자 및 그룹의 삭제가 자동으로 실행됩니다.
+   이후 단계는 이러한 항목이 확실히 삭제되었는지 확인하기 위해, 또는
+   데이터나 설정 파일을 수동으로 삭제하기 위해 실시합니다.
+
 단계 2: OpenSearch 제거
 --------------------------------------
 
@@ -109,28 +120,30 @@ RPM 패키지를 제거합니다::
 
     $ sudo rpm -e opensearch
 
-단계 3: 서비스 비활성화 및 삭제
---------------------------------
+단계 3: 서비스 비활성화 확인
+-------------------------------
 
-chkconfig의 경우::
+일반적으로 패키지 삭제 시 서비스가 비활성화되지만, 만약을 위해 확인·비활성화하는 경우 다음을 실행합니다.
 
-    $ sudo /sbin/chkconfig --del fess
-    $ sudo /sbin/chkconfig --del opensearch
-
-systemd의 경우::
+systemd 의 경우::
 
     $ sudo systemctl disable fess.service
     $ sudo systemctl disable opensearch.service
     $ sudo systemctl daemon-reload
+
+오래된 SysV init(chkconfig) 환경의 경우::
+
+    $ sudo /sbin/chkconfig --del fess
+    $ sudo /sbin/chkconfig --del opensearch
 
 단계 4: 데이터 디렉터리 삭제
 ----------------------------------
 
 .. warning::
 
-   이 작업을 실행하면 모든 인덱스 데이터와 설정이 완전히 삭제됩니다.
+   이 작업을 실행하면 모든 인덱스 데이터가 완전히 삭제됩니다.
 
-::
+데이터 디렉터리는 패키지 제거로는 삭제되지 않으므로 수동으로 삭제합니다::
 
     $ sudo rm -rf /var/lib/fess
     $ sudo rm -rf /var/lib/opensearch
@@ -138,10 +151,16 @@ systemd의 경우::
 단계 5: 설정 파일 삭제
 ----------------------------
 
-::
+설정 파일과 환경 설정 파일을 삭제합니다::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/sysconfig/fess
     $ sudo rm -rf /etc/opensearch
+
+.. note::
+
+   RPM 에서는 ``/etc/fess`` 내의 설정 파일이 ``.rpmsave`` 라는 이름으로 남는 경우가 있습니다.
+   완전히 삭제하려면 위와 같이 수동으로 삭제하십시오.
 
 단계 6: 로그 파일 삭제
 ----------------------------
@@ -151,10 +170,18 @@ systemd의 경우::
     $ sudo rm -rf /var/log/fess
     $ sudo rm -rf /var/log/opensearch
 
-단계 7: 사용자 및 그룹 삭제(옵션)
+단계 7: 임시 디렉터리 삭제(옵션)
+-----------------------------------------
+
+::
+
+    $ sudo rm -rf /var/tmp/fess
+
+단계 8: 사용자 및 그룹 삭제(옵션)
 -------------------------------------------
 
-시스템 사용자 및 그룹을 삭제하는 경우::
+일반적으로 패키지 삭제 시 ``fess`` 사용자·그룹은 삭제됩니다.
+남아 있는 경우나 OpenSearch 용 사용자·그룹을 삭제하는 경우 다음을 실행합니다::
 
     $ sudo userdel fess
     $ sudo groupdel fess
@@ -171,9 +198,14 @@ DEB 패키지를 제거합니다::
 
     $ sudo dpkg -r fess
 
-설정 파일도 포함하여 완전히 삭제하는 경우::
+설정 파일이나 환경 설정 파일도 포함하여 완전히 삭제하는 경우 purge 를 사용합니다::
 
     $ sudo dpkg -P fess
+
+.. note::
+
+   ``dpkg -r``(remove)에서는 설정 파일(conffile)인 ``/etc/default/fess`` 등은 남습니다.
+   ``dpkg -P``(purge)를 사용하면 이러한 설정 파일과 ``fess`` 사용자·그룹도 삭제됩니다.
 
 단계 2: OpenSearch 제거
 --------------------------------------
@@ -186,10 +218,10 @@ DEB 패키지를 제거합니다::
 
     $ sudo dpkg -P opensearch
 
-단계 3: 서비스 비활성화
---------------------------
+단계 3: 서비스 비활성화 확인
+-------------------------------
 
-::
+일반적으로 패키지 삭제 시 서비스가 비활성화됩니다. 만약을 위해 확인·비활성화하는 경우 다음을 실행합니다::
 
     $ sudo systemctl disable fess.service
     $ sudo systemctl disable opensearch.service
@@ -200,19 +232,20 @@ DEB 패키지를 제거합니다::
 
 .. warning::
 
-   이 작업을 실행하면 모든 인덱스 데이터와 설정이 완전히 삭제됩니다.
+   이 작업을 실행하면 모든 인덱스 데이터가 완전히 삭제됩니다.
 
 ::
 
     $ sudo rm -rf /var/lib/fess
     $ sudo rm -rf /var/lib/opensearch
 
-단계 5: 설정 파일 삭제(dpkg -P를 사용하지 않은 경우)
+단계 5: 설정 파일 삭제(dpkg -P 를 사용하지 않은 경우)
 ---------------------------------------------------------
 
 ::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/default/fess
     $ sudo rm -rf /etc/opensearch
 
 단계 6: 로그 파일 삭제
@@ -226,7 +259,8 @@ DEB 패키지를 제거합니다::
 단계 7: 사용자 및 그룹 삭제(옵션)
 -------------------------------------------
 
-시스템 사용자 및 그룹을 삭제하는 경우::
+``dpkg -P`` 를 사용하지 않은 경우 ``fess`` 사용자·그룹이 남습니다.
+삭제하는 경우 다음을 실행합니다::
 
     $ sudo userdel fess
     $ sudo groupdel fess
@@ -239,7 +273,7 @@ Docker 버전 제거
 단계 1: 컨테이너 및 네트워크 삭제
 ------------------------------------
 
-::
+컨테이너 및 Docker Compose 가 생성한 네트워크(``search_net``)를 삭제합니다::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
@@ -250,16 +284,22 @@ Docker 버전 제거
 
    이 작업을 실행하면 모든 데이터가 완전히 삭제됩니다.
 
-볼륨 목록 확인::
+|Fess| 의 데이터(인덱스나 사전 등)는 OpenSearch 의 볼륨에 저장됩니다.
+먼저 볼륨 목록을 확인합니다::
 
     $ docker volume ls
 
-Fess 관련 볼륨 삭제::
+OpenSearch 관련 볼륨을 삭제합니다::
 
-    $ docker volume rm fess-es-data
-    $ docker volume rm fess-data
+    $ docker volume rm <project>_search01_data
+    $ docker volume rm <project>_search01_dictionary
 
-또는 모든 볼륨을 일괄 삭제::
+.. note::
+
+   볼륨 이름에는 Docker Compose 의 프로젝트 이름(일반적으로 Compose 파일을 배치한
+   디렉터리 이름)이 접두사로 붙습니다. ``docker volume ls`` 로 실제 이름을 확인하십시오.
+
+컨테이너와 볼륨을 일괄로 삭제하는 경우 ``down`` 에 ``-v`` 옵션을 붙입니다::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down -v
 
@@ -269,20 +309,10 @@ Fess 관련 볼륨 삭제::
 Docker 이미지를 삭제하여 디스크 공간을 확보하는 경우::
 
     $ docker images | grep fess
-    $ docker rmi codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess-opensearch:3.7.0
 
-    $ docker images | grep opensearch
-    $ docker rmi opensearchproject/opensearch:3.6.0
-
-단계 4: 네트워크 삭제(옵션)
-----------------------------------------
-
-Docker Compose가 생성한 네트워크를 삭제::
-
-    $ docker network ls
-    $ docker network rm <network_name>
-
-단계 5: Compose 파일 삭제
+단계 4: Compose 파일 삭제
 --------------------------------
 
 ::
@@ -328,8 +358,8 @@ RPM/DEB 버전::
 
 Docker 버전::
 
-    $ docker ps -a | grep fess  # 컨테이너가 존재하지 않는지 확인
-    $ docker volume ls | grep fess  # 볼륨이 존재하지 않는지 확인
+    $ docker ps -a | grep -E 'fess01|search01'  # 컨테이너가 존재하지 않는지 확인
+    $ docker volume ls | grep search01           # 볼륨이 존재하지 않는지 확인
 
 패키지 확인
 --------------
@@ -352,19 +382,20 @@ DEB 버전::
 Fess만 삭제하고 OpenSearch 유지
 -----------------------------------
 
-OpenSearch를 다른 애플리케이션에서도 사용하고 있는 경우 Fess만 삭제할 수 있습니다.
+OpenSearch 를 다른 애플리케이션에서도 사용하고 있는 경우 Fess 만 삭제할 수 있습니다.
 
 1. Fess 중지
 2. Fess 패키지 또는 디렉터리 삭제
 3. Fess 데이터 디렉터리 삭제(``/var/lib/fess`` 등)
-4. OpenSearch는 삭제하지 않음
+4. OpenSearch 내에 생성된 |Fess| 의 인덱스(``fess.*``、``.fess_*`` 등) 삭제
+5. OpenSearch 는 삭제하지 않음
 
 OpenSearch만 삭제하고 Fess 유지
 -----------------------------------
 
 .. warning::
 
-   OpenSearch를 삭제하면 Fess는 작동하지 않게 됩니다.
+   OpenSearch 를 삭제하면 Fess 는 작동하지 않게 됩니다.
    다른 OpenSearch 클러스터에 연결하도록 설정을 변경하십시오.
 
 1. OpenSearch 중지

--- a/zh-cn/15.7/install/uninstall.rst
+++ b/zh-cn/15.7/install/uninstall.rst
@@ -1,6 +1,6 @@
-==================
+==========
 卸载步骤
-==================
+==========
 
 本页面说明完全卸载 |Fess| 的步骤。
 
@@ -9,26 +9,23 @@
    **卸载前的重要注意事项**
 
    - 卸载会删除所有数据
-   - 如有重要数据，必须获取备份
+   - 如有重要数据，请务必获取备份
    - 关于备份步骤，请参阅 :doc:`upgrade`
 
 卸载前的准备
-======================
+============
 
 获取备份
-----------------
+--------
 
 请备份必要的数据：
 
 1. **配置数据**
 
-   从管理页面的「系统」→「备份」下载
+   从管理页面的「系统」→「备份」下载。
+   通过此操作，可以将各种配置（包括爬取配置）以及搜索日志等一并导出。
 
-2. **爬取配置**
-
-   根据需要导出爬取配置
-
-3. **定制的配置文件**
+2. **定制的配置文件**
 
    TAR.GZ/ZIP 版::
 
@@ -39,14 +36,20 @@
 
        $ sudo cp -r /etc/fess /backup/
 
+.. note::
+
+   |Fess| 的索引和大部分配置都保存在 OpenSearch 中。
+   备份索引数据时，请使用 OpenSearch 的快照功能。
+   详细步骤请参阅 :doc:`upgrade`。
+
 停止服务
-------------
+--------
 
 卸载前，停止所有服务。
 
 TAR.GZ/ZIP 版::
 
-    $ ps aux | grep fess
+    $ ps aux | grep -E 'fess|opensearch'
     $ kill <fess_pid>
     $ kill <opensearch_pid>
 
@@ -60,62 +63,66 @@ Docker 版::
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
 TAR.GZ/ZIP 版的卸载
-=============================
+===================
 
 步骤 1: 删除 Fess
----------------------
+-----------------
 
 删除安装目录::
 
     $ rm -rf /path/to/fess-15.7.0
 
 步骤 2: 删除 OpenSearch
---------------------------
+-----------------------
 
 删除 OpenSearch 的安装目录::
 
-    $ rm -rf /path/to/opensearch-3.6.0
+    $ rm -rf /path/to/opensearch-3.7.0
 
 步骤 3: 删除数据目录（可选）
--------------------------------------------
+--------------------------
 
-默认情况下，数据目录在 Fess 的安装目录内，
-但如果指定了其他位置，也请删除该目录::
+|Fess| 的索引数据保存在 OpenSearch 中。
+默认情况下保存在 OpenSearch 的安装目录内（如 ``opensearch-3.7.0/data``），
+但如果通过 ``path.data`` 指定了其他位置，请同时删除该目录::
 
     $ rm -rf /path/to/data
 
 步骤 4: 删除日志目录（可选）
------------------------------------------
+--------------------------
 
 删除日志文件::
 
-    $ rm -rf /path/to/fess/logs
-    $ rm -rf /path/to/opensearch/logs
+    $ rm -rf /path/to/fess-15.7.0/logs
+    $ rm -rf /path/to/opensearch-3.7.0/logs
 
 RPM 版的卸载
-======================
+============
 
 步骤 1: 卸载 Fess
----------------------------------
+-----------------
 
 卸载 RPM 包::
 
     $ sudo rpm -e fess
 
+.. note::
+
+   卸载 |Fess| 包时，包的删除脚本会自动停止并禁用 ``fess`` 服务，
+   并删除 ``fess`` 用户和组。
+   后续步骤用于确认这些已被确实删除，或用于手动删除数据和配置文件。
+
 步骤 2: 卸载 OpenSearch
---------------------------------------
+-----------------------
 
 ::
 
     $ sudo rpm -e opensearch
 
-步骤 3: 禁用和删除服务
---------------------------------
+步骤 3: 确认服务已禁用
+--------------------
 
-chkconfig 的情况::
-
-    $ sudo /sbin/chkconfig --del fess
-    $ sudo /sbin/chkconfig --del opensearch
+通常在删除包时服务会被禁用，但如需保险起见进行确认和禁用，请执行以下命令。
 
 systemd 的情况::
 
@@ -123,38 +130,57 @@ systemd 的情况::
     $ sudo systemctl disable opensearch.service
     $ sudo systemctl daemon-reload
 
+旧版 SysV init（chkconfig）环境的情况::
+
+    $ sudo /sbin/chkconfig --del fess
+    $ sudo /sbin/chkconfig --del opensearch
+
 步骤 4: 删除数据目录
-----------------------------------
+------------------
 
 .. warning::
 
-   执行此操作会完全删除所有索引数据和配置。
+   执行此操作会完全删除所有索引数据。
 
-::
+数据目录在卸载包时不会被删除，因此需要手动删除::
 
     $ sudo rm -rf /var/lib/fess
     $ sudo rm -rf /var/lib/opensearch
 
 步骤 5: 删除配置文件
-----------------------------
+------------------
 
-::
+删除配置文件和环境配置文件::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/sysconfig/fess
     $ sudo rm -rf /etc/opensearch
 
+.. note::
+
+   在 RPM 中，``/etc/fess`` 内的配置文件可能会以 ``.rpmsave`` 的名称保留。
+   要完全删除，请如上所述手动删除。
+
 步骤 6: 删除日志文件
-----------------------------
+------------------
 
 ::
 
     $ sudo rm -rf /var/log/fess
     $ sudo rm -rf /var/log/opensearch
 
-步骤 7: 删除用户和组（可选）
--------------------------------------------
+步骤 7: 删除临时目录（可选）
+--------------------------
 
-删除系统用户和组::
+::
+
+    $ sudo rm -rf /var/tmp/fess
+
+步骤 8: 删除用户和组（可选）
+--------------------------
+
+通常在删除包时 ``fess`` 用户和组会被删除。
+如果仍有残留，或要删除 OpenSearch 用的用户和组，请执行以下命令::
 
     $ sudo userdel fess
     $ sudo groupdel fess
@@ -162,45 +188,50 @@ systemd 的情况::
     $ sudo groupdel opensearch
 
 DEB 版的卸载
-======================
+============
 
 步骤 1: 卸载 Fess
----------------------------------
+-----------------
 
 卸载 DEB 包::
 
     $ sudo dpkg -r fess
 
-包括配置文件完全删除::
+如需包括配置文件和环境配置文件在内完全删除，请使用 purge::
 
     $ sudo dpkg -P fess
 
+.. note::
+
+   使用 ``dpkg -r``（remove）时，作为配置文件（conffile）的 ``/etc/default/fess`` 等会保留。
+   使用 ``dpkg -P``（purge）时，这些配置文件以及 ``fess`` 用户和组也会被删除。
+
 步骤 2: 卸载 OpenSearch
---------------------------------------
+-----------------------
 
 ::
 
     $ sudo dpkg -r opensearch
 
-或包括配置文件删除::
+或者，包括配置文件一并删除::
 
     $ sudo dpkg -P opensearch
 
-步骤 3: 禁用服务
---------------------------
+步骤 3: 确认服务已禁用
+--------------------
 
-::
+通常在删除包时服务会被禁用。如需保险起见进行确认和禁用，请执行以下命令::
 
     $ sudo systemctl disable fess.service
     $ sudo systemctl disable opensearch.service
     $ sudo systemctl daemon-reload
 
 步骤 4: 删除数据目录
-----------------------------------
+------------------
 
 .. warning::
 
-   执行此操作会完全删除所有索引数据和配置。
+   执行此操作会完全删除所有索引数据。
 
 ::
 
@@ -208,15 +239,16 @@ DEB 版的卸载
     $ sudo rm -rf /var/lib/opensearch
 
 步骤 5: 删除配置文件（如未使用 dpkg -P）
----------------------------------------------------------
+------------------------------------
 
 ::
 
     $ sudo rm -rf /etc/fess
+    $ sudo rm -rf /etc/default/fess
     $ sudo rm -rf /etc/opensearch
 
 步骤 6: 删除日志文件
-----------------------------
+------------------
 
 ::
 
@@ -224,9 +256,10 @@ DEB 版的卸载
     $ sudo rm -rf /var/log/opensearch
 
 步骤 7: 删除用户和组（可选）
--------------------------------------------
+--------------------------
 
-删除系统用户和组::
+如果未使用 ``dpkg -P``，则 ``fess`` 用户和组会保留。
+如需删除，请执行以下命令::
 
     $ sudo userdel fess
     $ sudo groupdel fess
@@ -234,68 +267,64 @@ DEB 版的卸载
     $ sudo groupdel opensearch
 
 Docker 版的卸载
-=========================
+===============
 
 步骤 1: 删除容器和网络
-------------------------------------
+--------------------
 
-::
+删除容器，以及 Docker Compose 创建的网络（``search_net``）::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
 步骤 2: 删除卷
---------------------------
+------------
 
 .. warning::
 
    执行此操作会完全删除所有数据。
 
-确认卷列表::
+|Fess| 的数据（索引和词典等）保存在 OpenSearch 的卷中。
+首先，确认卷列表::
 
     $ docker volume ls
 
-删除 Fess 相关的卷::
+删除 OpenSearch 相关的卷::
 
-    $ docker volume rm fess-es-data
-    $ docker volume rm fess-data
+    $ docker volume rm <project>_search01_data
+    $ docker volume rm <project>_search01_dictionary
 
-或批量删除所有卷::
+.. note::
+
+   卷名会带有 Docker Compose 的项目名（通常是放置 Compose 文件的目录名）作为前缀。
+   请使用 ``docker volume ls`` 确认实际名称。
+
+如需一并删除容器和卷，请在 ``down`` 后加上 ``-v`` 选项::
 
     $ docker compose -f compose.yaml -f compose-opensearch3.yaml down -v
 
 步骤 3: 删除镜像（可选）
-------------------------------------
+----------------------
 
-删除 Docker 镜像以释放磁盘空间::
+如需删除 Docker 镜像以释放磁盘空间::
 
     $ docker images | grep fess
-    $ docker rmi codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess:15.7.0
+    $ docker rmi ghcr.io/codelibs/fess-opensearch:3.7.0
 
-    $ docker images | grep opensearch
-    $ docker rmi opensearchproject/opensearch:3.6.0
-
-步骤 4: 删除网络（可选）
-----------------------------------------
-
-删除 Docker Compose 创建的网络::
-
-    $ docker network ls
-    $ docker network rm <network_name>
-
-步骤 5: 删除 Compose 文件
---------------------------------
+步骤 4: 删除 Compose 文件
+-----------------------
 
 ::
 
     $ rm compose.yaml compose-opensearch3.yaml
 
 确认卸载
-====================
+========
 
 确认所有组件已删除。
 
 确认进程
-------------
+--------
 
 ::
 
@@ -305,7 +334,7 @@ Docker 版的卸载
 如果没有显示任何内容，则进程已停止。
 
 确认端口
-----------
+--------
 
 ::
 
@@ -315,7 +344,7 @@ Docker 版的卸载
 确认端口未被使用。
 
 确认文件
-------------
+--------
 
 TAR.GZ/ZIP 版::
 
@@ -328,11 +357,11 @@ RPM/DEB 版::
 
 Docker 版::
 
-    $ docker ps -a | grep fess  # 确认容器不存在
-    $ docker volume ls | grep fess  # 确认卷不存在
+    $ docker ps -a | grep -E 'fess01|search01'  # 确认容器不存在
+    $ docker volume ls | grep search01           # 确认卷不存在
 
 确认包
---------------
+------
 
 RPM 版::
 
@@ -347,36 +376,37 @@ DEB 版::
 如果没有显示任何内容，则包已删除。
 
 部分卸载
-======================
+========
 
 仅删除 Fess 保留 OpenSearch
------------------------------------
+---------------------------
 
-如果 OpenSearch 被其他应用程序使用，可以仅删除 Fess。
+如果 OpenSearch 也被其他应用程序使用，可以仅删除 Fess。
 
 1. 停止 Fess
 2. 删除 Fess 的包或目录
-3. 删除 Fess 的数据目录（``/var/lib/fess`` 等）
-4. 不删除 OpenSearch
+3. 删除 Fess 的数据目录（如 ``/var/lib/fess``）
+4. 删除 OpenSearch 中创建的 |Fess| 索引（如 ``fess.*``、``.fess_*``）
+5. 不删除 OpenSearch
 
 仅删除 OpenSearch 保留 Fess
------------------------------------
+---------------------------
 
 .. warning::
 
-   删除 OpenSearch 会导致 Fess 无法工作。
+   删除 OpenSearch 后，Fess 将无法工作。
    请更改配置以连接到其他 OpenSearch 集群。
 
 1. 停止 OpenSearch
 2. 删除 OpenSearch 的包或目录
-3. 删除 OpenSearch 的数据目录（``/var/lib/opensearch`` 等）
+3. 删除 OpenSearch 的数据目录（如 ``/var/lib/opensearch``）
 4. 更新 Fess 的配置以指定其他 OpenSearch 集群
 
 故障排除
-====================
+========
 
 无法删除包
-----------------------
+----------
 
 **症状:**
 
@@ -399,7 +429,7 @@ DEB 版::
        $ sudo dpkg -r --force-all fess
 
 无法删除目录
-------------------------
+----------
 
 **症状:**
 
@@ -420,7 +450,7 @@ DEB 版::
        $ sudo lsof | grep /path/to/directory
 
 重新安装的准备
-==================
+============
 
 如果卸载后要重新安装，请确认以下内容：
 
@@ -432,10 +462,10 @@ DEB 版::
 关于重新安装步骤，请参阅 :doc:`install`。
 
 下一步
-==========
+======
 
 卸载完成后：
 
 - 要安装新版本，请参阅 :doc:`install`
 - 要迁移数据，请参阅 :doc:`upgrade`
-- 要考虑替代搜索解决方案，请参阅 Fess 官方网站
+- 要考虑替代的搜索解决方案，请参阅 Fess 官方网站


### PR DESCRIPTION
## Summary

Reviewed `15.7/install/uninstall.rst` against the current implementation (Fess source, packaging, and the `docker-fess` Compose files) and corrected several inaccuracies. The same corrections were applied across all language versions.

## Why

The uninstall page referenced Docker images, volume names, and an OpenSearch version that do not match the actual 15.7 implementation, so following the instructions would not remove the right resources.

## Changes

- **Docker images** — use the real GitHub Container Registry images: `ghcr.io/codelibs/fess` and `ghcr.io/codelibs/fess-opensearch`. The previous `codelibs/fess` and upstream `opensearchproject/opensearch` images are not what Fess ships.
- **Docker volumes** — use the real volume names `search01_data` / `search01_dictionary` (defined in `compose-opensearch3.yaml`) and note the Compose project-name prefix. The previous `fess-es-data` / `fess-data` volumes do not exist, so `docker volume rm` and the `docker volume ls | grep fess` verification never matched anything.
- **OpenSearch version** — `3.6.0` → `3.7.0`, matching `fess-parent`.
- **Verification commands** — fixed the container/volume greps that could not match (`search01` container and `search01_*` volumes).
- **RPM/DEB accuracy** — documented the env files (`/etc/sysconfig/fess`, `/etc/default/fess`), noted that the package removal scripts already stop/disable the service and remove the `fess` user/group, added the `.rpmsave` caveat and `/var/tmp/fess` cleanup, and presented `chkconfig` as legacy (systemd is the supported path).
- **Clarification** — Fess index data lives in OpenSearch, not in the Fess installation directory.

## Languages updated

`ja` (source) and translations: `en`, `de`, `fr`, `es`, `ko`, `zh-cn`. Commands/paths are identical across languages; only prose and inline comments are localized.

## Verification

- No stale values (`fess-es-data`, `fess-data`, `opensearchproject/opensearch`, `3.6.0`) remain in any of the 7 files.
- Required corrected values are present in all files.
- All RST heading underlines are valid; no leftover untranslated text.

## Follow-up (out of scope)

The sibling install docs (`install-docker.rst`, `install-linux.rst`, `upgrade.rst`) still carry the same stale OpenSearch `3.6.0` and the nonexistent `fess-es-data` / `fess-data` volume names. These can be corrected in a separate PR.