### PR TITLE
docs(seo): strengthen English AI/enterprise-search framing and internal linking

### DIFF
--- a/en/15.7/config/crawler-basic.rst
+++ b/en/15.7/config/crawler-basic.rst
@@ -1,12 +1,14 @@
-=========================
-Basic Crawler Configuration
-=========================
+==================================================================
+Crawler Configuration: Web, File Server, and Database Crawling
+==================================================================
 
 Overview
 ========
 
-The |Fess| crawler is a feature that automatically collects content from websites, file systems, and other sources and registers it in the search index.
+The |Fess| crawler automatically collects content from **websites (web crawling)**, **file servers and shared folders (file crawling over SMB/FTP)**, and **databases and other data sources (database crawling via data store connectors)**, then registers it in the search index.
 This guide explains the basic concepts and configuration methods for the crawler.
+
+For database and other data-source crawling, see :doc:`datastore/ds-database` and :doc:`datastore/ds-overview`. To improve relevance across crawled content with hybrid (keyword + semantic) search, see :doc:`rank-fusion`.
 
 Basic Crawler Concepts
 =======================
@@ -722,3 +724,6 @@ References
 - :doc:`crawler-thumbnail` - Thumbnail Configuration
 - :doc:`setup-memory` - Memory Configuration
 - :doc:`admin-logging` - Log Configuration
+- :doc:`datastore/ds-overview` - Data Store Crawling Overview (databases and other data sources)
+- :doc:`datastore/ds-database` - Database Crawling Configuration
+- :doc:`rank-fusion` - Hybrid Search and Rank Fusion

--- a/en/15.7/config/llm-gemini.rst
+++ b/en/15.7/config/llm-gemini.rst
@@ -1,9 +1,11 @@
-============================
-Google Gemini Configuration
-============================
+===============================================
+Google Gemini Configuration (AI Search / RAG)
+===============================================
 
 Overview
 ========
+
+This page explains how to configure the ``fess-llm-gemini`` plugin so |Fess| can use Google Gemini for its **AI search mode (RAG: Retrieval-Augmented Generation)** — answering natural-language questions from your enterprise search index with cited sources. |Fess| calls the Google AI API (Generative Language API) to run RAG over your crawled documents with Gemini models.
 
 Google Gemini is a state-of-the-art Large Language Model (LLM) provided by Google.
 |Fess| can use the Google AI API (Generative Language API) to implement AI search mode functionality with Gemini models.
@@ -670,3 +672,5 @@ References
 - `Google AI Pricing <https://ai.google.dev/pricing>`__
 - :doc:`llm-overview` - LLM Integration Overview
 - :doc:`rag-chat` - AI Search Mode Details
+- :doc:`rank-fusion` - Hybrid search: combine keyword and semantic (vector) search
+- :doc:`../user/chat-search` - Using AI search mode (end-user guide)

--- a/en/15.7/config/llm-ollama.rst
+++ b/en/15.7/config/llm-ollama.rst
@@ -1,9 +1,11 @@
-==========================
-Ollama Configuration
-==========================
+======================================
+Ollama Configuration (Local LLM / RAG)
+======================================
 
 Overview
 ========
+
+This page explains how to configure the ``fess-llm-ollama`` plugin so |Fess| can use a locally-hosted Ollama model for its **AI search mode (RAG: Retrieval-Augmented Generation)** — answering natural-language questions from your enterprise search index with cited sources, without sending data to an external API. |Fess| calls the local Ollama API to run RAG over your crawled documents.
 
 Ollama is an open-source platform for running Large Language Models (LLMs) in local environments.
 |Fess| Ollama integration is provided as the ``fess-llm-ollama`` plugin and is suitable for use in private environments.
@@ -663,3 +665,5 @@ References
 - `Ollama GitHub <https://github.com/ollama/ollama>`__
 - :doc:`llm-overview` - LLM Integration Overview
 - :doc:`rag-chat` - AI Search Mode Details
+- :doc:`rank-fusion` - Hybrid search: combine keyword and semantic (vector) search
+- :doc:`../user/chat-search` - Using AI search mode (end-user guide)

--- a/en/15.7/config/llm-openai.rst
+++ b/en/15.7/config/llm-openai.rst
@@ -1,9 +1,11 @@
-==========================
-OpenAI Configuration
-==========================
+======================================
+OpenAI Configuration (AI Search / RAG)
+======================================
 
 Overview
 ========
+
+This page explains how to configure the ``fess-llm-openai`` plugin so |Fess| can use OpenAI for its **AI search mode (RAG: Retrieval-Augmented Generation)** — answering natural-language questions from your enterprise search index with cited sources. |Fess| calls the OpenAI API to run RAG over your crawled documents with GPT models.
 
 OpenAI is a cloud service that provides high-performance Large Language Models (LLM), including GPT-4.
 |Fess| can use the OpenAI API to implement AI mode functionality.
@@ -691,3 +693,5 @@ References
 - `OpenAI Pricing <https://openai.com/pricing>`__
 - :doc:`llm-overview` - LLM Integration Overview
 - :doc:`rag-chat` - AI Mode Details
+- :doc:`rank-fusion` - Hybrid search: combine keyword and semantic (vector) search
+- :doc:`../user/chat-search` - Using AI search mode (end-user guide)

--- a/en/15.7/config/llm-overview.rst
+++ b/en/15.7/config/llm-overview.rst
@@ -1,14 +1,16 @@
-==========================
-LLM Integration Overview
-==========================
+==============================================
+AI Search (RAG) and LLM Integration Overview
+==============================================
 
 Overview
 ========
 
 |Fess| supports AI search mode (RAG: Retrieval-Augmented Generation) functionality powered by Large Language Models (LLM).
-This feature allows users to retrieve information through conversational AI assistance based on search results.
+This feature allows users to retrieve information through conversational AI assistance based on search results, answering natural-language questions directly from your enterprise search index with cited sources.
 
 LLM integration is provided as ``fess-llm-*`` plugins. Install the plugin corresponding to the LLM provider you wish to use.
+
+To combine RAG with **semantic (vector) search**, see :doc:`rank-fusion` and the Semantic Search plugin.
 
 Supported Providers
 ===================

--- a/en/15.7/config/rank-fusion.rst
+++ b/en/15.7/config/rank-fusion.rst
@@ -1,9 +1,13 @@
-==================================
-Rank Fusion Settings
-==================================
+===================================================
+Hybrid Search and Rank Fusion (Semantic + Keyword)
+===================================================
 
 Overview
 ========
+
+**Hybrid search** in |Fess| combines traditional keyword search (BM25) with **semantic (vector) search** and merges the two result sets with **Rank Fusion** to produce more accurate, more relevant rankings. Rank Fusion integrates the results of multiple searchers into a single optimized ranking.
+
+To enable semantic search, install the Semantic Search plugin (``fess-webapp-semantic-search``) and add ``semantic`` to ``-Drank.fusion.searchers``.
 
 The Rank Fusion feature of |Fess| integrates multiple search results to
 provide more accurate search results.
@@ -12,7 +16,7 @@ What is Rank Fusion
 ===================
 
 Rank Fusion is a technique that combines results from multiple search algorithms
-or scoring methods to generate a single optimized ranking.
+or scoring methods (for example keyword/BM25 and semantic/vector search) to generate a single optimized ranking.
 
 Key benefits:
 

--- a/en/15.7/user/index.rst
+++ b/en/15.7/user/index.rst
@@ -20,3 +20,4 @@
    role-search
    special-char
    advanced-search
+   chat-search

--- a/en/15.8/config/crawler-basic.rst
+++ b/en/15.8/config/crawler-basic.rst
@@ -1,12 +1,14 @@
-=========================
-Basic Crawler Configuration
-=========================
+==================================================================
+Crawler Configuration: Web, File Server, and Database Crawling
+==================================================================
 
 Overview
 ========
 
-The |Fess| crawler is a feature that automatically collects content from websites, file systems, and other sources and registers it in the search index.
+The |Fess| crawler automatically collects content from **websites (web crawling)**, **file servers and shared folders (file crawling over SMB/FTP)**, and **databases and other data sources (database crawling via data store connectors)**, then registers it in the search index.
 This guide explains the basic concepts and configuration methods for the crawler.
+
+For database and other data-source crawling, see :doc:`datastore/ds-database` and :doc:`datastore/ds-overview`. To improve relevance across crawled content with hybrid (keyword + semantic) search, see :doc:`rank-fusion`.
 
 Basic Crawler Concepts
 =======================
@@ -722,3 +724,6 @@ References
 - :doc:`crawler-thumbnail` - Thumbnail Configuration
 - :doc:`setup-memory` - Memory Configuration
 - :doc:`admin-logging` - Log Configuration
+- :doc:`datastore/ds-overview` - Data Store Crawling Overview (databases and other data sources)
+- :doc:`datastore/ds-database` - Database Crawling Configuration
+- :doc:`rank-fusion` - Hybrid Search and Rank Fusion

--- a/en/15.8/config/llm-gemini.rst
+++ b/en/15.8/config/llm-gemini.rst
@@ -1,9 +1,11 @@
-============================
-Google Gemini Configuration
-============================
+===============================================
+Google Gemini Configuration (AI Search / RAG)
+===============================================
 
 Overview
 ========
+
+This page explains how to configure the ``fess-llm-gemini`` plugin so |Fess| can use Google Gemini for its **AI search mode (RAG: Retrieval-Augmented Generation)** — answering natural-language questions from your enterprise search index with cited sources. |Fess| calls the Google AI API (Generative Language API) to run RAG over your crawled documents with Gemini models.
 
 Google Gemini is a state-of-the-art Large Language Model (LLM) provided by Google.
 |Fess| can use the Google AI API (Generative Language API) to implement AI search mode functionality with Gemini models.
@@ -670,3 +672,5 @@ References
 - `Google AI Pricing <https://ai.google.dev/pricing>`__
 - :doc:`llm-overview` - LLM Integration Overview
 - :doc:`rag-chat` - AI Search Mode Details
+- :doc:`rank-fusion` - Hybrid search: combine keyword and semantic (vector) search
+- :doc:`../user/chat-search` - Using AI search mode (end-user guide)

--- a/en/15.8/config/llm-ollama.rst
+++ b/en/15.8/config/llm-ollama.rst
@@ -1,9 +1,11 @@
-==========================
-Ollama Configuration
-==========================
+======================================
+Ollama Configuration (Local LLM / RAG)
+======================================
 
 Overview
 ========
+
+This page explains how to configure the ``fess-llm-ollama`` plugin so |Fess| can use a locally-hosted Ollama model for its **AI search mode (RAG: Retrieval-Augmented Generation)** — answering natural-language questions from your enterprise search index with cited sources, without sending data to an external API. |Fess| calls the local Ollama API to run RAG over your crawled documents.
 
 Ollama is an open-source platform for running Large Language Models (LLMs) in local environments.
 |Fess| Ollama integration is provided as the ``fess-llm-ollama`` plugin and is suitable for use in private environments.
@@ -663,3 +665,5 @@ References
 - `Ollama GitHub <https://github.com/ollama/ollama>`__
 - :doc:`llm-overview` - LLM Integration Overview
 - :doc:`rag-chat` - AI Search Mode Details
+- :doc:`rank-fusion` - Hybrid search: combine keyword and semantic (vector) search
+- :doc:`../user/chat-search` - Using AI search mode (end-user guide)

--- a/en/15.8/config/llm-openai.rst
+++ b/en/15.8/config/llm-openai.rst
@@ -1,9 +1,11 @@
-==========================
-OpenAI Configuration
-==========================
+======================================
+OpenAI Configuration (AI Search / RAG)
+======================================
 
 Overview
 ========
+
+This page explains how to configure the ``fess-llm-openai`` plugin so |Fess| can use OpenAI for its **AI search mode (RAG: Retrieval-Augmented Generation)** — answering natural-language questions from your enterprise search index with cited sources. |Fess| calls the OpenAI API to run RAG over your crawled documents with GPT models.
 
 OpenAI is a cloud service that provides high-performance Large Language Models (LLM), including GPT-4.
 |Fess| can use the OpenAI API to implement AI mode functionality.
@@ -691,3 +693,5 @@ References
 - `OpenAI Pricing <https://openai.com/pricing>`__
 - :doc:`llm-overview` - LLM Integration Overview
 - :doc:`rag-chat` - AI Mode Details
+- :doc:`rank-fusion` - Hybrid search: combine keyword and semantic (vector) search
+- :doc:`../user/chat-search` - Using AI search mode (end-user guide)

--- a/en/15.8/config/llm-overview.rst
+++ b/en/15.8/config/llm-overview.rst
@@ -1,14 +1,16 @@
-==========================
-LLM Integration Overview
-==========================
+==============================================
+AI Search (RAG) and LLM Integration Overview
+==============================================
 
 Overview
 ========
 
 |Fess| supports AI search mode (RAG: Retrieval-Augmented Generation) functionality powered by Large Language Models (LLM).
-This feature allows users to retrieve information through conversational AI assistance based on search results.
+This feature allows users to retrieve information through conversational AI assistance based on search results, answering natural-language questions directly from your enterprise search index with cited sources.
 
 LLM integration is provided as ``fess-llm-*`` plugins. Install the plugin corresponding to the LLM provider you wish to use.
+
+To combine RAG with **semantic (vector) search**, see :doc:`rank-fusion` and the Semantic Search plugin.
 
 Supported Providers
 ===================

--- a/en/15.8/config/rank-fusion.rst
+++ b/en/15.8/config/rank-fusion.rst
@@ -1,9 +1,13 @@
-==================================
-Rank Fusion Settings
-==================================
+===================================================
+Hybrid Search and Rank Fusion (Semantic + Keyword)
+===================================================
 
 Overview
 ========
+
+**Hybrid search** in |Fess| combines traditional keyword search (BM25) with **semantic (vector) search** and merges the two result sets with **Rank Fusion** to produce more accurate, more relevant rankings. Rank Fusion integrates the results of multiple searchers into a single optimized ranking.
+
+To enable semantic search, install the Semantic Search plugin (``fess-webapp-semantic-search``) and add ``semantic`` to ``-Drank.fusion.searchers``.
 
 The Rank Fusion feature of |Fess| integrates multiple search results to
 provide more accurate search results.
@@ -12,7 +16,7 @@ What is Rank Fusion
 ===================
 
 Rank Fusion is a technique that combines results from multiple search algorithms
-or scoring methods to generate a single optimized ranking.
+or scoring methods (for example keyword/BM25 and semantic/vector search) to generate a single optimized ranking.
 
 Key benefits:
 

--- a/en/15.8/user/index.rst
+++ b/en/15.8/user/index.rst
@@ -20,3 +20,4 @@
    role-search
    special-char
    advanced-search
+   chat-search

--- a/en/articles/5/document.rst
+++ b/en/articles/5/document.rst
@@ -2,10 +2,7 @@
 Part 5: Tokenizing for Full-Text Search
 =======================================
 
-The search system finds documents that contain words that match the words you are searching for, but what these words look like is an important factor that also affects the quality of the search system.
-This time, I will introduce Analyzer, which is a function to make that word.
-Fess uses Elasticsearch as its search engine, and Elasticsearch uses Apache Lucene as its search library.
-Analyzer introduced this time is a function provided by Apache Lucene.
+In full-text search, a query only matches a document when their **words (tokens)** line up — so how text is broken into tokens directly determines search quality. This article introduces the **Analyzer**, the component that turns text into those tokens. Fess uses OpenSearch (or Elasticsearch) as its search engine, which builds on Apache Lucene; the Analyzer described here is a Lucene feature.
 
 First, let's look at the inverted index in order to consider how the words created by the Analyzer are used.
 
@@ -129,6 +126,11 @@ The tuning of the Analyzer is indispensable if you aim for better search quality
 If you know how Analyzer works, you can define and use your own Analyzer.
 
 Next time, I plan to take a closer look at Analyzer in Japanese documents.
+
+See Also
+========
+
+- :doc:`../6/document` - Part 6: Analyzer in Japanese
 
 .. |image0| image:: ../../../resources/images/en/article/5/inverted-index.png
 .. |image1| image:: ../../../resources/images/en/article/5/fess-index.png

--- a/en/getting-started.rst
+++ b/en/getting-started.rst
@@ -101,7 +101,7 @@ Default administrator account:
 
    Be sure to change the default password.
    Especially in production environments, we strongly recommend changing the password immediately after the first login.
-   For instructions on changing the password, refer to :doc:`15.6/admin/user-guide`.
+   For instructions on changing the password, refer to :doc:`15.7/admin/user-guide`.
 
 .. note::
 
@@ -139,8 +139,8 @@ Next Steps
 
 After understanding the basic usage, you can refer to the following documents to learn more:
 
-- :doc:`15.6/admin/index` — Details on crawl settings and search settings
-- :doc:`15.6/api/index` — Integration using the REST API
+- :doc:`15.7/admin/index` — Details on crawl settings and search settings
+- :doc:`15.7/api/index` — Integration using the REST API
 - :doc:`dev/index` — Customization and extension development
 
 .. |Browser search results display| image:: ../resources/images/en/fess_search_result.png

--- a/en/index.rst
+++ b/en/index.rst
@@ -5,7 +5,7 @@ Open Source Full-Text Search Server Fess
 Overview
 ====
 
-Fess is a **full-text search server that can be easily built in 5 minutes**.
+Fess is an open source **enterprise search server** built on OpenSearch (or Elasticsearch) — a **full-text search server that can be built in 5 minutes**. Fess crawls websites, file servers (SMB/FTP), and databases, and provides keyword, faceted, and role-based search out of the box. Optional plugins add **semantic (vector) search**, **hybrid search**, and an **AI search mode (RAG)** powered by LLMs such as Ollama, OpenAI, and Google Gemini.
 
 .. figure:: ../resources/images/en/demo-1.png
    :scale: 100%
@@ -53,7 +53,7 @@ Features
 
 -  Provided under Apache License (free software, free to use)
 
--  Crawls Web, file systems, Windows shared folders, and databases
+-  Crawls Web, file systems, Windows shared folders, and databases (web, file server, and database crawling)
 
 -  Supports many file formats including MS Office (Word/Excel/PowerPoint), PDF, and more
 
@@ -98,6 +98,10 @@ Features
 -  External text extraction support including OCR
 
 -  Flexible design for various use cases
+
+-  AI search mode (RAG: Retrieval-Augmented Generation) with LLM integration — Ollama, OpenAI, and Google Gemini (via ``fess-llm-*`` plugins)
+
+-  Hybrid search combining keyword (BM25) and semantic (vector) search via the Semantic Search plugin
 
 News
 ========

--- a/en/quick-start.rst
+++ b/en/quick-start.rst
@@ -70,7 +70,7 @@ Wait a couple of minutes for the services to initialize, then open your browser:
     docker compose -f compose.yaml -f compose-opensearch3.yaml down
 
 For advanced Docker configuration (custom settings, external OpenSearch, Kubernetes),
-see the :doc:`Docker Installation Guide <15.6/install/install-docker>`.
+see the :doc:`Docker Installation Guide <15.7/install/install-docker>`.
 
 ----
 
@@ -186,7 +186,7 @@ What's Next?
 
 - :doc:`Full Documentation <documentation>` - Complete reference guide
 - :doc:`Installation Guide <setup>` - Production deployment options
-- :doc:`Admin Guide <15.6/admin/index>` - Configuration and management
-- :doc:`API Reference <15.6/api/index>` - Integrate search into your applications
+- :doc:`Admin Guide <15.7/admin/index>` - Configuration and management
+- :doc:`API Reference <15.7/api/index>` - Integrate search into your applications
 - `Discussion Forum <https://discuss.codelibs.org/c/fessen/>`__ - Ask questions, share tips
 - `GitHub Issues <https://github.com/codelibs/fess/issues>`__ - Report bugs, request features


### PR DESCRIPTION
## Summary

Strengthens the highest-impression English documentation pages to capture the large untapped US/English search demand (the AI/LLM and semantic/hybrid clusters currently rank on page 2 despite high impressions). The changes reframe titles/intros toward the terms searchers actually use, connect related pages into a hub via internal links, and fix a few discoverability/freshness issues. Additive/reframe only — existing technical content is preserved, and semantic/hybrid/RAG are consistently described as plugin-provided.

## Changes

- **Docs overview (`en/index.rst`)**: intro and Features now mention enterprise search, web/file-server/database crawling, hybrid/semantic (vector) search, and AI search mode (RAG). The H1 is unchanged.
- **LLM config pages (`config/llm-gemini`, `llm-openai`, `llm-ollama`)**: H1 reframed to "(AI Search / RAG)" / "(Local LLM / RAG)"; intro explains RAG over the search index; References hub-link to rank-fusion and the end-user AI-search page.
- **`config/rank-fusion.rst`**: reframed to "Hybrid Search and Rank Fusion (Semantic + Keyword)" so the page can rank for the semantic/hybrid/vector-search queries it already documents.
- **`config/llm-overview.rst`**: "AI Search (RAG)" framing and a semantic-search cross-link.
- **`config/crawler-basic.rst`**: web / file-server / database-crawling terminology in the title and intro; cross-links to the database connector and hybrid-search pages.
- **`articles/5/document.rst`**: tighter opening paragraph (snippet), corrected engine reference (OpenSearch, not only Elasticsearch), and a See-Also link.
- **Discoverability / freshness**: added the "AI Search Mode" user page to the User Guide toctree; fixed stale `15.6/…` doc links in `quick-start.rst` / `getting-started.rst` to `15.7/…`.

## Notes

- Applied to both 15.7 and 15.8 for the versioned config/user pages; root pages are unversioned single files.
- `:doc:` link targets, heading underlines, and single-file RST parsing were verified statically (no full Sphinx build).
- English-only for now; structural changes (toctree fix, cross-links) can be propagated to other languages as a follow-up. A dedicated "Semantic Search Setup" page is a recommended larger follow-up.
