### PR TITLE
docs(install): correct 15.7 security guide against implementation

### DIFF
--- a/de/15.7/install/security.rst
+++ b/de/15.7/install/security.rst
@@ -22,17 +22,29 @@ Das Standard-Administratorpasswort (``admin`` / ``admin``) muss unbedingt geänd
 **Vorgehensweise:**
 
 1. Anmeldung in der Verwaltungsseite: http://localhost:8080/admin
-2. Klicken Sie auf „System" → „Benutzer"
+2. Klicken Sie auf „Benutzer" → „Benutzer"
 3. Wählen Sie den Benutzer ``admin``
 4. Setzen Sie ein starkes Passwort
 5. Klicken Sie auf die Schaltfläche „Aktualisieren"
 
+.. note::
+
+   Sobald Sie das Passwort von ``admin`` geändert haben, können Sie es nicht mehr auf einen einfachen Wert wie ``admin`` zurücksetzen (eine Sperrliste für Administratorpasswörter wird über ``password.invalid.admin.passwords`` konfiguriert). Außerdem können Sie das Initialpasswort des Benutzers ``admin`` bereits vor dem ersten Start ändern, indem Sie ``index.user.initial_password`` in ``fess_config.properties`` setzen.
+
 **Empfohlene Passwort-Richtlinie:**
 
-- Mindestens 12 Zeichen
-- Enthält Groß- und Kleinbuchstaben, Zahlen und Sonderzeichen
-- Vermeiden Sie Wörter aus dem Wörterbuch
-- Regelmäßige Änderung (alle 90 Tage empfohlen)
+|Fess| bietet eine integrierte Funktion, die die Mindest- und Höchstlänge des Passworts sowie Anforderungen an die Zeichenarten erzwingt. Konfigurieren Sie die folgenden Eigenschaften in ``fess_config.properties`` (Standardwerte in Klammern):
+
+- ``password.min.length`` (Standard: ``8``): Mindestlänge. 12 oder mehr wird empfohlen.
+- ``password.max.length`` (Standard: ``100``): Höchstlänge.
+- ``password.require.uppercase`` (Standard: ``false``): Großbuchstaben erforderlich.
+- ``password.require.lowercase`` (Standard: ``false``): Kleinbuchstaben erforderlich.
+- ``password.require.digit`` (Standard: ``false``): Ziffern erforderlich.
+- ``password.require.special.char`` (Standard: ``false``): Sonderzeichen erforderlich.
+
+.. note::
+
+   Standardmäßig beträgt die Mindestlänge ``8`` und alle Anforderungen an Zeichenarten sind deaktiviert. Um Passwörter zu stärken, setzen Sie die oben genannten Eigenschaften explizit. Beachten Sie, dass |Fess| keine Funktion zum Ablaufen von Passwörtern (erzwungene regelmäßige Änderung) besitzt. Wenn Sie regelmäßige Passwortänderungen als Betriebsregel durchsetzen möchten, führen Sie diese manuell durch.
 
 Aktivierung des OpenSearch-Sicherheits-Plugins
 -----------------------------------------------
@@ -53,11 +65,16 @@ Aktivierung des OpenSearch-Sicherheits-Plugins
 
 4. Neustart von OpenSearch
 
-5. Aktualisieren Sie die |Fess|-Konfiguration und fügen Sie OpenSearch-Authentifizierungsinformationen hinzu::
+5. Konfigurieren Sie auf Seiten von |Fess| die Verbindung zu OpenSearch.
+
+   Geben Sie die Verbindungs-URL über die Umgebungsvariable ``SEARCH_ENGINE_HTTP_URL`` an (bearbeiten Sie ``bin/fess.in.sh`` oder die Umgebungsdatei des Dienstes; der Standardwert stammt aus ``search_engine.http.url`` in ``fess_config.properties``)::
 
        SEARCH_ENGINE_HTTP_URL=https://opensearch:9200
-       SEARCH_ENGINE_USERNAME=admin
-       SEARCH_ENGINE_PASSWORD=<strong_password>
+
+   Geben Sie die Zugangsdaten über die folgenden Eigenschaften in ``fess_config.properties`` an (es gibt keine Umgebungsvariablen ``SEARCH_ENGINE_USERNAME`` / ``SEARCH_ENGINE_PASSWORD``)::
+
+       search_engine.username=admin
+       search_engine.password=<strong_password>
 
 Details finden Sie unter `OpenSearch Security Plugin <https://opensearch.org/docs/latest/security-plugin/>`__.
 
@@ -147,32 +164,32 @@ Nginx-Zugriffsbeschränkungsbeispiel::
         proxy_set_header Host $host;
     }
 
-Rollenbasierte Zugriffskontrolle (RBAC)
-----------------------------------------
+Rollen und Zugriffskontrolle
+----------------------------
 
-|Fess| unterstützt mehrere Benutzerrollen. Gemäß dem Prinzip der geringsten Rechte sollten Benutzern nur die minimal erforderlichen Rechte gewährt werden.
+|Fess| stellt standardmäßig zwei Rollen bereit:
 
-**Rollentypen:**
+- ``admin``: Administratorrolle, die alle Operationen einschließlich der Verwaltungsseite ausführen kann.
+- ``guest``: Rolle, die nicht angemeldeten (anonymen) Benutzern zugewiesen wird.
 
-- **Administrator**: Alle Rechte
-- **Normaler Benutzer**: Nur Suche
-- **Crawler-Administrator**: Verwaltung von Crawl-Konfigurationen
-- **Suchergebnis-Editor**: Bearbeitung von Suchergebnissen
+Alle anderen Rollen können frei über die Verwaltungsseite erstellt werden. In |Fess| ist eine Rolle ein Tag, das nur einen Namen besitzt, und wird hauptsächlich zur Zugriffskontrolle von Suchergebnissen verwendet (welche Dokumente ein Benutzer einsehen darf). Eine Rolle selbst ist nicht an bestimmte administrative Berechtigungen wie ‚Verwaltung von Crawl-Konfigurationen' oder ‚Bearbeitung von Suchergebnissen' gebunden.
+
+Befolgen Sie das Prinzip der geringsten Rechte: Gewähren Sie die Administratorrolle (``admin``) nur Benutzern, die administrative Aufgaben durchführen, und nicht allgemeinen Suchbenutzern.
 
 **Vorgehensweise:**
 
-1. Klicken Sie in der Verwaltungsseite auf „System" → „Rolle"
-2. Erstellen Sie erforderliche Rollen
-3. Weisen Sie Benutzern unter „System" → „Benutzer" Rollen zu
+1. Klicken Sie in der Verwaltungsseite auf „Benutzer" → „Rolle"
+2. Erstellen Sie die erforderlichen Rollen
+3. Weisen Sie Benutzern unter „Benutzer" → „Benutzer" Rollen zu
 
-Aktivierung von Audit-Protokollen
-----------------------------------
+Audit-Protokollierung
+----------------------
 
-Audit-Protokolle sind standardmäßig aktiviert, um Systemoperationsverläufe aufzuzeichnen.
+Der Systembetriebsverlauf, wie Authentifizierung und administrative Operationen, wird standardmäßig als Audit-Protokoll aufgezeichnet. Das Audit-Protokoll wird vom Logger ``fess.log.audit`` ausgegeben, der in ``log4j2.xml`` definiert ist, und sein Standard-Ausgabeziel ist ``audit.log``.
 
-Aktivieren Sie Audit-Protokolle in der Konfigurationsdatei (``log4j2.xml``)::
+Da dies standardmäßig aktiviert ist, ist keine zusätzliche Konfiguration erforderlich. Um das Ausgabeziel oder die Protokollstufe anzupassen, bearbeiten Sie die folgende Definition in ``log4j2.xml``::
 
-    <Logger name="org.codelibs.fess.audit" level="info" additivity="false">
+    <Logger name="fess.log.audit" additivity="false" level="info">
         <AppenderRef ref="AuditFile"/>
     </Logger>
 
@@ -236,7 +253,7 @@ Konfigurieren Sie bei Bedarf Sicherheits-Header in Nginx oder Apache::
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Strict-Transport-Security "max-age=315.7000; includeSubDomains" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'" always;
 
 Sicherheits-Checkliste
@@ -261,14 +278,14 @@ Netzwerksicherheit
 Zugriffskontrolle
 -----------------
 
-- [ ] Rollenbasierte Zugriffskontrolle konfiguriert
+- [ ] Rollen und Zugriffsberechtigungen angemessen konfiguriert (Administratorrolle nur an notwendige Benutzer vergeben)
 - [ ] Unnötige Benutzerkonten gelöscht
 - [ ] Passwort-Richtlinie konfiguriert
 
 Überwachung und Protokollierung
 --------------------------------
 
-- [ ] Audit-Protokolle aktiviert
+- [ ] Bestätigt, dass die Audit-Protokollierung aktiviert ist
 - [ ] Aufbewahrungsdauer für Protokolle konfiguriert
 - [ ] Log-Überwachungsmechanismus eingerichtet (falls möglich)
 

--- a/en/15.7/install/security.rst
+++ b/en/15.7/install/security.rst
@@ -22,17 +22,29 @@ The default administrator password (``admin`` / ``admin``) must be changed.
 **Procedure:**
 
 1. Log in to the admin screen: http://localhost:8080/admin
-2. Click "System" → "User"
+2. Click "User" → "User"
 3. Select the ``admin`` user
 4. Set a strong password
 5. Click the "Update" button
 
+.. note::
+
+   Once you have changed the password from ``admin``, you cannot set it back to a simple value such as ``admin`` (a blacklist of administrator passwords is configured via ``password.invalid.admin.passwords``). You can also change the initial password of the ``admin`` user before the first startup by setting ``index.user.initial_password`` in ``fess_config.properties``.
+
 **Recommended Password Policy:**
 
-- Minimum 12 characters
-- Include uppercase letters, lowercase letters, numbers, and symbols
-- Avoid dictionary words
-- Change regularly (recommended every 90 days)
+|Fess| provides a built-in feature that enforces the minimum/maximum password length and character-type requirements. Configure the following properties in ``fess_config.properties`` (defaults in parentheses):
+
+- ``password.min.length`` (default: ``8``): Minimum length. 12 or more is recommended.
+- ``password.max.length`` (default: ``100``): Maximum length.
+- ``password.require.uppercase`` (default: ``false``): Require uppercase letters.
+- ``password.require.lowercase`` (default: ``false``): Require lowercase letters.
+- ``password.require.digit`` (default: ``false``): Require digits.
+- ``password.require.special.char`` (default: ``false``): Require symbols.
+
+.. note::
+
+   By default, the minimum length is ``8`` and all character-type requirements are disabled. To strengthen passwords, set the properties above explicitly. Note that |Fess| has no password expiration (forced periodic change) feature; if you want to enforce periodic password changes as an operational rule, do so manually.
 
 Enable OpenSearch Security Plugin
 ----------------------------------
@@ -53,11 +65,16 @@ Enable OpenSearch Security Plugin
 
 4. Restart OpenSearch
 
-5. Update |Fess| configuration to add OpenSearch authentication credentials::
+5. Configure the connection to OpenSearch on the |Fess| side.
+
+   Specify the connection URL with the ``SEARCH_ENGINE_HTTP_URL`` environment variable (edit ``bin/fess.in.sh`` or the service environment file; the default value comes from ``search_engine.http.url`` in ``fess_config.properties``)::
 
        SEARCH_ENGINE_HTTP_URL=https://opensearch:9200
-       SEARCH_ENGINE_USERNAME=admin
-       SEARCH_ENGINE_PASSWORD=<strong_password>
+
+   Specify the credentials with the following properties in ``fess_config.properties`` (there are no ``SEARCH_ENGINE_USERNAME`` / ``SEARCH_ENGINE_PASSWORD`` environment variables)::
+
+       search_engine.username=admin
+       search_engine.password=<strong_password>
 
 For details, refer to the `OpenSearch Security Plugin <https://opensearch.org/docs/latest/security-plugin/>`__.
 
@@ -147,32 +164,32 @@ Nginx access restriction example::
         proxy_set_header Host $host;
     }
 
-Role-Based Access Control (RBAC)
----------------------------------
+Roles and Access Control
+------------------------
 
-|Fess| supports multiple user roles. Following the principle of least privilege, grant users only the minimum necessary permissions.
+|Fess| provides two built-in roles:
 
-**Role Types:**
+- ``admin``: Administrator role that can perform all operations, including the admin screen.
+- ``guest``: Role assigned to unauthenticated (anonymous) users.
 
-- **Administrator**: All permissions
-- **General User**: Search only
-- **Crawler Administrator**: Manage crawl configurations
-- **Search Result Editor**: Edit search results
+Any other roles can be freely created from the admin screen. In |Fess|, a role is a tag that has only a name and is used mainly for access control of search results (which documents a user can view). A role itself is not tied to specific administrative permissions such as "manage crawl configurations" or "edit search results".
+
+Following the principle of least privilege, grant the administrator role (``admin``) only to users who perform administrative tasks, and do not grant it to general search users.
 
 **Procedure:**
 
-1. Click "System" → "Role" in the admin screen
-2. Create necessary roles
-3. Assign roles to users in "System" → "User"
+1. Click "User" → "Role" in the admin screen
+2. Create the necessary roles
+3. Assign roles to users in "User" → "User"
 
-Enable Audit Logging
----------------------
+Audit Logging
+-------------
 
-Audit logging is enabled by default to record system operation history.
+System operation history, such as authentication and administrative operations, is recorded as an audit log by default. The audit log is output by the ``fess.log.audit`` logger defined in ``log4j2.xml``, and its default output destination is ``audit.log``.
 
-Enable audit logging in the configuration file (``log4j2.xml``)::
+Because it is enabled by default, no additional configuration is required. To customize the output destination or log level, edit the following definition in ``log4j2.xml``::
 
-    <Logger name="org.codelibs.fess.audit" level="info" additivity="false">
+    <Logger name="fess.log.audit" additivity="false" level="info">
         <AppenderRef ref="AuditFile"/>
     </Logger>
 
@@ -236,7 +253,7 @@ Configure security headers in Nginx or Apache as needed::
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Strict-Transport-Security "max-age=315.7000; includeSubDomains" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'" always;
 
 Security Checklist
@@ -261,14 +278,14 @@ Network Security
 Access Control
 --------------
 
-- [ ] Role-based access control configured
+- [ ] Configured roles and access permissions appropriately (grant the administrator role only to necessary users)
 - [ ] Unnecessary user accounts removed
 - [ ] Password policy configured
 
 Monitoring and Logging
 ----------------------
 
-- [ ] Audit logging enabled
+- [ ] Confirmed that audit logging is enabled
 - [ ] Log retention period configured
 - [ ] Log monitoring mechanism established (if possible)
 

--- a/es/15.7/install/security.rst
+++ b/es/15.7/install/security.rst
@@ -22,17 +22,27 @@ Asegúrese de cambiar la contraseña de administrador predeterminada (``admin`` 
 **Procedimiento:**
 
 1. Inicie sesión en la pantalla de administración: http://localhost:8080/admin
-2. Haga clic en "Sistema" → "Usuario"
+2. Haga clic en "Usuario" → "Usuario"
 3. Seleccione el usuario ``admin``
 4. Configure una contraseña fuerte
 5. Haga clic en el botón "Actualizar"
 
-**Política de Contraseñas Recomendada:**
+.. note::
 
-- Mínimo de 12 caracteres o más
-- Incluir letras mayúsculas, minúsculas, números y símbolos
-- Evitar palabras del diccionario
-- Cambiar periódicamente (se recomienda cada 90 días)
+   Una vez que haya cambiado la contraseña desde ``admin``, no podrá volver a establecerla en un valor simple como ``admin`` (una lista negra de contraseñas de administrador está configurada mediante ``password.invalid.admin.passwords``). También puede cambiar la contraseña inicial del usuario ``admin`` antes del primer inicio estableciendo ``index.user.initial_password`` en ``fess_config.properties``.
+
+|Fess| ofrece una función integrada que aplica los requisitos de longitud mínima/máxima y de tipos de caracteres de la contraseña. Configure las siguientes propiedades en ``fess_config.properties`` (los valores predeterminados se indican entre paréntesis):
+
+- ``password.min.length`` (valor predeterminado: ``8``): Longitud mínima. Se recomienda 12 o más.
+- ``password.max.length`` (valor predeterminado: ``100``): Longitud máxima.
+- ``password.require.uppercase`` (valor predeterminado: ``false``): Requerir letras mayúsculas.
+- ``password.require.lowercase`` (valor predeterminado: ``false``): Requerir letras minúsculas.
+- ``password.require.digit`` (valor predeterminado: ``false``): Requerir dígitos.
+- ``password.require.special.char`` (valor predeterminado: ``false``): Requerir símbolos.
+
+.. note::
+
+   De forma predeterminada, la longitud mínima es ``8`` y todos los requisitos de tipo de carácter están deshabilitados. Para reforzar las contraseñas, configure explícitamente las propiedades anteriores. Tenga en cuenta que |Fess| no cuenta con una función de expiración de contraseñas (cambio periódico forzado); si desea aplicar cambios periódicos de contraseña como regla operativa, hágalo manualmente.
 
 Habilitación del Plugin de Seguridad de OpenSearch
 ---------------------------------------------------
@@ -53,11 +63,16 @@ Habilitación del Plugin de Seguridad de OpenSearch
 
 4. Reinicie OpenSearch
 
-5. Actualice la configuración de |Fess| para agregar credenciales de autenticación de OpenSearch::
+5. Configure la conexión con OpenSearch en el lado de |Fess|.
+
+   Especifique la URL de conexión mediante la variable de entorno ``SEARCH_ENGINE_HTTP_URL`` (edite ``bin/fess.in.sh`` o el archivo de entorno del servicio; el valor predeterminado proviene de ``search_engine.http.url`` en ``fess_config.properties``)::
 
        SEARCH_ENGINE_HTTP_URL=https://opensearch:9200
-       SEARCH_ENGINE_USERNAME=admin
-       SEARCH_ENGINE_PASSWORD=<strong_password>
+
+   Especifique las credenciales mediante las siguientes propiedades en ``fess_config.properties`` (no existen las variables de entorno ``SEARCH_ENGINE_USERNAME`` / ``SEARCH_ENGINE_PASSWORD``)::
+
+       search_engine.username=admin
+       search_engine.password=<strong_password>
 
 Para más detalles, consulte `OpenSearch Security Plugin <https://opensearch.org/docs/latest/security-plugin/>`__.
 
@@ -147,32 +162,32 @@ Ejemplo de restricción de acceso con Nginx::
         proxy_set_header Host $host;
     }
 
-Control de Acceso Basado en Roles (RBAC)
------------------------------------------
+Roles y Control de Acceso
+--------------------------
 
-|Fess| admite múltiples roles de usuario. Siga el principio de mínimo privilegio otorgando a los usuarios solo los privilegios mínimos necesarios.
+|Fess| proporciona dos roles integrados:
 
-**Tipos de Roles:**
+- ``admin``: Rol de administrador que puede realizar todas las operaciones, incluida la pantalla de administración.
+- ``guest``: Rol asignado a los usuarios no autenticados (anónimos).
 
-- **Administrador**: Todos los privilegios
-- **Usuario General**: Solo búsqueda
-- **Administrador de Rastreador**: Gestión de configuración de rastreo
-- **Editor de Resultados de Búsqueda**: Edición de resultados de búsqueda
+Cualquier otro rol se puede crear libremente desde la pantalla de administración. En |Fess|, un rol es una etiqueta que solo tiene un nombre y se utiliza principalmente para el control de acceso a los resultados de búsqueda (qué documentos puede ver un usuario). Un rol en sí no está vinculado a permisos administrativos concretos, como "gestionar configuraciones de rastreo" o "editar resultados de búsqueda".
+
+Siguiendo el principio de mínimo privilegio, otorgue el rol de administrador (``admin``) únicamente a los usuarios que realizan tareas administrativas y no lo otorgue a los usuarios de búsqueda en general.
 
 **Procedimiento:**
 
-1. Haga clic en "Sistema" → "Rol" en la pantalla de administración
+1. Haga clic en "Usuario" → "Rol" en la pantalla de administración
 2. Cree los roles necesarios
-3. Asigne roles a usuarios en "Sistema" → "Usuario"
+3. Asigne roles a usuarios en "Usuario" → "Usuario"
 
-Habilitación de Registros de Auditoría
----------------------------------------
+Registro de Auditoría
+----------------------
 
-Los registros de auditoría están habilitados por defecto para registrar el historial de operaciones del sistema.
+El historial de operaciones del sistema, como la autenticación y las operaciones administrativas, se registra de forma predeterminada como registro de auditoría. El registro de auditoría se genera mediante el logger ``fess.log.audit`` definido en ``log4j2.xml``, y su destino de salida predeterminado es ``audit.log``.
 
-Habilite el registro de auditoría en el archivo de configuración (``log4j2.xml``)::
+Dado que está habilitado de forma predeterminada, no se requiere configuración adicional. Para personalizar el destino de salida o el nivel de registro, edite la siguiente definición en ``log4j2.xml``::
 
-    <Logger name="org.codelibs.fess.audit" level="info" additivity="false">
+    <Logger name="fess.log.audit" additivity="false" level="info">
         <AppenderRef ref="AuditFile"/>
     </Logger>
 
@@ -236,7 +251,7 @@ Según sea necesario, configure encabezados de seguridad en Nginx o Apache::
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Strict-Transport-Security "max-age=315.7000; includeSubDomains" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'" always;
 
 Lista de Verificación de Seguridad
@@ -261,14 +276,14 @@ Seguridad de Red
 Control de Acceso
 -----------------
 
-- [ ] Control de acceso basado en roles configurado
+- [ ] Roles y permisos de acceso configurados adecuadamente (otorgar el rol de administrador solo a los usuarios necesarios)
 - [ ] Cuentas de usuario innecesarias eliminadas
 - [ ] Política de contraseñas configurada
 
 Monitoreo y Registros
 ----------------------
 
-- [ ] Registros de auditoría habilitados
+- [ ] Se ha confirmado que el registro de auditoría está habilitado
 - [ ] Período de retención de registros configurado
 - [ ] Sistema de monitoreo de registros implementado (si es posible)
 

--- a/fr/15.7/install/security.rst
+++ b/fr/15.7/install/security.rst
@@ -22,17 +22,29 @@ Veuillez obligatoirement modifier le mot de passe administrateur par défaut (``
 **Procédure :**
 
 1. Connexion à l'écran d'administration : http://localhost:8080/admin
-2. Cliquez sur « Système » → « Utilisateur »
+2. Cliquez sur « Utilisateur » → « Utilisateur »
 3. Sélectionnez l'utilisateur ``admin``
 4. Définissez un mot de passe fort
 5. Cliquez sur le bouton « Mettre à jour »
 
+.. note::
+
+   Une fois le mot de passe modifié à partir de ``admin``, il n'est plus possible de le redéfinir avec une valeur aussi simple que ``admin`` (une liste noire de mots de passe administrateur est configurée via ``password.invalid.admin.passwords``). Vous pouvez également modifier le mot de passe initial de l'utilisateur ``admin`` avant le premier démarrage en définissant ``index.user.initial_password`` dans ``fess_config.properties``.
+
 **Politique de mot de passe recommandée :**
 
-- Minimum 12 caractères
-- Inclure des majuscules, des minuscules, des chiffres et des symboles
-- Éviter les mots du dictionnaire
-- Modifier régulièrement (tous les 90 jours recommandés)
+|Fess| dispose d'une fonctionnalité intégrée qui impose des exigences de longueur minimale/maximale et de types de caractères pour le mot de passe. Configurez les propriétés suivantes dans ``fess_config.properties`` (les valeurs par défaut sont indiquées entre parenthèses) :
+
+- ``password.min.length`` (par défaut : ``8``) : Longueur minimale. Une valeur de 12 caractères ou plus est recommandée.
+- ``password.max.length`` (par défaut : ``100``) : Longueur maximale.
+- ``password.require.uppercase`` (par défaut : ``false``) : Exiger des lettres majuscules.
+- ``password.require.lowercase`` (par défaut : ``false``) : Exiger des lettres minuscules.
+- ``password.require.digit`` (par défaut : ``false``) : Exiger des chiffres.
+- ``password.require.special.char`` (par défaut : ``false``) : Exiger des symboles.
+
+.. note::
+
+   Par défaut, la longueur minimale est de ``8`` caractères et toutes les exigences de type de caractères sont désactivées. Pour renforcer la sécurité des mots de passe, définissez explicitement les propriétés ci-dessus. Notez que |Fess| ne dispose pas de fonctionnalité d'expiration des mots de passe (changement périodique forcé) ; si vous souhaitez imposer un changement périodique du mot de passe comme règle opérationnelle, faites-le manuellement.
 
 Activation du plugin de sécurité OpenSearch
 --------------------------------------------
@@ -53,11 +65,16 @@ Activation du plugin de sécurité OpenSearch
 
 4. Redémarrage d'OpenSearch
 
-5. Mise à jour de la configuration de |Fess| pour ajouter les informations d'authentification OpenSearch ::
+5. Configurez la connexion à OpenSearch du côté |Fess|.
+
+   Spécifiez l'URL de connexion via la variable d'environnement ``SEARCH_ENGINE_HTTP_URL`` (modifiez ``bin/fess.in.sh`` ou le fichier d'environnement du service ; la valeur par défaut provient de ``search_engine.http.url`` dans ``fess_config.properties``) ::
 
        SEARCH_ENGINE_HTTP_URL=https://opensearch:9200
-       SEARCH_ENGINE_USERNAME=admin
-       SEARCH_ENGINE_PASSWORD=<mot_de_passe_fort>
+
+   Spécifiez les informations d'authentification via les propriétés suivantes dans ``fess_config.properties`` (il n'existe pas de variables d'environnement ``SEARCH_ENGINE_USERNAME`` / ``SEARCH_ENGINE_PASSWORD``) ::
+
+       search_engine.username=admin
+       search_engine.password=<mot_de_passe_fort>
 
 Pour plus de détails, consultez `OpenSearch Security Plugin <https://opensearch.org/docs/latest/security-plugin/>`__.
 
@@ -147,32 +164,32 @@ Exemple de restriction d'accès avec Nginx ::
         proxy_set_header Host $host;
     }
 
-Contrôle d'accès basé sur les rôles (RBAC)
--------------------------------------------
+Rôles et contrôle d'accès
+--------------------------
 
-|Fess| prend en charge plusieurs rôles d'utilisateur. Conformément au principe du moindre privilège, accordez uniquement les privilèges minimums nécessaires aux utilisateurs.
+|Fess| fournit deux rôles intégrés :
 
-**Types de rôles :**
+- ``admin`` : Rôle administrateur pouvant effectuer toutes les opérations, y compris sur l'écran d'administration.
+- ``guest`` : Rôle attribué aux utilisateurs non authentifiés (anonymes).
 
-- **Administrateur** : Tous les privilèges
-- **Utilisateur général** : Recherche uniquement
-- **Administrateur explorateur** : Gestion de la configuration d'exploration
-- **Éditeur de résultats de recherche** : Modification des résultats de recherche
+Tous les autres rôles peuvent être librement créés depuis l'écran d'administration. Dans |Fess|, un rôle est une étiquette ne comportant qu'un nom, principalement utilisée pour le contrôle d'accès aux résultats de recherche (quels documents un utilisateur peut consulter). Un rôle en lui-même n'est pas lié à des permissions administratives spécifiques telles que « gérer les configurations d'exploration » ou « modifier les résultats de recherche ».
+
+Conformément au principe du moindre privilège, accordez le rôle administrateur (``admin``) uniquement aux utilisateurs effectuant des tâches d'administration, et ne l'accordez pas aux utilisateurs de recherche généraux.
 
 **Procédure :**
 
-1. Cliquez sur « Système » → « Rôle » dans l'écran d'administration
+1. Cliquez sur « Utilisateur » → « Rôle » dans l'écran d'administration
 2. Créez les rôles nécessaires
-3. Attribuez des rôles aux utilisateurs dans « Système » → « Utilisateur »
+3. Attribuez des rôles aux utilisateurs dans « Utilisateur » → « Utilisateur »
 
-Activation des journaux d'audit
---------------------------------
+Journalisation d'audit
+------------------------
 
-Les journaux d'audit sont activés par défaut pour enregistrer l'historique des opérations du système.
+L'historique des opérations du système, telles que l'authentification et les opérations d'administration, est enregistré par défaut sous forme de journal d'audit. Le journal d'audit est généré par le logger ``fess.log.audit`` défini dans ``log4j2.xml``, et sa destination de sortie par défaut est ``audit.log``.
 
-Activation des journaux d'audit dans le fichier de configuration (``log4j2.xml``) ::
+Étant activé par défaut, aucune configuration supplémentaire n'est nécessaire. Pour personnaliser la destination de sortie ou le niveau de journalisation, modifiez la définition suivante dans ``log4j2.xml`` ::
 
-    <Logger name="org.codelibs.fess.audit" level="info" additivity="false">
+    <Logger name="fess.log.audit" additivity="false" level="info">
         <AppenderRef ref="AuditFile"/>
     </Logger>
 
@@ -236,7 +253,7 @@ Si nécessaire, configurez les en-têtes de sécurité dans Nginx ou Apache ::
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Strict-Transport-Security "max-age=315.7000; includeSubDomains" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'" always;
 
 Liste de vérification de sécurité
@@ -261,14 +278,14 @@ Sécurité réseau
 Contrôle d'accès
 ----------------
 
-- [ ] Contrôle d'accès basé sur les rôles configuré
+- [ ] Rôles et permissions d'accès configurés de manière appropriée (rôle administrateur accordé uniquement aux utilisateurs nécessaires)
 - [ ] Comptes utilisateurs inutiles supprimés
 - [ ] Politique de mot de passe configurée
 
 Surveillance et journalisation
 -------------------------------
 
-- [ ] Journaux d'audit activés
+- [ ] Vérifié que les journaux d'audit sont activés
 - [ ] Période de conservation des journaux configurée
 - [ ] Mécanisme de surveillance des journaux établi (si possible)
 

--- a/ja/15.7/install/security.rst
+++ b/ja/15.7/install/security.rst
@@ -22,17 +22,29 @@
 **手順:**
 
 1. 管理画面にログイン: http://localhost:8080/admin
-2. 「システム」→「ユーザー」をクリック
+2. 「ユーザー」→「ユーザー」をクリック
 3. ``admin`` ユーザーを選択
 4. 強力なパスワードを設定
 5. 「更新」ボタンをクリック
 
+.. note::
+
+   一度 ``admin`` から変更したパスワードは、``admin`` のような単純な文字列には戻せません（``password.invalid.admin.passwords`` により管理者パスワードのブラックリストが設定されています）。また、初回起動前であれば ``fess_config.properties`` の ``index.user.initial_password`` で ``admin`` ユーザーの初期パスワードを変更できます。
+
 **推奨パスワードポリシー:**
 
-- 最低 12 文字以上
-- 英大文字、英小文字、数字、記号を含む
-- 辞書にある単語を避ける
-- 定期的に変更する（90日ごとを推奨）
+|Fess| はパスワードの最小・最大文字数と文字種の要件を強制する機能を備えています。``fess_config.properties`` で以下のプロパティを設定してください（括弧内は既定値）。
+
+- ``password.min.length`` （既定値: ``8``）: 最小文字数。12 以上を推奨します。
+- ``password.max.length`` （既定値: ``100``）: 最大文字数。
+- ``password.require.uppercase`` （既定値: ``false``）: 英大文字を必須にする。
+- ``password.require.lowercase`` （既定値: ``false``）: 英小文字を必須にする。
+- ``password.require.digit`` （既定値: ``false``）: 数字を必須にする。
+- ``password.require.special.char`` （既定値: ``false``）: 記号を必須にする。
+
+.. note::
+
+   既定では最小文字数は ``8`` で、文字種の要件はすべて無効です。パスワード強度を高めるには、上記のプロパティを明示的に設定してください。なお、|Fess| にはパスワードの有効期限（定期変更の強制）機能はありません。定期的なパスワード変更を運用ルールとする場合は、手動で対応してください。
 
 OpenSearch のセキュリティプラグイン有効化
 --------------------------------------
@@ -53,11 +65,16 @@ OpenSearch のセキュリティプラグイン有効化
 
 4. OpenSearch を再起動
 
-5. |Fess| の設定を更新して、OpenSearch の認証情報を追加::
+5. |Fess| 側で OpenSearch への接続情報を設定します。
+
+   接続先 URL は環境変数 ``SEARCH_ENGINE_HTTP_URL`` で指定します（``bin/fess.in.sh`` またはサービスの環境設定ファイルを編集します。既定値は ``fess_config.properties`` の ``search_engine.http.url``）::
 
        SEARCH_ENGINE_HTTP_URL=https://opensearch:9200
-       SEARCH_ENGINE_USERNAME=admin
-       SEARCH_ENGINE_PASSWORD=<strong_password>
+
+   認証情報は ``fess_config.properties`` の以下のプロパティで指定します（``SEARCH_ENGINE_USERNAME`` / ``SEARCH_ENGINE_PASSWORD`` という環境変数は存在しません）::
+
+       search_engine.username=admin
+       search_engine.password=<strong_password>
 
 詳細は `OpenSearch Security Plugin <https://opensearch.org/docs/latest/security-plugin/>`__ を参照してください。
 
@@ -147,32 +164,32 @@ Nginx でのアクセス制限例::
         proxy_set_header Host $host;
     }
 
-ロールベースアクセス制御 (RBAC)
------------------------------
+ロールとアクセス制御
+------------------
 
-|Fess| は複数のユーザーロールをサポートしています。最小権限の原則に従って、ユーザーに必要最小限の権限のみを付与してください。
+|Fess| には、あらかじめ 2 つのロールが用意されています。
 
-**ロールの種類:**
+- ``admin``: 管理画面を含むすべての操作が可能な管理者ロール
+- ``guest``: 未ログイン（匿名）ユーザーに割り当てられるロール
 
-- **管理者**: すべての権限
-- **一般ユーザー**: 検索のみ
-- **クローラー管理者**: クロール設定の管理
-- **検索結果編集者**: 検索結果の編集
+これら以外のロールは、管理画面から自由に作成できます。|Fess| のロールは名前のみを持つタグであり、主に検索結果へのアクセス制御（どのドキュメントを表示できるか）に使用されます。ロール自体に「クロール設定の管理」「検索結果の編集」といった個別の管理権限が紐づくわけではありません。
+
+最小権限の原則に従い、管理者ロール（``admin``）は管理業務を行うユーザーにのみ付与し、一般の検索ユーザーには付与しないでください。
 
 **手順:**
 
-1. 管理画面で「システム」→「ロール」をクリック
+1. 管理画面で「ユーザー」→「ロール」をクリック
 2. 必要なロールを作成
-3. 「システム」→「ユーザー」でユーザーにロールを割り当て
+3. 「ユーザー」→「ユーザー」でユーザーにロールを割り当て
 
-監査ログの有効化
---------------
+監査ログ
+------
 
-システムの操作履歴を記録するために、監査ログがデフォルトで有効になっています。
+認証や管理操作などのシステムの操作履歴は、監査ログとしてデフォルトで記録されます。監査ログは ``log4j2.xml`` に定義された ``fess.log.audit`` ロガーによって出力され、既定の出力先は ``audit.log`` です。
 
-設定ファイル（``log4j2.xml``）で監査ログを有効化::
+デフォルトで有効になっているため、追加の設定は不要です。出力先やログレベルをカスタマイズする場合は、``log4j2.xml`` の以下の定義を編集してください::
 
-    <Logger name="org.codelibs.fess.audit" level="info" additivity="false">
+    <Logger name="fess.log.audit" additivity="false" level="info">
         <AppenderRef ref="AuditFile"/>
     </Logger>
 
@@ -236,7 +253,7 @@ Nginx でのアクセス制限例::
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Strict-Transport-Security "max-age=315.7000; includeSubDomains" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'" always;
 
 セキュリティチェックリスト
@@ -261,14 +278,14 @@ Nginx でのアクセス制限例::
 アクセス制御
 ----------
 
-- [ ] ロールベースアクセス制御を設定済み
+- [ ] ロールとアクセス権限を適切に設定済み（管理者ロールを必要なユーザーのみに付与）
 - [ ] 不要なユーザーアカウントを削除済み
 - [ ] パスワードポリシーを設定済み
 
 監視とログ
 --------
 
-- [ ] 監査ログを有効化済み
+- [ ] 監査ログが有効になっていることを確認済み
 - [ ] ログの保存期間を設定済み
 - [ ] ログ監視の仕組みを構築済み（可能な場合）
 

--- a/ko/15.7/install/security.rst
+++ b/ko/15.7/install/security.rst
@@ -22,17 +22,29 @@
 **절차:**
 
 1. 관리 화면에 로그인: http://localhost:8080/admin
-2. "시스템"→"사용자" 클릭
+2. "사용자"→"사용자" 클릭
 3. ``admin`` 사용자 선택
 4. 강력한 비밀번호 설정
 5. "업데이트" 버튼 클릭
 
+.. note::
+
+   한 번 ``admin`` 에서 변경한 비밀번호는 ``admin`` 과 같은 단순한 문자열로는 다시 설정할 수 없습니다(``password.invalid.admin.passwords`` 에 의해 관리자 비밀번호의 블랙리스트가 설정되어 있습니다). 또한 최초 시작 전이라면 ``fess_config.properties`` 의 ``index.user.initial_password`` 로 ``admin`` 사용자의 초기 비밀번호를 변경할 수 있습니다.
+
 **권장 비밀번호 정책:**
 
-- 최소 12자 이상
-- 영문 대문자, 영문 소문자, 숫자, 기호 포함
-- 사전에 있는 단어 회피
-- 정기적으로 변경(90일마다 권장)
+|Fess| 는 비밀번호의 최소·최대 문자 수와 문자 종류 요건을 강제하는 기능을 제공합니다. ``fess_config.properties`` 에서 다음 속성을 설정하십시오(괄호 안은 기본값입니다).
+
+- ``password.min.length`` (기본값: ``8``): 최소 문자 수. 12자 이상을 권장합니다.
+- ``password.max.length`` (기본값: ``100``): 최대 문자 수.
+- ``password.require.uppercase`` (기본값: ``false``): 영문 대문자를 필수로 설정합니다.
+- ``password.require.lowercase`` (기본값: ``false``): 영문 소문자를 필수로 설정합니다.
+- ``password.require.digit`` (기본값: ``false``): 숫자를 필수로 설정합니다.
+- ``password.require.special.char`` (기본값: ``false``): 기호를 필수로 설정합니다.
+
+.. note::
+
+   기본값에서는 최소 문자 수가 ``8`` 이며 문자 종류 요건은 모두 비활성화되어 있습니다. 비밀번호 강도를 높이려면 위의 속성을 명시적으로 설정하십시오. 또한 |Fess| 에는 비밀번호 유효기간(정기 변경 강제) 기능이 없습니다. 정기적인 비밀번호 변경을 운영 규칙으로 정하고자 하는 경우에는 수동으로 대응하십시오.
 
 OpenSearch 보안 플러그인 활성화
 --------------------------------------
@@ -53,11 +65,16 @@ OpenSearch 보안 플러그인 활성화
 
 4. OpenSearch 재시작
 
-5. |Fess| 설정을 업데이트하여 OpenSearch 인증 정보 추가::
+5. |Fess| 측에서 OpenSearch로의 연결 정보를 설정합니다.
+
+   연결 URL은 환경 변수 ``SEARCH_ENGINE_HTTP_URL`` 로 지정합니다(``bin/fess.in.sh`` 또는 서비스의 환경 설정 파일을 편집합니다. 기본값은 ``fess_config.properties`` 의 ``search_engine.http.url`` 입니다)::
 
        SEARCH_ENGINE_HTTP_URL=https://opensearch:9200
-       SEARCH_ENGINE_USERNAME=admin
-       SEARCH_ENGINE_PASSWORD=<strong_password>
+
+   인증 정보는 ``fess_config.properties`` 의 다음 속성으로 지정합니다(``SEARCH_ENGINE_USERNAME`` / ``SEARCH_ENGINE_PASSWORD`` 라는 환경 변수는 존재하지 않습니다)::
+
+       search_engine.username=admin
+       search_engine.password=<strong_password>
 
 자세한 내용은 `OpenSearch Security Plugin <https://opensearch.org/docs/latest/security-plugin/>`__ 을 참조하십시오.
 
@@ -147,32 +164,32 @@ Nginx에서 액세스 제한 예::
         proxy_set_header Host $host;
     }
 
-역할 기반 액세스 제어 (RBAC)
------------------------------
+역할과 액세스 제어
+--------------------
 
-|Fess| 는 여러 사용자 역할을 지원합니다. 최소 권한 원칙에 따라 사용자에게 필요 최소한의 권한만 부여하십시오.
+|Fess| 에는 미리 2개의 역할이 준비되어 있습니다.
 
-**역할 유형:**
+- ``admin``: 관리 화면을 포함한 모든 작업이 가능한 관리자 역할
+- ``guest``: 로그인하지 않은(익명) 사용자에게 할당되는 역할
 
-- **관리자**: 모든 권한
-- **일반 사용자**: 검색만
-- **크롤러 관리자**: 크롤 설정 관리
-- **검색 결과 편집자**: 검색 결과 편집
+이 외의 역할은 관리 화면에서 자유롭게 생성할 수 있습니다. |Fess| 의 역할은 이름만을 가진 태그이며, 주로 검색 결과에 대한 액세스 제어(어떤 문서를 표시할 수 있는지)에 사용됩니다. 역할 자체에 "크롤 설정 관리", "검색 결과 편집"과 같은 개별 관리 권한이 연결되어 있는 것은 아닙니다.
+
+최소 권한 원칙에 따라 관리자 역할(``admin``)은 관리 업무를 수행하는 사용자에게만 부여하고, 일반 검색 사용자에게는 부여하지 마십시오.
 
 **절차:**
 
-1. 관리 화면에서 "시스템"→"역할" 클릭
+1. 관리 화면에서 "사용자"→"역할" 클릭
 2. 필요한 역할 생성
-3. "시스템"→"사용자"에서 사용자에게 역할 할당
+3. "사용자"→"사용자"에서 사용자에게 역할 할당
 
-감사 로그 활성화
---------------
+감사 로그
+------------
 
-시스템 작업 이력을 기록하기 위해 감사 로그가 기본적으로 활성화되어 있습니다.
+인증이나 관리 작업 등 시스템의 작업 이력은 기본적으로 감사 로그로 기록됩니다. 감사 로그는 ``log4j2.xml`` 에 정의된 ``fess.log.audit`` 로거에 의해 출력되며, 기본 출력 대상은 ``audit.log`` 입니다.
 
-설정 파일(``log4j2.xml``)에서 감사 로그 활성화::
+기본적으로 활성화되어 있으므로 추가 설정은 필요하지 않습니다. 출력 대상이나 로그 레벨을 커스터마이즈하려면 ``log4j2.xml`` 의 다음 정의를 편집하십시오::
 
-    <Logger name="org.codelibs.fess.audit" level="info" additivity="false">
+    <Logger name="fess.log.audit" additivity="false" level="info">
         <AppenderRef ref="AuditFile"/>
     </Logger>
 
@@ -236,7 +253,7 @@ Nginx에서 액세스 제한 예::
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Strict-Transport-Security "max-age=315.7000; includeSubDomains" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'" always;
 
 보안 체크리스트
@@ -261,14 +278,14 @@ Nginx에서 액세스 제한 예::
 액세스 제어
 ----------
 
-- [ ] 역할 기반 액세스 제어 설정 완료
+- [ ] 역할과 액세스 권한을 적절히 설정 완료(관리자 역할을 필요한 사용자에게만 부여)
 - [ ] 불필요한 사용자 계정 삭제 완료
 - [ ] 비밀번호 정책 설정 완료
 
 모니터링 및 로그
 --------
 
-- [ ] 감사 로그 활성화 완료
+- [ ] 감사 로그가 활성화되어 있음을 확인 완료
 - [ ] 로그 보존 기간 설정 완료
 - [ ] 로그 모니터링 체계 구축 완료(가능한 경우)
 

--- a/zh-cn/15.7/install/security.rst
+++ b/zh-cn/15.7/install/security.rst
@@ -22,17 +22,29 @@
 **步骤:**
 
 1. 登录管理页面: http://localhost:8080/admin
-2. 点击「系统」→「用户」
+2. 点击「用户」→「用户」
 3. 选择 ``admin`` 用户
 4. 设置强密码
 5. 点击「更新」按钮
 
+.. note::
+
+   一旦将密码从 ``admin`` 更改后，就不能再设置回 ``admin`` 这样的简单字符串（``password.invalid.admin.passwords`` 中配置了管理员密码黑名单）。此外，在首次启动前，可以通过在 ``fess_config.properties`` 中设置 ``index.user.initial_password`` 来更改 ``admin`` 用户的初始密码。
+
 **推荐密码策略:**
 
-- 至少 12 个字符
-- 包含大写字母、小写字母、数字、符号
-- 避免使用字典中的单词
-- 定期更改（建议每 90 天）
+|Fess| 具备强制密码最小/最大长度及字符类型要求的内置功能。请在 ``fess_config.properties`` 中设置以下属性（括号内为默认值）。
+
+- ``password.min.length`` （默认值: ``8``）：最小长度。建议设置为 12 以上。
+- ``password.max.length`` （默认值: ``100``）：最大长度。
+- ``password.require.uppercase`` （默认值: ``false``）：要求包含大写字母。
+- ``password.require.lowercase`` （默认值: ``false``）：要求包含小写字母。
+- ``password.require.digit`` （默认值: ``false``）：要求包含数字。
+- ``password.require.special.char`` （默认值: ``false``）：要求包含符号。
+
+.. note::
+
+   默认情况下，最小长度为 ``8``，且所有字符类型要求均处于禁用状态。若要增强密码强度，请显式设置上述属性。另外，|Fess| 没有密码过期（强制定期更改）功能。如果希望将定期更改密码作为运维规则强制执行，请手动进行。
 
 启用 OpenSearch 安全插件
 --------------------------------------
@@ -53,11 +65,16 @@
 
 4. 重启 OpenSearch
 
-5. 更新 |Fess| 的配置，添加 OpenSearch 的认证信息::
+5. 在 |Fess| 一侧配置连接到 OpenSearch 的信息。
+
+   请通过环境变量 ``SEARCH_ENGINE_HTTP_URL`` 指定连接 URL（可编辑 ``bin/fess.in.sh`` 或服务的环境配置文件；默认值来自 ``fess_config.properties`` 中的 ``search_engine.http.url``）::
 
        SEARCH_ENGINE_HTTP_URL=https://opensearch:9200
-       SEARCH_ENGINE_USERNAME=admin
-       SEARCH_ENGINE_PASSWORD=<strong_password>
+
+   请通过 ``fess_config.properties`` 中的以下属性指定认证信息（不存在 ``SEARCH_ENGINE_USERNAME`` / ``SEARCH_ENGINE_PASSWORD`` 这样的环境变量）::
+
+       search_engine.username=admin
+       search_engine.password=<strong_password>
 
 详情请参阅 `OpenSearch Security Plugin <https://opensearch.org/docs/latest/security-plugin/>`__。
 
@@ -147,32 +164,32 @@ Nginx 访问限制示例::
         proxy_set_header Host $host;
     }
 
-基于角色的访问控制 (RBAC)
------------------------------
+角色与访问控制
+--------------------
 
-|Fess| 支持多个用户角色。遵循最小权限原则，仅授予用户必要的最小权限。
+|Fess| 预置了两个角色。
 
-**角色类型:**
+- ``admin``: 可执行包括管理页面在内的所有操作的管理员角色
+- ``guest``: 分配给未登录（匿名）用户的角色
 
-- **管理员**: 所有权限
-- **普通用户**: 仅限搜索
-- **爬虫管理员**: 爬取配置管理
-- **搜索结果编辑者**: 搜索结果编辑
+除此之外的角色可以在管理页面中自由创建。|Fess| 中的角色只是一个仅有名称的标签，主要用于搜索结果的访问控制（决定用户可以查看哪些文档）。角色本身并不与「管理爬取配置」「编辑搜索结果」等具体的管理权限绑定。
+
+遵循最小权限原则，管理员角色（``admin``）仅应授予执行管理业务的用户，不要授予普通搜索用户。
 
 **步骤:**
 
-1. 在管理页面点击「系统」→「角色」
+1. 在管理页面点击「用户」→「角色」
 2. 创建必要的角色
-3. 在「系统」→「用户」中为用户分配角色
+3. 在「用户」→「用户」中为用户分配角色
 
-启用审计日志
---------------
+审计日志
+--------
 
-为了记录系统操作历史，审计日志默认启用。
+认证、管理操作等系统操作历史，默认会作为审计日志被记录。审计日志由 ``log4j2.xml`` 中定义的 ``fess.log.audit`` 记录器输出，默认输出目标为 ``audit.log``。
 
-在配置文件（``log4j2.xml``）中启用审计日志::
+由于默认已启用，无需额外配置。如需自定义输出目标或日志级别，请编辑 ``log4j2.xml`` 中的以下定义::
 
-    <Logger name="org.codelibs.fess.audit" level="info" additivity="false">
+    <Logger name="fess.log.audit" additivity="false" level="info">
         <AppenderRef ref="AuditFile"/>
     </Logger>
 
@@ -236,7 +253,7 @@ Nginx 访问限制示例::
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Strict-Transport-Security "max-age=315.7000; includeSubDomains" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'" always;
 
 安全检查清单
@@ -261,14 +278,14 @@ Nginx 访问限制示例::
 访问控制
 ----------
 
-- [ ] 已配置基于角色的访问控制
+- [ ] 已适当配置角色和访问权限（仅将管理员角色授予必要的用户）
 - [ ] 已删除不必要的用户账号
 - [ ] 已配置密码策略
 
 监控和日志
 --------
 
-- [ ] 已启用审计日志
+- [ ] 已确认审计日志已启用
 - [ ] 已配置日志保存期限
 - [ ] 已构建日志监控机制（如可能）
 


### PR DESCRIPTION
## Summary

Reviewed `install/security.rst` (15.7) against the current Fess implementation and corrected several inaccuracies, then applied the same corrections consistently across all seven languages (ja, en, de, fr, es, ko, zh-cn).

## Corrections

- **Admin UI navigation** — User and Role management live under the top-level **User** menu, not **System**. Fixed the menu paths in the password-change and role sections.
- **Roles** — Replaced the fabricated role list (e.g. "Crawler Administrator", "Search Result Editor") with the two actual built-in roles, `admin` and `guest`, and clarified that a role is a name-only tag used mainly for search-result access control rather than an admin-permission bundle.
- **Password policy** — Replaced generic advice with the actual configurable properties (`password.min.length`, `password.max.length`, `password.require.uppercase` / `lowercase` / `digit` / `special.char`) and their defaults, added a note about the admin-password blacklist and `index.user.initial_password`, and clarified that Fess has no password-expiration (forced periodic change) feature.
- **OpenSearch credentials** — `SEARCH_ENGINE_USERNAME` / `SEARCH_ENGINE_PASSWORD` environment variables do not exist. Credentials are configured via `search_engine.username` / `search_engine.password` in `fess_config.properties`; the endpoint URL uses the `SEARCH_ENGINE_HTTP_URL` environment variable.
- **Audit log** — Corrected the logger name from `org.codelibs.fess.audit` to `fess.log.audit`, and clarified that audit logging is enabled by default (output to `audit.log`). The `log4j2.xml` snippet is now presented as a reference for customization rather than as a step required to "enable" it.
- **HSTS header** — Fixed the corrupted `max-age=315.7000` value back to `max-age=31536000` (1 year).

## Verification

- Property names, logger name, and file paths verified against the Fess source (`fess_config.properties`, `log4j2.xml`, `bin/fess.in.sh`, `FessBoot.java`, the admin UI sidebar, and the i18n label files).
- RST validated with docutils; no new warnings introduced.