### PR TITLE
docs(i18n): restore Spanish and French diacritics (es/fr, 15.7 + 15.8)

### DIFF
--- a/es/15.7/api/admin/api-admin-accesstoken.rst
+++ b/es/15.7/api/admin/api-admin-accesstoken.rst
@@ -2,16 +2,16 @@
 AccessToken API
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de AccessToken es una API para gestionar los tokens de acceso a la API de |Fess|.
-Permite ejecutar la creacion, obtencion, actualizacion y eliminacion de tokens.
+Permite ejecutar la creación, obtención, actualización y eliminación de tokens.
 
-Los tokens de acceso se utilizan para la autenticacion al invocar la API de busqueda
-o la Admin API de |Fess| de forma programatica.
-Para conocer las especificaciones comunes de la Admin API (metodo de autenticacion, formato de respuesta,
-valores de ``status``, respuestas de error y codigos de estado HTTP), incluyendo esta API,
+Los tokens de acceso se utilizan para la autenticación al invocar la API de búsqueda
+o la Admin API de |Fess| de forma programática.
+Para conocer las especificaciones comunes de la Admin API (método de autenticación, formato de respuesta,
+valores de ``status``, respuestas de error y códigos de estado HTTP), incluyendo esta API,
 consulte :doc:`api-admin-overview`.
 
 .. note::
@@ -34,9 +34,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de tokens de acceso
@@ -63,29 +63,29 @@ Solicitud
 
     GET /api/admin/accesstoken/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25; puede cambiarse con ``paging.page.size``)
+     - Número de elementos por página (predeterminado: 25; puede cambiarse con ``paging.page.size``)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1; predeterminado: 1)
+     - Número de página (comienza en 1; predeterminado: 1)
    * - ``id``
      - String
      - No
-     - Filtro para obtener unicamente el token con el ID especificado
+     - Filtro para obtener únicamente el token con el ID especificado
 
 Respuesta
 ---------
@@ -117,11 +117,11 @@ Respuesta
 
 .. note::
 
-   Cada objeto de token incluye tambien informacion de auditoria y version:
+   Cada objeto de token incluye también información de auditoría y versión:
    ``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime`` y ``versionNo``.
-   ``createdTime`` y ``updatedTime`` se expresan en milisegundos desde la epoca (valor numerico).
+   ``createdTime`` y ``updatedTime`` se expresan en milisegundos desde la época (valor numérico).
    Los campos con valor ``null`` se excluyen de la respuesta.
-   ``permissions`` se devuelve como una cadena separada por saltos de linea (``\n``).
+   ``permissions`` se devuelve como una cadena separada por saltos de línea (``\n``).
 
 Obtener Token de Acceso
 =======================
@@ -179,7 +179,7 @@ Cuerpo de la Solicitud
       "expires": "2026-01-01T00:00:00"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -188,24 +188,24 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre del token (maximo 1000 caracteres)
+     - Sí
+     - Nombre del token (máximo 1000 caracteres)
    * - ``permissions``
      - No
-     - Permisos otorgados a este token. Se pueden especificar multiples valores separados por saltos de linea (``\n``) (ejemplo: ``{role}admin-api``). Los tokens que invocan la Admin API deben tener un permiso que coincida con ``api.admin.access.permissions`` (valor predeterminado: ``{role}admin-api``).
+     - Permisos otorgados a este token. Se pueden especificar múltiples valores separados por saltos de línea (``\n``) (ejemplo: ``{role}admin-api``). Los tokens que invocan la Admin API deben tener un permiso que coincida con ``api.admin.access.permissions`` (valor predeterminado: ``{role}admin-api``).
    * - ``parameterName``
      - No
-     - Nombre del parametro de solicitud para pasar permisos adicionales. Si una solicitud autenticada con este token incluye un parametro con el nombre aqui especificado, su valor se agrega a ``permissions``. Si se omite, no se configura.
+     - Nombre del parámetro de solicitud para pasar permisos adicionales. Si una solicitud autenticada con este token incluye un parámetro con el nombre aquí especificado, su valor se agrega a ``permissions``. Si se omite, no se configura.
    * - ``expires``
      - No
-     - Fecha de expiracion. Se especifica como cadena en formato ``YYYY-MM-DDTHH:MM:SS`` (ejemplo: ``2026-01-01T00:00:00``). Si se omite, el token no tiene fecha de expiracion.
+     - Fecha de expiración. Se especifica como cadena en formato ``YYYY-MM-DDTHH:MM:SS`` (ejemplo: ``2026-01-01T00:00:00``). Si se omite, el token no tiene fecha de expiración.
 
 .. note::
 
-   La cadena del token (``token``) se genera automaticamente en el servidor. Si se especifica
-   ``token`` en el cuerpo de la solicitud, sera ignorado. Como la respuesta de creacion no incluye
+   La cadena del token (``token``) se genera automáticamente en el servidor. Si se especifica
+   ``token`` en el cuerpo de la solicitud, será ignorado. Como la respuesta de creación no incluye
    la cadena del token generada, obtenga el token mediante "Obtener Token de Acceso"
    (``GET /setting/{id}``).
 
@@ -246,10 +246,10 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
-En la actualizacion se utilizan los mismos campos que en la creacion, mas los siguientes campos adicionales.
+En la actualización se utilizan los mismos campos que en la creación, más los siguientes campos adicionales.
 
 .. list-table::
    :header-rows: 1
@@ -257,18 +257,18 @@ En la actualizacion se utilizan los mismos campos que en la creacion, mas los si
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
+     - Sí
      - ID del token a actualizar
    * - ``versionNo``
-     - Si
-     - Numero de version para el bloqueo optimista. Especifique el ``versionNo`` del token obtenido previamente.
+     - Sí
+     - Número de versión para el bloqueo optimista. Especifique el ``versionNo`` del token obtenido previamente.
 
 .. note::
 
    La cadena del token (``token``) no puede actualizarse. Si se especifica ``token``
-   en el cuerpo de la solicitud, sera ignorado y se mantendra el valor existente.
+   en el cuerpo de la solicitud, será ignorado y se mantendrá el valor existente.
 
 Respuesta
 ---------
@@ -323,7 +323,7 @@ Crear Token API
 Llamada a la API Usando el Token
 ---------------------------------
 
-El token creado se utiliza para la autenticacion al invocar la API de busqueda u otras APIs.
+El token creado se utiliza para la autenticación al invocar la API de búsqueda u otras APIs.
 
 .. code-block:: bash
 
@@ -334,9 +334,9 @@ El token creado se utiliza para la autenticacion al invocar la API de busqueda u
     # Usar el token como parametro de consulta (requiere configurar api.access.token.request.parameter)
     curl "http://localhost:8080/api/v2/search?q=test&token=your_token_here"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API (autenticacion, formato de respuesta y errores)
-- :doc:`../api-search` - API de busqueda
-- :doc:`../../admin/accesstoken-guide` - Guia de gestion de tokens de acceso
+- :doc:`api-admin-overview` - Visión general de Admin API (autenticación, formato de respuesta y errores)
+- :doc:`../api-search` - API de búsqueda
+- :doc:`../../admin/accesstoken-guide` - Guía de gestión de tokens de acceso

--- a/es/15.7/api/admin/api-admin-backup.rst
+++ b/es/15.7/api/admin/api-admin-backup.rst
@@ -2,13 +2,13 @@
 API de Backup
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Backup es una API para consultar y descargar los datos objetivo de copia de seguridad de |Fess|.
-Permite obtener la lista de objetivos de copia de seguridad y descargar archivos de copia de seguridad individuales (propiedades del sistema, datos masivos de cada indice, datos NDJSON de registros).
+Permite obtener la lista de objetivos de copia de seguridad y descargar archivos de copia de seguridad individuales (propiedades del sistema, datos masivos de cada índice, datos NDJSON de registros).
 
-Esta API es exclusivamente de consulta y descarga (solo lectura). La funcionalidad de restauracion para subir archivos de copia de seguridad no esta disponible a traves de la API; si necesita restaurar, utilice Informacion del sistema → Copia de seguridad en la pantalla de administracion.
+Esta API es exclusivamente de consulta y descarga (solo lectura). La funcionalidad de restauración para subir archivos de copia de seguridad no está disponible a través de la API; si necesita restaurar, utilice Información del sistema → Copia de seguridad en la pantalla de administración.
 
 URL Base
 ========
@@ -17,17 +17,17 @@ URL Base
 
     /api/admin/backup
 
-Autenticacion
+Autenticación
 =============
 
-Al igual que con el resto de Admin APIs, se requiere autenticacion mediante token de acceso. El token de acceso debe tener el permiso ``Radmin-api`` (configurado en ``api.admin.access.permissions``; el valor predeterminado es ``Radmin-api``).
+Al igual que con el resto de Admin APIs, se requiere autenticación mediante token de acceso. El token de acceso debe tener el permiso ``Radmin-api`` (configurado en ``api.admin.access.permissions``; el valor predeterminado es ``Radmin-api``).
 El token de acceso se especifica en el encabezado de la solicitud.
 
 ::
 
     Authorization: Bearer <token de acceso>
 
-Para mas detalles sobre la autenticacion y como obtener el token de acceso, consulte :doc:`api-admin-overview`.
+Para más detalles sobre la autenticación y como obtener el token de acceso, consulte :doc:`api-admin-overview`.
 
 Lista de Endpoints
 ==================
@@ -36,9 +36,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /files
      - Obtener lista de objetivos de copia de seguridad
@@ -49,7 +49,7 @@ Lista de Endpoints
 Obtener Lista de Objetivos de Copia de Seguridad
 ================================================
 
-Devuelve la lista de objetivos de copia de seguridad. Los objetivos se determinan en funcion de la configuracion de ``index.backup.targets`` e ``index.backup.log.targets``, y se devuelve una lista combinada de ambos.
+Devuelve la lista de objetivos de copia de seguridad. Los objetivos se determinan en función de la configuración de ``index.backup.targets`` e ``index.backup.log.targets``, y se devuelve una lista combinada de ambos.
 
 Solicitud
 ---------
@@ -61,10 +61,10 @@ Solicitud
 Respuesta
 ---------
 
-En ``files`` se almacena un arreglo de objetos que representan los objetivos de copia de seguridad, y en ``total`` el numero de elementos.
+En ``files`` se almacena un arreglo de objetos que representan los objetivos de copia de seguridad, y en ``total`` el número de elementos.
 Cada objeto tiene ``id`` y ``name``, y en ambos se establece el nombre del objetivo (``fess_config.bulk``, ``system.properties``, ``search_log.ndjson``, etc.).
 
-A continuacion se muestra un ejemplo con la configuracion predeterminada (cuando ``index.backup.targets`` e ``index.backup.log.targets`` tienen sus valores por defecto).
+A continuación se muestra un ejemplo con la configuración predeterminada (cuando ``index.backup.targets`` e ``index.backup.log.targets`` tienen sus valores por defecto).
 
 .. code-block:: json
 
@@ -90,15 +90,15 @@ A continuacion se muestra un ejemplo con la configuracion predeterminada (cuando
 
 .. note::
 
-   En ``version`` se establece la version del producto de |Fess| en ejecucion. El contenido de ``files`` varia
-   segun la configuracion de ``index.backup.targets`` / ``index.backup.log.targets``, por lo que
+   En ``version`` se establece la versión del producto de |Fess| en ejecución. El contenido de ``files`` varía
+   según la configuración de ``index.backup.targets`` / ``index.backup.log.targets``, por lo que
    el ejemplo anterior corresponde a los valores por defecto.
 
 Descargar Archivo de Copia de Seguridad
 =======================================
 
 Descarga el contenido del archivo de copia de seguridad especificado. En ``{id}`` se especifica el ``id`` (nombre del objetivo) obtenido en la lista.
-Segun el tipo de ``{id}``, el contenido de la respuesta cambia de la siguiente manera.
+Según el tipo de ``{id}``, el contenido de la respuesta cambia de la siguiente manera.
 
 .. list-table::
    :header-rows: 1
@@ -108,18 +108,18 @@ Segun el tipo de ``{id}``, el contenido de la respuesta cambia de la siguiente m
      - Contenido
    * - ``system.properties``
      - Contenido de las propiedades del sistema (``application/octet-stream``)
-   * - ``*.bulk`` o nombre de indice sin extension
-     - Datos masivos generados al recorrer el indice con el mismo nombre que el objetivo (``application/octet-stream``). El nombre sin ``.bulk`` se trata como nombre del indice.
+   * - ``*.bulk`` o nombre de índice sin extensión
+     - Datos masivos generados al recorrer el índice con el mismo nombre que el objetivo (``application/octet-stream``). El nombre sin ``.bulk`` se trata como nombre del índice.
    * - ``*.ndjson`` (``search_log`` / ``user_info`` / ``click_log`` / ``favorite_log``)
      - Datos NDJSON del registro correspondiente (``application/x-ndjson``)
 
 .. note::
 
-   ``fess.json`` y ``doc.json`` son archivos de definicion de mapeo (esquema) del indice.
+   ``fess.json`` y ``doc.json`` son archivos de definición de mapeo (esquema) del índice.
    Se incluyen en la lista de objetivos (``/files``), pero en la descarga de esta API se tratan
-   como procesamiento de desplazamiento del indice, al igual que ``.bulk``. Para realizar copias de
-   seguridad y restauraciones que incluyan la definicion de mapeo, utilice
-   Informacion del sistema → Copia de seguridad en la pantalla de administracion.
+   como procesamiento de desplazamiento del índice, al igual que ``.bulk``. Para realizar copias de
+   seguridad y restauraciones que incluyan la definición de mapeo, utilice
+   Información del sistema → Copia de seguridad en la pantalla de administración.
 
 Si se especifica un ``{id}`` que no existe entre los objetivos de copia de seguridad, se devuelve una respuesta de error con un valor distinto de 0 en ``status`` y el mensaje de error (``Could not find any backup index.``).
 
@@ -137,7 +137,7 @@ El flujo del archivo de copia de seguridad. En formato NDJSON se devuelve con ``
 
 .. note::
 
-   La exportacion de registros (``*.ndjson``) esta sujeta a la restriccion de ``index.backup.log.load.timeout`` (valor predeterminado ``60000`` milisegundos).
+   La exportación de registros (``*.ndjson``) está sujeta a la restricción de ``index.backup.log.load.timeout`` (valor predeterminado ``60000`` milisegundos).
    Si la salida tarda demasiado, los datos del registro pueden quedar truncados.
 
 Ejemplos de Uso
@@ -151,7 +151,7 @@ Obtener Lista de Objetivos de Copia de Seguridad
     curl -X GET "http://localhost:8080/api/admin/backup/files" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Descargar Indice de Configuracion
+Descargar Índice de Configuración
 ---------------------------------
 
 .. code-block:: bash
@@ -160,7 +160,7 @@ Descargar Indice de Configuracion
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o fess_config.bulk
 
-Descargar Registro de Busqueda
+Descargar Registro de Búsqueda
 ------------------------------
 
 .. code-block:: bash
@@ -169,8 +169,8 @@ Descargar Registro de Busqueda
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o search_log.ndjson
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-log` - API de registros

--- a/es/15.7/api/admin/api-admin-badword.rst
+++ b/es/15.7/api/admin/api-admin-badword.rst
@@ -2,11 +2,11 @@
 API de BadWord
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de BadWord es para gestionar las palabras prohibidas (exclusion de palabras de sugerencia inapropiadas) de |Fess|.
-Puede configurar palabras clave que no desea mostrar en la funcion de sugerencias.
+La API de BadWord es para gestionar las palabras prohibidas (exclusión de palabras de sugerencia inapropiadas) de |Fess|.
+Puede configurar palabras clave que no desea mostrar en la función de sugerencias.
 
 URL Base
 ========
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de palabras prohibidas
@@ -57,25 +57,25 @@ Solicitud
 
     GET /api/admin/badword/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Número de elementos por página (predeterminado: 20)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``id``
      - String
      - No
@@ -144,7 +144,7 @@ Cuerpo de la Solicitud
       "suggestWord": "spam_keyword"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -153,9 +153,9 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``suggestWord``
-     - Si
+     - Sí
      - Palabra clave a excluir (no puede contener espacios en blanco)
 
 Respuesta
@@ -232,7 +232,7 @@ Respuesta
 Subir CSV de Palabras Prohibidas
 ================================
 
-Registra palabras prohibidas en bloque a partir de un archivo CSV. El archivo se envia como ``multipart/form-data``. La importacion se ejecuta de forma asincrona en el servidor.
+Registra palabras prohibidas en bloque a partir de un archivo CSV. El archivo se envía como ``multipart/form-data``. La importación se ejecuta de forma asíncrona en el servidor.
 
 Solicitud
 ---------
@@ -242,33 +242,33 @@ Solicitud
     PUT /api/admin/badword/upload
     Content-Type: multipart/form-data
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``badWordFile``
-     - Si
+     - Sí
      - Archivo CSV de palabras prohibidas a subir
 
 Formato CSV
 ~~~~~~~~~~~
 
-- La primera linea se omite como fila de encabezado (el nombre de la columna es arbitrario; al descargar se escribe ``BadWord``).
-- A partir de la segunda linea, escriba una palabra prohibida por linea como ``suggestWord``.
-- Las lineas cuyo valor esta en blanco se ignoran.
+- La primera línea se omite como fila de encabezado (el nombre de la columna es arbitrario; al descargar se escribe ``BadWord``).
+- A partir de la segunda línea, escriba una palabra prohibida por línea como ``suggestWord``.
+- Las líneas cuyo valor está en blanco se ignoran.
 - Anteponga ``--`` a una palabra para eliminarla (por ejemplo, ``--spam`` elimina ``spam``).
-- Especificar una palabra ya registrada se trata como una actualizacion (se restablecen el usuario y la fecha de actualizacion).
+- Especificar una palabra ya registrada se trata como una actualización (se restablecen el usuario y la fecha de actualización).
 
 .. note::
 
-   Dado que la importacion se ejecuta de forma asincrona en el servidor, una respuesta ``status: 0``
-   indica que la solicitud fue aceptada, no que la importacion se haya completado.
+   Dado que la importación se ejecuta de forma asíncrona en el servidor, una respuesta ``status: 0``
+   indica que la solicitud fue aceptada, no que la importación se haya completado.
 
 Respuesta
 ---------
@@ -285,7 +285,7 @@ Descargar CSV de Palabras Prohibidas
 ====================================
 
 Descarga las palabras prohibidas registradas como archivo CSV (``badword.csv``). La respuesta es un flujo ``application/octet-stream``.
-El CSV tiene una fila de encabezado ``BadWord`` en la primera linea, seguida de una palabra prohibida registrada por linea.
+El CSV tiene una fila de encabezado ``BadWord`` en la primera línea, seguida de una palabra prohibida registrada por línea.
 
 Solicitud
 ---------
@@ -327,10 +327,10 @@ Descargar Archivo CSV
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o badword.csv
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-suggest` - API de gestion de sugerencias
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-suggest` - API de gestión de sugerencias
 - :doc:`api-admin-elevateword` - API de palabras elevadas
-- :doc:`../../admin/badword-guide` - Guia de gestion de palabras prohibidas
+- :doc:`../../admin/badword-guide` - Guía de gestión de palabras prohibidas

--- a/es/15.7/api/admin/api-admin-boostdoc.rst
+++ b/es/15.7/api/admin/api-admin-boostdoc.rst
@@ -2,24 +2,24 @@
 BoostDoc API
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de BoostDoc es para gestionar la configuracion de impulso de documentos de |Fess|.
-Al configurar el impulso de documentos, puede elevar la puntuacion de los documentos que
+La API de BoostDoc es para gestionar la configuración de impulso de documentos de |Fess|.
+Al configurar el impulso de documentos, puede elevar la puntuación de los documentos que
 coincidan con ciertas condiciones y hacer que aparezcan con mayor facilidad en las posiciones
-superiores de los resultados de busqueda.
+superiores de los resultados de búsqueda.
 
-El impulso se aplica a cada documento en el momento de la indexacion (durante el rastreo).
-La condicion (``urlExpr``) y el valor de impulso (``boostExpr``) se evaluan ambos como expresiones Groovy.
-Las reglas multiples se evaluan en orden ascendente segun ``sortOrder``, y solo se aplica el valor de
-impulso de la primera regla cuya condicion coincida (una vez encontrada una regla que coincida,
+El impulso se aplica a cada documento en el momento de la indexación (durante el rastreo).
+La condición (``urlExpr``) y el valor de impulso (``boostExpr``) se evaluan ambos como expresiones Groovy.
+Las reglas múltiples se evaluan en orden ascendente según ``sortOrder``, y solo se aplica el valor de
+impulso de la primera regla cuya condición coincida (una vez encontrada una regla que coincida,
 las reglas siguientes no se evaluan).
 
 .. note::
 
-   En el panel de administracion, ``urlExpr`` se muestra como "Condicion" y ``boostExpr`` como "Expresion de valor de impulso".
-   Para mas detalles sobre los elementos de configuracion, consulte :doc:`../../admin/boostdoc-guide`.
+   En el panel de administración, ``urlExpr`` se muestra como "Condición" y ``boostExpr`` como "Expresión de valor de impulso".
+   Para más detalles sobre los elementos de configuración, consulte :doc:`../../admin/boostdoc-guide`.
 
 URL Base
 ========
@@ -28,7 +28,7 @@ URL Base
 
     /api/admin/boostdoc
 
-Autenticacion
+Autenticación
 =============
 
 Para usar esta API, se requiere un token de acceso con el permiso ``Radmin-api``.
@@ -41,9 +41,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de impulsos de documentos
@@ -70,33 +70,33 @@ Solicitud
 
     GET /api/admin/boostdoc/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25)
+     - Número de elementos por página (predeterminado: 25)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1. Predeterminado: 1)
+     - Número de página (comienza en 1. Predeterminado: 1)
    * - ``urlExpr``
      - String
      - No
-     - Filtrado por expresion de condicion (coincidencia parcial)
+     - Filtrado por expresión de condición (coincidencia parcial)
    * - ``boostExpr``
      - String
      - No
-     - Filtrado por expresion de valor de impulso (coincidencia parcial)
+     - Filtrado por expresión de valor de impulso (coincidencia parcial)
 
 Respuesta
 ---------
@@ -121,8 +121,8 @@ Respuesta
 
 .. note::
 
-   Ademas de los campos mostrados anteriormente, cada objeto de configuracion en la respuesta incluye tambien metadatos de creacion/actualizacion (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``).
-   ``versionNo`` es obligatorio al actualizar (PUT), por lo que debe obtener su valor actual mediante la API de obtencion individual o de lista antes de actualizar.
+   Además de los campos mostrados anteriormente, cada objeto de configuración en la respuesta incluye también metadatos de creación/actualización (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``).
+   ``versionNo`` es obligatorio al actualizar (PUT), por lo que debe obtener su valor actual mediante la API de obtención individual o de lista antes de actualizar.
 
 Obtener Impulso de Documento
 =============================
@@ -174,7 +174,7 @@ Cuerpo de la Solicitud
       "sortOrder": 0
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -183,16 +183,16 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``urlExpr``
-     - Si
-     - Expresion de condicion. Expresion Groovy que determina los documentos objetivo del impulso y devuelve ``Boolean``. Corresponde a "Condicion" en el panel de administracion (maximo 10000 caracteres).
+     - Sí
+     - Expresión de condición. Expresión Groovy que determina los documentos objetivo del impulso y devuelve ``Boolean``. Corresponde a "Condición" en el panel de administración (máximo 10000 caracteres).
    * - ``boostExpr``
-     - Si
-     - Expresion de valor de impulso. Expresion Groovy que devuelve el valor de impulso (numerico). Tambien se puede especificar un valor fijo como ``3.0``. Corresponde a "Expresion de valor de impulso" en el panel de administracion (maximo 10000 caracteres).
+     - Sí
+     - Expresión de valor de impulso. Expresión Groovy que devuelve el valor de impulso (numérico). También se puede especificar un valor fijo como ``3.0``. Corresponde a "Expresión de valor de impulso" en el panel de administración (máximo 10000 caracteres).
    * - ``sortOrder``
-     - Si
-     - Orden de aplicacion. Las reglas se evaluan en orden ascendente y se aplica el valor de impulso de la primera regla cuya condicion coincida (valor inicial del formulario: 0; entero mayor o igual a 0).
+     - Sí
+     - Orden de aplicación. Las reglas se evaluan en orden ascendente y se aplica el valor de impulso de la primera regla cuya condición coincida (valor inicial del formulario: 0; entero mayor o igual a 0).
 
 Respuesta
 ---------
@@ -231,7 +231,7 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Al actualizar, ademas de los campos utilizados al crear, ``id`` (el identificador de la regla objetivo, hasta 1000 caracteres) y ``versionNo`` (el numero de version para bloqueo optimista) son obligatorios. Especifique el numero de version actual obtenido desde la respuesta de la API de obtencion individual o de lista para ``versionNo``. La actualizacion falla si el numero de version no coincide.
+Al actualizar, además de los campos utilizados al crear, ``id`` (el identificador de la regla objetivo, hasta 1000 caracteres) y ``versionNo`` (el número de versión para bloqueo optimista) son obligatorios. Especifique el número de versión actual obtenido desde la respuesta de la API de obtención individual o de lista para ``versionNo``. La actualización falla si el número de versión no coincide.
 
 Respuesta
 ---------
@@ -267,58 +267,58 @@ Respuesta
       }
     }
 
-Acerca de las Expresiones de Condicion y de Valor de Impulso
+Acerca de las Expresiones de Condición y de Valor de Impulso
 =============================================================
 
-``urlExpr`` (condicion) y ``boostExpr`` (expresion de valor de impulso) se evaluan ambas como expresiones Groovy.
-Dentro de la expresion, se pueden referenciar los valores de campo del documento a indexar como variables con el nombre del campo.
+``urlExpr`` (condición) y ``boostExpr`` (expresión de valor de impulso) se evaluan ambas como expresiones Groovy.
+Dentro de la expresión, se pueden referenciar los valores de campo del documento a indexar como variables con el nombre del campo.
 
-- ``urlExpr`` debe devolver ``Boolean`` (ejemplo: ``url.startsWith("https://docs.example.com/")``). Una simple cadena de expresion regular (ejemplo: ``.*docs\.example\.com.*``) no devuelve ``Boolean`` como expresion Groovy y por lo tanto no funciona como condicion. Para usar expresiones regulares, utilice ``String#matches`` de Groovy.
-- ``boostExpr`` debe devolver un valor numerico. El resultado se convierte a ``float`` y el impulso se aplica solo si es mayor que 0.
+- ``urlExpr`` debe devolver ``Boolean`` (ejemplo: ``url.startsWith("https://docs.example.com/")``). Una simple cadena de expresión regular (ejemplo: ``.*docs\.example\.com.*``) no devuelve ``Boolean`` como expresión Groovy y por lo tanto no funciona como condición. Para usar expresiones regulares, utilice ``String#matches`` de Groovy.
+- ``boostExpr`` debe devolver un valor numérico. El resultado se convierte a ``float`` y el impulso se aplica solo si es mayor que 0.
 
 .. note::
 
-   Principales variables de campo disponibles dentro de la expresion: ``url``, ``title``, ``content``, ``content_length``, ``last_modified``, entre otros.
-   ``click_count`` y ``favorite_count`` estan disponibles cuando ``indexer.click.count.enabled`` /
-   ``indexer.favorite.count.enabled`` estan habilitados (ambos habilitados por defecto).
+   Principales variables de campo disponibles dentro de la expresión: ``url``, ``title``, ``content``, ``content_length``, ``last_modified``, entre otros.
+   ``click_count`` y ``favorite_count`` están disponibles cuando ``indexer.click.count.enabled`` /
+   ``indexer.favorite.count.enabled`` están habilitados (ambos habilitados por defecto).
    La sintaxis de calculo de fechas de OpenSearch como ``now - 7d`` no se puede usar en Groovy.
 
-Ejemplos de Expresion de Condicion (``urlExpr``)
+Ejemplos de Expresión de Condición (``urlExpr``)
 -------------------------------------------------
 
 .. list-table::
    :header-rows: 1
    :widths: 45 55
 
-   * - Expresion de condicion
-     - Descripcion
+   * - Expresión de condición
+     - Descripción
    * - ``url.startsWith("https://docs.example.com/")``
      - Aplica a documentos cuya URL comienza con la URL especificada
    * - ``url.matches("https://www\\.example\\.com/.*")``
-     - Evalua la URL mediante expresion regular (``String#matches`` de Groovy)
+     - Evalua la URL mediante expresión regular (``String#matches`` de Groovy)
    * - ``title.contains("Notas de la version")``
-     - Aplica a documentos que contienen una palabra especifica en el titulo
+     - Aplica a documentos que contienen una palabra específica en el título
 
-Ejemplos de Expresion de Valor de Impulso (``boostExpr``)
+Ejemplos de Expresión de Valor de Impulso (``boostExpr``)
 ----------------------------------------------------------
 
 .. list-table::
    :header-rows: 1
    :widths: 45 55
 
-   * - Expresion de valor de impulso
-     - Descripcion
+   * - Expresión de valor de impulso
+     - Descripción
    * - ``3.0``
      - Impulso con valor fijo
    * - ``click_count * 0.1 + 1``
-     - Impulso segun el numero de clics
+     - Impulso según el número de clics
    * - ``Math.log(click_count + 1)``
-     - Impulso en escala logaritmica basado en el numero de clics
+     - Impulso en escala logaritmica basado en el número de clics
 
 Ejemplos de Uso
 ===============
 
-Impulso de Sitio de Documentacion
+Impulso de Sitio de Documentación
 ----------------------------------
 
 .. code-block:: bash
@@ -346,9 +346,9 @@ Impulso de Contenido con Muchos Clics
            "sortOrder": 10
          }'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-elevateword` - API de palabras elevadas
-- :doc:`../../admin/boostdoc-guide` - Guia de gestion de impulso de documentos
+- :doc:`../../admin/boostdoc-guide` - Guía de gestión de impulso de documentos

--- a/es/15.7/api/admin/api-admin-crawlinginfo.rst
+++ b/es/15.7/api/admin/api-admin-crawlinginfo.rst
@@ -2,10 +2,10 @@
 API de CrawlingInfo
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de CrawlingInfo es para consultar y gestionar la informacion de rastreo (sesiones de rastreo) de |Fess|.
+La API de CrawlingInfo es para consultar y gestionar la información de rastreo (sesiones de rastreo) de |Fess|.
 Permite operaciones como obtener la lista de sesiones de rastreo, obtenerlas individualmente y eliminarlas.
 
 URL Base
@@ -22,23 +22,23 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /logs
-     - Obtener lista de informacion de rastreo
+     - Obtener lista de información de rastreo
    * - GET
      - /log/{id}
-     - Obtener informacion de rastreo
+     - Obtener información de rastreo
    * - DELETE
      - /log/{id}
-     - Eliminar informacion de rastreo
+     - Eliminar información de rastreo
    * - DELETE
      - /all
      - Eliminar en lote sesiones de rastreo (excepto las activas)
 
-Obtener Lista de Informacion de Rastreo
+Obtener Lista de Información de Rastreo
 =======================================
 
 Solicitud
@@ -48,29 +48,29 @@ Solicitud
 
     GET /api/admin/crawlinginfo/logs
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Número de elementos por página (predeterminado: 20)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (basado en 1, predeterminado: 1)
+     - Número de página (basado en 1, predeterminado: 1)
    * - ``sessionId``
      - String
      - No
-     - Filtro por ID de sesion (coincidencia parcial)
+     - Filtro por ID de sesión (coincidencia parcial)
 
 Respuesta
 ---------
@@ -108,25 +108,25 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``id``
-     - ID de informacion de rastreo
+     - ID de información de rastreo
    * - ``sessionId``
-     - ID de sesion
+     - ID de sesión
    * - ``name``
-     - Nombre de sesion
+     - Nombre de sesión
    * - ``expiredTime``
-     - Fecha de expiracion (milisegundos epoch; devuelto como cadena de texto)
+     - Fecha de expiración (milisegundos epoch; devuelto como cadena de texto)
    * - ``createdTime``
-     - Hora de creacion (milisegundos epoch; devuelto como numero)
+     - Hora de creación (milisegundos epoch; devuelto como número)
 
 .. note::
 
-   Cada objeto de registro en la respuesta incluye tambien un campo interno ``crudMode``
-   (un entero que indica el modo de operacion CRUD, siempre ``0`` para operaciones de lectura).
+   Cada objeto de registro en la respuesta incluye también un campo interno ``crudMode``
+   (un entero que indica el modo de operación CRUD, siempre ``0`` para operaciones de lectura).
    Los clientes pueden ignorarlo sin problema.
 
-Obtener Informacion de Rastreo
+Obtener Información de Rastreo
 ==============================
 
 Solicitud
@@ -154,7 +154,7 @@ Respuesta
       }
     }
 
-Eliminar Informacion de Rastreo
+Eliminar Información de Rastreo
 ===============================
 
 Solicitud
@@ -178,7 +178,7 @@ Respuesta
 Eliminar en Lote Sesiones de Rastreo
 =====================================
 
-Elimina todas las sesiones de rastreo (y sus datos de parametros), excepto las que estan en ejecucion en ese momento. No existe umbral de antiguedad ni de tiempo; se eliminan todas las sesiones que no esten en ejecucion.
+Elimina todas las sesiones de rastreo (y sus datos de parámetros), excepto las que están en ejecución en ese momento. No existe umbral de antigüedad ni de tiempo; se eliminan todas las sesiones que no estén en ejecución.
 
 Solicitud
 ---------
@@ -201,7 +201,7 @@ Respuesta
 Ejemplos de Uso
 ===============
 
-Obtener Lista de Informacion de Rastreo
+Obtener Lista de Información de Rastreo
 ---------------------------------------
 
 .. code-block:: bash
@@ -209,7 +209,7 @@ Obtener Lista de Informacion de Rastreo
     curl -X GET "http://localhost:8080/api/admin/crawlinginfo/logs?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Filtrar por Sesion Especifica
+Filtrar por Sesión Específica
 -----------------------------
 
 .. code-block:: bash
@@ -217,7 +217,7 @@ Filtrar por Sesion Especifica
     curl -X GET "http://localhost:8080/api/admin/crawlinginfo/logs?sessionId=20250129100000" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Obtener Informacion de Rastreo
+Obtener Información de Rastreo
 ------------------------------
 
 .. code-block:: bash
@@ -225,7 +225,7 @@ Obtener Informacion de Rastreo
     curl -X GET "http://localhost:8080/api/admin/crawlinginfo/log/crawling_info_id_1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Eliminar Informacion de Rastreo
+Eliminar Información de Rastreo
 -------------------------------
 
 .. code-block:: bash
@@ -241,10 +241,10 @@ Eliminar en Lote Sesiones
     curl -X DELETE "http://localhost:8080/api/admin/crawlinginfo/all" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-failureurl` - API de URLs fallidas
 - :doc:`api-admin-joblog` - API de registro de trabajos
-- :doc:`../../admin/crawlinginfo-guide` - Guia de informacion de rastreo
+- :doc:`../../admin/crawlinginfo-guide` - Guía de información de rastreo

--- a/es/15.7/api/admin/api-admin-dataconfig.rst
+++ b/es/15.7/api/admin/api-admin-dataconfig.rst
@@ -2,10 +2,10 @@
 API de DataConfig
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de DataConfig es para gestionar la configuracion de almacen de datos de |Fess|.
+La API de DataConfig es para gestionar la configuración de almacén de datos de |Fess|.
 Puede operar configuraciones de rastreo para fuentes de datos como bases de datos, CSV y JSON.
 
 URL Base
@@ -22,26 +22,26 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
-     - Obtener lista de configuraciones de almacen de datos
+     - Obtener lista de configuraciones de almacén de datos
    * - GET
      - /setting/{id}
-     - Obtener configuracion de almacen de datos
+     - Obtener configuración de almacén de datos
    * - POST
      - /setting
-     - Crear configuracion de almacen de datos
+     - Crear configuración de almacén de datos
    * - PUT
      - /setting
-     - Actualizar configuracion de almacen de datos
+     - Actualizar configuración de almacén de datos
    * - DELETE
      - /setting/{id}
-     - Eliminar configuracion de almacen de datos
+     - Eliminar configuración de almacén de datos
 
-Obtener Lista de Configuraciones de Almacen de Datos
+Obtener Lista de Configuraciones de Almacén de Datos
 ====================================================
 
 Solicitud
@@ -51,29 +51,29 @@ Solicitud
 
     GET /api/admin/dataconfig/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25)
+     - Número de elementos por página (predeterminado: 25)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``name``
      - String
      - No
-     - Filtrar por nombre de configuracion
+     - Filtrar por nombre de configuración
    * - ``handlerName``
      - String
      - No
@@ -81,7 +81,7 @@ Parametros
    * - ``description``
      - String
      - No
-     - Filtrar por descripcion
+     - Filtrar por descripción
 
 Respuesta
 ---------
@@ -110,7 +110,7 @@ Respuesta
       }
     }
 
-Obtener Configuracion de Almacen de Datos
+Obtener Configuración de Almacén de Datos
 =========================================
 
 Solicitud
@@ -144,7 +144,7 @@ Respuesta
       }
     }
 
-Crear Configuracion de Almacen de Datos
+Crear Configuración de Almacén de Datos
 =======================================
 
 Solicitud
@@ -171,7 +171,7 @@ Cuerpo de la Solicitud
       "permissions": "{role}admin\n{role}user"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -180,37 +180,37 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre de la configuracion
+     - Sí
+     - Nombre de la configuración
    * - ``description``
      - No
-     - Descripcion de la configuracion
+     - Descripción de la configuración
    * - ``handlerName``
-     - Si
-     - Nombre del manejador de almacen de datos
+     - Sí
+     - Nombre del manejador de almacén de datos
    * - ``handlerParameter``
      - No
-     - Parametros del manejador (informacion de conexion, etc.)
+     - Parámetros del manejador (información de conexión, etc.)
    * - ``handlerScript``
      - No
-     - Script de transformacion de datos
+     - Script de transformación de datos
    * - ``boost``
-     - Si
-     - Valor de impulso en resultados de busqueda
+     - Sí
+     - Valor de impulso en resultados de búsqueda
    * - ``available``
-     - Si
+     - Sí
      - Habilitado/Deshabilitado (cadena ``"true"`` / ``"false"``)
    * - ``sortOrder``
-     - Si
-     - Orden de visualizacion
+     - Sí
+     - Orden de visualización
    * - ``permissions``
      - No
-     - Roles con permiso de acceso (separados por saltos de linea si son varios)
+     - Roles con permiso de acceso (separados por saltos de línea si son varios)
    * - ``virtualHosts``
      - No
-     - Hosts virtuales (separados por saltos de linea si son varios)
+     - Hosts virtuales (separados por saltos de línea si son varios)
 
 Respuesta
 ---------
@@ -225,7 +225,7 @@ Respuesta
       }
     }
 
-Actualizar Configuracion de Almacen de Datos
+Actualizar Configuración de Almacén de Datos
 ============================================
 
 Solicitud
@@ -253,7 +253,7 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Las solicitudes de actualizacion requieren los mismos campos obligatorios que la creacion (``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``), ademas de los siguientes campos:
+Las solicitudes de actualización requieren los mismos campos obligatorios que la creación (``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``), además de los siguientes campos:
 
 .. list-table::
    :header-rows: 1
@@ -261,13 +261,13 @@ Las solicitudes de actualizacion requieren los mismos campos obligatorios que la
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
-     - ID de la configuracion a actualizar
+     - Sí
+     - ID de la configuración a actualizar
    * - ``versionNo``
-     - Si
-     - Numero de version para el bloqueo optimista (especifique el valor obtenido al recuperar la configuracion)
+     - Sí
+     - Número de versión para el bloqueo optimista (especifique el valor obtenido al recuperar la configuración)
 
 Respuesta
 ---------
@@ -282,7 +282,7 @@ Respuesta
       }
     }
 
-Eliminar Configuracion de Almacen de Datos
+Eliminar Configuración de Almacén de Datos
 ==========================================
 
 Solicitud
@@ -311,27 +311,27 @@ Tipos de Manejador
    :widths: 30 70
 
    * - Nombre del Manejador
-     - Descripcion
+     - Descripción
    * - ``DatabaseDataStore``
-     - Conecta a base de datos via JDBC
+     - Conecta a base de datos vía JDBC
    * - ``CsvDataStore``
      - Lee datos de un archivo CSV (procesa cada fila como un documento)
    * - ``CsvListDataStore``
-     - Lee archivos CSV y elimina automaticamente los archivos procesados (una extension de ``CsvDataStore`` con filtrado basado en marcas de tiempo)
+     - Lee archivos CSV y elimina automáticamente los archivos procesados (una extensión de ``CsvDataStore`` con filtrado basado en marcas de tiempo)
    * - ``JsonDataStore``
      - Lee datos de archivos JSON o API JSON
 
 .. note::
 
-   Los tipos de manejador disponibles dependen de los plugins de almacen de datos instalados.
+   Los tipos de manejador disponibles dependen de los plugins de almacén de datos instalados.
    Los manejadores indicados arriba se incluyen de forma predeterminada. Al instalar plugins de
-   almacen de datos como SharePoint, Slack o Salesforce, los nombres de manejador correspondientes
+   almacén de datos como SharePoint, Slack o Salesforce, los nombres de manejador correspondientes
    quedan disponibles.
 
 Ejemplos de Uso
 ===============
 
-Configuracion de Rastreo de Base de Datos
+Configuración de Rastreo de Base de Datos
 -----------------------------------------
 
 .. code-block:: bash
@@ -349,10 +349,10 @@ Configuracion de Rastreo de Base de Datos
            "sortOrder": 0
          }'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-webconfig` - API de configuracion de rastreo web
-- :doc:`api-admin-fileconfig` - API de configuracion de rastreo de archivos
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de almacen de datos
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-webconfig` - API de configuración de rastreo web
+- :doc:`api-admin-fileconfig` - API de configuración de rastreo de archivos
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de almacén de datos

--- a/es/15.7/api/admin/api-admin-dict.rst
+++ b/es/15.7/api/admin/api-admin-dict.rst
@@ -2,12 +2,12 @@
 API de Dict
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Dict es para gestionar los diccionarios de |Fess|.
-En el endpoint raiz se puede obtener la lista de diccionarios disponibles.
-La referencia, creacion, actualizacion y eliminacion de elementos de diccionario individuales, asi como la carga y descarga de archivos de diccionario, se operan mediante los subendpoints por tipo de diccionario (synonym, kuromoji, mapping, protwords, stopwords, stemmeroverride).
+En el endpoint raíz se puede obtener la lista de diccionarios disponibles.
+La referencia, creación, actualización y eliminación de elementos de diccionario individuales, así como la carga y descarga de archivos de diccionario, se operan mediante los subendpoints por tipo de diccionario (synonym, kuromoji, mapping, protwords, stopwords, stemmeroverride).
 
 URL Base
 ========
@@ -19,16 +19,16 @@ URL Base
 Lista de Endpoints
 ==================
 
-Raiz del Diccionario
+Raíz del Diccionario
 --------------------
 
 .. list-table::
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /
      - Obtener lista de diccionarios
@@ -44,9 +44,9 @@ Estos valores coinciden con el valor del campo ``type`` incluido en la respuesta
    :header-rows: 1
    :widths: 15 50 35
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /{type}/settings/{dictId}
      - Obtener lista de elementos del diccionario
@@ -116,7 +116,7 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``settings[].id``
      - ID del diccionario (usado como ``{dictId}`` en las operaciones de diccionario individuales)
    * - ``settings[].type``
@@ -124,9 +124,9 @@ Campos de Respuesta
    * - ``settings[].path``
      - Ruta del archivo de diccionario
    * - ``settings[].timestamp``
-     - Fecha y hora de actualizacion del archivo de diccionario
+     - Fecha y hora de actualización del archivo de diccionario
    * - ``total``
-     - Numero total de archivos de diccionario
+     - Número total de archivos de diccionario
 
 Obtener Lista de Elementos del Diccionario
 ==========================================
@@ -140,34 +140,34 @@ Solicitud
 
     GET /api/admin/dict/{type}/settings/{dictId}
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametros
+   * - Parámetros
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``dictId``
      - String
-     - Si
-     - ID del diccionario (parametro de ruta)
+     - Sí
+     - ID del diccionario (parámetro de ruta)
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (por defecto: 25)
+     - Número de elementos por página (por defecto: 25)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, por defecto: 1)
+     - Número de página (comienza en 1, por defecto: 1)
 
 Respuesta
 ---------
 
-Los campos de cada elemento del arreglo ``settings`` de la respuesta varian segun el tipo de diccionario (consulte "Campos de Elementos por Tipo de Diccionario" mas adelante).
+Los campos de cada elemento del arreglo ``settings`` de la respuesta varían según el tipo de diccionario (consulte "Campos de Elementos por Tipo de Diccionario" más adelante).
 
 .. code-block:: json
 
@@ -192,7 +192,7 @@ El ejemplo anterior corresponde al diccionario ``synonym``.
 Obtener Elemento del Diccionario
 ================================
 
-Obtiene un elemento especifico dentro del diccionario.
+Obtiene un elemento específico dentro del diccionario.
 
 Solicitud
 ---------
@@ -201,25 +201,25 @@ Solicitud
 
     GET /api/admin/dict/{type}/setting/{dictId}/{id}
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametros
+   * - Parámetros
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``dictId``
      - String
-     - Si
-     - ID del diccionario (parametro de ruta)
+     - Sí
+     - ID del diccionario (parámetro de ruta)
    * - ``id``
      - Long
-     - Si
-     - ID del elemento (parametro de ruta)
+     - Sí
+     - ID del elemento (parámetro de ruta)
 
 Respuesta
 ---------
@@ -326,25 +326,25 @@ Solicitud
 
     DELETE /api/admin/dict/{type}/setting/{dictId}/{id}
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametros
+   * - Parámetros
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``dictId``
      - String
-     - Si
-     - ID del diccionario (parametro de ruta)
+     - Sí
+     - ID del diccionario (parámetro de ruta)
    * - ``id``
      - Long
-     - Si
-     - ID del elemento (parametro de ruta)
+     - Sí
+     - ID del elemento (parámetro de ruta)
 
 Respuesta
 ---------
@@ -373,7 +373,7 @@ Solicitud
     PUT /api/admin/dict/{type}/upload/{dictId}
     Content-Type: multipart/form-data
 
-El nombre del campo de archivo varia segun el tipo de diccionario (consulte "Campos de Elementos por Tipo de Diccionario" mas adelante).
+El nombre del campo de archivo varía según el tipo de diccionario (consulte "Campos de Elementos por Tipo de Diccionario" más adelante).
 
 Respuesta
 ---------
@@ -404,8 +404,8 @@ La respuesta es el binario del archivo de diccionario ( ``application/octet-stre
 Campos de Elementos por Tipo de Diccionario
 ===========================================
 
-Los campos del cuerpo de la solicitud de creacion y actualizacion de elementos del diccionario, asi como los de la respuesta, varian segun el tipo de diccionario.
-``id`` (ID del elemento) y ``dictId`` (ID del diccionario) se incluyen en comun en la respuesta.
+Los campos del cuerpo de la solicitud de creación y actualización de elementos del diccionario, así como los de la respuesta, varían según el tipo de diccionario.
+``id`` (ID del elemento) y ``dictId`` (ID del diccionario) se incluyen en común en la respuesta.
 
 .. list-table::
    :header-rows: 1
@@ -483,8 +483,8 @@ Descargar Archivo del Diccionario de Sinonimos
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o synonym.txt
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`../../admin/dict-guide` - Guia de gestion de diccionarios
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`../../admin/dict-guide` - Guía de gestión de diccionarios

--- a/es/15.7/api/admin/api-admin-documents.rst
+++ b/es/15.7/api/admin/api-admin-documents.rst
@@ -2,11 +2,11 @@
 API de Documents
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de Documents es una Admin API de |Fess| para registrar documentos de forma masiva en el indice.
-Permite a sistemas externos agregar documentos generados directamente al indice sin necesidad de un rastreador.
+La API de Documents es una Admin API de |Fess| para registrar documentos de forma masiva en el índice.
+Permite a sistemas externos agregar documentos generados directamente al índice sin necesidad de un rastreador.
 Se pueden registrar varios documentos en una sola solicitud.
 
 URL Base
@@ -16,12 +16,12 @@ URL Base
 
     /api/admin/documents
 
-Autenticacion
+Autenticación
 =============
 
-Para llamar a esta API se requiere autenticacion mediante token de acceso, tal como se describe en :doc:`api-admin-overview`.
+Para llamar a esta API se requiere autenticación mediante token de acceso, tal como se describe en :doc:`api-admin-overview`.
 El token debe tener el permiso de acceso a Admin API (por defecto ``Radmin-api``).
-Este permiso se puede cambiar mediante la clave de configuracion ``api.admin.access.permissions``.
+Este permiso se puede cambiar mediante la clave de configuración ``api.admin.access.permissions``.
 
 Lista de Endpoints
 ==================
@@ -30,21 +30,21 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - PUT
      - /bulk
      - Registro masivo de documentos
 
 .. note::
 
-   Este endpoint acepta unicamente el metodo ``PUT``.
+   Este endpoint acepta únicamente el método ``PUT``.
 
 Registro Masivo de Documentos
 ==============================
 
-Registra varios documentos en el indice de forma masiva.
+Registra varios documentos en el índice de forma masiva.
 
 Solicitud
 ---------
@@ -74,7 +74,7 @@ Cuerpo de la Solicitud
       ]
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -83,20 +83,20 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``documents``
-     - Si
-     - Arreglo de documentos a registrar. Cada documento se especifica como un mapa de nombres de campo y valores. Si es ``null`` o un arreglo vacio, se devuelve un error (``status`` = ``1``).
+     - Sí
+     - Arreglo de documentos a registrar. Cada documento se especifica como un mapa de nombres de campo y valores. Si es ``null`` o un arreglo vacío, se devuelve un error (``status`` = ``1``).
 
 Campos del Documento
 ~~~~~~~~~~~~~~~~~~~~
 
-En cada documento se pueden especificar libremente los campos del indice como un mapa de nombres y valores.
-Como minimo, se deben especificar ``url`` y ``title`` (segun la configuracion de campos requeridos
+En cada documento se pueden especificar libremente los campos del índice como un mapa de nombres y valores.
+Como mínimo, se deben especificar ``url`` y ``title`` (según la configuración de campos requeridos
 ``index.admin.required.fields``; el valor predeterminado es ``url,title,role,boost``, y dado que
-``role`` y ``boost`` se autocompletan como se describe mas adelante, en la practica ``url`` y ``title`` son obligatorios).
+``role`` y ``boost`` se autocompletan como se describe más adelante, en la práctica ``url`` y ``title`` son obligatorios).
 
-Los siguientes campos se completan automaticamente si se omiten:
+Los siguientes campos se completan automáticamente si se omiten:
 
 .. list-table::
    :header-rows: 1
@@ -105,7 +105,7 @@ Los siguientes campos se completan automaticamente si se omiten:
    * - Campo
      - Valor predeterminado al omitir
    * - ``content_length``
-     - Suma del numero de caracteres de ``title`` y ``content``
+     - Suma del número de caracteres de ``title`` y ``content``
    * - ``favorite_count``
      - ``0``
    * - ``click_count``
@@ -113,13 +113,13 @@ Los siguientes campos se completan automaticamente si se omiten:
    * - ``boost``
      - ``1.0``
    * - ``role``
-     - Rol de busqueda para invitados (rol de busqueda configurado para usuarios invitados)
+     - Rol de búsqueda para invitados (rol de búsqueda configurado para usuarios invitados)
    * - ``last_modified``
      - Hora actual
    * - ``timestamp``
      - Hora actual
 
-Ademas, los siguientes campos se generan automaticamente al registrar:
+Además, los siguientes campos se generan automáticamente al registrar:
 
 - ``id`` - Se genera de forma determinista a partir de la ``url`` del documento (y de ``role`` y ``virtual_host``),
   y se utiliza como ID de documento en OpenSearch (``_id``). Este valor se devuelve en ``items[].id``
@@ -129,16 +129,16 @@ Ademas, los siguientes campos se generan automaticamente al registrar:
 .. note::
 
    Dado que ``id`` se genera de forma determinista a partir de ``url``, si se registra de nuevo
-   un documento con la misma ``url``, el documento existente sera actualizado
-   (``items[].result`` sera ``OK``).
+   un documento con la misma ``url``, el documento existente será actualizado
+   (``items[].result`` será ``OK``).
 
 Notas Adicionales
 ~~~~~~~~~~~~~~~~~
 
-- Si se incluye ``"auto"`` en el campo ``lang``, el idioma se detecta automaticamente a partir del cuerpo del documento.
-- Si se especifica ``config_id``, se aplica el pipeline de ingesta (ingest pipeline) de la configuracion de rastreo correspondiente.
-- Si la generacion de miniaturas esta habilitada (``thumbnail.crawler.enabled``), se intentara generar una miniatura al registrar.
-- Los valores de cada campo se validan segun la configuracion de tipo del campo (``index.admin.array.fields``,
+- Si se incluye ``"auto"`` en el campo ``lang``, el idioma se detecta automáticamente a partir del cuerpo del documento.
+- Si se especifica ``config_id``, se aplica el pipeline de ingesta (ingest pipeline) de la configuración de rastreo correspondiente.
+- Si la generación de miniaturas está habilitada (``thumbnail.crawler.enabled``), se intentará generar una miniatura al registrar.
+- Los valores de cada campo se validan según la configuración de tipo del campo (``index.admin.array.fields``,
   ``index.admin.date.fields``, ``index.admin.long.fields``, etc.).
   Si el tipo no coincide, se devuelve un error (``status`` = ``1``).
 
@@ -170,8 +170,8 @@ Los elementos exitosos incluyen ``result`` e ``id``, y los elementos fallidos in
 Cuando ``status`` es ``0``, indica que todos los documentos se registraron correctamente.
 En ``items[].result`` se establece ``CREATED`` para nuevos documentos y ``OK`` para documentos existentes actualizados.
 
-Si el registro falla en alguno de los elementos, ``status`` sera ``9`` (FAILED) y
-el elemento correspondiente incluira el campo ``message`` (en ``result`` se establecera
+Si el registro falla en alguno de los elementos, ``status`` será ``9`` (FAILED) y
+el elemento correspondiente incluirá el campo ``message`` (en ``result`` se establecerá
 el nombre del estado de error, como ``CONFLICT`` o ``BAD_REQUEST``). Los elementos exitosos devuelven su ``id`` normalmente.
 
 .. code-block:: json
@@ -195,7 +195,7 @@ el nombre del estado de error, como ``CONFLICT`` o ``BAD_REQUEST``). Los element
 
 .. note::
 
-   Si la solicitud en si es invalida (``documents`` no especificado o vacio, campos requeridos ausentes,
+   Si la solicitud en sí es inválida (``documents`` no especificado o vacío, campos requeridos ausentes,
    tipo de campo incorrecto, etc.), el proceso de registro de documentos no se ejecuta y
    se devuelve una respuesta de error con ``status`` = ``1`` (BAD_REQUEST) y ``message``.
    En este caso, no se devuelve el arreglo ``items``.
@@ -208,13 +208,13 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``items``
      - Arreglo de resultados de procesamiento de cada documento
    * - ``items[].result``
      - Nombre del estado del resultado de procesamiento. ``CREATED`` para nuevos documentos, ``OK`` para actualizaciones, o nombre del estado de error como ``BAD_REQUEST`` en caso de fallo
    * - ``items[].id``
-     - ID del documento registrado (solo en caso de exito)
+     - ID del documento registrado (solo en caso de éxito)
    * - ``items[].message``
      - Mensaje con el motivo del fallo (solo en caso de fallo)
 
@@ -239,10 +239,10 @@ Registro Masivo de Documentos
            ]
          }'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-searchlist` - API de busqueda y gestion de documentos
-- :doc:`api-admin-crawlinginfo` - API de informacion de rastreo
-- :doc:`../../admin/searchlist-guide` - Guia de gestion de lista de busqueda
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-searchlist` - API de búsqueda y gestión de documentos
+- :doc:`api-admin-crawlinginfo` - API de información de rastreo
+- :doc:`../../admin/searchlist-guide` - Guía de gestión de lista de búsqueda

--- a/es/15.7/api/admin/api-admin-elevateword.rst
+++ b/es/15.7/api/admin/api-admin-elevateword.rst
@@ -2,11 +2,11 @@
 API de ElevateWord
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de ElevateWord es para gestionar las palabras elevadas (manipulacion del orden de busqueda para palabras clave especificas) de |Fess|.
-Puede colocar documentos especificos en posiciones superiores o inferiores para ciertas consultas de busqueda.
+La API de ElevateWord es para gestionar las palabras elevadas (manipulación del orden de búsqueda para palabras clave específicas) de |Fess|.
+Puede colocar documentos específicos en posiciones superiores o inferiores para ciertas consultas de búsqueda.
 
 URL Base
 ========
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de palabras elevadas
@@ -57,25 +57,25 @@ Solicitud
 
     GET /api/admin/elevateword/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Número de elementos por página (predeterminado: 20)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``id``
      - String
      - No
@@ -156,7 +156,7 @@ Cuerpo de la Solicitud
       "labelTypeIds": ["label1"]
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -165,18 +165,18 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``suggestWord``
-     - Si
+     - Sí
      - Palabra clave a elevar
    * - ``reading``
      - No
-     - Lectura fonetica
+     - Lectura fonética
    * - ``permissions``
      - No
-     - Permisos de acceso (cadena separada por saltos de linea, uno por linea. Valor inicial del formulario: permisos de visualizacion predeterminados de la busqueda)
+     - Permisos de acceso (cadena separada por saltos de línea, uno por línea. Valor inicial del formulario: permisos de visualización predeterminados de la búsqueda)
    * - ``boost``
-     - Si
+     - Sí
      - Valor de impulso (valor inicial del formulario: 100.0)
    * - ``labelTypeIds``
      - No
@@ -223,10 +223,10 @@ Cuerpo de la Solicitud
 
 .. note::
 
-   Al actualizar, los siguientes campos son obligatorios ademas de los campos utilizados para la creacion:
+   Al actualizar, los siguientes campos son obligatorios además de los campos utilizados para la creación:
 
    - ``id`` - ID de la palabra elevada a actualizar
-   - ``versionNo`` - Numero de version para el bloqueo optimista. Especifique el valor obtenido de ``GET /setting/{id}``.
+   - ``versionNo`` - Número de versión para el bloqueo optimista. Especifique el valor obtenido de ``GET /setting/{id}``.
 
 Respuesta
 ---------
@@ -267,7 +267,7 @@ Respuesta
 Subir CSV de Palabras Elevadas
 ==============================
 
-Registra palabras elevadas en bloque a partir de un archivo CSV. El archivo se envia como ``multipart/form-data``. La importacion se ejecuta de forma asincrona en el servidor.
+Registra palabras elevadas en bloque a partir de un archivo CSV. El archivo se envía como ``multipart/form-data``. La importación se ejecuta de forma asíncrona en el servidor.
 
 Solicitud
 ---------
@@ -277,18 +277,18 @@ Solicitud
     PUT /api/admin/elevateword/upload
     Content-Type: multipart/form-data
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``elevateWordFile``
-     - Si
+     - Sí
      - Archivo CSV de palabras elevadas a subir
 
 Respuesta
@@ -331,7 +331,7 @@ Elevar Nombre de Producto
            "permissions": "{role}guest"
          }'
 
-Elevar a Etiqueta Especifica
+Elevar a Etiqueta Específica
 ----------------------------
 
 .. code-block:: bash
@@ -364,10 +364,10 @@ Descargar Archivo CSV
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o elevate.csv
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-keymatch` - API de coincidencia de claves
 - :doc:`api-admin-boostdoc` - API de impulso de documentos
-- :doc:`../../admin/elevateword-guide` - Guia de gestion de palabras elevadas
+- :doc:`../../admin/elevateword-guide` - Guía de gestión de palabras elevadas

--- a/es/15.7/api/admin/api-admin-failureurl.rst
+++ b/es/15.7/api/admin/api-admin-failureurl.rst
@@ -2,7 +2,7 @@
 API de FailureUrl
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de FailureUrl es para gestionar las URLs de rastreo fallidas de |Fess|.
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /logs
      - Obtener lista de URLs fallidas
@@ -48,25 +48,25 @@ Solicitud
 
     GET /api/admin/failureurl/logs
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Número de elementos por página (predeterminado: 20)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``url``
      - String
      - No
@@ -74,11 +74,11 @@ Parametros
    * - ``errorCountMin``
      - Integer
      - No
-     - Limite inferior del numero de errores (mayor o igual al valor especificado)
+     - Límite inferior del número de errores (mayor o igual al valor especificado)
    * - ``errorCountMax``
      - Integer
      - No
-     - Limite superior del numero de errores (menor o igual al valor especificado)
+     - Límite superior del número de errores (menor o igual al valor especificado)
    * - ``errorName``
      - String
      - No
@@ -126,7 +126,7 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``id``
      - ID de URL fallida
    * - ``url``
@@ -134,19 +134,19 @@ Campos de Respuesta
    * - ``threadName``
      - Nombre del hilo
    * - ``errorName``
-     - Nombre del error (nombre de clase completamente calificado de la excepcion ocurrida; por ejemplo, ``java.net.ConnectException``)
+     - Nombre del error (nombre de clase completamente calificado de la excepción ocurrida; por ejemplo, ``java.net.ConnectException``)
    * - ``errorLog``
-     - Registro de error (mensaje de la excepcion o traza de pila)
+     - Registro de error (mensaje de la excepción o traza de pila)
    * - ``errorCount``
-     - Numero de ocurrencias del error (valor numerico representado como cadena)
+     - Número de ocurrencias del error (valor numérico representado como cadena)
    * - ``lastAccessTime``
-     - Hora del ultimo acceso (milisegundos epoch representados como cadena)
+     - Hora del último acceso (milisegundos epoch representados como cadena)
    * - ``configId``
-     - ID de configuracion de rastreo
+     - ID de configuración de rastreo
 
 .. note::
 
-   Todos los campos de respuesta se devuelven como cadenas (JSON string). ``errorCount`` es un valor numerico representado como cadena y ``lastAccessTime`` son milisegundos epoch representados como cadena.
+   Todos los campos de respuesta se devuelven como cadenas (JSON string). ``errorCount`` es un valor numérico representado como cadena y ``lastAccessTime`` son milisegundos epoch representados como cadena.
 
 Obtener URL Fallida
 ===================
@@ -203,7 +203,7 @@ Respuesta
 Eliminar Todas las URLs Fallidas
 ================================
 
-Elimina todas las URLs fallidas. No tiene parametros.
+Elimina todas las URLs fallidas. No tiene parámetros.
 
 Solicitud
 ---------
@@ -226,28 +226,28 @@ Respuesta
 Tipos de Error
 ==============
 
-``errorName`` almacena el nombre de clase completamente calificado de la excepcion ocurrida durante el rastreo, tal como fue capturado. No es una enumeracion fija; puede aparecer cualquier nombre de clase dependiendo de la excepcion que se haya producido. A continuacion se muestran ejemplos representativos.
+``errorName`` almacena el nombre de clase completamente calificado de la excepción ocurrida durante el rastreo, tal como fue capturado. No es una enumeración fija; puede aparecer cualquier nombre de clase dependiendo de la excepción que se haya producido. A continuación se muestran ejemplos representativos.
 
 .. list-table::
    :header-rows: 1
    :widths: 50 50
 
    * - Nombre de Error (ejemplo)
-     - Descripcion
+     - Descripción
    * - ``java.net.ConnectException``
-     - Conexion rechazada (no se puede conectar al servidor)
+     - Conexión rechazada (no se puede conectar al servidor)
    * - ``java.net.UnknownHostException``
      - No se pudo resolver el nombre de host (error de DNS)
    * - ``java.net.SocketTimeoutException``
-     - Tiempo de espera de conexion o lectura agotado
+     - Tiempo de espera de conexión o lectura agotado
    * - ``javax.net.ssl.SSLException``
      - Error en el protocolo de enlace SSL/TLS o en el certificado
    * - ``java.io.IOException``
      - Error de entrada/salida
    * - ``org.codelibs.fess.exception.ContentNotFoundException``
-     - URL que devolvio un codigo de estado HTTP configurado en ``crawler.failure.url.status.codes`` (predeterminado: 403, 404, 410)
+     - URL que devolvió un código de estado HTTP configurado en ``crawler.failure.url.status.codes`` (predeterminado: 403, 404, 410)
    * - ``org.codelibs.fess.crawler.exception.MaxLengthExceededException``
-     - El contenido supero la longitud maxima
+     - El contenido superó la longitud máxima
 
 Ejemplos de Uso
 ===============
@@ -260,7 +260,7 @@ Obtener Lista de URLs Fallidas
     curl -X GET "http://localhost:8080/api/admin/failureurl/logs?size=100&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Filtrar por Numero de Errores
+Filtrar por Número de Errores
 -----------------------------
 
 .. code-block:: bash
@@ -302,7 +302,7 @@ Eliminar Todas las URLs Fallidas
     curl -X DELETE "http://localhost:8080/api/admin/failureurl/all" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Agregacion por Tipo de Error
+Agregación por Tipo de Error
 ----------------------------
 
 .. code-block:: bash
@@ -312,10 +312,10 @@ Agregacion por Tipo de Error
          -H "Authorization: Bearer YOUR_TOKEN" | \
          jq '[.response.logs[].errorName] | group_by(.) | map({error: .[0], count: length})'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-crawlinginfo` - API de informacion de rastreo
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-crawlinginfo` - API de información de rastreo
 - :doc:`api-admin-joblog` - API de registro de trabajos
-- :doc:`../../admin/failureurl-guide` - Guia de gestion de URLs fallidas
+- :doc:`../../admin/failureurl-guide` - Guía de gestión de URLs fallidas

--- a/es/15.7/api/admin/api-admin-fileconfig.rst
+++ b/es/15.7/api/admin/api-admin-fileconfig.rst
@@ -2,10 +2,10 @@
 API de FileConfig
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de FileConfig es para gestionar la configuracion de rastreo de archivos de |Fess|.
+La API de FileConfig es para gestionar la configuración de rastreo de archivos de |Fess|.
 Puede operar configuraciones de rastreo para sistemas de archivos locales, carpetas compartidas SMB/CIFS, FTP y diversos almacenes de objetos.
 
 URL Base
@@ -17,8 +17,8 @@ URL Base
 
 .. note::
 
-   Todos los endpoints requieren privilegios de administrador y un token de acceso valido.
-   Consulte :doc:`api-admin-overview` para obtener informacion sobre la autenticacion.
+   Todos los endpoints requieren privilegios de administrador y un token de acceso válido.
+   Consulte :doc:`api-admin-overview` para obtener información sobre la autenticación.
 
 Lista de Endpoints
 ==================
@@ -27,24 +27,24 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de configuraciones de rastreo de archivos
    * - GET
      - /setting/{id}
-     - Obtener configuracion de rastreo de archivos
+     - Obtener configuración de rastreo de archivos
    * - POST
      - /setting
-     - Crear configuracion de rastreo de archivos
+     - Crear configuración de rastreo de archivos
    * - PUT
      - /setting
-     - Actualizar configuracion de rastreo de archivos
+     - Actualizar configuración de rastreo de archivos
    * - DELETE
      - /setting/{id}
-     - Eliminar configuracion de rastreo de archivos
+     - Eliminar configuración de rastreo de archivos
 
 Obtener Lista de Configuraciones de Rastreo de Archivos
 ========================================================
@@ -58,31 +58,31 @@ Solicitud
 
 .. note::
 
-   El endpoint de lista tambien acepta ``PUT`` ademas de ``GET``.
+   El endpoint de lista también acepta ``PUT`` además de ``GET``.
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 10 55
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25, segun la configuracion ``paging.page.size``)
+     - Número de elementos por página (predeterminado: 25, según la configuración ``paging.page.size``)
    * - ``name``
      - String
      - No
-     - Filtrar por nombre de configuracion
+     - Filtrar por nombre de configuración
    * - ``paths``
      - String
      - No
@@ -90,7 +90,7 @@ Parametros
    * - ``description``
      - String
      - No
-     - Filtrar por descripcion
+     - Filtrar por descripción
 
 Respuesta
 ---------
@@ -126,9 +126,9 @@ Respuesta
       }
     }
 
-``total`` indica el numero total de configuraciones que coinciden con los criterios de busqueda.
+``total`` indica el número total de configuraciones que coinciden con los criterios de búsqueda.
 
-Obtener Configuracion de Rastreo de Archivos
+Obtener Configuración de Rastreo de Archivos
 ============================================
 
 Solicitud
@@ -176,12 +176,12 @@ Respuesta
 
 .. note::
 
-   La respuesta incluye los campos de auditoria ``createdBy``, ``createdTime``,
-   ``updatedBy``, ``updatedTime`` y ``versionNo``, que son asignados automaticamente
-   en el momento del registro o la actualizacion.
-   ``versionNo`` es obligatorio al actualizar (consulte la seccion "Actualizar configuracion de rastreo de archivos" a continuacion).
+   La respuesta incluye los campos de auditoría ``createdBy``, ``createdTime``,
+   ``updatedBy``, ``updatedTime`` y ``versionNo``, que son asignados automáticamente
+   en el momento del registro o la actualización.
+   ``versionNo`` es obligatorio al actualizar (consulte la sección "Actualizar configuración de rastreo de archivos" a continuación).
 
-Crear Configuracion de Rastreo de Archivos
+Crear Configuración de Rastreo de Archivos
 ==========================================
 
 Solicitud
@@ -210,7 +210,7 @@ Cuerpo de la Solicitud
       "permissions": "{role}admin\n{role}user"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -219,63 +219,63 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre de la configuracion (maximo 200 caracteres)
+     - Sí
+     - Nombre de la configuración (máximo 200 caracteres)
    * - ``description``
      - No
-     - Descripcion de la configuracion (maximo 1000 caracteres)
+     - Descripción de la configuración (máximo 1000 caracteres)
    * - ``paths``
-     - Si
-     - Ruta de inicio de rastreo (separadas por salto de linea si son multiples). Se especifica con uno de los protocolos: ``file:``, ``smb:``, ``smb1:``, ``ftp:``, ``storage:``, ``s3:`` o ``gcs:``
+     - Sí
+     - Ruta de inicio de rastreo (separadas por salto de línea si son múltiples). Se especifica con uno de los protocolos: ``file:``, ``smb:``, ``smb1:``, ``ftp:``, ``storage:``, ``s3:`` o ``gcs:``
    * - ``includedPaths``
      - No
-     - Patron de expresion regular para rutas a rastrear
+     - Patrón de expresión regular para rutas a rastrear
    * - ``excludedPaths``
      - No
-     - Patron de expresion regular para rutas a excluir del rastreo
+     - Patrón de expresión regular para rutas a excluir del rastreo
    * - ``includedDocPaths``
      - No
-     - Patron de expresion regular para rutas a indexar
+     - Patrón de expresión regular para rutas a indexar
    * - ``excludedDocPaths``
      - No
-     - Patron de expresion regular para rutas a excluir del indice
+     - Patrón de expresión regular para rutas a excluir del índice
    * - ``configParameter``
      - No
-     - Parametros de configuracion adicionales (formato ``key=value``, un elemento por linea)
+     - Parámetros de configuración adicionales (formato ``key=value``, un elemento por línea)
    * - ``depth``
      - No
-     - Profundidad de rastreo (0 o mas)
+     - Profundidad de rastreo (0 o más)
    * - ``maxAccessCount``
      - No
-     - Numero maximo de accesos (0 o mas)
+     - Número máximo de accesos (0 o más)
    * - ``numOfThread``
-     - Si
-     - Numero de hilos paralelos (1 o mas)
+     - Sí
+     - Número de hilos paralelos (1 o más)
    * - ``intervalTime``
-     - Si
-     - Intervalo de acceso (milisegundos, 0 o mas)
+     - Sí
+     - Intervalo de acceso (milisegundos, 0 o más)
    * - ``boost``
-     - Si
-     - Valor de impulso en resultados de busqueda
+     - Sí
+     - Valor de impulso en resultados de búsqueda
    * - ``available``
-     - Si
+     - Sí
      - Habilitado/Deshabilitado (cadena ``"true"`` / ``"false"``)
    * - ``sortOrder``
-     - Si
-     - Orden de visualizacion (0 o mas)
+     - Sí
+     - Orden de visualización (0 o más)
    * - ``permissions``
      - No
-     - Roles con permiso de acceso (separados por saltos de linea si son varios)
+     - Roles con permiso de acceso (separados por saltos de línea si son varios)
    * - ``virtualHosts``
      - No
-     - Hosts virtuales (separados por saltos de linea si son varios)
+     - Hosts virtuales (separados por saltos de línea si son varios)
 
 .. note::
 
-   Los campos de auditoria como ``createdBy``, ``createdTime``, ``updatedBy`` y ``updatedTime``
-   son asignados automaticamente por el servidor, por lo que no es necesario incluirlos en el cuerpo de la solicitud.
+   Los campos de auditoría como ``createdBy``, ``createdTime``, ``updatedBy`` y ``updatedTime``
+   son asignados automáticamente por el servidor, por lo que no es necesario incluirlos en el cuerpo de la solicitud.
 
 Respuesta
 ---------
@@ -290,7 +290,7 @@ Respuesta
       }
     }
 
-Actualizar Configuracion de Rastreo de Archivos
+Actualizar Configuración de Rastreo de Archivos
 ===============================================
 
 Solicitud
@@ -304,8 +304,8 @@ Solicitud
 Cuerpo de la Solicitud
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Al actualizar, ademas de los campos de creacion, son obligatorios ``id`` para identificar
-el registro a actualizar y ``versionNo`` como numero de version.
+Al actualizar, además de los campos de creación, son obligatorios ``id`` para identificar
+el registro a actualizar y ``versionNo`` como número de versión.
 En ``versionNo`` se debe especificar el valor actual incluido en la respuesta de la API de consulta (GET).
 
 .. code-block:: json
@@ -326,7 +326,7 @@ En ``versionNo`` se debe especificar el valor actual incluido en la respuesta de
       "versionNo": 1
     }
 
-Campos Adicionales para la Actualizacion
+Campos Adicionales para la Actualización
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -335,13 +335,13 @@ Campos Adicionales para la Actualizacion
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
-     - ID de la configuracion a actualizar (maximo 1000 caracteres)
+     - Sí
+     - ID de la configuración a actualizar (máximo 1000 caracteres)
    * - ``versionNo``
-     - Si
-     - Numero de version actual del registro a actualizar. Se especifica el valor de ``versionNo`` incluido en la respuesta de la API de consulta (GET)
+     - Sí
+     - Número de versión actual del registro a actualizar. Se especifica el valor de ``versionNo`` incluido en la respuesta de la API de consulta (GET)
 
 Respuesta
 ---------
@@ -356,7 +356,7 @@ Respuesta
       }
     }
 
-Eliminar Configuracion de Rastreo de Archivos
+Eliminar Configuración de Rastreo de Archivos
 =============================================
 
 Solicitud
@@ -380,7 +380,7 @@ Respuesta
 Formato de Rutas
 ================
 
-En ``paths`` se pueden utilizar los siguientes protocolos (los protocolos disponibles pueden modificarse mediante la configuracion ``crawler.file.protocols``).
+En ``paths`` se pueden utilizar los siguientes protocolos (los protocolos disponibles pueden modificarse mediante la configuración ``crawler.file.protocols``).
 
 .. list-table::
    :header-rows: 1
@@ -405,14 +405,14 @@ En ``paths`` se pueden utilizar los siguientes protocolos (los protocolos dispon
 
 .. note::
 
-   Las credenciales de autenticacion (nombre de usuario y contrasena) para SMB/CIFS y FTP
-   no se incluyen en la ruta, sino que se configuran en la seccion "Autenticacion de archivos".
-   Consulte :doc:`../../admin/fileauth-guide` para mas informacion.
+   Las credenciales de autenticación (nombre de usuario y contraseña) para SMB/CIFS y FTP
+   no se incluyen en la ruta, sino que se configuran en la sección "Autenticación de archivos".
+   Consulte :doc:`../../admin/fileauth-guide` para más información.
 
 Ejemplos de Uso
 ===============
 
-Configuracion de Rastreo de Archivos Locales
+Configuración de Rastreo de Archivos Locales
 --------------------------------------------
 
 .. code-block:: bash
@@ -433,7 +433,7 @@ Configuracion de Rastreo de Archivos Locales
            "permissions": "{role}guest"
          }'
 
-Configuracion de Rastreo de Recurso Compartido SMB
+Configuración de Rastreo de Recurso Compartido SMB
 --------------------------------------------------
 
 .. code-block:: bash
@@ -457,14 +457,14 @@ Configuracion de Rastreo de Recurso Compartido SMB
 
 .. note::
 
-   Si el acceso al recurso compartido SMB requiere autenticacion, registre previamente
-   las credenciales del host de destino en la configuracion de "Autenticacion de archivos".
+   Si el acceso al recurso compartido SMB requiere autenticación, registre previamente
+   las credenciales del host de destino en la configuración de "Autenticación de archivos".
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-webconfig` - API de configuracion de rastreo web
-- :doc:`api-admin-dataconfig` - API de configuracion de almacen de datos
-- :doc:`../../admin/fileconfig-guide` - Guia de configuracion de rastreo de archivos
-- :doc:`../../admin/fileauth-guide` - Guia de configuracion de autenticacion de archivos
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-webconfig` - API de configuración de rastreo web
+- :doc:`api-admin-dataconfig` - API de configuración de almacén de datos
+- :doc:`../../admin/fileconfig-guide` - Guía de configuración de rastreo de archivos
+- :doc:`../../admin/fileauth-guide` - Guía de configuración de autenticación de archivos

--- a/es/15.7/api/admin/api-admin-general.rst
+++ b/es/15.7/api/admin/api-admin-general.rst
@@ -2,16 +2,16 @@
 API de General
 ==========================
 
-Descripcion General
+Descripción General
 ===================
 
-La API de General es una API para gestionar la configuracion general de |Fess|
-(configuracion de todo el sistema). Puede obtener y actualizar configuraciones
-relacionadas con el rastreo, el registro, la visualizacion de resultados de
-busqueda, las sugerencias, los periodos de retencion de registros, las
-notificaciones, la autenticacion (LDAP / SSO) y la integracion con
+La API de General es una API para gestionar la configuración general de |Fess|
+(configuración de todo el sistema). Puede obtener y actualizar configuraciones
+relacionadas con el rastreo, el registro, la visualización de resultados de
+búsqueda, las sugerencias, los periodos de retención de registros, las
+notificaciones, la autenticación (LDAP / SSO) y la integración con
 almacenamiento en la nube. Estas configuraciones corresponden a los ajustes
-"General" en la interfaz de administracion (:doc:`../../admin/general-guide`).
+"General" en la interfaz de administración (:doc:`../../admin/general-guide`).
 
 URL Base
 ========
@@ -22,7 +22,7 @@ URL Base
 
 Para acceder a esta API se requiere un token de acceso con el permiso
 ``Radmin-api``. Consulte :doc:`api-admin-overview` para obtener detalles sobre
-la autenticacion.
+la autenticación.
 
 Lista de Endpoints
 ==================
@@ -31,17 +31,17 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /
-     - Obtener configuracion general
+     - Obtener configuración general
    * - PUT
      - /
-     - Actualizar configuracion general
+     - Actualizar configuración general
 
-Obtener Configuracion General
+Obtener Configuración General
 ==============================
 
 Solicitud
@@ -51,17 +51,17 @@ Solicitud
 
     GET /api/admin/general
 
-Este endpoint no acepta parametros de consulta.
+Este endpoint no acepta parámetros de consulta.
 
 Respuesta
 ---------
 
-``response.setting`` contiene la configuracion general actual. La respuesta
-incluye todos los campos de configuracion actualizables; el ejemplo a
-continuacion muestra solo los campos representativos. Los ajustes de
-activacion/desactivacion se expresan como las cadenas ``"true"`` /
-``"false"``, mientras que valores como los dias de retencion y el numero de
-hilos se expresan como numeros.
+``response.setting`` contiene la configuración general actual. La respuesta
+incluye todos los campos de configuración actualizables; el ejemplo a
+continuación muestra solo los campos representativos. Los ajustes de
+activación/desactivación se expresan como las cadenas ``"true"`` /
+``"false"``, mientras que valores como los días de retención y el número de
+hilos se expresan como números.
 
 .. code-block:: json
 
@@ -108,24 +108,24 @@ hilos se expresan como numeros.
 .. note::
 
    Lo anterior muestra solo campos representativos a modo de ejemplo. El objeto ``setting``
-   real en la respuesta contiene todos los campos de configuracion general (rastreo, busqueda,
-   notificaciones, LDAP, SSO, almacenamiento, etc.). Consulte la pagina de ajustes "General"
-   en la interfaz de administracion para la lista completa.
+   real en la respuesta contiene todos los campos de configuración general (rastreo, búsqueda,
+   notificaciones, LDAP, SSO, almacenamiento, etc.). Consulte la página de ajustes "General"
+   en la interfaz de administración para la lista completa.
 
 .. note::
 
    Por razones de seguridad, los campos que contienen credenciales no se devuelven con sus
    valores reales.
 
-   - La contrasena del administrador LDAP ``ldapAdminSecurityCredentials`` siempre se
+   - La contraseña del administrador LDAP ``ldapAdminSecurityCredentials`` siempre se
      devuelve como ``null``.
    - Otros secretos (``storageAccessKey`` / ``storageSecretKey`` /
      ``oicClientId`` / ``oicClientSecret`` / ``spnegoPreauthPassword`` /
      ``entraidClientId`` / ``entraidClientSecret``) se devuelven enmascarados como
-     ``"**********"`` cuando estan configurados, o como una cadena vacia (``""``) cuando
-     no lo estan.
+     ``"**********"`` cuando están configurados, o como una cadena vacía (``""``) cuando
+     no lo están.
 
-Actualizar Configuracion General
+Actualizar Configuración General
 =================================
 
 Solicitud
@@ -139,8 +139,8 @@ Solicitud
 Cuerpo de la Solicitud
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Las actualizaciones se procesan como una actualizacion parcial (merge). El
-servidor carga la configuracion actual y luego sobreescribe unicamente los
+Las actualizaciones se procesan como una actualización parcial (merge). El
+servidor carga la configuración actual y luego sobreescribe únicamente los
 campos no nulos (no ``null``) incluidos en la solicitud. Los campos no
 incluidos en la solicitud, y los campos establecidos como ``null``, conservan
 sus valores existentes.
@@ -148,33 +148,33 @@ sus valores existentes.
 .. warning::
 
    Los siguientes cuatro campos son requeridos y DEBEN incluirse en CADA solicitud PUT,
-   incluso en una actualizacion parcial:
+   incluso en una actualización parcial:
 
    - ``dayForCleanup``
    - ``crawlingThreadCount``
    - ``failureCountThreshold``
    - ``csvFileEncoding``
 
-   Si falta alguno de ellos, la solicitud falla la validacion y la API devuelve HTTP 400
+   Si falta alguno de ellos, la solicitud falla la validación y la API devuelve HTTP 400
    con ``status: 1`` y un ``message`` de error. Dado que el valor enviado sobreescribe la
-   configuracion existente, para mantener un valor sin cambios primero recuperelo con
-   ``GET`` y envielo tal cual. Todos los demas campos son opcionales; los campos omitidos
+   configuración existente, para mantener un valor sin cambios primero recupérelo con
+   ``GET`` y envíelo tal cual. Todos los demás campos son opcionales; los campos omitidos
    conservan sus valores existentes.
 
 .. note::
 
-   Los campos numericos tienen validacion de tipo y rango. Enviar un valor que no pueda
-   interpretarse como un entero, o un valor fuera del rango permitido, falla la validacion
-   (HTTP 400 con ``status: 1``). El rango valido de cada campo numerico se indica en la
-   tabla de campos a continuacion.
+   Los campos numéricos tienen validación de tipo y rango. Enviar un valor que no pueda
+   interpretarse como un entero, o un valor fuera del rango permitido, falla la validación
+   (HTTP 400 con ``status: 1``). El rango válido de cada campo numérico se indica en la
+   tabla de campos a continuación.
 
 .. note::
 
-   Para los campos de activacion/desactivacion (tipo ``available``), solo ``"true"`` o
-   ``"on"`` (ambos sin distincion de mayusculas y minusculas) significan habilitado.
-   Cualquier otro valor (como ``"false"`` o una cadena vacia) se trata como deshabilitado
-   (``false``). El valor existente se mantiene unicamente cuando el campo se omite (no se
-   envia). En la respuesta GET, estos campos se devuelven como las cadenas ``"true"`` /
+   Para los campos de activación/desactivación (tipo ``available``), solo ``"true"`` o
+   ``"on"`` (ambos sin distinción de mayúsculas y minúsculas) significan habilitado.
+   Cualquier otro valor (como ``"false"`` o una cadena vacía) se trata como deshabilitado
+   (``false``). El valor existente se mantiene únicamente cuando el campo se omite (no se
+   envía). En la respuesta GET, estos campos se devuelven como las cadenas ``"true"`` /
    ``"false"``.
 
 .. code-block:: json
@@ -191,10 +191,10 @@ sus valores existentes.
 Campos Principales
 ~~~~~~~~~~~~~~~~~~
 
-Los elementos de configuracion son muy variados. A continuacion se muestran
+Los elementos de configuración son muy variados. A continuación se muestran
 los campos representativos (todos los campos corresponden a los ajustes
-"General" en la interfaz de administracion). Los ajustes de
-activacion/desactivacion se especifican como las cadenas ``"true"`` /
+"General" en la interfaz de administración). Los ajustes de
+activación/desactivación se especifican como las cadenas ``"true"`` /
 ``"false"``.
 
 .. list-table::
@@ -203,64 +203,64 @@ activacion/desactivacion se especifican como las cadenas ``"true"`` /
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``incrementalCrawling``
      - No
      - Habilitar/deshabilitar el rastreo incremental
    * - ``dayForCleanup``
-     - Si
-     - Numero de dias que se conservan los documentos rastreados (-1=limpieza deshabilitada; rango: -1 a 1000)
+     - Sí
+     - Número de días que se conservan los documentos rastreados (-1=limpieza deshabilitada; rango: -1 a 1000)
    * - ``crawlingThreadCount``
-     - Si
-     - Numero de hilos usados para el rastreo (rango: 0 a 100)
+     - Sí
+     - Número de hilos usados para el rastreo (rango: 0 a 100)
    * - ``failureCountThreshold``
-     - Si
-     - Umbral del numero de fallos para detener el rastreo de una URL (-1=deshabilitado; rango: -1 a 10000)
+     - Sí
+     - Umbral del número de fallos para detener el rastreo de una URL (-1=deshabilitado; rango: -1 a 10000)
    * - ``csvFileEncoding``
-     - Si
-     - Codificacion de la exportacion CSV
+     - Sí
+     - Codificación de la exportación CSV
    * - ``searchLog``
      - No
-     - Habilitar/deshabilitar el registro de consultas de busqueda
+     - Habilitar/deshabilitar el registro de consultas de búsqueda
    * - ``userInfo``
      - No
-     - Habilitar/deshabilitar el registro de informacion de usuario
+     - Habilitar/deshabilitar el registro de información de usuario
    * - ``userFavorite``
      - No
-     - Habilitar/deshabilitar la funcion de favoritos
+     - Habilitar/deshabilitar la función de favoritos
    * - ``webApiJson``
      - No
      - Habilitar/deshabilitar la Web API JSON
    * - ``appValue``
      - No
-     - Valor de configuracion adicional especifico de la aplicacion
+     - Valor de configuración adicional específico de la aplicación
    * - ``virtualHostValue``
      - No
-     - Configuracion de host virtual (para entornos multi-tenant)
+     - Configuración de host virtual (para entornos multi-tenant)
    * - ``popularWord``
      - No
-     - Habilitar/deshabilitar la agregacion y visualizacion de palabras populares
+     - Habilitar/deshabilitar la agregación y visualización de palabras populares
    * - ``defaultLabelValue``
      - No
      - Valor de etiqueta predeterminado
    * - ``defaultSortValue``
      - No
-     - Orden de clasificacion predeterminado
+     - Orden de clasificación predeterminado
    * - ``appendQueryParameter``
      - No
-     - Agregar parametros de consulta a la URL de los resultados de busqueda
+     - Agregar parámetros de consulta a la URL de los resultados de búsqueda
    * - ``loginRequired``
      - No
-     - Si se requiere inicio de sesion para buscar
+     - Si se requiere inicio de sesión para buscar
    * - ``loginLink``
      - No
-     - Habilitar o deshabilitar la visualizacion del enlace de inicio de sesion en la pantalla de busqueda
+     - Habilitar o deshabilitar la visualización del enlace de inicio de sesión en la pantalla de búsqueda
    * - ``thumbnail``
      - No
-     - Habilitar/deshabilitar la generacion de miniaturas
+     - Habilitar/deshabilitar la generación de miniaturas
    * - ``resultCollapsed``
      - No
-     - Habilitar o deshabilitar el colapso de documentos similares en los resultados de busqueda
+     - Habilitar o deshabilitar el colapso de documentos similares en los resultados de búsqueda
    * - ``ignoreFailureType``
      - No
      - Tipos de fallo de rastreo a ignorar
@@ -269,34 +269,34 @@ activacion/desactivacion se especifican como las cadenas ``"true"`` /
      - Cadena User-Agent enviada durante el rastreo
    * - ``purgeSearchLogDay``
      - No
-     - Numero de dias que se conservan los registros de busqueda (-1=deshabilitado; rango: -1 a 100000)
+     - Número de días que se conservan los registros de búsqueda (-1=deshabilitado; rango: -1 a 100000)
    * - ``purgeJobLogDay``
      - No
-     - Numero de dias que se conservan los registros de trabajos (-1=deshabilitado; rango: -1 a 100000)
+     - Número de días que se conservan los registros de trabajos (-1=deshabilitado; rango: -1 a 100000)
    * - ``purgeUserInfoDay``
      - No
-     - Numero de dias que se conserva la informacion de usuario (-1=deshabilitado; rango: -1 a 100000)
+     - Número de días que se conserva la información de usuario (-1=deshabilitado; rango: -1 a 100000)
    * - ``purgeSuggestSearchLogDay``
      - No
-     - Numero de dias que se conservan los registros de busqueda de sugerencias (0=deshabilitado; rango: 0 a 100000)
+     - Número de días que se conservan los registros de búsqueda de sugerencias (0=deshabilitado; rango: 0 a 100000)
    * - ``purgeByBots``
      - No
-     - User-Agent de bots cuyos registros de busqueda se descartan
+     - User-Agent de bots cuyos registros de búsqueda se descartan
    * - ``notificationTo``
      - No
-     - Direccion de correo electronico de destino de las notificaciones del sistema
+     - Dirección de correo electrónico de destino de las notificaciones del sistema
    * - ``notificationLogin``
      - No
-     - Mensaje de notificacion que se muestra en la pagina de inicio de sesion
+     - Mensaje de notificación que se muestra en la página de inicio de sesión
    * - ``notificationSearchTop``
      - No
-     - Mensaje de notificacion que se muestra en la pagina principal de busqueda
+     - Mensaje de notificación que se muestra en la página principal de búsqueda
    * - ``notificationAdvanceSearch``
      - No
-     - Mensaje de notificacion que se muestra en la pagina de busqueda avanzada
+     - Mensaje de notificación que se muestra en la página de búsqueda avanzada
    * - ``suggestSearchLog``
      - No
-     - Habilitar/deshabilitar las sugerencias a partir de los registros de busqueda
+     - Habilitar/deshabilitar las sugerencias a partir de los registros de búsqueda
    * - ``suggestDocuments``
      - No
      - Habilitar/deshabilitar las sugerencias a partir de los documentos
@@ -305,10 +305,10 @@ activacion/desactivacion se especifican como las cadenas ``"true"`` /
      - Nivel de registro del log del sistema
    * - ``logNotificationEnabled``
      - No
-     - Habilitar/deshabilitar la notificacion de logs ERROR/WARN
+     - Habilitar/deshabilitar la notificación de logs ERROR/WARN
    * - ``logNotificationLevel``
      - No
-     - Nivel de notificacion de logs
+     - Nivel de notificación de logs
    * - ``slackWebhookUrls``
      - No
      - URL de Slack Webhook para notificaciones
@@ -317,7 +317,7 @@ activacion/desactivacion se especifican como las cadenas ``"true"`` /
      - URL de Google Chat Webhook para notificaciones
    * - ``searchUseBrowserLocale``
      - No
-     - Si se utiliza el idioma del navegador para la busqueda
+     - Si se utiliza el idioma del navegador para la búsqueda
    * - ``ragLlmName``
      - No
      - Nombre del proveedor LLM utilizado para RAG
@@ -325,22 +325,22 @@ activacion/desactivacion se especifican como las cadenas ``"true"`` /
      - No
      - Nivel de registro para los paquetes relacionados con LLM
 
-Campos Relacionados con Autenticacion
+Campos Relacionados con Autenticación
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Las configuraciones relacionadas con LDAP y SSO (OpenID Connect, SAML,
-SPNEGO, Entra ID) tambien se gestionan con esta API. A continuacion se
+SPNEGO, Entra ID) también se gestionan con esta API. A continuación se
 muestran los campos representativos (todos los campos corresponden a los
-ajustes "General" en la interfaz de administracion).
+ajustes "General" en la interfaz de administración).
 
 .. list-table::
    :header-rows: 1
    :widths: 40 60
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``ldapProviderUrl``
-     - URL de conexion LDAP
+     - URL de conexión LDAP
    * - ``ldapBaseDn``
      - DN base de LDAP
    * - ``ldapSecurityPrincipal``
@@ -348,26 +348,26 @@ ajustes "General" en la interfaz de administracion).
    * - ``ldapAdminSecurityPrincipal``
      - Principal de seguridad para operaciones administrativas LDAP
    * - ``ldapAdminSecurityCredentials``
-     - Contrasena del administrador LDAP (se reemplaza por ``null`` en la respuesta)
+     - Contraseña del administrador LDAP (se reemplaza por ``null`` en la respuesta)
    * - ``ldapAccountFilter`` / ``ldapGroupFilter``
-     - Filtros de busqueda de usuarios/grupos
+     - Filtros de búsqueda de usuarios/grupos
    * - ``ldapMemberofAttribute``
      - Nombre del atributo LDAP que indica la pertenencia a un grupo
    * - ``ssoType``
      - Tipo de SSO (``none`` / ``oic`` / ``saml`` / ``spnego`` / ``entraid``)
    * - ``oicClientId`` / ``oicClientSecret`` / ``oicAuthServerUrl`` y otros
-     - Configuracion de OpenID Connect
+     - Configuración de OpenID Connect
    * - ``samlIdpEntityid`` / ``samlSpEntityid`` y otros
-     - Configuracion de SAML
+     - Configuración de SAML
    * - ``spnegoKrb5Conf`` / ``spnegoLoginConf`` y otros
-     - Configuracion de SPNEGO
+     - Configuración de SPNEGO
    * - ``entraidClientId`` / ``entraidTenant`` y otros
-     - Configuracion de Microsoft Entra ID
+     - Configuración de Microsoft Entra ID
 
 Campos Relacionados con Almacenamiento
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tambien se puede gestionar la configuracion de integracion con almacenamiento
+También se puede gestionar la configuración de integración con almacenamiento
 en la nube (S3 / GCS).
 
 .. list-table::
@@ -375,17 +375,17 @@ en la nube (S3 / GCS).
    :widths: 40 60
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``storageType``
      - Tipo de almacenamiento (``auto`` / ``s3`` / ``gcs``)
    * - ``storageEndpoint``
      - URL del endpoint del almacenamiento
    * - ``storageAccessKey`` / ``storageSecretKey``
-     - Clave de acceso/clave secreta para la autenticacion
+     - Clave de acceso/clave secreta para la autenticación
    * - ``storageBucket``
      - Nombre del bucket
    * - ``storageRegion``
-     - Region de S3
+     - Región de S3
    * - ``storageProjectId`` / ``storageCredentialsPath``
      - ID de proyecto de GCS / ruta del archivo de credenciales
 
@@ -394,18 +394,18 @@ en la nube (S3 / GCS).
    Los campos de tipo secreto como ``ldapAdminSecurityCredentials``,
    ``storageAccessKey`` / ``storageSecretKey``, ``oicClientId`` / ``oicClientSecret``,
    ``entraidClientId`` / ``entraidClientSecret`` y ``spnegoPreauthPassword`` conservan su
-   valor almacenado (no se actualizan) cuando se envia el valor enmascarado ``"**********"``
-   tal cual. Envie el valor real solo cuando desee cambiarlo.
+   valor almacenado (no se actualizan) cuando se envía el valor enmascarado ``"**********"``
+   tal cual. Envíe el valor real solo cuando desee cambiarlo.
 
-   Dado que esta comprobacion se basa en si la cadena queda vacia tras eliminar los
-   asteriscos, enviar una cadena vacia (``""``) o un valor compuesto unicamente de
+   Dado que esta comprobación se basa en si la cadena queda vacía tras eliminar los
+   asteriscos, enviar una cadena vacía (``""``) o un valor compuesto únicamente de
    asteriscos tampoco actualiza el valor. Por lo tanto, estos campos de tipo secreto no
-   pueden borrarse a un valor vacio mediante la API.
+   pueden borrarse a un valor vacío mediante la API.
 
 Respuesta
 ---------
 
-En caso de actualizacion exitosa, solo se devuelven ``version`` y ``status``
+En caso de actualización exitosa, solo se devuelven ``version`` y ``status``
 (no se incluyen ``id`` ni ``created``).
 
 .. code-block:: json
@@ -417,9 +417,9 @@ En caso de actualizacion exitosa, solo se devuelven ``version`` y ``status``
       }
     }
 
-Si la actualizacion falla (por ejemplo, debido a un error de validacion), la API
+Si la actualización falla (por ejemplo, debido a un error de validación), la API
 devuelve HTTP 400 y ``status`` se establece en un valor distinto de cero (``1``
-para un error de validacion), y ``message`` contiene los detalles del error.
+para un error de validación), y ``message`` contiene los detalles del error.
 Consulte :doc:`api-admin-overview` para la lista de valores de ``status``.
 
 Ejemplos de Uso
@@ -427,13 +427,13 @@ Ejemplos de Uso
 
 .. note::
 
-   Los ejemplos a continuacion incluyen los campos requeridos (``dayForCleanup``,
+   Los ejemplos a continuación incluyen los campos requeridos (``dayForCleanup``,
    ``crawlingThreadCount``, ``failureCountThreshold``, ``csvFileEncoding``). Como estos
    deben enviarse siempre independientemente de lo que se desee cambiar, recupere los
-   valores actuales con ``GET`` e incluyalos en la operacion real (los ejemplos a
-   continuacion usan los valores predeterminados).
+   valores actuales con ``GET`` e inclúyalos en la operación real (los ejemplos a
+   continuación usan los valores predeterminados).
 
-Actualizar la Configuracion de Rastreo
+Actualizar la Configuración de Rastreo
 ---------------------------------------
 
 .. code-block:: bash
@@ -449,7 +449,7 @@ Actualizar la Configuracion de Rastreo
            "csvFileEncoding": "UTF-8"
          }'
 
-Actualizar el Periodo de Retencion de Registros
+Actualizar el Periodo de Retención de Registros
 -------------------------------------------------
 
 .. code-block:: bash
@@ -467,7 +467,7 @@ Actualizar el Periodo de Retencion de Registros
            "purgeUserInfoDay": 90
          }'
 
-Actualizar la Configuracion de Sugerencias
+Actualizar la Configuración de Sugerencias
 -------------------------------------------
 
 .. code-block:: bash
@@ -484,9 +484,9 @@ Actualizar la Configuracion de Sugerencias
            "suggestDocuments": "true"
          }'
 
-Informacion de Referencia
+Información de Referencia
 ==========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-systeminfo` - API de informacion del sistema
-- :doc:`../../admin/general-guide` - Guia de configuracion general
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-systeminfo` - API de información del sistema
+- :doc:`../../admin/general-guide` - Guía de configuración general

--- a/es/15.7/api/admin/api-admin-group.rst
+++ b/es/15.7/api/admin/api-admin-group.rst
@@ -2,11 +2,11 @@
 API de Group
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Group es para gestionar grupos de |Fess|.
-Puede operar creacion, actualizacion y eliminacion de grupos.
+Puede operar creación, actualización y eliminación de grupos.
 
 URL Base
 ========
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de grupos
@@ -51,25 +51,25 @@ Solicitud
 
     GET /api/admin/group/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25)
+     - Número de elementos por página (predeterminado: 25)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``id``
      - String
      - No
@@ -157,7 +157,7 @@ Cuerpo de la Solicitud
       }
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -166,10 +166,10 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre del grupo (maximo 100 caracteres)
+     - Sí
+     - Nombre del grupo (máximo 100 caracteres)
    * - ``attributes``
      - No
      - Mapa de atributos (incluye atributos LDAP como ``gidNumber``). Los valores se especifican como cadenas
@@ -212,7 +212,7 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -221,19 +221,19 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
+     - Sí
      - ID del grupo a actualizar
    * - ``name``
-     - Si
-     - Nombre del grupo (maximo 100 caracteres)
+     - Sí
+     - Nombre del grupo (máximo 100 caracteres)
    * - ``attributes``
      - No
      - Mapa de atributos (incluye atributos LDAP como ``gidNumber``). Los valores se especifican como cadenas
    * - ``versionNo``
-     - Si
-     - Numero de version para el bloqueo optimista. Especifique el valor de ``versionNo`` obtenido al obtener el grupo
+     - Sí
+     - Número de versión para el bloqueo optimista. Especifique el valor de ``versionNo`` obtenido al obtener el grupo
 
 Respuesta
 ---------
@@ -297,10 +297,10 @@ Obtener Lista de Grupos
     curl -X GET "http://localhost:8080/api/admin/group/settings" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-user` - API de gestion de usuarios
-- :doc:`api-admin-role` - API de gestion de roles
-- :doc:`../../admin/group-guide` - Guia de gestion de grupos
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-user` - API de gestión de usuarios
+- :doc:`api-admin-role` - API de gestión de roles
+- :doc:`../../admin/group-guide` - Guía de gestión de grupos

--- a/es/15.7/api/admin/api-admin-joblog.rst
+++ b/es/15.7/api/admin/api-admin-joblog.rst
@@ -2,11 +2,11 @@
 API de JobLog
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de JobLog es para consultar y gestionar los registros de ejecucion de trabajos de |Fess|.
-Permite obtener y eliminar el historial de ejecucion, los resultados y la informacion de errores
+La API de JobLog es para consultar y gestionar los registros de ejecución de trabajos de |Fess|.
+Permite obtener y eliminar el historial de ejecución, los resultados y la información de errores
 de trabajos programados y de rastreo.
 
 URL Base
@@ -23,9 +23,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /logs
      - Obtener lista de registros de trabajos
@@ -46,25 +46,25 @@ Solicitud
 
     GET /api/admin/joblog/logs
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Número de elementos por página (predeterminado: 20)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (basado en 1, predeterminado: 1)
+     - Número de página (basado en 1, predeterminado: 1)
    * - ``id``
      - String
      - No
@@ -114,30 +114,30 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``id``
      - ID del registro de trabajo
    * - ``jobName``
      - Nombre del trabajo
    * - ``jobStatus``
-     - Estado del trabajo (``ok``: exitoso, ``fail``: fallido, ``running``: en ejecucion)
+     - Estado del trabajo (``ok``: exitoso, ``fail``: fallido, ``running``: en ejecución)
    * - ``target``
-     - Objetivo de ejecucion (nombre del objetivo del programador; el valor predeterminado es ``all``)
+     - Objetivo de ejecución (nombre del objetivo del programador; el valor predeterminado es ``all``)
    * - ``scriptType``
      - Tipo de script (ejemplo: ``groovy``)
    * - ``scriptData``
      - Script ejecutado
    * - ``scriptResult``
-     - Resultado de la ejecucion
+     - Resultado de la ejecución
    * - ``startTime``
      - Hora de inicio (milisegundos epoch; devuelto como cadena de texto)
    * - ``endTime``
-     - Hora de finalizacion (milisegundos epoch; devuelto como cadena de texto). No se devuelve para trabajos en ejecucion.
+     - Hora de finalización (milisegundos epoch; devuelto como cadena de texto). No se devuelve para trabajos en ejecución.
 
 .. note::
 
-   Cada objeto de registro en la respuesta incluye tambien un campo interno ``crudMode``
-   (un entero que indica el modo de operacion CRUD, siempre ``0`` para operaciones de lectura).
+   Cada objeto de registro en la respuesta incluye también un campo interno ``crudMode``
+   (un entero que indica el modo de operación CRUD, siempre ``0`` para operaciones de lectura).
    Los clientes pueden ignorarlo sin problema.
 
 Obtener Registro de Trabajo
@@ -236,7 +236,7 @@ Eliminar Registro de Trabajo
     curl -X DELETE "http://localhost:8080/api/admin/joblog/log/joblog_id_1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Calcular Tasa de Exito de Trabajos
+Calcular Tasa de Éxito de Trabajos
 ------------------------------------
 
 .. code-block:: bash
@@ -245,10 +245,10 @@ Calcular Tasa de Exito de Trabajos
          -H "Authorization: Bearer YOUR_TOKEN" | \
          jq '.response.logs | {total: length, ok: [.[] | select(.jobStatus=="ok")] | length, fail: [.[] | select(.jobStatus=="fail")] | length}'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-scheduler` - API del programador
-- :doc:`api-admin-crawlinginfo` - API de informacion de rastreo
-- :doc:`../../admin/joblog-guide` - Guia de gestion de registros de trabajos
+- :doc:`api-admin-crawlinginfo` - API de información de rastreo
+- :doc:`../../admin/joblog-guide` - Guía de gestión de registros de trabajos

--- a/es/15.7/api/admin/api-admin-log.rst
+++ b/es/15.7/api/admin/api-admin-log.rst
@@ -2,7 +2,7 @@
 API de Log
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Log es para consultar y descargar los archivos de registro de |Fess|.
@@ -15,17 +15,17 @@ URL Base
 
     /api/admin/log
 
-Autenticacion
+Autenticación
 =============
 
-Al igual que con el resto de Admin APIs, se requiere autenticacion mediante token de acceso. El token de acceso debe tener el permiso ``Radmin-api`` (configurado en ``api.admin.access.permissions``; el valor predeterminado es ``Radmin-api``).
+Al igual que con el resto de Admin APIs, se requiere autenticación mediante token de acceso. El token de acceso debe tener el permiso ``Radmin-api`` (configurado en ``api.admin.access.permissions``; el valor predeterminado es ``Radmin-api``).
 El token de acceso se especifica en el encabezado de la solicitud.
 
 ::
 
     Authorization: Bearer <token de acceso>
 
-Para mas detalles sobre la autenticacion y como obtener el token de acceso, consulte :doc:`api-admin-overview`.
+Para más detalles sobre la autenticación y cómo obtener el token de acceso, consulte :doc:`api-admin-overview`.
 
 Lista de Endpoints
 ==================
@@ -34,9 +34,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /files
      - Obtener lista de archivos de registro
@@ -60,7 +60,7 @@ Solicitud
 Respuesta
 ---------
 
-En ``files`` se almacena un arreglo de objetos que representan la informacion de cada archivo de registro, y en ``total`` el numero de elementos.
+En ``files`` se almacena un arreglo de objetos que representan la información de cada archivo de registro, y en ``total`` el número de elementos.
 Cada objeto tiene los siguientes campos.
 
 .. list-table::
@@ -68,13 +68,13 @@ Cada objeto tiene los siguientes campos.
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``id``
      - Valor del nombre de archivo codificado en Base64 URL (se usa como ``{id}`` al descargar)
    * - ``name``
      - Nombre del archivo de registro
    * - ``lastModified``
-     - Fecha/hora de la ultima modificacion
+     - Fecha/hora de la última modificación
 
 .. code-block:: json
 
@@ -100,7 +100,7 @@ Cada objeto tiene los siguientes campos.
 
 .. note::
 
-   En ``version`` se establece la version del producto de |Fess| en ejecucion. El contenido y la cantidad de elementos en ``files`` dependen de los archivos de registro presentes en el servidor, por lo que el ejemplo anterior es solo una muestra.
+   En ``version`` se establece la versión del producto de |Fess| en ejecución. El contenido y la cantidad de elementos en ``files`` dependen de los archivos de registro presentes en el servidor, por lo que el ejemplo anterior es solo una muestra.
 
 Descargar Archivo de Registro
 =============================
@@ -109,7 +109,7 @@ Descarga el contenido del archivo de registro especificado.
 En ``{id}`` se especifica el ``id`` devuelto en la lista (el valor del nombre de archivo codificado en Base64 URL) tal cual.
 La respuesta se devuelve como un flujo ``application/octet-stream``.
 Por razones de seguridad, solo se aceptan nombres que terminen en ``.log`` o ``.log.gz``; los nombres que contienen operaciones de ruta como ``..`` no son aceptados.
-Si se especifica un nombre de archivo inexistente o un nombre no permitido como archivo de registro, se devuelve una respuesta vacia.
+Si se especifica un nombre de archivo inexistente o un nombre no permitido como archivo de registro, se devuelve una respuesta vacía.
 
 Solicitud
 ---------
@@ -143,8 +143,8 @@ Descargar Archivo de Registro
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o fess.log
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-backup` - API de respaldo

--- a/es/15.7/api/admin/api-admin-overview.rst
+++ b/es/15.7/api/admin/api-admin-overview.rst
@@ -1,14 +1,14 @@
 ===========================
-Vision General de Admin API
+Visión General de Admin API
 ===========================
 
-Vision General
+Visión General
 ==============
 
-|Fess| Admin API es una API RESTful para acceder programaticamente a las funciones de administracion.
-Puede ejecutar a traves de la API la mayoria de las operaciones disponibles en el panel de administracion, como la configuracion de rastreo, la gestion de usuarios y el control del programador.
+|Fess| Admin API es una API RESTful para acceder programáticamente a las funciones de administración.
+Puede ejecutar a través de la API la mayoría de las operaciones disponibles en el panel de administración, como la configuración de rastreo, la gestión de usuarios y el control del programador.
 
-Al utilizar esta API, puede automatizar la configuracion de |Fess| o integrarse con sistemas externos.
+Al utilizar esta API, puede automatizar la configuración de |Fess| o integrarse con sistemas externos.
 
 URL Base
 ========
@@ -25,15 +25,15 @@ Por ejemplo, en un entorno local:
 
     http://localhost:8080/api/admin/
 
-Autenticacion
+Autenticación
 =============
 
-Para acceder a Admin API, se requiere autenticacion mediante un token de acceso.
+Para acceder a Admin API, se requiere autenticación mediante un token de acceso.
 
-Obtencion del Token de Acceso
+Obtención del Token de Acceso
 -----------------------------
 
-1. Inicie sesion en el panel de administracion
+1. Inicie sesión en el panel de administración
 2. Vaya a "Sistema" -> "Tokens de Acceso"
 3. Haga clic en "Crear Nuevo"
 4. Ingrese el nombre del token y configure en el campo "Permisos" los permisos que desea otorgar al token (para usar Admin API, ingrese ``{role}admin-api``)
@@ -48,15 +48,15 @@ Incluya el token de acceso en el encabezado de la solicitud:
 
     Authorization: Bearer <token de acceso>
 
-Tambien puede omitir ``Bearer`` y especificar solo el token:
+También puede omitir ``Bearer`` y especificar solo el token:
 
 ::
 
     Authorization: <token de acceso>
 
-La especificacion mediante parametro de consulta tambien es posible, pero esta deshabilitada de forma predeterminada. Si configura un nombre de parametro en
-``api.access.token.request.parameter`` de ``fess_config.properties``, podra pasar el
-token con ese nombre (como el valor predeterminado esta vacio, solo es valida la especificacion mediante el encabezado).
+La especificación mediante parámetro de consulta también es posible, pero está deshabilitada de forma predeterminada. Si configura un nombre de parámetro en
+``api.access.token.request.parameter`` de ``fess_config.properties``, podrá pasar el
+token con ese nombre (como el valor predeterminado está vacío, solo es válida la especificación mediante el encabezado).
 Por ejemplo, si configura ``api.access.token.request.parameter=token``:
 
 ::
@@ -74,7 +74,7 @@ Ejemplo con cURL
 Permisos Requeridos
 -------------------
 
-El acceso a Admin API se controla mediante un unico conjunto de permisos, no por funcion. Para utilizar
+El acceso a Admin API se controla mediante un único conjunto de permisos, no por función. Para utilizar
 cualquiera de los endpoints de Admin API, el token de acceso debe tener otorgado alguno de los permisos
 configurados en ``api.admin.access.permissions`` de ``fess_config.properties``.
 
@@ -92,9 +92,9 @@ El valor predeterminado es ``Radmin-api``, que es la forma codificada del rol ``
 Patrones Comunes
 ================
 
-Los recursos que tienen configuraciones (webconfig, user, role, etc.) siguen el siguiente patron CRUD comun.
-Sin embargo, algunos recursos (systeminfo, stats, storage, plugin, log, backup, documents, suggest, la raiz de dict, etc.)
-tienen una estructura de endpoints propia distinta de este patron comun, por lo que debe consultar la pagina de cada recurso.
+Los recursos que tienen configuraciones (webconfig, user, role, etc.) siguen el siguiente patrón CRUD común.
+Sin embargo, algunos recursos (systeminfo, stats, storage, plugin, log, backup, documents, suggest, la raíz de dict, etc.)
+tienen una estructura de endpoints propia distinta de este patrón común, por lo que debe consultar la página de cada recurso.
 
 Obtener Lista (GET /settings)
 -----------------------------
@@ -108,21 +108,21 @@ Solicitud
 
     GET /api/admin/<recurso>/settings
 
-Parametros (paginacion):
+Parámetros (paginación):
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 65
 
-   * - Parametro
+   * - Parámetro
      - Tipo
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
-     - Numero de elementos por pagina (predeterminado: 25. Modificable mediante ``paging.page.size`` de ``fess_config.properties``)
+     - Número de elementos por página (predeterminado: 25. Modificable mediante ``paging.page.size`` de ``fess_config.properties``)
    * - ``page``
      - Integer
-     - Numero de pagina (comienza en 1. Predeterminado: 1. Si se especifica un valor menor o igual a 0, se trata como 1)
+     - Número de página (comienza en 1. Predeterminado: 1. Si se especifica un valor menor o igual a 0, se trata como 1)
 
 Respuesta
 ~~~~~~~~~
@@ -141,13 +141,13 @@ Respuesta
 .. note::
 
    El objeto ``response`` de todas las respuestas incluye siempre ``version``,
-   que indica la version del producto (por ejemplo, ``"15.7.0"``). En los ejemplos siguientes
+   que indica la versión del producto (por ejemplo, ``"15.7.0"``). En los ejemplos siguientes
    puede omitirse por brevedad.
 
-Obtener Configuracion Individual (GET /setting/{id})
+Obtener Configuración Individual (GET /setting/{id})
 ----------------------------------------------------
 
-Obtiene una configuracion individual especificando el ID.
+Obtiene una configuración individual especificando el ID.
 
 Solicitud
 ~~~~~~~~~
@@ -171,7 +171,7 @@ Respuesta
 Crear Nuevo (POST /setting)
 ---------------------------
 
-Crea una nueva configuracion.
+Crea una nueva configuración.
 
 Solicitud
 ~~~~~~~~~
@@ -202,7 +202,7 @@ Respuesta
 Actualizar (PUT /setting)
 -------------------------
 
-Actualiza una configuracion existente.
+Actualiza una configuración existente.
 
 Solicitud
 ~~~~~~~~~
@@ -234,7 +234,7 @@ Respuesta
 Eliminar (DELETE /setting/{id})
 -------------------------------
 
-Elimina una configuracion.
+Elimina una configuración.
 
 Solicitud
 ~~~~~~~~~
@@ -246,7 +246,7 @@ Solicitud
 Respuesta
 ~~~~~~~~~
 
-El formato de la respuesta de eliminacion difiere segun el recurso (accion). Muchos recursos
+El formato de la respuesta de eliminación difiere según el recurso (acción). Muchos recursos
 devuelven solo ``status``.
 
 .. code-block:: json
@@ -257,8 +257,8 @@ devuelven solo ``status``.
       }
     }
 
-En algunos recursos, el resultado de la eliminacion se devuelve como ``ApiUpdateResponse``, con
-el ``id`` de la configuracion eliminada y ``created`` (``false`` al eliminar).
+En algunos recursos, el resultado de la eliminación se devuelve como ``ApiUpdateResponse``, con
+el ``id`` de la configuración eliminada y ``created`` (``false`` al eliminar).
 
 .. code-block:: json
 
@@ -270,14 +270,14 @@ el ``id`` de la configuracion eliminada y ``created`` (``false`` al eliminar).
       }
     }
 
-Ademas, en los recursos que devuelven ``ApiDeleteResponse`` puede agregarse ``count``,
-que indica el numero de elementos eliminados (valor predeterminado ``1``). Consulte la pagina de cada recurso para conocer el formato real.
+Además, en los recursos que devuelven ``ApiDeleteResponse`` puede agregarse ``count``,
+que indica el número de elementos eliminados (valor predeterminado ``1``). Consulte la página de cada recurso para conocer el formato real.
 
 Formato de Respuesta
 ====================
 
 Todas las respuestas se envuelven en un objeto ``response`` que incluye siempre
-``version``, que indica la version del producto, y ``status``, que indica el resultado del procesamiento.
+``version``, que indica la versión del producto, y ``status``, que indica el resultado del procesamiento.
 
 Los valores de ``status`` son los siguientes.
 
@@ -286,15 +286,15 @@ Los valores de ``status`` son los siguientes.
    :widths: 15 85
 
    * - Valor
-     - Descripcion
+     - Descripción
    * - ``0``
-     - OK (exito)
+     - OK (éxito)
    * - ``1``
-     - BAD_REQUEST (solicitud invalida)
+     - BAD_REQUEST (solicitud inválida)
    * - ``2``
      - SYSTEM_ERROR (error del sistema)
    * - ``3``
-     - UNAUTHORIZED (error de autenticacion)
+     - UNAUTHORIZED (error de autenticación)
    * - ``9``
      - FAILED (procesamiento fallido)
 
@@ -311,7 +311,7 @@ Respuesta Exitosa
       }
     }
 
-``status: 0`` indica exito.
+``status: 0`` indica éxito.
 
 Respuesta de Error
 ------------------
@@ -329,36 +329,36 @@ contiene el mensaje de error.
       }
     }
 
-Codigos de Estado HTTP
+Códigos de Estado HTTP
 ----------------------
 
-Admin API devuelve en la mayoria de los casos el estado HTTP ``200``, y el resultado del procesamiento se indica
-en el campo ``status`` del cuerpo de la respuesta. Por lo tanto, no determine el exito o el fallo por el codigo de estado HTTP,
+Admin API devuelve en la mayoría de los casos el estado HTTP ``200``, y el resultado del procesamiento se indica
+en el campo ``status`` del cuerpo de la respuesta. Por lo tanto, no determine el éxito o el fallo por el código de estado HTTP,
 sino por el valor de ``status`` del cuerpo.
 
-Los codigos de estado HTTP que se devuelven realmente son los siguientes.
+Los códigos de estado HTTP que se devuelven realmente son los siguientes.
 
 .. list-table::
    :header-rows: 1
    :widths: 15 85
 
-   * - Codigo
-     - Descripcion
+   * - Código
+     - Descripción
    * - 200
-     - Respuesta normal. Ademas del caso de exito (``status: 0``), la mayoria de los errores tambien se
-       devuelven con este codigo. Por ejemplo, si el token de acceso no se especifica o es invalido, o si los permisos son insuficientes, se devuelve
+     - Respuesta normal. Además del caso de éxito (``status: 0``), la mayoría de los errores también se
+       devuelven con este código. Por ejemplo, si el token de acceso no se especifica o es inválido, o si los permisos son insuficientes, se devuelve
        ``status: 3``; y un error del sistema se devuelve como ``status: 2``, ambos con HTTP ``200``.
    * - 400
-     - Error de validacion de los parametros de la solicitud. El ``status`` del cuerpo de la respuesta sera ``1``.
-       Este codigo tambien se devuelve cuando se intenta obtener un recurso inexistente.
+     - Error de validación de los parámetros de la solicitud. El ``status`` del cuerpo de la respuesta será ``1``.
+       Este código también se devuelve cuando se intenta obtener un recurso inexistente.
    * - 401
-     - Cuando ocurre una excepcion relacionada con la autenticacion de inicio de sesion. El ``status`` del cuerpo de la respuesta sera ``3``.
-       Tenga en cuenta que, si el token de acceso no se especifica o es invalido, no se devuelve este codigo, sino HTTP ``200`` con
+     - Cuando ocurre una excepción relacionada con la autenticación de inicio de sesión. El ``status`` del cuerpo de la respuesta será ``3``.
+       Tenga en cuenta que, si el token de acceso no se especifica o es inválido, no se devuelve este código, sino HTTP ``200`` con
        ``status: 3``.
 
 .. note::
 
-   Admin API no devuelve codigos de estado HTTP como ``403``, ``404`` o ``500``.
+   Admin API no devuelve códigos de estado HTTP como ``403``, ``404`` o ``500``.
    Tanto los permisos insuficientes como la inexistencia de un recurso se indican mediante el
    ``status`` incluido en el cuerpo de la respuesta HTTP ``200`` o ``400``.
 
@@ -367,7 +367,7 @@ APIs Disponibles
 
 |Fess| proporciona las siguientes Admin APIs.
 
-Configuracion de Rastreo
+Configuración de Rastreo
 ------------------------
 
 .. list-table::
@@ -375,22 +375,22 @@ Configuracion de Rastreo
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-webconfig`
-     - Configuracion de rastreo web
+     - Configuración de rastreo web
    * - :doc:`api-admin-fileconfig`
-     - Configuracion de rastreo de archivos
+     - Configuración de rastreo de archivos
    * - :doc:`api-admin-dataconfig`
-     - Configuracion de almacen de datos
+     - Configuración de almacén de datos
 
 .. note::
 
-   Ademas, los siguientes recursos relacionados con credenciales de autenticacion y control de rastreo
-   tambien se ofrecen como API (actualmente no tienen una pagina propia): ``webauth`` (autenticacion web), ``fileauth`` (autenticacion de archivos),
+   Además, los siguientes recursos relacionados con credenciales de autenticación y control de rastreo
+   también se ofrecen como API (actualmente no tienen una página propia): ``webauth`` (autenticación web), ``fileauth`` (autenticación de archivos),
    ``reqheader`` (encabezados de solicitud), ``pathmap`` (mapeo de rutas),
-   ``duplicatehost`` (hosts duplicados), ``searchlist`` (operaciones de busqueda/lista de documentos).
+   ``duplicatehost`` (hosts duplicados), ``searchlist`` (operaciones de búsqueda/lista de documentos).
 
-Gestion de Indices
+Gestión de Índices
 ------------------
 
 .. list-table::
@@ -398,15 +398,15 @@ Gestion de Indices
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-documents`
      - Operaciones masivas de documentos
    * - :doc:`api-admin-crawlinginfo`
-     - Informacion de rastreo
+     - Información de rastreo
    * - :doc:`api-admin-failureurl`
-     - Gestion de URLs fallidas
+     - Gestión de URLs fallidas
    * - :doc:`api-admin-backup`
-     - Copia de seguridad/Restauracion
+     - Copia de seguridad/Restauración
 
 Programador
 -----------
@@ -416,13 +416,13 @@ Programador
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-scheduler`
-     - Programacion de trabajos
+     - Programación de trabajos
    * - :doc:`api-admin-joblog`
-     - Obtencion de registros de trabajos
+     - Obtención de registros de trabajos
 
-Gestion de Usuarios y Permisos
+Gestión de Usuarios y Permisos
 ------------------------------
 
 .. list-table::
@@ -430,17 +430,17 @@ Gestion de Usuarios y Permisos
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-user`
-     - Gestion de usuarios
+     - Gestión de usuarios
    * - :doc:`api-admin-role`
-     - Gestion de roles
+     - Gestión de roles
    * - :doc:`api-admin-group`
-     - Gestion de grupos
+     - Gestión de grupos
    * - :doc:`api-admin-accesstoken`
-     - Gestion de tokens API
+     - Gestión de tokens API
 
-Ajuste de Busqueda
+Ajuste de Búsqueda
 ------------------
 
 .. list-table::
@@ -448,7 +448,7 @@ Ajuste de Busqueda
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-labeltype`
      - Tipos de etiqueta
    * - :doc:`api-admin-keymatch`
@@ -464,7 +464,7 @@ Ajuste de Busqueda
    * - :doc:`api-admin-relatedquery`
      - Consultas relacionadas
    * - :doc:`api-admin-suggest`
-     - Gestion de sugerencias
+     - Gestión de sugerencias
 
 Sistema
 -------
@@ -474,21 +474,21 @@ Sistema
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-general`
-     - Configuracion general
+     - Configuración general
    * - :doc:`api-admin-systeminfo`
-     - Informacion del sistema
+     - Información del sistema
    * - :doc:`api-admin-stats`
-     - Estadisticas del sistema
+     - Estadísticas del sistema
    * - :doc:`api-admin-log`
-     - Obtencion de registros
+     - Obtención de registros
    * - :doc:`api-admin-searchlist`
-     - Busqueda y gestion de documentos
+     - Búsqueda y gestión de documentos
    * - :doc:`api-admin-storage`
-     - Gestion de almacenamiento
+     - Gestión de almacenamiento
    * - :doc:`api-admin-plugin`
-     - Gestion de plugins
+     - Gestión de plugins
 
 Diccionario
 -----------
@@ -498,14 +498,14 @@ Diccionario
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-dict`
-     - Gestion de diccionarios (sinonimos, palabras vacias, etc.)
+     - Gestión de diccionarios (sinónimos, palabras vacías, etc.)
 
 Ejemplos de Uso
 ===============
 
-Crear Configuracion de Rastreo Web
+Crear Configuración de Rastreo Web
 ----------------------------------
 
 .. code-block:: bash
@@ -530,9 +530,9 @@ Crear Configuracion de Rastreo Web
 
 .. note::
 
-   Al crear una configuracion de rastreo web, son obligatorios ``name``, ``urls``, ``userAgent``, ``numOfThread``,
+   Al crear una configuración de rastreo web, son obligatorios ``name``, ``urls``, ``userAgent``, ``numOfThread``,
    ``intervalTime``, ``boost``, ``available`` y ``sortOrder``. Si se omiten,
-   se produce un error de validacion (``status: 1``). ``available`` se especifica como una cadena de texto y
+   se produce un error de validación (``status: 1``). ``available`` se especifica como una cadena de texto y
    se establece en ``"true"`` o ``"false"``.
 
 Iniciar Trabajo Programado
@@ -551,8 +551,8 @@ Obtener Lista de Usuarios
     curl "http://localhost:8080/api/admin/user/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`../api-overview` - Vision general de API
-- :doc:`../../admin/accesstoken-guide` - Guia de gestion de tokens de acceso
+- :doc:`../api-overview` - Visión general de API
+- :doc:`../../admin/accesstoken-guide` - Guía de gestión de tokens de acceso

--- a/es/15.7/api/admin/api-admin-plugin.rst
+++ b/es/15.7/api/admin/api-admin-plugin.rst
@@ -2,11 +2,11 @@
 API de Plugin
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Plugin es para gestionar los plugins (artefactos) de |Fess|.
-Permite obtener la lista de plugins instalados y de plugins instalables, asi como instalar y eliminar plugins.
+Permite obtener la lista de plugins instalados y de plugins instalables, así como instalar y eliminar plugins.
 
 URL Base
 ========
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /installed
      - Obtener lista de plugins instalados
@@ -38,7 +38,7 @@ Lista de Endpoints
      - /
      - Eliminar plugin
 
-Campos de Informacion del Plugin
+Campos de Información del Plugin
 =================================
 
 Los endpoints de listado (``/installed`` y ``/available``) devuelven un arreglo ``plugins``
@@ -49,18 +49,18 @@ cuyos elementos son objetos con los siguientes campos.
    :widths: 15 85
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``type``
-     - ID de tipo del artefacto. Puede ser uno de: ``fess-ds`` (almacen de datos), ``fess-theme`` (tema),
-       ``fess-ingest`` (Ingest), ``fess-script`` (script), ``fess-webapp`` (aplicacion web),
+     - ID de tipo del artefacto. Puede ser uno de: ``fess-ds`` (almacén de datos), ``fess-theme`` (tema),
+       ``fess-ingest`` (Ingest), ``fess-script`` (script), ``fess-webapp`` (aplicación web),
        ``fess-thumbnail`` (miniatura), ``fess-crawler`` (crawler), ``fess-llm`` (LLM),
-       ``jar`` (JAR de proposito general no incluido en los anteriores).
+       ``jar`` (JAR de propósito general no incluido en los anteriores).
    * - ``id``
      - Identificador con formato ``{name}:{version}``.
    * - ``name``
      - Nombre del plugin.
    * - ``version``
-     - Version del plugin.
+     - Versión del plugin.
    * - ``url``
      - URL de descarga del artefacto. Solo se incluye en la respuesta de ``/available``. En ``/installed``
        el valor no existe, por lo que el campo se omite por completo.
@@ -86,8 +86,8 @@ Solicitud
 Respuesta
 ---------
 
-En ``plugins`` se almacena un arreglo de objetos que representan la informacion de los plugins.
-Consulte `Campos de Informacion del Plugin`_ para conocer los campos de cada objeto.
+En ``plugins`` se almacena un arreglo de objetos que representan la información de los plugins.
+Consulte `Campos de Información del Plugin`_ para conocer los campos de cada objeto.
 En los plugins instalados, ``url`` no se incluye en la salida.
 
 .. code-block:: json
@@ -112,7 +112,7 @@ Obtener Lista de Plugins Instalables
 
 Devuelve la lista de plugins instalables. Obtiene artefactos de todos los tipos desde los repositorios
 configurados en ``plugin.repositories`` de ``fess_config.properties``.
-Los resultados se almacenan en cache durante un tiempo determinado (5 minutos por defecto).
+Los resultados se almacenan en caché durante un tiempo determinado (5 minutos por defecto).
 
 Solicitud
 ---------
@@ -124,8 +124,8 @@ Solicitud
 Respuesta
 ---------
 
-En ``plugins`` se almacena un arreglo de objetos que representan la informacion de los plugins instalables.
-Consulte `Campos de Informacion del Plugin`_ para conocer los campos de cada objeto.
+En ``plugins`` se almacena un arreglo de objetos que representan la información de los plugins instalables.
+Consulte `Campos de Información del Plugin`_ para conocer los campos de cada objeto.
 Los plugins instalables incluyen el campo ``url`` con la URL de descarga.
 
 .. code-block:: json
@@ -149,7 +149,7 @@ Los plugins instalables incluyen el campo ``url`` con la URL de descarga.
 Instalar Plugin
 ===============
 
-Instala el plugin con el nombre y la version especificados.
+Instala el plugin con el nombre y la versión especificados.
 
 Solicitud
 ---------
@@ -169,7 +169,7 @@ Cuerpo de la Solicitud
       "version": "15.7.0"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -178,18 +178,18 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre del plugin (maximo 100 caracteres)
+     - Sí
+     - Nombre del plugin (máximo 100 caracteres)
    * - ``version``
-     - Si
-     - Version del plugin (maximo 100 caracteres)
+     - Sí
+     - Versión del plugin (máximo 100 caracteres)
 
 .. note::
 
    ``name`` y ``version`` deben coincidir con alguno de los plugins instalables obtenidos mediante ``/available``.
-   Si no existe un artefacto que coincida, se devolvera un error.
+   Si no existe un artefacto que coincida, se devolverá un error.
 
 Respuesta
 ---------
@@ -205,8 +205,8 @@ Cuando la solicitud es aceptada, se devuelve una respuesta con ``status`` igual 
       }
     }
 
-Si no existe un artefacto que corresponda a ``name`` o ``version``, ``status`` sera
-``1`` (BAD_REQUEST) y ``message`` se establecera con ``invalid name or version``.
+Si no existe un artefacto que corresponda a ``name`` o ``version``, ``status`` será
+``1`` (BAD_REQUEST) y ``message`` se establecerá con ``invalid name or version``.
 
 .. code-block:: json
 
@@ -220,16 +220,16 @@ Si no existe un artefacto que corresponda a ``name`` o ``version``, ``status`` s
 
 .. note::
 
-   El proceso de instalacion se ejecuta de forma asincrona en segundo plano. La respuesta con ``status: 0``
-   indica que la solicitud fue aceptada, pero no garantiza que la instalacion haya finalizado.
-   Una vez completada la instalacion, si ya existian plugins con el mismo nombre pero distinta version,
-   estos se eliminan automaticamente. Si la descarga o la instalacion fallan, el error se registra
+   El proceso de instalación se ejecuta de forma asíncrona en segundo plano. La respuesta con ``status: 0``
+   indica que la solicitud fue aceptada, pero no garantiza que la instalación haya finalizado.
+   Una vez completada la instalación, si ya existían plugins con el mismo nombre pero distinta versión,
+   estos se eliminan automáticamente. Si la descarga o la instalación fallan, el error se registra
    en el log del servidor, pero no se refleja en la respuesta de la API.
 
 Eliminar Plugin
 ===============
 
-Elimina el plugin con el nombre y la version especificados.
+Elimina el plugin con el nombre y la versión especificados.
 
 Solicitud
 ---------
@@ -249,7 +249,7 @@ Cuerpo de la Solicitud
       "version": "15.7.0"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -258,13 +258,13 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre del plugin (maximo 100 caracteres)
+     - Sí
+     - Nombre del plugin (máximo 100 caracteres)
    * - ``version``
      - No
-     - Version del plugin (maximo 100 caracteres). Se recomienda especificarlo para identificar de forma unica el artefacto a eliminar.
+     - Versión del plugin (máximo 100 caracteres). Se recomienda especificarlo para identificar de forma única el artefacto a eliminar.
 
 Respuesta
 ---------
@@ -282,9 +282,9 @@ Cuando la solicitud es aceptada, se devuelve una respuesta con ``status`` igual 
 
 .. note::
 
-   El proceso de eliminacion se ejecuta de forma asincrona en segundo plano. La respuesta con ``status: 0``
-   indica que la solicitud fue aceptada, pero no determina si el plugin existe ni si la eliminacion fue exitosa.
-   Si la eliminacion falla (por ejemplo, si el archivo no existe), el error se registra en el log del servidor,
+   El proceso de eliminación se ejecuta de forma asíncrona en segundo plano. La respuesta con ``status: 0``
+   indica que la solicitud fue aceptada, pero no determina si el plugin existe ni si la eliminación fue exitosa.
+   Si la eliminación falla (por ejemplo, si el archivo no existe), el error se registra en el log del servidor,
    pero no se refleja en la respuesta de la API.
 
 Ejemplos de Uso
@@ -324,7 +324,7 @@ Eliminar un Plugin
            "version": "15.7.0"
          }'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API

--- a/es/15.7/api/admin/api-admin-relatedquery.rst
+++ b/es/15.7/api/admin/api-admin-relatedquery.rst
@@ -2,17 +2,17 @@
 API de RelatedQuery
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de RelatedQuery es una API para gestionar las consultas relacionadas de |Fess|.
-Permite registrar y administrar candidatos de palabras clave de busqueda relacionadas
-(``queries``) para las palabras clave de busqueda (``term``) que introduce el usuario.
-Las consultas relacionadas registradas se muestran como sugerencias de busqueda relacionadas
-en la pantalla de busqueda.
+Permite registrar y administrar candidatos de palabras clave de búsqueda relacionadas
+(``queries``) para las palabras clave de búsqueda (``term``) que introduce el usuario.
+Las consultas relacionadas registradas se muestran como sugerencias de búsqueda relacionadas
+en la pantalla de búsqueda.
 
-Para obtener informacion detallada sobre la autenticacion, el formato de respuesta comun
-(el campo ``version`` y los codigos ``status``), la paginacion y las respuestas de error,
+Para obtener información detallada sobre la autenticación, el formato de respuesta común
+(el campo ``version`` y los códigos ``status``), la paginación y las respuestas de error,
 consulte :doc:`api-admin-overview`.
 
 URL Base
@@ -29,9 +29,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de consultas relacionadas
@@ -58,25 +58,25 @@ Solicitud
 
     GET /api/admin/relatedquery/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25. Modificable mediante ``paging.page.size`` de ``fess_config.properties``)
+     - Número de elementos por página (predeterminado: 25. Modificable mediante ``paging.page.size`` de ``fess_config.properties``)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1. Predeterminado: 1)
+     - Número de página (comienza en 1. Predeterminado: 1)
 
 Respuesta
 ---------
@@ -101,9 +101,9 @@ Respuesta
 
 .. note::
 
-   Cada configuracion incluye ``versionNo`` (numero de version para el bloqueo optimista). Los campos
-   ``virtualHost`` y los campos de auditoria (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``)
-   se incluyen unicamente cuando tienen un valor asignado. Un ``virtualHost`` vacio no se incluye
+   Cada configuración incluye ``versionNo`` (número de versión para el bloqueo optimista). Los campos
+   ``virtualHost`` y los campos de auditoría (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``)
+   se incluyen únicamente cuando tienen un valor asignado. Un ``virtualHost`` vacío no se incluye
    en la respuesta.
 
 Obtener Consulta Relacionada
@@ -157,7 +157,7 @@ Cuerpo de la Solicitud
       "virtualHost": ""
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -166,20 +166,20 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``term``
-     - Si
-     - Palabra clave de busqueda (maximo 10000 caracteres)
+     - Sí
+     - Palabra clave de búsqueda (máximo 10000 caracteres)
    * - ``queries``
-     - Si
-     - Consultas relacionadas. Cadena separada por saltos de linea, una por linea (las lineas vacias se ignoran; maximo 10000 caracteres)
+     - Sí
+     - Consultas relacionadas. Cadena separada por saltos de línea, una por línea (las líneas vacías se ignoran; máximo 10000 caracteres)
    * - ``virtualHost``
      - No
-     - Host virtual (maximo 1000 caracteres)
+     - Host virtual (máximo 1000 caracteres)
 
 .. note::
 
-   ``crudMode`` es configurado automaticamente por la API, por lo que no es necesario incluirlo en el cuerpo de la solicitud.
+   ``crudMode`` es configurado automáticamente por la API, por lo que no es necesario incluirlo en el cuerpo de la solicitud.
 
 Respuesta
 ---------
@@ -219,7 +219,7 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -228,22 +228,22 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
-     - ID de la consulta relacionada a actualizar (maximo 1000 caracteres)
+     - Sí
+     - ID de la consulta relacionada a actualizar (máximo 1000 caracteres)
    * - ``term``
-     - Si
-     - Palabra clave de busqueda (maximo 10000 caracteres)
+     - Sí
+     - Palabra clave de búsqueda (máximo 10000 caracteres)
    * - ``queries``
-     - Si
-     - Consultas relacionadas. Cadena separada por saltos de linea, una por linea (las lineas vacias se ignoran; maximo 10000 caracteres)
+     - Sí
+     - Consultas relacionadas. Cadena separada por saltos de línea, una por línea (las líneas vacías se ignoran; máximo 10000 caracteres)
    * - ``virtualHost``
      - No
-     - Host virtual (maximo 1000 caracteres)
+     - Host virtual (máximo 1000 caracteres)
    * - ``versionNo``
-     - Si
-     - Numero de version para el bloqueo optimista. Debe especificarse el valor incluido en la respuesta de la consulta de obtencion
+     - Sí
+     - Número de versión para el bloqueo optimista. Debe especificarse el valor incluido en la respuesta de la consulta de obtención
 
 Respuesta
 ---------
@@ -285,9 +285,9 @@ Respuesta de Error
 ==================
 
 Cuando una solicitud falla, ``status`` se establece en un valor distinto de 0 y ``message``
-contiene el detalle del error. Por ejemplo, en errores de validacion como la ausencia de campos
+contiene el detalle del error. Por ejemplo, en errores de validación como la ausencia de campos
 obligatorios, ``status`` toma el valor ``1``.
-Para consultar la lista de codigos de estado, vea :doc:`api-admin-overview`.
+Para consultar la lista de códigos de estado, vea :doc:`api-admin-overview`.
 
 .. code-block:: json
 
@@ -328,10 +328,10 @@ Consultas Relacionadas con Ayuda
            "queries": "help center\nhelp documentation\nhelp contact support"
          }'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-relatedcontent` - API de contenido relacionado
-- :doc:`api-admin-suggest` - API de gestion de sugerencias
-- :doc:`../../admin/relatedquery-guide` - Guia de gestion de consultas relacionadas
+- :doc:`api-admin-suggest` - API de gestión de sugerencias
+- :doc:`../../admin/relatedquery-guide` - Guía de gestión de consultas relacionadas

--- a/es/15.7/api/admin/api-admin-role.rst
+++ b/es/15.7/api/admin/api-admin-role.rst
@@ -2,11 +2,11 @@
 API de Role
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Role es para gestionar roles de |Fess|.
-Puede operar creacion, actualizacion y eliminacion de roles.
+Puede operar creación, actualización y eliminación de roles.
 
 URL Base
 ========
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de roles
@@ -51,25 +51,25 @@ Solicitud
 
     GET /api/admin/role/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25. Configurable mediante ``paging.page.size`` en ``fess_config.properties``)
+     - Número de elementos por página (predeterminado: 25. Configurable mediante ``paging.page.size`` en ``fess_config.properties``)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1. Los valores de 0 o menos se tratan como 1)
+     - Número de página (comienza en 1, predeterminado: 1. Los valores de 0 o menos se tratan como 1)
    * - ``id``
      - String
      - No
@@ -145,7 +145,7 @@ Cuerpo de la Solicitud
       "name": "editor"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -154,10 +154,10 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre del rol (maximo 100 caracteres)
+     - Sí
+     - Nombre del rol (máximo 100 caracteres)
    * - ``attributes``
      - No
      - Mapa de atributos. Los valores se especifican como cadenas
@@ -197,7 +197,7 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -206,19 +206,19 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
+     - Sí
      - ID del rol a actualizar
    * - ``name``
-     - Si
-     - Nombre del rol (maximo 100 caracteres)
+     - Sí
+     - Nombre del rol (máximo 100 caracteres)
    * - ``attributes``
      - No
      - Mapa de atributos. Los valores se especifican como cadenas
    * - ``versionNo``
-     - Si
-     - Numero de version para el bloqueo optimista. Especifique el valor de ``versionNo`` obtenido al obtener el rol
+     - Sí
+     - Número de versión para el bloqueo optimista. Especifique el valor de ``versionNo`` obtenido al obtener el rol
 
 Respuesta
 ---------
@@ -279,10 +279,10 @@ Obtener Lista de Roles
     curl -X GET "http://localhost:8080/api/admin/role/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-user` - API de gestion de usuarios
-- :doc:`api-admin-group` - API de gestion de grupos
-- :doc:`../../admin/role-guide` - Guia de gestion de roles
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-user` - API de gestión de usuarios
+- :doc:`api-admin-group` - API de gestión de grupos
+- :doc:`../../admin/role-guide` - Guía de gestión de roles

--- a/es/15.7/api/admin/api-admin-scheduler.rst
+++ b/es/15.7/api/admin/api-admin-scheduler.rst
@@ -2,11 +2,11 @@
 API de Scheduler
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Scheduler es para gestionar trabajos programados de |Fess|.
-Puede iniciar/detener trabajos de rastreo, crear/actualizar/eliminar configuraciones de programacion.
+Puede iniciar/detener trabajos de rastreo, crear/actualizar/eliminar configuraciones de programación.
 
 URL Base
 ========
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de trabajos programados
@@ -57,25 +57,25 @@ Solicitud
 
     GET /api/admin/scheduler/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (por defecto: 25; configurable mediante ``paging.page.size`` en ``fess_config.properties``)
+     - Número de elementos por página (por defecto: 25; configurable mediante ``paging.page.size`` en ``fess_config.properties``)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (a partir de 1; por defecto: 1)
+     - Número de página (a partir de 1; por defecto: 1)
 
 Respuesta
 ---------
@@ -108,11 +108,11 @@ Respuesta
 
 .. note::
 
-   El objeto ``response`` siempre incluye ``version`` (version del producto) y ``status`` (codigo de resultado). Consulte la descripcion general de Admin API (:doc:`api-admin-overview`) para conocer el formato de respuesta comun. Los ejemplos posteriores pueden omitir ``version`` por brevedad.
+   El objeto ``response`` siempre incluye ``version`` (versión del producto) y ``status`` (código de resultado). Consulte la descripción general de Admin API (:doc:`api-admin-overview`) para conocer el formato de respuesta común. Los ejemplos posteriores pueden omitir ``version`` por brevedad.
 
 .. note::
 
-   En las respuestas, ``jobLogging`` / ``crawler`` / ``available`` se devuelven como cadenas (``"true"`` / ``"false"``). ``running`` es un campo booleano exclusivo de respuesta que indica si el trabajo se esta ejecutando en ese momento (no puede especificarse en las solicitudes). ``total`` es el numero total de trabajos que coinciden con la consulta.
+   En las respuestas, ``jobLogging`` / ``crawler`` / ``available`` se devuelven como cadenas (``"true"`` / ``"false"``). ``running`` es un campo booleano exclusivo de respuesta que indica si el trabajo se está ejecutando en ese momento (no puede especificarse en las solicitudes). ``total`` es el número total de trabajos que coinciden con la consulta.
 
 Obtener Trabajo Programado
 ==========================
@@ -177,7 +177,7 @@ Cuerpo de la Solicitud
       "sortOrder": 1
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -186,22 +186,22 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
+     - Sí
      - Nombre del trabajo (max. 100 caracteres)
    * - ``target``
-     - Si
-     - Objetivo de ejecucion (max. 100 caracteres). Especifique ``all`` o un nombre de objetivo especifico
+     - Sí
+     - Objetivo de ejecución (max. 100 caracteres). Especifique ``all`` o un nombre de objetivo específico
    * - ``cronExpression``
      - No
-     - Expresion Cron (segundo minuto hora dia mes dia-semana). Max. 100 caracteres, validada como expresion cron. Si esta vacia, el trabajo no se ejecuta de forma programada y solo puede iniciarse manualmente
+     - Expresión Cron (segundo minuto hora día mes día-semana). Max. 100 caracteres, validada como expresión cron. Si está vacía, el trabajo no se ejecuta de forma programada y solo puede iniciarse manualmente
    * - ``scriptType``
-     - Si
+     - Sí
      - Tipo de script (max. 100 caracteres). Actualmente solo se admite ``groovy``
    * - ``scriptData``
      - No
-     - Script de ejecucion. El tamano maximo sigue ``form.admin.max.input.size`` en ``fess_config.properties``
+     - Script de ejecución. El tamaño máximo sigue ``form.admin.max.input.size`` en ``fess_config.properties``
    * - ``jobLogging``
      - No
      - Habilitar registro de trabajos (cadena)
@@ -212,16 +212,16 @@ Descripcion de Campos
      - No
      - Habilitado/Deshabilitado (cadena)
    * - ``sortOrder``
-     - Si
-     - Orden de visualizacion (entero entre 0 y 2147483647)
+     - Sí
+     - Orden de visualización (entero entre 0 y 2147483647)
 
 .. note::
 
-   ``jobLogging`` / ``crawler`` / ``available`` son campos de cadena. En las solicitudes, especificar ``"on"`` o ``"true"`` (sin distincion de mayusculas y minusculas) los habilita; cualquier otro valor (``"false"``, cadena vacia o no especificado) se trata como deshabilitado. En las respuestas se devuelven como ``"true"`` / ``"false"``.
+   ``jobLogging`` / ``crawler`` / ``available`` son campos de cadena. En las solicitudes, especificar ``"on"`` o ``"true"`` (sin distinción de mayúsculas y minúsculas) los habilita; cualquier otro valor (``"false"``, cadena vacía o no especificado) se trata como deshabilitado. En las respuestas se devuelven como ``"true"`` / ``"false"``.
 
 .. note::
 
-   ``crudMode`` se establece automaticamente en el servidor y no es necesario especificarlo en las solicitudes. Los campos de auditoria como ``createdBy`` / ``createdTime`` tambien se establecen en el servidor.
+   ``crudMode`` se establece automáticamente en el servidor y no es necesario especificarlo en las solicitudes. Los campos de auditoría como ``createdBy`` / ``createdTime`` también se establecen en el servidor.
 
 Respuesta
 ---------
@@ -243,8 +243,8 @@ Ejemplos de Expresiones Cron
    :header-rows: 1
    :widths: 40 60
 
-   * - Expresion Cron
-     - Descripcion
+   * - Expresión Cron
+     - Descripción
    * - ``0 0 2 * * ?``
      - Ejecutar diariamente a las 2 AM
    * - ``0 0 0/6 * * ?``
@@ -252,7 +252,7 @@ Ejemplos de Expresiones Cron
    * - ``0 0 2 * * MON``
      - Ejecutar cada lunes a las 2 AM
    * - ``0 0 2 1 * ?``
-     - Ejecutar el dia 1 de cada mes a las 2 AM
+     - Ejecutar el día 1 de cada mes a las 2 AM
 
 Actualizar Trabajo Programado
 =============================
@@ -286,7 +286,7 @@ Cuerpo de la Solicitud
 
 .. note::
 
-   Para las actualizaciones, ``id`` (max. 1000 caracteres) y ``versionNo`` son obligatorios. ``versionNo`` se utiliza para el bloqueo optimista; especifique el valor devuelto en la respuesta de obtencion. Si el valor no coincide, la actualizacion falla. Los demas campos obligatorios (``name`` / ``target`` / ``scriptType`` / ``sortOrder``) son los mismos que para la creacion.
+   Para las actualizaciones, ``id`` (max. 1000 caracteres) y ``versionNo`` son obligatorios. ``versionNo`` se utiliza para el bloqueo optimista; especifique el valor devuelto en la respuesta de obtención. Si el valor no coincide, la actualización falla. Los demás campos obligatorios (``name`` / ``target`` / ``scriptType`` / ``sortOrder``) son los mismos que para la creación.
 
 Respuesta
 ---------
@@ -356,21 +356,21 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``jobLogId``
-     - ID del registro del trabajo iniciado. Se emite cuando el registro de trabajos esta habilitado. Es ``null`` cuando el registro de trabajos esta deshabilitado.
+     - ID del registro del trabajo iniciado. Se emite cuando el registro de trabajos está habilitado. Es ``null`` cuando el registro de trabajos está deshabilitado.
 
 Notas
 -----
 
-- Si el trabajo ya esta en ejecucion, el inicio falla y se devuelve un error (``status`` distinto de ``0``).
-- Si el trabajo esta deshabilitado (``available`` no esta habilitado), el inicio tambien falla con un error.
-- ``jobLogId`` solo se emite cuando el registro de trabajos esta habilitado (``jobLogging`` esta habilitado).
+- Si el trabajo ya está en ejecución, el inicio falla y se devuelve un error (``status`` distinto de ``0``).
+- Si el trabajo está deshabilitado (``available`` no está habilitado), el inicio también falla con un error.
+- ``jobLogId`` solo se emite cuando el registro de trabajos está habilitado (``jobLogging`` está habilitado).
 
 Detener Trabajo
 ===============
 
-Detiene un trabajo en ejecucion.
+Detiene un trabajo en ejecución.
 
 Solicitud
 ---------
@@ -429,9 +429,9 @@ Verificar Estado del Trabajo
 
     # Puede verificar el estado de ejecucion con el campo running
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-joblog` - API de registro de trabajos
-- :doc:`../../admin/scheduler-guide` - Guia de gestion del programador
+- :doc:`../../admin/scheduler-guide` - Guía de gestión del programador

--- a/es/15.7/api/admin/api-admin-stats.rst
+++ b/es/15.7/api/admin/api-admin-stats.rst
@@ -2,16 +2,16 @@
 API de Stats
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de Stats es una API para obtener metricas del sistema del servidor donde se ejecuta |Fess|.
-Puede ver informacion estadistica de la JVM, el sistema operativo, el proceso, el cluster del motor de busqueda (OpenSearch) y el sistema de archivos.
+La API de Stats es una API para obtener métricas del sistema del servidor donde se ejecuta |Fess|.
+Puede ver información estadística de la JVM, el sistema operativo, el proceso, el clúster del motor de búsqueda (OpenSearch) y el sistema de archivos.
 
 .. note::
 
-   Esta API no devuelve datos de analisis de busqueda como consultas de busqueda o clics.
-   Para buscar y gestionar documentos del indice, consulte :doc:`api-admin-searchlist`.
+   Esta API no devuelve datos de análisis de búsqueda como consultas de búsqueda o clics.
+   Para buscar y gestionar documentos del índice, consulte :doc:`api-admin-searchlist`.
 
 URL Base
 ========
@@ -21,7 +21,7 @@ URL Base
     /api/admin/stats
 
 El acceso a esta API requiere un token de acceso con el permiso ``Radmin-api``.
-Para obtener detalles sobre la autenticacion, consulte :doc:`api-admin-overview`.
+Para obtener detalles sobre la autenticación, consulte :doc:`api-admin-overview`.
 
 Lista de Endpoints
 ==================
@@ -30,14 +30,14 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /
-     - Obtener informacion estadistica del sistema
+     - Obtener información estadística del sistema
 
-Obtener Informacion Estadistica del Sistema
+Obtener Información Estadística del Sistema
 ===========================================
 
 Solicitud
@@ -47,18 +47,18 @@ Solicitud
 
     GET /api/admin/stats
 
-Este endpoint no acepta parametros de consulta.
+Este endpoint no acepta parámetros de consulta.
 
 Respuesta
 ---------
 
-La respuesta incluye ``version``, que indica la version del producto, ``status``, que indica
-el resultado del procesamiento, y un objeto ``stats`` que almacena las metricas del sistema.
+La respuesta incluye ``version``, que indica la versión del producto, ``status``, que indica
+el resultado del procesamiento, y un objeto ``stats`` que almacena las métricas del sistema.
 ``stats`` tiene cinco claves: ``jvm`` / ``os`` / ``process`` / ``engine`` / ``fs``.
 
 .. note::
 
-   Los nombres de campo de los objetos bajo ``stats`` se presentan en snake_case (palabras en minusculas separadas por guiones bajos, por ejemplo ``non_heap``).
+   Los nombres de campo de los objetos bajo ``stats`` se presentan en snake_case (palabras en minúsculas separadas por guiones bajos, por ejemplo ``non_heap``).
    Los campos cuyo valor es ``null`` se omiten de la respuesta.
 
 .. code-block:: json
@@ -143,15 +143,15 @@ Campos de Respuesta (Nivel Superior)
    :widths: 20 80
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``version``
-     - La version del producto de |Fess| (por ejemplo, ``15.7.0``).
+     - La versión del producto de |Fess| (por ejemplo, ``15.7.0``).
    * - ``status``
-     - Codigo que indica el resultado del procesamiento. ``0`` indica que se completo correctamente.
+     - Código que indica el resultado del procesamiento. ``0`` indica que se completó correctamente.
    * - ``stats``
-     - Objeto que almacena las metricas del sistema. Tiene cinco claves: ``jvm`` / ``os`` / ``process`` / ``engine`` / ``fs``.
+     - Objeto que almacena las métricas del sistema. Tiene cinco claves: ``jvm`` / ``os`` / ``process`` / ``engine`` / ``fs``.
 
-``jvm``: Estadisticas de la JVM
+``jvm``: Estadísticas de la JVM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -159,13 +159,13 @@ Campos de Respuesta (Nivel Superior)
    :widths: 35 65
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``memory.heap.used``
      - Memoria heap utilizada (bytes).
    * - ``memory.heap.committed``
      - Memoria heap comprometida (bytes).
    * - ``memory.heap.max``
-     - Memoria heap maxima (bytes).
+     - Memoria heap máxima (bytes).
    * - ``memory.heap.percent``
      - Porcentaje de uso de la memoria heap (%).
    * - ``memory.non_heap.used``
@@ -173,27 +173,27 @@ Campos de Respuesta (Nivel Superior)
    * - ``memory.non_heap.committed``
      - Memoria no-heap comprometida (bytes).
    * - ``memory.non_heap.max``
-     - Memoria no-heap maxima (bytes). En la implementacion actual este valor no se establece y siempre devuelve ``0``.
+     - Memoria no-heap máxima (bytes). En la implementación actual este valor no se establece y siempre devuelve ``0``.
    * - ``memory.non_heap.percent``
-     - Porcentaje de uso de la memoria no-heap (%). En la implementacion actual este valor no se establece y siempre devuelve ``0``.
+     - Porcentaje de uso de la memoria no-heap (%). En la implementación actual este valor no se establece y siempre devuelve ``0``.
    * - ``pools``
-     - Arreglo de grupos de buffers. Cada elemento incluye ``key`` (nombre del grupo), ``count`` (numero de buffers), ``used`` (memoria utilizada, bytes) y ``capacity`` (capacidad total, bytes).
+     - Arreglo de grupos de buffers. Cada elemento incluye ``key`` (nombre del grupo), ``count`` (número de buffers), ``used`` (memoria utilizada, bytes) y ``capacity`` (capacidad total, bytes).
    * - ``gc``
-     - Arreglo de recolectores de basura. Cada elemento incluye ``key`` (nombre del recolector), ``count`` (numero de recolecciones) y ``time`` (tiempo acumulado de recoleccion, milisegundos).
+     - Arreglo de recolectores de basura. Cada elemento incluye ``key`` (nombre del recolector), ``count`` (número de recolecciones) y ``time`` (tiempo acumulado de recolección, milisegundos).
    * - ``threads.count``
-     - Numero actual de hilos.
+     - Número actual de hilos.
    * - ``threads.peak``
-     - Numero maximo de hilos alcanzado.
+     - Número máximo de hilos alcanzado.
    * - ``classes.loaded``
-     - Numero de clases cargadas actualmente.
+     - Número de clases cargadas actualmente.
    * - ``classes.total_loaded``
-     - Numero total de clases cargadas desde que se inicio la JVM.
+     - Número total de clases cargadas desde que se inició la JVM.
    * - ``classes.unloaded``
-     - Numero total de clases descargadas.
+     - Número total de clases descargadas.
    * - ``uptime``
      - Tiempo de actividad de la JVM (milisegundos).
 
-``os``: Estadisticas del Sistema Operativo
+``os``: Estadísticas del Sistema Operativo
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -201,11 +201,11 @@ Campos de Respuesta (Nivel Superior)
    :widths: 35 65
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``memory.physical.free``
-     - Memoria fisica libre (bytes).
+     - Memoria física libre (bytes).
    * - ``memory.physical.total``
-     - Memoria fisica total (bytes).
+     - Memoria física total (bytes).
    * - ``memory.swap_space.free``
      - Espacio de intercambio libre (bytes).
    * - ``memory.swap_space.total``
@@ -215,7 +215,7 @@ Campos de Respuesta (Nivel Superior)
    * - ``load_averages``
      - Arreglo de promedios de carga (1, 5 y 15 minutos). Los valores que no se pueden obtener pueden ser ``-1``.
 
-``process``: Estadisticas del Proceso
+``process``: Estadísticas del Proceso
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -223,77 +223,77 @@ Campos de Respuesta (Nivel Superior)
    :widths: 35 65
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``file_fescriptor.open``
-     - Numero de descriptores de archivo abiertos actualmente.
+     - Número de descriptores de archivo abiertos actualmente.
    * - ``file_fescriptor.max``
-     - Numero maximo de descriptores de archivo que se pueden abrir.
+     - Número máximo de descriptores de archivo que se pueden abrir.
    * - ``cpu.percent``
      - Porcentaje de uso de CPU del proceso (%).
    * - ``cpu.total``
      - Tiempo de CPU acumulado utilizado por el proceso (milisegundos).
    * - ``virtual_memory.total``
-     - Tamano total de la memoria virtual del proceso (bytes).
+     - Tamaño total de la memoria virtual del proceso (bytes).
 
 .. note::
 
-   El nombre de clave ``process.file_fescriptor`` es la conversion a snake_case del nombre de campo del codigo fuente
-   ``fileFescriptor`` (que se origina de una falta de ortografia de ``fileDescriptor``). Coincide con
-   la implementacion y no es un error tipografico en este documento.
+   El nombre de clave ``process.file_fescriptor`` es la conversión a snake_case del nombre de campo del código fuente
+   ``fileFescriptor`` (que se origina de una falta de ortografía de ``fileDescriptor``). Coincide con
+   la implementación y no es un error tipografico en este documento.
 
-``engine``: Estadisticas del Cluster del Motor de Busqueda
+``engine``: Estadísticas del Clúster del Motor de Búsqueda
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Informacion de salud del cluster del motor de busqueda (OpenSearch).
+Información de salud del clúster del motor de búsqueda (OpenSearch).
 
 .. list-table::
    :header-rows: 1
    :widths: 35 65
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``cluster_name``
-     - Nombre del cluster.
+     - Nombre del clúster.
    * - ``number_of_nodes``
-     - Numero total de nodos en el cluster.
+     - Número total de nodos en el clúster.
    * - ``number_of_data_nodes``
-     - Numero de nodos de datos.
+     - Número de nodos de datos.
    * - ``active_primary_shards``
-     - Numero de shards primarios activos.
+     - Número de shards primarios activos.
    * - ``active_shards``
-     - Numero de shards activos.
+     - Número de shards activos.
    * - ``active_shards_percent``
      - Porcentaje de shards activos (%).
    * - ``relocating_shards``
-     - Numero de shards en reubicacion.
+     - Número de shards en reubicación.
    * - ``initializing_shards``
-     - Numero de shards en inicializacion.
+     - Número de shards en inicialización.
    * - ``unassigned_shards``
-     - Numero de shards sin asignar.
+     - Número de shards sin asignar.
    * - ``delayed_unassigned_shards``
-     - Numero de shards sin asignar con retraso.
+     - Número de shards sin asignar con retraso.
    * - ``number_of_pending_tasks``
-     - Numero de tareas pendientes.
+     - Número de tareas pendientes.
    * - ``number_of_in_flight_fetch``
-     - Numero de operaciones de recuperacion en curso.
+     - Número de operaciones de recuperación en curso.
    * - ``status``
-     - Estado de salud del cluster (``green`` / ``yellow`` / ``red``).
+     - Estado de salud del clúster (``green`` / ``yellow`` / ``red``).
    * - ``exception``
-     - Mensaje de error que se incluye solo cuando ocurre un error, como cuando no se puede alcanzar el cluster. En este caso, ``status`` se vuelve ``red``.
+     - Mensaje de error que se incluye solo cuando ocurre un error, como cuando no se puede alcanzar el clúster. En este caso, ``status`` se vuelve ``red``.
 
-``fs``: Estadisticas del Sistema de Archivos
+``fs``: Estadísticas del Sistema de Archivos
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Arreglo de estadisticas para cada raiz (las raices obtenidas de ``File.listRoots()``).
+Arreglo de estadísticas para cada raíz (las raíces obtenidas de ``File.listRoots()``).
 
 .. list-table::
    :header-rows: 1
    :widths: 35 65
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``path``
-     - Ruta absoluta de la raiz.
+     - Ruta absoluta de la raíz.
    * - ``total``
      - Capacidad total (bytes).
    * - ``free``
@@ -308,7 +308,7 @@ Arreglo de estadisticas para cada raiz (las raices obtenidas de ``File.listRoots
 Ejemplos de Uso
 ===============
 
-Obtener Informacion Estadistica del Sistema
+Obtener Información Estadística del Sistema
 -------------------------------------------
 
 .. code-block:: bash
@@ -325,7 +325,7 @@ Verificar el Uso del Heap de la JVM
          -H "Authorization: Bearer YOUR_TOKEN" \
          | jq '.response.stats.jvm.memory.heap.percent'
 
-Verificar el Estado del Cluster del Motor de Busqueda
+Verificar el Estado del Clúster del Motor de Búsqueda
 ------------------------------------------------------
 
 .. code-block:: bash
@@ -334,9 +334,9 @@ Verificar el Estado del Cluster del Motor de Busqueda
          -H "Authorization: Bearer YOUR_TOKEN" \
          | jq '.response.stats.engine.status'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-systeminfo` - API de informacion del sistema
-- :doc:`api-admin-searchlist` - API de busqueda y gestion de documentos
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-systeminfo` - API de información del sistema
+- :doc:`api-admin-searchlist` - API de búsqueda y gestión de documentos

--- a/es/15.7/api/admin/api-admin-storage.rst
+++ b/es/15.7/api/admin/api-admin-storage.rst
@@ -2,11 +2,11 @@
 Storage API
 ===========
 
-Vision General
+Visión General
 ==============
 
 Storage API es una API para gestionar el almacenamiento de objetos de |Fess|.
-Permite obtener el listado de archivos y directorios en el almacenamiento, asi como descargar, eliminar y subir archivos.
+Permite obtener el listado de archivos y directorios en el almacenamiento, así como descargar, eliminar y subir archivos.
 
 URL Base
 ========
@@ -15,17 +15,17 @@ URL Base
 
     /api/admin/storage
 
-Autenticacion
+Autenticación
 =============
 
-Todos los endpoints de Admin API, incluida Storage API, requieren autenticacion mediante un token de acceso.
+Todos los endpoints de Admin API, incluida Storage API, requieren autenticación mediante un token de acceso.
 Especifique el token de acceso en el encabezado ``Authorization`` de la solicitud.
 
 ::
 
     Authorization: Bearer <token de acceso>
 
-Para obtener informacion sobre como obtener el token de acceso y los permisos necesarios (de forma predeterminada, el rol ``admin-api``),
+Para obtener información sobre cómo obtener el token de acceso y los permisos necesarios (de forma predeterminada, el rol ``admin-api``),
 consulte :doc:`api-admin-overview`.
 
 Lista de Endpoints
@@ -35,9 +35,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /list/{id}
      - Obtener listado de archivos y directorios
@@ -55,7 +55,7 @@ Obtener Listado de Archivos y Directorios
 =========================================
 
 Devuelve el listado de archivos y directorios ubicados bajo el directorio especificado.
-En ``{id}`` especifique el ``id`` del directorio obtenido en el listado. Si se omite ``{id}``, se obtiene el listado del directorio raiz.
+En ``{id}`` especifique el ``id`` del directorio obtenido en el listado. Si se omite ``{id}``, se obtiene el listado del directorio raíz.
 
 Solicitud
 ---------
@@ -67,7 +67,7 @@ Solicitud
 Respuesta
 ---------
 
-En ``items`` se almacena un array de objetos que representan la informacion de archivos y directorios (primero los directorios, luego los archivos).
+En ``items`` se almacena un array de objetos que representan la información de archivos y directorios (primero los directorios, luego los archivos).
 Cada objeto tiene los siguientes campos.
 
 .. list-table::
@@ -75,7 +75,7 @@ Cada objeto tiene los siguientes campos.
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``id``
      - Identificador codificado. Cadena que representa la ruta del objeto codificada en Base64 seguro para URL, utilizada como ``{id}`` al descargar o eliminar.
    * - ``path``
@@ -85,11 +85,11 @@ Cada objeto tiene los siguientes campos.
    * - ``hashCode``
      - Valor de hash utilizado en el procesamiento interno (no es un valor estable que represente el contenido del objeto)
    * - ``size``
-     - Tamano (en bytes)
+     - Tamaño (en bytes)
    * - ``directory``
      - Indica si es un directorio (boolean)
    * - ``lastModified``
-     - Fecha y hora de la ultima modificacion (formato ISO 8601; incluido solo para archivos)
+     - Fecha y hora de la última modificación (formato ISO 8601; incluido solo para archivos)
 
 .. code-block:: json
 
@@ -140,7 +140,7 @@ Flujo binario del archivo (``Content-Type: application/octet-stream``).
 .. note::
 
    La respuesta de esta API no incluye el encabezado ``Content-Disposition``.
-   El nombre del archivo con el que se guarda debe especificarse en el lado del cliente (en cURL, utilice la opcion ``-o``).
+   El nombre del archivo con el que se guarda debe especificarse en el lado del cliente (en cURL, utilice la opción ``-o``).
 
 Eliminar un Archivo
 ===================
@@ -169,7 +169,7 @@ Respuesta
 Subir un Archivo
 ================
 
-Sube un archivo al almacenamiento. El envio se realiza en formato ``multipart/form-data``.
+Sube un archivo al almacenamiento. El envío se realiza en formato ``multipart/form-data``.
 El directorio de destino se especifica mediante el campo de formulario ``path``, no como parte de la ruta URL.
 
 Solicitud
@@ -180,7 +180,7 @@ Solicitud
     PUT /api/admin/storage/upload
     Content-Type: multipart/form-data
 
-Descripcion de los Campos
+Descripción de los Campos
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -189,12 +189,12 @@ Descripcion de los Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``path``
      - No
-     - Ruta del directorio de destino (sin barras al inicio ni al final). Si se omite, el archivo se guarda en el raiz (directamente bajo el bucket).
+     - Ruta del directorio de destino (sin barras al inicio ni al final). Si se omite, el archivo se guarda en el raíz (directamente bajo el bucket).
    * - ``file``
-     - Si
+     - Sí
      - Archivo a subir
 
 Respuesta
@@ -212,8 +212,8 @@ Respuesta
 Errores
 =======
 
-Cada endpoint devuelve una respuesta con ``status`` distinto de 0 (``1`` en caso de error de validacion) cuando el procesamiento falla.
-El campo ``message`` del cuerpo de la respuesta contiene el detalle del error. Para obtener informacion sobre los valores de status y los codigos de estado HTTP, consulte :doc:`api-admin-overview`.
+Cada endpoint devuelve una respuesta con ``status`` distinto de 0 (``1`` en caso de error de validación) cuando el procesamiento falla.
+El campo ``message`` del cuerpo de la respuesta contiene el detalle del error. Para obtener información sobre los valores de status y los códigos de estado HTTP, consulte :doc:`api-admin-overview`.
 
 Los principales casos de error son los siguientes.
 
@@ -224,18 +224,18 @@ Los principales casos de error son los siguientes.
    * - Endpoint
      - Principales casos en que se produce un error
    * - Obtener listado de archivos y directorios
-     - Cuando el numero de elementos supera el limite
+     - Cuando el número de elementos supera el límite
    * - Descargar un archivo
-     - Cuando el ``id`` es invalido o la descarga falla
+     - Cuando el ``id`` es inválido o la descarga falla
    * - Eliminar un archivo
-     - Cuando el ``id`` es invalido o la eliminacion falla
+     - Cuando el ``id`` es inválido o la eliminación falla
    * - Subir un archivo
      - Cuando no se especifica ``file`` o la subida falla
 
 Ejemplos de Uso
 ===============
 
-Obtener Listado del Directorio Raiz
+Obtener Listado del Directorio Raíz
 ------------------------------------
 
 .. code-block:: bash
@@ -270,7 +270,7 @@ Subir un Archivo
          -F "path=subdir" \
          -F "file=@sample.txt"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API

--- a/es/15.7/api/admin/api-admin-suggest.rst
+++ b/es/15.7/api/admin/api-admin-suggest.rst
@@ -2,20 +2,20 @@
 Suggest API
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Suggest es una API para gestionar las palabras de sugerencia utilizadas por la funcionalidad de sugerencias de |Fess|.
-Permite obtener informacion estadistica sobre el numero de palabras de sugerencia y eliminar palabras de sugerencia.
+Permite obtener información estadística sobre el número de palabras de sugerencia y eliminar palabras de sugerencia.
 
 Las palabras de sugerencia incluyen las generadas a partir de documentos rastreados (derivadas de documentos) y
-las generadas a partir de las consultas de busqueda de los usuarios (derivadas de consultas de busqueda). Esta API permite
+las generadas a partir de las consultas de búsqueda de los usuarios (derivadas de consultas de búsqueda). Esta API permite
 eliminarlas por tipo o eliminarlas todas a la vez.
 
-Autenticacion
+Autenticación
 =============
 
-El acceso a esta API requiere autenticacion mediante un token de acceso. Especifique el token de acceso
+El acceso a esta API requiere autenticación mediante un token de acceso. Especifique el token de acceso
 en la cabecera de la solicitud.
 
 ::
@@ -23,7 +23,7 @@ en la cabecera de la solicitud.
     Authorization: Bearer <token de acceso>
 
 El token de acceso debe tener el permiso de Admin API (por defecto ``Radmin-api``).
-Para obtener informacion sobre como obtener un token de acceso y los detalles de los permisos, consulte :doc:`api-admin-overview`.
+Para obtener información sobre cómo obtener un token de acceso y los detalles de los permisos, consulte :doc:`api-admin-overview`.
 
 URL Base
 ========
@@ -39,12 +39,12 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /
-     - Obtener informacion estadistica de palabras de sugerencia
+     - Obtener información estadística de palabras de sugerencia
    * - DELETE
      - /all
      - Eliminar todas las palabras de sugerencia
@@ -53,12 +53,12 @@ Lista de Endpoints
      - Eliminar palabras de sugerencia derivadas de documentos
    * - DELETE
      - /query
-     - Eliminar palabras de sugerencia derivadas de consultas de busqueda
+     - Eliminar palabras de sugerencia derivadas de consultas de búsqueda
 
-Obtener Informacion Estadistica de Palabras de Sugerencia
+Obtener Información Estadística de Palabras de Sugerencia
 =========================================================
 
-Obtiene informacion estadistica sobre el numero de palabras de sugerencia.
+Obtiene información estadística sobre el número de palabras de sugerencia.
 
 Solicitud
 ---------
@@ -92,25 +92,25 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``setting.totalWordsNum``
-     - Numero total de palabras de sugerencia (numero de palabras de sugerencia registradas en el indice de sugerencias)
+     - Número total de palabras de sugerencia (número de palabras de sugerencia registradas en el índice de sugerencias)
    * - ``setting.documentWordsNum``
-     - Numero de palabras de sugerencia derivadas de documentos (numero de palabras de sugerencia con frecuencia de documento igual o superior a 1)
+     - Número de palabras de sugerencia derivadas de documentos (número de palabras de sugerencia con frecuencia de documento igual o superior a 1)
    * - ``setting.queryWordsNum``
-     - Numero de palabras de sugerencia derivadas de consultas de busqueda (numero de palabras de sugerencia con frecuencia de consulta igual o superior a 1)
+     - Número de palabras de sugerencia derivadas de consultas de búsqueda (número de palabras de sugerencia con frecuencia de consulta igual o superior a 1)
 
 .. note::
 
-   ``documentWordsNum`` y ``queryWordsNum`` no son excluyentes entre si. Si una palabra de sugerencia tiene origen
-   tanto en documentos como en consultas de busqueda, se incluye en el recuento de ambos. Por este motivo,
+   ``documentWordsNum`` y ``queryWordsNum`` no son excluyentes entre sí. Si una palabra de sugerencia tiene origen
+   tanto en documentos como en consultas de búsqueda, se incluye en el recuento de ambos. Por este motivo,
    la suma de ``documentWordsNum`` y ``queryWordsNum`` puede no coincidir con ``totalWordsNum``.
 
 Eliminar Todas las Palabras de Sugerencia
 =========================================
 
-Elimina todas las palabras de sugerencia. Se eliminan todas las palabras de sugerencia del indice de sugerencias,
-independientemente de si son derivadas de documentos o de consultas de busqueda.
+Elimina todas las palabras de sugerencia. Se eliminan todas las palabras de sugerencia del índice de sugerencias,
+independientemente de si son derivadas de documentos o de consultas de búsqueda.
 
 Solicitud
 ---------
@@ -155,10 +155,10 @@ Respuesta
       }
     }
 
-Eliminar Palabras de Sugerencia Derivadas de Consultas de Busqueda
+Eliminar Palabras de Sugerencia Derivadas de Consultas de Búsqueda
 ==================================================================
 
-Elimina las palabras de sugerencia generadas a partir de consultas de busqueda (palabras de sugerencia derivadas de consultas de busqueda).
+Elimina las palabras de sugerencia generadas a partir de consultas de búsqueda (palabras de sugerencia derivadas de consultas de búsqueda).
 
 Solicitud
 ---------
@@ -182,7 +182,7 @@ Respuesta
 Respuesta de Error
 ==================
 
-Si el proceso de eliminacion falla, se devuelve el estado HTTP ``400`` y el campo ``status`` del cuerpo de la
+Si el proceso de eliminación falla, se devuelve el estado HTTP ``400`` y el campo ``status`` del cuerpo de la
 respuesta se establece en ``1`` (BAD_REQUEST), con el campo ``message`` conteniendo el mensaje de error.
 
 .. code-block:: json
@@ -195,14 +195,14 @@ respuesta se establece en ``1`` (BAD_REQUEST), con el campo ``message`` contenie
       }
     }
 
-Si el token de acceso no se especifica, no es valido o los permisos son insuficientes, el campo ``status`` del
+Si el token de acceso no se especifica, no es válido o los permisos son insuficientes, el campo ``status`` del
 cuerpo de la respuesta se establece en ``3`` (UNAUTHORIZED). Para consultar la lista de valores de ``status``
-y codigos de estado HTTP, consulte :doc:`api-admin-overview`.
+y códigos de estado HTTP, consulte :doc:`api-admin-overview`.
 
 Ejemplos de Uso
 ===============
 
-Obtener Informacion Estadistica
+Obtener Información Estadística
 -------------------------------
 
 .. code-block:: bash
@@ -226,7 +226,7 @@ Eliminar Palabras de Sugerencia Derivadas de Documentos
     curl -X DELETE "http://localhost:8080/api/admin/suggest/document" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Eliminar Palabras de Sugerencia Derivadas de Consultas de Busqueda
+Eliminar Palabras de Sugerencia Derivadas de Consultas de Búsqueda
 ------------------------------------------------------------------
 
 .. code-block:: bash
@@ -234,10 +234,10 @@ Eliminar Palabras de Sugerencia Derivadas de Consultas de Busqueda
     curl -X DELETE "http://localhost:8080/api/admin/suggest/query" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-badword` - API de palabras prohibidas
 - :doc:`api-admin-elevateword` - API de palabras elevadas
-- :doc:`../../admin/suggest-guide` - Guia de gestion de sugerencias
+- :doc:`../../admin/suggest-guide` - Guía de gestión de sugerencias

--- a/es/15.7/api/admin/api-admin-systeminfo.rst
+++ b/es/15.7/api/admin/api-admin-systeminfo.rst
@@ -2,11 +2,11 @@
 API de SystemInfo
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de SystemInfo es para obtener informacion del sistema de |Fess|.
-Permite verificar las variables de entorno, las propiedades del sistema de Java, las propiedades de configuracion de |Fess| y la informacion para reportes de errores.
+La API de SystemInfo es para obtener información del sistema de |Fess|.
+Permite verificar las variables de entorno, las propiedades del sistema de Java, las propiedades de configuración de |Fess| y la información para reportes de errores.
 
 URL Base
 ========
@@ -16,7 +16,7 @@ URL Base
     /api/admin/systeminfo
 
 El acceso a esta API requiere un token de acceso con el permiso ``Radmin-api``.
-Para mas detalles sobre la autenticacion, consulte :doc:`api-admin-overview`.
+Para más detalles sobre la autenticación, consulte :doc:`api-admin-overview`.
 
 Lista de Endpoints
 ==================
@@ -25,14 +25,14 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /
-     - Obtener informacion del sistema
+     - Obtener información del sistema
 
-Obtener Informacion del Sistema
+Obtener Información del Sistema
 ===============================
 
 Solicitud
@@ -42,12 +42,12 @@ Solicitud
 
     GET /api/admin/systeminfo
 
-Este endpoint no acepta parametros de consulta.
+Este endpoint no acepta parámetros de consulta.
 
 Respuesta
 ---------
 
-La respuesta incluye ``version``, que indica la version del producto, ``status``, que indica el resultado del procesamiento, y los siguientes cuatro grupos de propiedades. Cada grupo de propiedades es un arreglo de objetos que tienen ``label`` y ``value``.
+La respuesta incluye ``version``, que indica la versión del producto, ``status``, que indica el resultado del procesamiento, y los siguientes cuatro grupos de propiedades. Cada grupo de propiedades es un arreglo de objetos que tienen ``label`` y ``value``.
 
 .. code-block:: json
 
@@ -85,36 +85,36 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``version``
-     - Version del producto |Fess| (ejemplo: ``15.7.0``).
+     - Versión del producto |Fess| (ejemplo: ``15.7.0``).
    * - ``status``
-     - Codigo que indica el resultado del procesamiento. ``0`` significa finalizacion exitosa.
+     - Código que indica el resultado del procesamiento. ``0`` significa finalización exitosa.
    * - ``envProps``
-     - Lista de variables de entorno (arreglo de ``label`` / ``value``). Se devuelven los valores obtenidos mediante ``System.getenv()`` tal como estan.
+     - Lista de variables de entorno (arreglo de ``label`` / ``value``). Se devuelven los valores obtenidos mediante ``System.getenv()`` tal como están.
    * - ``systemProps``
-     - Lista de propiedades del sistema de Java (arreglo de ``label`` / ``value``). Se devuelven los valores obtenidos mediante ``System.getProperties()`` tal como estan.
+     - Lista de propiedades del sistema de Java (arreglo de ``label`` / ``value``). Se devuelven los valores obtenidos mediante ``System.getProperties()`` tal como están.
    * - ``fessProps``
-     - Lista de propiedades de configuracion de |Fess| (arreglo de ``label`` / ``value``). Incluye los valores de configuracion de ``fess_config.properties`` y las propiedades del sistema establecidas desde la pantalla de administracion. Los elementos sensibles son enmascarados (vease la nota a continuacion).
+     - Lista de propiedades de configuración de |Fess| (arreglo de ``label`` / ``value``). Incluye los valores de configuración de ``fess_config.properties`` y las propiedades del sistema establecidas desde la pantalla de administración. Los elementos sensibles son enmascarados (véase la nota a continuación).
    * - ``bugReportProps``
-     - Lista de informacion recopilada para reportes de errores (arreglo de ``label`` / ``value``). Incluye las principales propiedades del sistema relacionadas con el SO y el entorno de ejecucion de Java (``os.name``, ``os.version``, ``java.vm.version``, etc.) y los valores de propiedades del sistema de |Fess|.
+     - Lista de información recopilada para reportes de errores (arreglo de ``label`` / ``value``). Incluye las principales propiedades del sistema relacionadas con el SO y el entorno de ejecución de Java (``os.name``, ``os.version``, ``java.vm.version``, etc.) y los valores de propiedades del sistema de |Fess|.
 
 .. note::
 
-   En ``fessProps``, los siguientes valores de configuracion sensibles son enmascarados y se devuelven como ``XXXXXXXX``:
+   En ``fessProps``, los siguientes valores de configuración sensibles son enmascarados y se devuelven como ``XXXXXXXX``:
    ``http.proxy.password``, ``ldap.admin.security.credentials``, ``spnego.preauth.password``,
    ``app.cipher.key``, ``oic.client.id``, ``oic.client.secret``.
 
 .. warning::
 
    ``envProps`` (variables de entorno) y ``systemProps`` (propiedades del sistema de Java) no son enmascarados:
-   los valores configurados se devuelven tal como estan. Si las variables de entorno o las propiedades del sistema
-   contienen informacion confidencial como credenciales, esos valores apareceran en la respuesta.
+   los valores configurados se devuelven tal como están. Si las variables de entorno o las propiedades del sistema
+   contienen información confidencial como credenciales, esos valores aparecerán en la respuesta.
 
 Ejemplos de Uso
 ===============
 
-Obtener Informacion del Sistema
+Obtener Información del Sistema
 -------------------------------
 
 .. code-block:: bash
@@ -122,7 +122,7 @@ Obtener Informacion del Sistema
     curl -X GET "http://localhost:8080/api/admin/systeminfo" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Extraer una Propiedad del Sistema Especifica
+Extraer una Propiedad del Sistema Específica
 --------------------------------------------
 
 .. code-block:: bash
@@ -142,10 +142,10 @@ Mostrar la Lista de Variables de Entorno
          -H "Authorization: Bearer YOUR_TOKEN" \
          | jq -r '.response.envProps[] | "\(.label)=\(.value)"'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-stats` - API de estadisticas
-- :doc:`api-admin-general` - API de configuracion general
-- :doc:`../../admin/systeminfo-guide` - Guia de informacion del sistema
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-stats` - API de estadísticas
+- :doc:`api-admin-general` - API de configuración general
+- :doc:`../../admin/systeminfo-guide` - Guía de información del sistema

--- a/es/15.7/api/admin/api-admin-user.rst
+++ b/es/15.7/api/admin/api-admin-user.rst
@@ -2,19 +2,19 @@
 API de User
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de User es una API REST para gestionar cuentas de usuario de |Fess|.
-Permite crear, obtener, actualizar y eliminar usuarios, ademas de asignar roles y grupos.
+Permite crear, obtener, actualizar y eliminar usuarios, además de asignar roles y grupos.
 
-Esta es una API de administracion, y el acceso requiere autenticacion con un token de acceso de administrador.
-Consulte :doc:`api-admin-overview` para conocer el metodo de autenticacion y las especificaciones comunes.
+Esta es una API de administración, y el acceso requiere autenticación con un token de acceso de administrador.
+Consulte :doc:`api-admin-overview` para conocer el método de autenticación y las especificaciones comunes.
 
-Cada respuesta esta envuelta en un objeto ``response`` e incluye los siguientes campos comunes:
+Cada respuesta está envuelta en un objeto ``response`` e incluye los siguientes campos comunes:
 
-- ``version`` : La cadena de version del producto |Fess|.
-- ``status`` : El codigo de estado del resultado (``0`` =exito, ``1`` =solicitud incorrecta, ``2`` =error del sistema, ``3`` =no autorizado, ``9`` =fallo).
+- ``version`` : La cadena de versión del producto |Fess|.
+- ``status`` : El código de estado del resultado (``0`` =éxito, ``1`` =solicitud incorrecta, ``2`` =error del sistema, ``3`` =no autorizado, ``9`` =fallo).
 
 URL Base
 ========
@@ -30,9 +30,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Listar usuarios
@@ -59,31 +59,31 @@ Solicitud
 
     GET /api/admin/user/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 15 10 10 65
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina. El valor predeterminado es el valor configurado ``paging.page.size`` (predeterminado: 25).
+     - Número de elementos por página. El valor predeterminado es el valor configurado ``paging.page.size`` (predeterminado: 25).
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1). El valor predeterminado es 1.
+     - Número de página (comienza en 1). El valor predeterminado es 1.
 
 .. note::
 
-   En la implementacion actual, el endpoint de lista de usuarios no aplica los parametros ``size`` y ``page``.
-   Siempre devuelve la primera pagina, con el numero de elementos definido por la configuracion del servidor ``paging.page.size`` (predeterminado: 25), ordenado por nombre de usuario (``name``) en orden ascendente.
-   El numero total de usuarios coincidentes esta disponible en ``response.total``.
+   En la implementación actual, el endpoint de lista de usuarios no aplica los parámetros ``size`` y ``page``.
+   Siempre devuelve la primera página, con el número de elementos definido por la configuración del servidor ``paging.page.size`` (predeterminado: 25), ordenado por nombre de usuario (``name``) en orden ascendente.
+   El número total de usuarios coincidentes está disponible en ``response.total``.
 
 Respuesta
 ---------
@@ -112,8 +112,8 @@ Respuesta
       }
     }
 
-- ``settings`` : El array de usuarios en la pagina actual.
-- ``total`` : El numero total de usuarios coincidentes.
+- ``settings`` : El array de usuarios en la página actual.
+- ``total`` : El número total de usuarios coincidentes.
 
 Obtener Usuario
 ===============
@@ -189,7 +189,7 @@ Cuerpo de la Solicitud
       "groups": ["group_id_1"]
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -198,19 +198,19 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre de usuario (ID de inicio de sesion)
+     - Sí
+     - Nombre de usuario (ID de inicio de sesión)
    * - ``password``
      - No
-     - Contrasena
+     - Contraseña
    * - ``confirmPassword``
      - No
-     - Contrasena de confirmacion
+     - Contraseña de confirmación
    * - ``attributes``
      - No
-     - Mapa de atributos (vease mas adelante)
+     - Mapa de atributos (véase más adelante)
    * - ``roles``
      - No
      - Array de IDs de roles
@@ -220,23 +220,23 @@ Descripcion de Campos
 
 .. note::
 
-   La API REST no realiza la verificacion de contrasena obligatoria, la verificacion de coincidencia entre ``password`` y ``confirmPassword``, ni la validacion de politica de contrasenas (estas se aplican unicamente en la interfaz de administracion).
-   En la practica, se recomienda especificar una ``password`` valida cuyo valor coincida con ``confirmPassword``.
+   La API REST no realiza la verificación de contraseña obligatoria, la verificación de coincidencia entre ``password`` y ``confirmPassword``, ni la validación de política de contraseñas (estas se aplican únicamente en la interfaz de administración).
+   En la práctica, se recomienda especificar una ``password`` válida cuyo valor coincida con ``confirmPassword``.
 
 Las claves de ``attributes`` son los nombres de atributos de la entidad de usuario (los nombres de elementos derivados del esquema LDAP).
-Las claves mas comunes son:
+Las claves más comunes son:
 
 - ``surname``, ``givenName``, ``displayName``, ``mail``
 - ``telephoneNumber``, ``mobile``, ``homePhone``
 - ``employeeNumber``, ``title``, ``description``, ``homeDirectory``
 - ``uidNumber``, ``gidNumber``
 
-``uidNumber`` y ``gidNumber`` deben ser numericos (su tipo se valida en la actualizacion).
-Tambien se pueden especificar muchas otras claves de atributos LDAP.
+``uidNumber`` y ``gidNumber`` deben ser numéricos (su tipo se valida en la actualización).
+También se pueden especificar muchas otras claves de atributos LDAP.
 
 .. note::
 
-   En la creacion, el ID de usuario (ID de documento) se genera automaticamente como el valor codificado en Base64 URL del nombre de usuario
+   En la creación, el ID de usuario (ID de documento) se genera automáticamente como el valor codificado en Base64 URL del nombre de usuario
    (por ejemplo, el nombre de usuario ``admin`` se convierte en ``YWRtaW4=``).
 
 Respuesta
@@ -287,7 +287,7 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -296,25 +296,25 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
+     - Sí
      - El ID de documento del usuario a actualizar.
    * - ``name``
-     - Si
-     - Nombre de usuario (ID de inicio de sesion)
+     - Sí
+     - Nombre de usuario (ID de inicio de sesión)
    * - ``versionNo``
-     - Si
-     - Numero de version (para bloqueo optimista)
+     - Sí
+     - Número de versión (para bloqueo optimista)
    * - ``password``
      - No
-     - Nueva contrasena (se actualiza solo cuando se especifica)
+     - Nueva contraseña (se actualiza solo cuando se especifica)
    * - ``confirmPassword``
      - No
-     - Contrasena de confirmacion
+     - Contraseña de confirmación
    * - ``attributes``
      - No
-     - Mapa de atributos (vease "Crear Usuario")
+     - Mapa de atributos (véase "Crear Usuario")
    * - ``roles``
      - No
      - Array de IDs de roles
@@ -324,9 +324,9 @@ Descripcion de Campos
 
 .. note::
 
-   En la actualizacion, ``id``, ``name`` y ``versionNo`` son obligatorios.
-   ``versionNo`` es el valor devuelto al obtener el usuario objetivo (GET), y corresponde a la version del documento de OpenSearch.
-   Si no coincide con la version actual, la solicitud se trata como un conflicto y la actualizacion es rechazada.
+   En la actualización, ``id``, ``name`` y ``versionNo`` son obligatorios.
+   ``versionNo`` es el valor devuelto al obtener el usuario objetivo (GET), y corresponde a la versión del documento de OpenSearch.
+   Si no coincide con la versión actual, la solicitud se trata como un conflicto y la actualización es rechazada.
 
 Respuesta
 ---------
@@ -342,7 +342,7 @@ Respuesta
       }
     }
 
-- ``created`` : ``false`` para una actualizacion.
+- ``created`` : ``false`` para una actualización.
 
 Eliminar Usuario
 ================
@@ -358,7 +358,7 @@ Especifique el ID de documento del usuario a eliminar en ``{id}``.
 
 .. note::
 
-   No es posible eliminar el usuario que tiene la sesion actualmente iniciada.
+   No es posible eliminar el usuario que tiene la sesión actualmente iniciada.
 
 Respuesta
 ---------
@@ -418,7 +418,7 @@ Cambiar Roles de Usuario
 Referencia
 ==========
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-role` - API de gestion de roles
-- :doc:`api-admin-group` - API de gestion de grupos
-- :doc:`../../admin/user-guide` - Guia de gestion de usuarios
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-role` - API de gestión de roles
+- :doc:`api-admin-group` - API de gestión de grupos
+- :doc:`../../admin/user-guide` - Guía de gestión de usuarios

--- a/es/15.7/api/admin/api-admin-webconfig.rst
+++ b/es/15.7/api/admin/api-admin-webconfig.rst
@@ -2,11 +2,11 @@
 API de WebConfig
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de WebConfig es para gestionar la configuracion de rastreo web de |Fess|.
-Puede operar configuraciones como URLs de rastreo, profundidad de rastreo y patrones de exclusion.
+La API de WebConfig es para gestionar la configuración de rastreo web de |Fess|.
+Puede operar configuraciones como URLs de rastreo, profundidad de rastreo y patrones de exclusión.
 
 URL Base
 ========
@@ -17,8 +17,8 @@ URL Base
 
 .. note::
 
-   Todos los endpoints requieren privilegios de administrador y un token de acceso valido.
-   Consulte :doc:`api-admin-overview` para obtener informacion sobre la autenticacion.
+   Todos los endpoints requieren privilegios de administrador y un token de acceso válido.
+   Consulte :doc:`api-admin-overview` para obtener información sobre la autenticación.
 
 Lista de Endpoints
 ==================
@@ -27,24 +27,24 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de configuraciones de rastreo web
    * - GET
      - /setting/{id}
-     - Obtener configuracion de rastreo web
+     - Obtener configuración de rastreo web
    * - POST
      - /setting
-     - Crear configuracion de rastreo web
+     - Crear configuración de rastreo web
    * - PUT
      - /setting
-     - Actualizar configuracion de rastreo web
+     - Actualizar configuración de rastreo web
    * - DELETE
      - /setting/{id}
-     - Eliminar configuracion de rastreo web
+     - Eliminar configuración de rastreo web
 
 Obtener Lista de Configuraciones de Rastreo Web
 ===============================================
@@ -58,31 +58,31 @@ Solicitud
 
 .. note::
 
-   El endpoint de lista tambien acepta ``PUT`` ademas de ``GET``.
+   El endpoint de lista también acepta ``PUT`` además de ``GET``.
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 10 55
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25, segun la configuracion ``paging.page.size``)
+     - Número de elementos por página (predeterminado: 25, según la configuración ``paging.page.size``)
    * - ``name``
      - String
      - No
-     - Filtrar por nombre de configuracion
+     - Filtrar por nombre de configuración
    * - ``urls``
      - String
      - No
@@ -90,7 +90,7 @@ Parametros
    * - ``description``
      - String
      - No
-     - Filtrar por descripcion
+     - Filtrar por descripción
 
 Respuesta
 ---------
@@ -127,9 +127,9 @@ Respuesta
       }
     }
 
-``total`` indica el numero total de configuraciones que coinciden con los criterios de busqueda.
+``total`` indica el número total de configuraciones que coinciden con los criterios de búsqueda.
 
-Obtener Configuracion de Rastreo Web
+Obtener Configuración de Rastreo Web
 =====================================
 
 Solicitud
@@ -178,12 +178,12 @@ Respuesta
 
 .. note::
 
-   La respuesta incluye los campos de auditoria ``createdBy``, ``createdTime``,
-   ``updatedBy``, ``updatedTime`` y ``versionNo``, que son asignados automaticamente
-   en el momento del registro o la actualizacion.
-   ``versionNo`` es obligatorio al actualizar (consulte la seccion "Actualizar configuracion de rastreo web" a continuacion).
+   La respuesta incluye los campos de auditoría ``createdBy``, ``createdTime``,
+   ``updatedBy``, ``updatedTime`` y ``versionNo``, que son asignados automáticamente
+   en el momento del registro o la actualización.
+   ``versionNo`` es obligatorio al actualizar (consulte la sección "Actualizar configuración de rastreo web" a continuación).
 
-Crear Configuracion de Rastreo Web
+Crear Configuración de Rastreo Web
 ===================================
 
 Solicitud
@@ -213,7 +213,7 @@ Cuerpo de la Solicitud
       "permissions": "{role}admin\n{role}user"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -222,66 +222,66 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre de la configuracion (maximo 200 caracteres)
+     - Sí
+     - Nombre de la configuración (máximo 200 caracteres)
    * - ``description``
      - No
-     - Descripcion de la configuracion (maximo 1000 caracteres)
+     - Descripción de la configuración (máximo 1000 caracteres)
    * - ``urls``
-     - Si
-     - URL de inicio de rastreo (separadas por salto de linea si son multiples). Se especifica con ``http:`` o ``https:``
+     - Sí
+     - URL de inicio de rastreo (separadas por salto de línea si son múltiples). Se especifica con ``http:`` o ``https:``
    * - ``includedUrls``
      - No
-     - Patron de expresion regular para URLs a rastrear
+     - Patrón de expresión regular para URLs a rastrear
    * - ``excludedUrls``
      - No
-     - Patron de expresion regular para URLs a excluir del rastreo
+     - Patrón de expresión regular para URLs a excluir del rastreo
    * - ``includedDocUrls``
      - No
-     - Patron de expresion regular para URLs a indexar
+     - Patrón de expresión regular para URLs a indexar
    * - ``excludedDocUrls``
      - No
-     - Patron de expresion regular para URLs a excluir del indice
+     - Patrón de expresión regular para URLs a excluir del índice
    * - ``configParameter``
      - No
-     - Parametros de configuracion adicionales (formato ``key=value``, un elemento por linea)
+     - Parámetros de configuración adicionales (formato ``key=value``, un elemento por línea)
    * - ``depth``
      - No
-     - Profundidad de rastreo (0 o mas)
+     - Profundidad de rastreo (0 o más)
    * - ``maxAccessCount``
      - No
-     - Numero maximo de accesos (0 o mas)
+     - Número máximo de accesos (0 o más)
    * - ``userAgent``
-     - Si
-     - Cadena User-Agent (maximo 200 caracteres)
+     - Sí
+     - Cadena User-Agent (máximo 200 caracteres)
    * - ``numOfThread``
-     - Si
-     - Numero de hilos paralelos (1 o mas)
+     - Sí
+     - Número de hilos paralelos (1 o más)
    * - ``intervalTime``
-     - Si
-     - Intervalo de acceso (milisegundos, 0 o mas)
+     - Sí
+     - Intervalo de acceso (milisegundos, 0 o más)
    * - ``boost``
-     - Si
-     - Valor de impulso en resultados de busqueda
+     - Sí
+     - Valor de impulso en resultados de búsqueda
    * - ``available``
-     - Si
+     - Sí
      - Habilitado/Deshabilitado (cadena ``"true"`` / ``"false"``)
    * - ``sortOrder``
-     - Si
-     - Orden de visualizacion (0 o mas)
+     - Sí
+     - Orden de visualización (0 o más)
    * - ``permissions``
      - No
-     - Roles con permiso de acceso (separados por saltos de linea si son varios)
+     - Roles con permiso de acceso (separados por saltos de línea si son varios)
    * - ``virtualHosts``
      - No
-     - Hosts virtuales (separados por saltos de linea si son varios)
+     - Hosts virtuales (separados por saltos de línea si son varios)
 
 .. note::
 
-   Los campos de auditoria como ``createdBy``, ``createdTime``, ``updatedBy`` y ``updatedTime``
-   son asignados automaticamente por el servidor, por lo que no es necesario incluirlos en el cuerpo de la solicitud.
+   Los campos de auditoría como ``createdBy``, ``createdTime``, ``updatedBy`` y ``updatedTime``
+   son asignados automáticamente por el servidor, por lo que no es necesario incluirlos en el cuerpo de la solicitud.
 
 Respuesta
 ---------
@@ -296,7 +296,7 @@ Respuesta
       }
     }
 
-Actualizar Configuracion de Rastreo Web
+Actualizar Configuración de Rastreo Web
 =========================================
 
 Solicitud
@@ -310,8 +310,8 @@ Solicitud
 Cuerpo de la Solicitud
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Al actualizar, ademas de los campos de creacion, son obligatorios ``id`` para identificar
-el registro a actualizar y ``versionNo`` como numero de version.
+Al actualizar, además de los campos de creación, son obligatorios ``id`` para identificar
+el registro a actualizar y ``versionNo`` como número de versión.
 En ``versionNo`` se debe especificar el valor actual incluido en la respuesta de la API de consulta (GET).
 
 .. code-block:: json
@@ -333,7 +333,7 @@ En ``versionNo`` se debe especificar el valor actual incluido en la respuesta de
       "versionNo": 1
     }
 
-Campos Adicionales para la Actualizacion
+Campos Adicionales para la Actualización
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -342,13 +342,13 @@ Campos Adicionales para la Actualizacion
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
-     - ID de la configuracion a actualizar (maximo 1000 caracteres)
+     - Sí
+     - ID de la configuración a actualizar (máximo 1000 caracteres)
    * - ``versionNo``
-     - Si
-     - Numero de version actual del registro a actualizar. Se especifica el valor de ``versionNo`` incluido en la respuesta de la API de consulta (GET)
+     - Sí
+     - Número de versión actual del registro a actualizar. Se especifica el valor de ``versionNo`` incluido en la respuesta de la API de consulta (GET)
 
 Respuesta
 ---------
@@ -363,7 +363,7 @@ Respuesta
       }
     }
 
-Eliminar Configuracion de Rastreo Web
+Eliminar Configuración de Rastreo Web
 =======================================
 
 Solicitud
@@ -393,8 +393,8 @@ En ``includedUrls`` / ``excludedUrls`` / ``includedDocUrls`` / ``excludedDocUrls
    :header-rows: 1
    :widths: 50 50
 
-   * - Patron
-     - Descripcion
+   * - Patrón
+     - Descripción
    * - ``.*example\\.com.*``
      - Todas las URLs que contienen example.com
    * - ``https://example\\.com/docs/.*``
@@ -402,14 +402,14 @@ En ``includedUrls`` / ``excludedUrls`` / ``includedDocUrls`` / ``excludedDocUrls
    * - ``.*\\.(pdf|doc|docx)$``
      - Archivos PDF, DOC, DOCX
    * - ``.*\\?.*``
-     - URLs con parametros de consulta
+     - URLs con parámetros de consulta
    * - ``.*/(login|logout|admin)/.*``
-     - URLs que contienen rutas especificas
+     - URLs que contienen rutas específicas
 
 Ejemplos de Uso
 ===============
 
-Configuracion de Rastreo de Sitio Corporativo
+Configuración de Rastreo de Sitio Corporativo
 ---------------------------------------------
 
 .. code-block:: bash
@@ -433,7 +433,7 @@ Configuracion de Rastreo de Sitio Corporativo
            "permissions": "{role}guest"
          }'
 
-Configuracion de Rastreo de Sitio de Documentacion
+Configuración de Rastreo de Sitio de Documentación
 ----------------------------------------------------
 
 .. code-block:: bash
@@ -455,10 +455,10 @@ Configuracion de Rastreo de Sitio de Documentacion
            "sortOrder": 0
          }'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-fileconfig` - API de configuracion de rastreo de archivos
-- :doc:`api-admin-dataconfig` - API de configuracion de almacen de datos
-- :doc:`../../admin/webconfig-guide` - Guia de configuracion de rastreo web
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-fileconfig` - API de configuración de rastreo de archivos
+- :doc:`api-admin-dataconfig` - API de configuración de almacén de datos
+- :doc:`../../admin/webconfig-guide` - Guía de configuración de rastreo web

--- a/es/15.7/api/admin/index.rst
+++ b/es/15.7/api/admin/index.rst
@@ -2,17 +2,17 @@
 Referencia de Admin API
 ==========================
 
-|Fess| Admin API es una API RESTful para acceder programaticamente a las funciones de administracion.
+|Fess| Admin API es una API RESTful para acceder programáticamente a las funciones de administración.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Vision General
+   :caption: Visión General
 
    api-admin-overview
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion de Rastreo
+   :caption: Configuración de Rastreo
 
    api-admin-webconfig
    api-admin-fileconfig
@@ -20,7 +20,7 @@ Referencia de Admin API
 
 .. toctree::
    :maxdepth: 2
-   :caption: Gestion de Indices
+   :caption: Gestión de Índices
 
    api-admin-documents
    api-admin-crawlinginfo
@@ -36,7 +36,7 @@ Referencia de Admin API
 
 .. toctree::
    :maxdepth: 2
-   :caption: Gestion de Usuarios y Permisos
+   :caption: Gestión de Usuarios y Permisos
 
    api-admin-user
    api-admin-role
@@ -45,7 +45,7 @@ Referencia de Admin API
 
 .. toctree::
    :maxdepth: 2
-   :caption: Ajuste de Busqueda
+   :caption: Ajuste de Búsqueda
 
    api-admin-labeltype
    api-admin-keymatch
@@ -75,6 +75,6 @@ Referencia de Admin API
 
 .. toctree::
    :maxdepth: 2
-   :caption: Registro de Busqueda
+   :caption: Registro de Búsqueda
 
    api-admin-searchlist

--- a/es/15.7/config/datastore/ds-atlassian.rst
+++ b/es/15.7/config/datastore/ds-atlassian.rst
@@ -2,11 +2,11 @@
 Conector de Atlassian
 ==================================
 
-Descripcion General
+Descripción General
 ===================
 
 El conector de Atlassian proporciona funcionalidad para obtener datos de productos Atlassian
-(Jira, Confluence) y registrarlos en el indice de |Fess|.
+(Jira, Confluence) y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-atlassian``.
 
@@ -19,25 +19,25 @@ Productos Compatibles
 Requisitos Previos
 ==================
 
-1. Se requiere instalacion del plugin
-2. Se requieren credenciales de autenticacion apropiadas para productos Atlassian
-3. Para la version Cloud, se puede usar OAuth 2.0; para Server, OAuth 1.0a o autenticacion basica
+1. Se requiere instalación del plugin
+2. Se requieren credenciales de autenticación apropiadas para productos Atlassian
+3. Para la versión Cloud, se puede usar OAuth 2.0; para Server, OAuth 1.0a o autenticación básica
 
-Instalacion del Plugin
+Instalación del Plugin
 ----------------------
 
-Instale desde la consola de administracion en "Sistema" -> "Plugins":
+Instale desde la consola de administración en "Sistema" -> "Plugins":
 
 1. Descargue ``fess-ds-atlassian-X.X.X.jar`` de Maven Central
-2. Cargue e instale desde la pantalla de administracion de plugins
+2. Cargue e instale desde la pantalla de administración de plugins
 3. Reinicie |Fess|
 
-Metodo de Configuracion
+Método de Configuración
 =======================
 
-Configure desde la consola de administracion en "Rastreador" -> "Almacen de Datos" -> "Crear Nuevo".
+Configure desde la consola de administración en "Rastreador" -> "Almacén de Datos" -> "Crear Nuevo".
 
-Configuracion Basica
+Configuración Básica
 --------------------
 
 .. list-table::
@@ -45,7 +45,7 @@ Configuracion Basica
    :widths: 25 75
 
    * - Elemento
-     - Ejemplo de Configuracion
+     - Ejemplo de Configuración
    * - Nombre
      - Company Jira/Confluence
    * - Nombre del Manejador
@@ -53,10 +53,10 @@ Configuracion Basica
    * - Habilitado
      - Activado
 
-Configuracion de Parametros
+Configuración de Parámetros
 ---------------------------
 
-Ejemplo version Cloud (OAuth 2.0):
+Ejemplo versión Cloud (OAuth 2.0):
 
 ::
 
@@ -68,7 +68,7 @@ Ejemplo version Cloud (OAuth 2.0):
     oauth2.access_token=your_access_token
     oauth2.refresh_token=your_refresh_token
 
-Ejemplo version Server (Autenticacion Basica):
+Ejemplo versión Server (Autenticación Básica):
 
 ::
 
@@ -78,7 +78,7 @@ Ejemplo version Server (Autenticacion Basica):
     basic.username=admin
     basic.password=your_password
 
-Ejemplo version Server (OAuth 1.0a):
+Ejemplo versión Server (OAuth 1.0a):
 
 ::
 
@@ -90,25 +90,25 @@ Ejemplo version Server (OAuth 1.0a):
     oauth.secret=verification_code
     oauth.access_token=your_access_token
 
-Lista de Parametros
+Lista de Parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``home``
-     - Si
+     - Sí
      - URL de la instancia de Atlassian
    * - ``is_cloud``
      - No
-     - ``true`` para Cloud, ``false`` para Server (predeterminado: ``true``). Solo se utiliza para la seleccion del endpoint durante la autenticacion OAuth 2.0; se ignora en la autenticacion Basica y OAuth 1.0a.
+     - ``true`` para Cloud, ``false`` para Server (predeterminado: ``true``). Solo se utiliza para la selección del endpoint durante la autenticación OAuth 2.0; se ignora en la autenticación Básica y OAuth 1.0a.
    * - ``auth_type``
-     - Si
-     - Tipo de autenticacion: ``oauth``, ``oauth2``, ``basic``
+     - Sí
+     - Tipo de autenticación: ``oauth``, ``oauth2``, ``basic``
    * - ``oauth.consumer_key``
      - Para OAuth 1.0a
      - Clave del consumidor (normalmente ``OauthKey``)
@@ -117,7 +117,7 @@ Lista de Parametros
      - Clave privada RSA (formato PEM)
    * - ``oauth.secret``
      - Para OAuth 1.0a
-     - Codigo de verificacion
+     - Código de verificación
    * - ``oauth.access_token``
      - Para OAuth 1.0a
      - Token de acceso
@@ -132,46 +132,46 @@ Lista de Parametros
      - Token de acceso
    * - ``oauth2.refresh_token``
      - No
-     - Token de actualizacion (OAuth 2.0)
+     - Token de actualización (OAuth 2.0)
    * - ``oauth2.token_url``
      - No
      - URL del token (OAuth 2.0, predeterminado: ``https://auth.atlassian.com/oauth/token``)
    * - ``basic.username``
-     - Para autenticacion basica
+     - Para autenticación básica
      - Nombre de usuario
    * - ``basic.password``
-     - Para autenticacion basica
-     - Contrasena
+     - Para autenticación básica
+     - Contraseña
    * - ``issue.jql``
      - No
-     - JQL (solo Jira, condiciones de busqueda avanzadas). Si no se especifica, se procesan todas las incidencias (``created is not empty``).
+     - JQL (solo Jira, condiciones de búsqueda avanzadas). Si no se especifica, se procesan todas las incidencias (``created is not empty``).
    * - ``issue_max_results``
      - No
-     - Resultados maximos por solicitud de API de Jira (predeterminado: ``50``, solo Jira)
+     - Resultados máximos por solicitud de API de Jira (predeterminado: ``50``, solo Jira)
    * - ``content_limit``
      - No
-     - Elementos maximos por solicitud de API de Confluence (predeterminado: ``25``, solo Confluence)
+     - Elementos máximos por solicitud de API de Confluence (predeterminado: ``25``, solo Confluence)
    * - ``ignore_error``
      - No
      - Continuar procesamiento en caso de error (predeterminado: ``true``)
    * - ``include_pattern``
      - No
-     - Patron de inclusion de URL (regex)
+     - Patrón de inclusión de URL (regex)
    * - ``exclude_pattern``
      - No
-     - Patron de exclusion de URL (regex)
+     - Patrón de exclusión de URL (regex)
    * - ``number_of_threads``
      - No
-     - Numero de hilos para procesamiento paralelo (predeterminado: ``1``)
+     - Número de hilos para procesamiento paralelo (predeterminado: ``1``)
    * - ``proxy_host``
      - No
      - Nombre de host del proxy HTTP
    * - ``proxy_port``
      - No
-     - Numero de puerto del proxy HTTP
+     - Número de puerto del proxy HTTP
    * - ``connection_timeout``
      - No
-     - Tiempo de espera de conexion HTTP (milisegundos)
+     - Tiempo de espera de conexión HTTP (milisegundos)
    * - ``read_timeout``
      - No
      - Tiempo de espera de lectura HTTP (milisegundos)
@@ -179,7 +179,7 @@ Lista de Parametros
      - No
      - Intervalo entre el procesamiento de cada documento (en milisegundos, predeterminado: ``0``)
 
-Configuracion de Script
+Configuración de Script
 -----------------------
 
 Para Jira
@@ -196,9 +196,9 @@ Campos disponibles:
 
 - ``issue.view_url`` - URL de la incidencia
 - ``issue.summary`` - Resumen de la incidencia
-- ``issue.description`` - Descripcion de la incidencia
+- ``issue.description`` - Descripción de la incidencia
 - ``issue.comments`` - Comentarios de la incidencia
-- ``issue.last_modified`` - Fecha de ultima modificacion
+- ``issue.last_modified`` - Fecha de última modificación
 
 Para Confluence
 ~~~~~~~~~~~~~~~
@@ -212,34 +212,34 @@ Para Confluence
 
 Campos disponibles:
 
-- ``content.view_url`` - URL de la pagina
-- ``content.title`` - Titulo de la pagina
-- ``content.body`` - Cuerpo de la pagina
-- ``content.comments`` - Comentarios de la pagina
-- ``content.last_modified`` - Fecha de ultima modificacion
+- ``content.view_url`` - URL de la página
+- ``content.title`` - Título de la página
+- ``content.body`` - Cuerpo de la página
+- ``content.comments`` - Comentarios de la página
+- ``content.last_modified`` - Fecha de última modificación
 
 .. note::
-   El conector de Confluence recupera tanto paginas regulares (page) como entradas de blog (blogpost).
+   El conector de Confluence recupera tanto páginas regulares (page) como entradas de blog (blogpost).
 
-Configuracion de Autenticacion OAuth 2.0
+Configuración de Autenticación OAuth 2.0
 ========================================
 
-Para la Version Cloud (Recomendado)
+Para la Versión Cloud (Recomendado)
 -----------------------------------
 
-1. Cree una aplicacion en Atlassian Developer Console
+1. Cree una aplicación en Atlassian Developer Console
 2. Obtenga credenciales de OAuth 2.0
 3. Configure los alcances requeridos:
 
    - Jira: ``read:jira-work``, ``read:jira-user``
    - Confluence: ``read:confluence-content.all``, ``read:confluence-user``
 
-4. Obtenga tokens de acceso y actualizacion
+4. Obtenga tokens de acceso y actualización
 
-Configuracion de Autenticacion OAuth 1.0a
+Configuración de Autenticación OAuth 1.0a
 =========================================
 
-Para la Version Server
+Para la Versión Server
 ----------------------
 
 1. Cree un Application Link en Jira o Confluence
@@ -250,31 +250,31 @@ Para la Version Server
        openssl genrsa -out private_key.pem 2048
        openssl rsa -in private_key.pem -pubout -out public_key.pem
 
-3. Registre la clave publica en el Application Link
-4. Configure la clave privada en los parametros
+3. Registre la clave pública en el Application Link
+4. Configure la clave privada en los parámetros
 
-Configuracion de Autenticacion Basica
+Configuración de Autenticación Básica
 =====================================
 
-Configuracion Simple para Version Server
+Configuración Simple para Versión Server
 ----------------------------------------
 
 .. warning::
-   La autenticacion basica no se recomienda por razones de seguridad. Use autenticacion OAuth siempre que sea posible.
+   La autenticación básica no se recomienda por razones de seguridad. Use autenticación OAuth siempre que sea posible.
 
-Al usar autenticacion basica:
+Al usar autenticación básica:
 
 1. Prepare una cuenta de usuario con permisos de administrador
-2. Configure el nombre de usuario y contrasena en los parametros
-3. Asegure una conexion segura usando HTTPS
+2. Configure el nombre de usuario y contraseña en los parámetros
+3. Asegure una conexión segura usando HTTPS
 
-Busqueda Avanzada con JQL
+Búsqueda Avanzada con JQL
 =========================
 
 Filtrar Incidencias de Jira con JQL
 -----------------------------------
 
-Rastree solo incidencias que coincidan con condiciones especificas:
+Rastree solo incidencias que coincidan con condiciones específicas:
 
 ::
 
@@ -290,7 +290,7 @@ Rastree solo incidencias que coincidan con condiciones especificas:
     # Combinacion de multiples condiciones
     issue.jql=project IN ("PROJ1", "PROJ2") AND updated >= -90d AND status != "Done"
 
-Para mas detalles sobre JQL, consulte la `Documentacion JQL de Atlassian <https://confluence.atlassian.com/jirasoftwarecloud/advanced-searching-764478330.html>`_.
+Para más detalles sobre JQL, consulte la `Documentación JQL de Atlassian <https://confluence.atlassian.com/jirasoftwarecloud/advanced-searching-764478330.html>`_.
 
 Ejemplos de Uso
 ===============
@@ -298,7 +298,7 @@ Ejemplos de Uso
 Rastreo de Jira Cloud
 ---------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -323,7 +323,7 @@ Script:
 Rastreo de Confluence Server
 ----------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -343,64 +343,64 @@ Script:
     last_modified=content.last_modified
     digest=content.title
 
-Solucion de Problemas
+Solución de Problemas
 =====================
 
-Errores de Autenticacion
+Errores de Autenticación
 ------------------------
 
-**Sintoma**: ``401 Unauthorized`` o ``403 Forbidden``
+**Síntoma**: ``401 Unauthorized`` o ``403 Forbidden``
 
 **Verifique**:
 
-1. Verifique que las credenciales de autenticacion sean correctas
-2. Para la version Cloud, verifique que los alcances apropiados esten configurados
-3. Para la version Server, verifique que el usuario tenga los permisos apropiados
-4. Para OAuth 2.0, verifique la expiracion del token
+1. Verifique que las credenciales de autenticación sean correctas
+2. Para la versión Cloud, verifique que los alcances apropiados estén configurados
+3. Para la versión Server, verifique que el usuario tenga los permisos apropiados
+4. Para OAuth 2.0, verifique la expiración del token
 
-Errores de Conexion
+Errores de Conexión
 -------------------
 
-**Sintoma**: ``Connection refused`` o tiempo de espera de conexion
+**Síntoma**: ``Connection refused`` o tiempo de espera de conexión
 
 **Verifique**:
 
 1. Verifique que la URL ``home`` sea correcta
-2. Verifique la configuracion del firewall
-3. Verifique que la instancia de Atlassian este en ejecucion
-4. Verifique que el parametro ``is_cloud`` este configurado correctamente
+2. Verifique la configuración del firewall
+3. Verifique que la instancia de Atlassian este en ejecución
+4. Verifique que el parámetro ``is_cloud`` esté configurado correctamente
 
 No Se Pueden Obtener Datos
 --------------------------
 
-**Sintoma**: El rastreo tiene exito pero hay 0 documentos
+**Síntoma**: El rastreo tiene éxito pero hay 0 documentos
 
 **Verifique**:
 
-1. Verifique que JQL no este filtrando demasiado
+1. Verifique que JQL no esté filtrando demasiado
 2. Verifique que el usuario tenga permisos de lectura en los proyectos/espacios
-3. Verifique la configuracion del script
+3. Verifique la configuración del script
 4. Revise los logs en busca de errores
 
-Actualizacion de Token OAuth 2.0
+Actualización de Token OAuth 2.0
 --------------------------------
 
-**Sintoma**: Ocurren errores de autenticacion despues de un tiempo
+**Síntoma**: Ocurren errores de autenticación después de un tiempo
 
-**Solucion**:
+**Solución**:
 
-Los tokens de acceso OAuth 2.0 tienen fechas de expiracion. Configure el token de actualizacion para permitir la renovacion automatica:
+Los tokens de acceso OAuth 2.0 tienen fechas de expiración. Configure el token de actualización para permitir la renovación automática:
 
 ::
 
     oauth2.refresh_token=your_refresh_token
 
-Cuando los tokens se renuevan, el nuevo token de acceso y el token de actualizacion se guardan automaticamente en la configuracion del almacen de datos, por lo que los rastreos posteriores utilizan los tokens actualizados sin necesidad de actualizarlos manualmente.
+Cuando los tokens se renuevan, el nuevo token de acceso y el token de actualización se guardan automáticamente en la configuración del almacén de datos, por lo que los rastreos posteriores utilizan los tokens actualizados sin necesidad de actualizarlos manualmente.
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`ds-overview` - Descripcion General de Conectores de Almacen de Datos
+- :doc:`ds-overview` - Descripción General de Conectores de Almacén de Datos
 - :doc:`ds-database` - Conector de Base de Datos
-- :doc:`../../admin/dataconfig-guide` - Guia de Configuracion de Almacen de Datos
+- :doc:`../../admin/dataconfig-guide` - Guía de Configuración de Almacén de Datos
 - `Atlassian Developer <https://developer.atlassian.com/>`_

--- a/es/15.7/config/datastore/ds-box.rst
+++ b/es/15.7/config/datastore/ds-box.rst
@@ -2,30 +2,30 @@
 Conector de Box
 ===========================
 
-Descripcion general
+Descripción general
 ===================
 
 El conector de Box proporciona la funcionalidad de obtener archivos del almacenamiento
-en la nube Box.com y registrarlos en el indice de |Fess|.
+en la nube Box.com y registrarlos en el índice de |Fess|.
 
 Este conector se conecta a la empresa mediante JWT (Server Authentication) y rastreo
 recursivo de los archivos accesibles para cada usuario de la empresa suplantando su
 identidad (impersonation). Los usuarios a rastrear pueden acotarse mediante el
-parametro ``filter_term``.
+parámetro ``filter_term``.
 
 Esta funcionalidad requiere el plugin ``fess-ds-box``.
 
 Requisitos previos
 ==================
 
-1. Se requiere la instalacion del plugin
-2. Se requiere una cuenta de desarrollador de Box y la creacion de una aplicacion
-3. Se requiere la configuracion de autenticacion JWT (JSON Web Token)
+1. Se requiere la instalación del plugin
+2. Se requiere una cuenta de desarrollador de Box y la creación de una aplicación
+3. Se requiere la configuración de autenticación JWT (JSON Web Token)
 
-Instalacion del plugin
+Instalación del plugin
 ----------------------
 
-Metodo 1: Colocar el archivo JAR directamente
+Método 1: Colocar el archivo JAR directamente
 
 ::
 
@@ -37,18 +37,18 @@ Metodo 1: Colocar el archivo JAR directamente
     # o
     cp fess-ds-box-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Metodo 2: Instalar desde la consola de administracion
+Método 2: Instalar desde la consola de administración
 
 1. Abra "Sistema" -> "Plugins"
 2. Cargue el archivo JAR
 3. Reinicie |Fess|
 
-Metodo de configuracion
+Método de configuración
 =======================
 
-Configure desde la consola de administracion en "Rastreador" -> "Almacen de datos" -> "Crear nuevo".
+Configure desde la consola de administración en "Rastreador" -> "Almacén de datos" -> "Crear nuevo".
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -56,7 +56,7 @@ Configuracion basica
    :widths: 25 75
 
    * - Elemento
-     - Ejemplo de configuracion
+     - Ejemplo de configuración
    * - Nombre
      - Company Box Storage
    * - Nombre del manejador
@@ -64,10 +64,10 @@ Configuracion basica
    * - Habilitado
      - Activado
 
-Configuracion de parametros
+Configuración de parámetros
 ----------------------------
 
-Ejemplo de autenticacion JWT:
+Ejemplo de autenticación JWT:
 
 ::
 
@@ -78,103 +78,103 @@ Ejemplo de autenticacion JWT:
     passphrase=7ba8sd9f7a9sd8f7a9sd8f7a9sd8f
     enterprise_id=1923456
 
-Lista de parametros
+Lista de parámetros
 ~~~~~~~~~~~~~~~~~~~
 
-Parametros de autenticacion (obligatorios)
+Parámetros de autenticación (obligatorios)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``client_id``
-     - Si
-     - ID de cliente de la aplicacion Box
+     - Sí
+     - ID de cliente de la aplicación Box
    * - ``client_secret``
-     - Si
-     - Secreto de cliente de la aplicacion Box
+     - Sí
+     - Secreto de cliente de la aplicación Box
    * - ``public_key_id``
-     - Si
-     - ID de la clave publica
+     - Sí
+     - ID de la clave pública
    * - ``private_key``
-     - Si
-     - Clave privada (formato PEM, los saltos de linea se representan con ``\n``)
+     - Sí
+     - Clave privada (formato PEM, los saltos de línea se representan con ``\n``)
    * - ``passphrase``
-     - Si
-     - Frase de contrasena de la clave privada
+     - Sí
+     - Frase de contraseña de la clave privada
    * - ``enterprise_id``
-     - Si
+     - Sí
      - ID de empresa de Box
 
-Parametros de rastreo (opcionales)
+Parámetros de rastreo (opcionales)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
    :widths: 25 20 55
 
-   * - Parametro
+   * - Parámetro
      - Valor predeterminado
-     - Descripcion
+     - Descripción
    * - ``max_size``
      - ``10000000``
-     - Tamano maximo de archivo a rastrear (bytes). El valor predeterminado es 10 MB.
+     - Tamaño máximo de archivo a rastrear (bytes). El valor predeterminado es 10 MB.
    * - ``supported_mimetypes``
      - ``.*``
-     - Tipos MIME a rastrear (expresion regular). Se pueden especificar varios separados por comas.
+     - Tipos MIME a rastrear (expresión regular). Se pueden especificar varios separados por comas.
    * - ``include_pattern``
      - (ninguno)
-     - Patron de URL a incluir en el rastreo
+     - Patrón de URL a incluir en el rastreo
    * - ``exclude_pattern``
      - (ninguno)
-     - Patron de URL a excluir del rastreo
+     - Patrón de URL a excluir del rastreo
    * - ``number_of_threads``
      - ``1``
-     - Numero de hilos del proceso de rastreo
+     - Número de hilos del proceso de rastreo
    * - ``ignore_folder``
      - ``true``
-     - Indica si las carpetas deben quedar fuera del indice. En la implementacion actual, las carpetas en si mismas no se indexan (solo los archivos son el objetivo), por lo que este parametro no tiene efecto.
+     - Indica si las carpetas deben quedar fuera del índice. En la implementación actual, las carpetas en si mismas no se indexan (solo los archivos son el objetivo), por lo que este parámetro no tiene efecto.
    * - ``ignore_error``
      - ``true``
      - Indica si se debe continuar el procesamiento cuando ocurre un error
    * - ``filter_term``
      - (ninguno)
-     - Condicion de filtro para acotar los usuarios de la empresa a rastrear. Si no se especifica, se incluyen todos los usuarios de la empresa.
+     - Condición de filtro para acotar los usuarios de la empresa a rastrear. Si no se especifica, se incluyen todos los usuarios de la empresa.
    * - ``fields``
      - (todos los campos)
-     - Especificacion de los campos a obtener desde la API de Box
+     - Especificación de los campos a obtener desde la API de Box
 
-Parametros de conexion (opcionales)
+Parámetros de conexión (opcionales)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
    :widths: 25 20 55
 
-   * - Parametro
+   * - Parámetro
      - Valor predeterminado
-     - Descripcion
+     - Descripción
    * - ``base_url``
      - ``https://app.box.com``
      - URL base para construir la URL de apertura del archivo en el navegador (``file.url``). No afecta a los endpoints de la API utilizados por el SDK de Box.
    * - ``max_retry_count``
      - ``10``
-     - Numero maximo de reintentos de la llamada a la API
+     - Número máximo de reintentos de la llamada a la API
    * - ``proxy_host``
      - (ninguno)
      - Nombre de host del proxy HTTP
    * - ``proxy_port``
      - (ninguno)
-     - Numero de puerto del proxy HTTP
+     - Número de puerto del proxy HTTP
    * - ``refresh_token_interval``
      - ``3540``
-     - Intervalo de actualizacion del token (segundos). El valor predeterminado es 59 minutos.
+     - Intervalo de actualización del token (segundos). El valor predeterminado es 59 minutos.
 
-Configuracion de script
+Configuración de script
 -----------------------
 
 ::
@@ -200,7 +200,7 @@ Campos principales
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``file.url``
      - Enlace para abrir el archivo en el navegador
    * - ``file.contents``
@@ -212,19 +212,19 @@ Campos principales
    * - ``file.name``
      - Nombre del archivo
    * - ``file.size``
-     - Tamano del archivo (bytes)
+     - Tamaño del archivo (bytes)
    * - ``file.created_at``
-     - Fecha y hora de creacion
+     - Fecha y hora de creación
    * - ``file.modified_at``
-     - Fecha y hora de ultima modificacion
+     - Fecha y hora de última modificación
    * - ``file.download_url``
      - URL de descarga directa de Box
    * - ``file.id``
      - ID de elemento de Box
    * - ``file.description``
-     - Descripcion del archivo
+     - Descripción del archivo
    * - ``file.extension``
-     - Extension del archivo
+     - Extensión del archivo
    * - ``file.sha1``
      - Hash SHA1 del archivo
    * - ``file.path_collection``
@@ -238,11 +238,11 @@ Campos de metadatos
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``file.type``
      - Tipo de elemento ("file" o "folder")
    * - ``file.file_version``
-     - Informacion de version del archivo
+     - Información de versión del archivo
    * - ``file.sequence_id``
      - ID de secuencia
    * - ``file.etag``
@@ -250,66 +250,66 @@ Campos de metadatos
    * - ``file.trashed_at``
      - Fecha y hora de traslado a la papelera
    * - ``file.purged_at``
-     - Fecha y hora de eliminacion definitiva
+     - Fecha y hora de eliminación definitiva
    * - ``file.content_created_at``
-     - Fecha y hora de creacion del contenido
+     - Fecha y hora de creación del contenido
    * - ``file.content_modified_at``
-     - Fecha y hora de modificacion del contenido
+     - Fecha y hora de modificación del contenido
    * - ``file.created_by``
-     - Informacion del creador
+     - Información del creador
    * - ``file.modified_by``
-     - Informacion del modificador
+     - Información del modificador
    * - ``file.owned_by``
-     - Informacion del propietario
+     - Información del propietario
    * - ``file.shared_link``
-     - Informacion del enlace compartido
+     - Información del enlace compartido
    * - ``file.parent``
-     - Informacion de la carpeta padre
+     - Información de la carpeta padre
    * - ``file.item_status``
      - Estado del elemento
    * - ``file.version_number``
-     - Numero de version
+     - Número de versión
    * - ``file.comment_count``
-     - Numero de comentarios
+     - Número de comentarios
    * - ``file.permissions``
-     - Informacion de permisos
+     - Información de permisos
    * - ``file.tags``
-     - Informacion de etiquetas
+     - Información de etiquetas
    * - ``file.lock``
-     - Informacion de bloqueo
+     - Información de bloqueo
    * - ``file.is_package``
      - Indicador de paquete
    * - ``file.is_watermark``
      - Indicador de marca de agua
    * - ``file.collections``
-     - Informacion de colecciones
+     - Información de colecciones
    * - ``file.representations``
-     - Informacion de representaciones
+     - Información de representaciones
    * - ``file.api``
-     - Objeto BoxFileAPI (para obtener informacion de colaboracion y permisos)
+     - Objeto BoxFileAPI (para obtener información de colaboración y permisos)
 
-Para mas detalles, consulte el `Objeto File de Box <https://developer.box.com/reference#file-object>`_.
+Para más detalles, consulte el `Objeto File de Box <https://developer.box.com/reference#file-object>`_.
 
-Configuracion de autenticacion de Box
+Configuración de autenticación de Box
 ======================================
 
-Pasos de configuracion de autenticacion JWT
+Pasos de configuración de autenticación JWT
 --------------------------------------------
 
-1. Crear una aplicacion en Box Developer Console
+1. Crear una aplicación en Box Developer Console
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Acceda a https://app.box.com/developers/console:
 
 1. Haga clic en "Create New App"
 2. Seleccione "Custom App"
-3. Seleccione "Server Authentication (with JWT)" como metodo de autenticacion
-4. Ingrese el nombre de la aplicacion y cree
+3. Seleccione "Server Authentication (with JWT)" como método de autenticación
+4. Ingrese el nombre de la aplicación y cree
 
-2. Configuracion de la aplicacion
+2. Configuración de la aplicación
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Configure en la pestana "Configuration":
+Configure en la pestaña "Configuration":
 
 **Application Scopes**:
 
@@ -327,15 +327,15 @@ Configure en la pestana "Configuration":
 3. Aprobar en la empresa
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-En la consola de administracion de Box:
+En la consola de administración de Box:
 
 1. Abra "Apps" -> "Custom Apps"
-2. Apruebe la aplicacion creada
+2. Apruebe la aplicación creada
 
-4. Obtener las credenciales de autenticacion
+4. Obtener las credenciales de autenticación
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Obtenga la siguiente informacion del archivo JSON descargado:
+Obtenga la siguiente información del archivo JSON descargado:
 
 ::
 
@@ -355,7 +355,7 @@ Obtenga la siguiente informacion del archivo JSON descargado:
 Formato de la clave privada
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Reemplace los saltos de linea de ``private_key`` con ``\n`` para convertirla en una sola linea:
+Reemplace los saltos de línea de ``private_key`` con ``\n`` para convertirla en una sola línea:
 
 ::
 
@@ -367,7 +367,7 @@ Ejemplos de uso
 Rastrear todo el almacenamiento Box de la empresa
 --------------------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -392,12 +392,12 @@ Script:
     created=file.created_at
     last_modified=file.modified_at
 
-Rastrear solo una carpeta especifica
+Rastrear solo una carpeta específica
 -------------------------------------
 
-Es posible filtrar por ruta de carpeta mediante el parametro ``include_pattern``.
+Es posible filtrar por ruta de carpeta mediante el parámetro ``include_pattern``.
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -426,9 +426,9 @@ Script:
 Rastrear solo archivos PDF
 --------------------------
 
-Es posible filtrar por tipo MIME mediante el parametro ``supported_mimetypes``.
+Es posible filtrar por tipo MIME mediante el parámetro ``supported_mimetypes``.
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -454,30 +454,30 @@ Script:
     created=file.created_at
     last_modified=file.modified_at
 
-Solucion de problemas
+Solución de problemas
 =====================
 
-Errores de autenticacion
+Errores de autenticación
 ------------------------
 
-**Sintoma**: ``Authentication failed`` o ``Invalid grant``
+**Síntoma**: ``Authentication failed`` o ``Invalid grant``
 
 **Verifique**:
 
 1. Verifique que ``client_id`` y ``client_secret`` sean correctos
-2. Verifique que la clave privada se haya copiado correctamente (los saltos de linea esten como ``\n``)
-3. Verifique que la frase de contrasena sea correcta
-4. Verifique que la aplicacion este aprobada en la consola de administracion de Box
+2. Verifique que la clave privada se haya copiado correctamente (los saltos de línea estén como ``\n``)
+3. Verifique que la frase de contraseña sea correcta
+4. Verifique que la aplicación esté aprobada en la consola de administración de Box
 5. Verifique que ``enterprise_id`` sea correcto
 
 Error de formato de clave privada
 ----------------------------------
 
-**Sintoma**: ``Invalid private key format``
+**Síntoma**: ``Invalid private key format``
 
-**Solucion**:
+**Solución**:
 
-Verifique que los saltos de linea de la clave privada esten correctamente convertidos a ``\n``:
+Verifique que los saltos de línea de la clave privada estén correctamente convertidos a ``\n``:
 
 ::
 
@@ -492,38 +492,38 @@ Verifique que los saltos de linea de la clave privada esten correctamente conver
 No se pueden obtener archivos
 ------------------------------
 
-**Sintoma**: El rastreo finaliza con exito pero hay 0 archivos
+**Síntoma**: El rastreo finaliza con éxito pero hay 0 archivos
 
 **Verifique**:
 
-1. Verifique que "Read all files and folders" este habilitado en Application Scopes
+1. Verifique que "Read all files and folders" esté habilitado en Application Scopes
 2. Verifique que App Access Level sea "App + Enterprise Access"
 3. Verifique que realmente existan archivos en el almacenamiento de Box
 4. Verifique que la cuenta de servicio tenga los permisos apropiados
 
-Cuando hay un gran numero de archivos
+Cuando hay un gran número de archivos
 --------------------------------------
 
-**Sintoma**: El rastreo tarda mucho tiempo o se agota el tiempo de espera
+**Síntoma**: El rastreo tarda mucho tiempo o se agota el tiempo de espera
 
-**Solucion**:
+**Solución**:
 
-Divida el procesamiento en la configuracion del almacen de datos:
+Divida el procesamiento en la configuración del almacén de datos:
 
 1. Ajuste el intervalo de rastreo
-2. Configure multiples almacenes de datos (por unidad de carpeta, etc.)
-3. Aumente el numero de hilos con el parametro ``number_of_threads``
-4. Distribuya la carga con la configuracion de programacion
+2. Configure múltiples almacenes de datos (por unidad de carpeta, etc.)
+3. Aumente el número de hilos con el parámetro ``number_of_threads``
+4. Distribuya la carga con la configuración de programación
 
 Permisos y control de acceso
 =============================
 
-Reflejar los permisos de colaboracion de Box
+Reflejar los permisos de colaboración de Box
 ---------------------------------------------
 
 Mediante el objeto ``BoxFileAPI`` proporcionado por el campo ``file.api``, es posible
-asignar la informacion de colaboracion de Box a los roles de busqueda de |Fess|.
-``file.api.collaborationRoles`` devuelve una lista de roles de busqueda correspondientes
+asignar la información de colaboración de Box a los roles de búsqueda de |Fess|.
+``file.api.collaborationRoles`` devuelve una lista de roles de búsqueda correspondientes
 a los usuarios y grupos que tienen acceso al archivo.
 
 Establecer los permisos en el script:
@@ -540,22 +540,22 @@ Establecer los permisos en el script:
     last_modified=file.modified_at
 
 .. note::
-   ``file.api.collaborationRoles`` obtiene la informacion de colaboracion de cada archivo,
-   lo que incrementa el numero de llamadas a la API de Box y puede hacer que el rastreo
-   tarde mas tiempo.
+   ``file.api.collaborationRoles`` obtiene la información de colaboración de cada archivo,
+   lo que incrementa el número de llamadas a la API de Box y puede hacer que el rastreo
+   tarde más tiempo.
 
-Para asignar un rol fijo a todos los archivos, especifiquelo de la siguiente manera:
+Para asignar un rol fijo a todos los archivos, especifíquelo de la siguiente manera:
 
 ::
 
     role="{role}box-users"
 
-Informacion de referencia
+Información de referencia
 ==========================
 
-- :doc:`ds-overview` - Descripcion general de conectores de almacen de datos
+- :doc:`ds-overview` - Descripción general de conectores de almacén de datos
 - :doc:`ds-dropbox` - Conector de Dropbox
 - :doc:`ds-gsuite` - Conector de Google Workspace
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de almacen de datos
-- `Documentacion para desarrolladores de Box <https://developer.box.com/>`_
-- `Autenticacion de Box Platform <https://developer.box.com/guides/authentication/>`_
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de almacén de datos
+- `Documentación para desarrolladores de Box <https://developer.box.com/>`_
+- `Autenticación de Box Platform <https://developer.box.com/guides/authentication/>`_

--- a/es/15.7/config/datastore/ds-csv.rst
+++ b/es/15.7/config/datastore/ds-csv.rst
@@ -2,11 +2,11 @@
 Conector CSV
 ==================================
 
-Descripcion general
+Descripción general
 ===================
 
 El conector CSV proporciona la funcionalidad para obtener datos de archivos CSV
-y registrarlos en el indice de |Fess|.
+y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-csv``.
 
@@ -15,12 +15,12 @@ Requisitos previos
 
 1. Es necesario instalar el plugin
 2. Se requiere acceso a los archivos CSV
-3. Es necesario conocer la codificacion de caracteres del archivo CSV
+3. Es necesario conocer la codificación de caracteres del archivo CSV
 
-Instalacion del plugin
+Instalación del plugin
 ----------------------
 
-Metodo 1: Colocar el archivo JAR directamente
+Método 1: Colocar el archivo JAR directamente
 
 ::
 
@@ -32,18 +32,18 @@ Metodo 1: Colocar el archivo JAR directamente
     # o
     cp fess-ds-csv-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Metodo 2: Instalar desde la pantalla de administracion
+Método 2: Instalar desde la pantalla de administración
 
 1. Abrir "Sistema" -> "Plugins"
 2. Subir el archivo JAR
 3. Reiniciar |Fess|
 
-Configuracion
+Configuración
 =============
 
-Configure desde la pantalla de administracion en "Crawler" -> "Data Store" -> "Crear nuevo".
+Configure desde la pantalla de administración en "Crawler" -> "Data Store" -> "Crear nuevo".
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -59,7 +59,7 @@ Configuracion basica
    * - Habilitado
      - Activado
 
-Configuracion de parametros
+Configuración de parámetros
 ---------------------------
 
 Archivo local:
@@ -73,7 +73,7 @@ Archivo local:
     quote_character="
     quote_disabled=false
 
-Multiples archivos:
+Múltiples archivos:
 
 ::
 
@@ -86,70 +86,70 @@ Multiples archivos:
 
 .. note::
 
-   El procesamiento de comillas (quote) y el procesamiento de escape estan **deshabilitados** por defecto.
-   Si desea manejar CSV con caracteres separadores o saltos de linea dentro de campos entrecomillados
-   (compatible con RFC 4180), especifique explicitamente ``quote_disabled=false`` para habilitar
+   El procesamiento de comillas (quote) y el procesamiento de escape están **deshabilitados** por defecto.
+   Si desea manejar CSV con caracteres separadores o saltos de línea dentro de campos entrecomillados
+   (compatible con RFC 4180), especifique explícitamente ``quote_disabled=false`` para habilitar
    el procesamiento de comillas.
-   Consulte la seccion "Habilitacion del procesamiento de comillas y escape" mas adelante para mas detalles.
+   Consulte la sección "Habilitación del procesamiento de comillas y escape" más adelante para más detalles.
 
-Lista de parametros
+Lista de parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``files``
      - No
-     - Ruta del archivo CSV (ruta local, multiples rutas separadas por comas). Se requiere especificar ``files`` o ``directories``. Si se especifican ambos, ``files`` tiene prioridad. Los archivos deben tener extension ``.csv`` o ``.tsv``; los archivos con otras extensiones son omitidos.
+     - Ruta del archivo CSV (ruta local, múltiples rutas separadas por comas). Se requiere especificar ``files`` o ``directories``. Si se especifican ambos, ``files`` tiene prioridad. Los archivos deben tener extensión ``.csv`` o ``.tsv``; los archivos con otras extensiones son omitidos.
    * - ``directories``
      - No
-     - Ruta del directorio que contiene archivos CSV (multiples rutas separadas por comas). Solo se procesan los archivos ``.csv`` y ``.tsv`` dentro del directorio. Se utiliza cuando no se especifica ``files``.
+     - Ruta del directorio que contiene archivos CSV (múltiples rutas separadas por comas). Solo se procesan los archivos ``.csv`` y ``.tsv`` dentro del directorio. Se utiliza cuando no se especifica ``files``.
    * - ``file_encoding``
      - No
-     - Codificacion de caracteres (predeterminado: UTF-8)
+     - Codificación de caracteres (predeterminado: UTF-8)
    * - ``has_header_line``
      - No
      - Si tiene fila de encabezado (predeterminado: false)
    * - ``separator_character``
      - No
-     - Caracter separador (predeterminado: coma ``,``). Se pueden especificar secuencias de escape como ``\t`` (separador de tabulador).
+     - Carácter separador (predeterminado: coma ``,``). Se pueden especificar secuencias de escape como ``\t`` (separador de tabulador).
    * - ``quote_character``
      - No
-     - Caracter de comillas (predeterminado: comillas dobles ``"``). Sin embargo, el procesamiento de comillas esta deshabilitado por defecto (consulte ``quote_disabled``).
+     - Carácter de comillas (predeterminado: comillas dobles ``"``). Sin embargo, el procesamiento de comillas está deshabilitado por defecto (consulte ``quote_disabled``).
    * - ``escape_character``
      - No
-     - Caracter de escape (predeterminado: barra invertida ``\``). Sin embargo, el procesamiento de escape esta deshabilitado por defecto (consulte ``escape_disabled``).
+     - Carácter de escape (predeterminado: barra invertida ``\``). Sin embargo, el procesamiento de escape está deshabilitado por defecto (consulte ``escape_disabled``).
 
 .. note::
 
-   Si tanto ``files`` como ``directories`` estan vacios, se producira un error (``DataStoreException``).
+   Si tanto ``files`` como ``directories`` están vacíos, se producirá un error (``DataStoreException``).
    Debe especificar al menos uno de los dos.
 
-Parametros avanzados
+Parámetros avanzados
 ~~~~~~~~~~~~~~~~~~~~
 
-Los siguientes parametros controlan de forma detallada el comportamiento del analisis del CSV:
+Los siguientes parámetros controlan de forma detallada el comportamiento del análisis del CSV:
 
 .. list-table::
    :header-rows: 1
    :widths: 30 70
 
-   * - Parametro
-     - Descripcion
+   * - Parámetro
+     - Descripción
    * - ``quote_disabled``
      - Si deshabilitar el procesamiento de comillas (predeterminado: true). Especifique ``false`` para manejar campos entrecomillados compatibles con RFC 4180.
    * - ``escape_disabled``
      - Si deshabilitar el procesamiento de escape (predeterminado: true). Especifique ``false`` para habilitar el escape mediante ``escape_character``.
    * - ``skip_lines``
-     - Numero de lineas iniciales a omitir (predeterminado: 0)
+     - Número de líneas iniciales a omitir (predeterminado: 0)
    * - ``ignore_line_patterns``
-     - Patron de expresion regular para ignorar lineas (por ejemplo: ``^#.*`` para ignorar lineas de comentario)
+     - Patrón de expresión regular para ignorar líneas (por ejemplo: ``^#.*`` para ignorar líneas de comentario)
    * - ``ignore_empty_lines``
-     - Si ignorar las lineas vacias (predeterminado: false)
+     - Si ignorar las líneas vacías (predeterminado: false)
    * - ``ignore_trailing_whitespaces``
      - Si ignorar los espacios en blanco al final (predeterminado: false)
    * - ``ignore_leading_whitespaces``
@@ -157,16 +157,16 @@ Los siguientes parametros controlan de forma detallada el comportamiento del ana
    * - ``null_string``
      - Cadena que se trata como valor nulo
    * - ``break_string``
-     - Cadena que reemplaza los saltos de linea dentro de los valores de campo
+     - Cadena que reemplaza los saltos de línea dentro de los valores de campo
    * - ``readInterval``
      - Tiempo de espera por cada registro procesado (milisegundos) (predeterminado: 0)
 
-Configuracion de scripts
+Configuración de scripts
 ------------------------
 
 Los valores de cada campo se construyen referenciando los valores de cada columna del CSV. Las columnas
 del CSV pueden referenciarse directamente en el script como **variables sin prefijo**
-(no se usa ningun prefijo como ``data.``).
+(no se usa ningún prefijo como ``data.``).
 
 Con encabezado (referenciando por nombre de columna):
 
@@ -178,7 +178,7 @@ Con encabezado (referenciando por nombre de columna):
     digest=category
     price=price
 
-Sin encabezado (referenciando por indice de columna):
+Sin encabezado (referenciando por índice de columna):
 
 ::
 
@@ -190,20 +190,20 @@ Sin encabezado (referenciando por indice de columna):
 Campos disponibles
 ~~~~~~~~~~~~~~~~~~
 
-- ``<nombre_columna>`` - Referencia directa por nombre de columna del encabezado (solo cuando ``has_header_line=true`` y el nombre de columna no esta en blanco)
-- ``cell<N>`` - Referencia por indice de columna (empezando desde 1: ``cell1``, ``cell2``...; disponible independientemente de si hay encabezado)
-- ``csvfile`` - Ruta completa del archivo CSV que se esta procesando
-- ``csvfilename`` - Nombre del archivo CSV que se esta procesando
+- ``<nombre_columna>`` - Referencia directa por nombre de columna del encabezado (solo cuando ``has_header_line=true`` y el nombre de columna no está en blanco)
+- ``cell<N>`` - Referencia por índice de columna (empezando desde 1: ``cell1``, ``cell2``...; disponible independientemente de si hay encabezado)
+- ``csvfile`` - Ruta completa del archivo CSV que se está procesando
+- ``csvfilename`` - Nombre del archivo CSV que se está procesando
 
 .. note::
 
-   Si el nombre de columna contiene caracteres invalidos como identificadores de Groovy (espacios,
+   Si el nombre de columna contiene caracteres inválidos como identificadores de Groovy (espacios,
    guiones, etc.), no se puede referenciar por nombre de columna. En ese caso, use ``cell<N>``.
 
 Detalles del formato CSV
 =========================
 
-CSV estandar (compatible con RFC 4180)
+CSV estándar (compatible con RFC 4180)
 ---------------------------------------
 
 ::
@@ -215,16 +215,16 @@ CSV estandar (compatible con RFC 4180)
 
 .. note::
 
-   Para incluir el caracter separador dentro de un campo entrecomillado como ``"Book, Programming"``
+   Para incluir el carácter separador dentro de un campo entrecomillado como ``"Book, Programming"``
    arriba, es necesario especificar ``quote_disabled=false`` para habilitar el procesamiento de comillas.
-   Cuando el procesamiento de comillas esta deshabilitado (valor predeterminado), las comillas se tratan
-   como caracteres normales y los campos se dividen por el caracter separador.
+   Cuando el procesamiento de comillas está deshabilitado (valor predeterminado), las comillas se tratan
+   como caracteres normales y los campos se dividen por el carácter separador.
 
-Habilitacion del procesamiento de comillas y escape
+Habilitación del procesamiento de comillas y escape
 ----------------------------------------------------
 
-El procesamiento de comillas y el procesamiento de escape estan deshabilitados por defecto.
-Habilitelos explicitamente de la siguiente manera.
+El procesamiento de comillas y el procesamiento de escape están deshabilitados por defecto.
+Habilítelos explícitamente de la siguiente manera.
 
 Habilitar el procesamiento de comillas:
 
@@ -270,16 +270,16 @@ Comillas simples (requiere habilitar el procesamiento de comillas):
     quote_disabled=false
     quote_character='
 
-Codificacion
+Codificación
 ------------
 
-Archivo en espanol con codificacion Shift_JIS:
+Archivo en español con codificación Shift_JIS:
 
 ::
 
     file_encoding=Shift_JIS
 
-Archivo con codificacion EUC-JP:
+Archivo con codificación EUC-JP:
 
 ::
 
@@ -288,7 +288,7 @@ Archivo con codificacion EUC-JP:
 Ejemplos de uso
 ===============
 
-CSV de catalogo de productos
+CSV de catálogo de productos
 ----------------------------
 
 Archivo CSV (products.csv):
@@ -300,7 +300,7 @@ Archivo CSV (products.csv):
     1002,Mouse,Mouse inalambrico,2500,Perifericos,true
     1003,Teclado,Teclado mecanico,8500,Perifericos,false
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -319,7 +319,7 @@ Script:
     digest=category
     price=price
 
-Filtrado por informacion de stock:
+Filtrado por información de stock:
 
 ::
 
@@ -340,7 +340,7 @@ Archivo CSV (employees.csv):
     E002,Maria Lopez,Desarrollo,maria@example.com,03-2345-6789,Gerente
     E003,Pedro Rodriguez,Administracion,pedro@example.com,03-3456-7890,Encargado
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -369,7 +369,7 @@ Archivo CSV (data.csv):
     2,Producto B,Este es el producto B,2000
     3,Producto C,Este es el producto C,3000
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -387,10 +387,10 @@ Script:
     content=cell3
     price=cell4
 
-Integracion de multiples archivos CSV
+Integración de múltiples archivos CSV
 -------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -419,7 +419,7 @@ Archivo TSV (data.tsv):
     1	Articulo1	Este es el contenido del articulo 1	Noticias
     2	Articulo2	Este es el contenido del articulo 2	Blog
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -437,30 +437,30 @@ Script:
     content=content
     digest=category
 
-Solucion de problemas
+Solución de problemas
 =====================
 
 Archivo no encontrado
 ---------------------
 
-**Sintoma**: El crawl se ejecuta pero el archivo no se procesa; el log muestra ``is not found``
+**Síntoma**: El crawl se ejecuta pero el archivo no se procesa; el log muestra ``is not found``
 
 **Verificaciones**:
 
 1. Verificar que la ruta del archivo sea correcta (se recomienda ruta absoluta)
 2. Confirmar que el archivo existe
-3. Verificar que la extension del archivo sea ``.csv`` o ``.tsv`` (los archivos con otras extensiones son omitidos)
+3. Verificar que la extensión del archivo sea ``.csv`` o ``.tsv`` (los archivos con otras extensiones son omitidos)
 4. Verificar que tiene permisos de lectura
 5. Confirmar que es accesible desde el usuario que ejecuta |Fess|
 
 Caracteres ilegibles
 --------------------
 
-**Sintoma**: Los caracteres no se muestran correctamente
+**Síntoma**: Los caracteres no se muestran correctamente
 
-**Solucion**:
+**Solución**:
 
-Especificar la codificacion correcta:
+Especificar la codificación correcta:
 
 ::
 
@@ -476,7 +476,7 @@ Especificar la codificacion correcta:
     # Windows estandar (CP932)
     file_encoding=Windows-31J
 
-Verificar la codificacion del archivo:
+Verificar la codificación del archivo:
 
 ::
 
@@ -487,11 +487,11 @@ Verificar la codificacion del archivo:
 Las columnas no se reconocen correctamente
 ------------------------------------------
 
-**Sintoma**: El delimitador de columnas no se reconoce correctamente, o los campos entrecomillados se dividen incorrectamente
+**Síntoma**: El delimitador de columnas no se reconoce correctamente, o los campos entrecomillados se dividen incorrectamente
 
 **Verificaciones**:
 
-1. Verificar que el caracter separador sea correcto:
+1. Verificar que el carácter separador sea correcto:
 
    ::
 
@@ -504,7 +504,7 @@ Las columnas no se reconocen correctamente
        # Punto y coma
        separator_character=;
 
-2. Para manejar campos entrecomillados (campos que contienen el caracter separador), habilitar el procesamiento de comillas:
+2. Para manejar campos entrecomillados (campos que contienen el carácter separador), habilitar el procesamiento de comillas:
 
    ::
 
@@ -515,9 +515,9 @@ Las columnas no se reconocen correctamente
 Manejo de la fila de encabezado
 --------------------------------
 
-**Sintoma**: La primera fila se reconoce como datos
+**Síntoma**: La primera fila se reconoce como datos
 
-**Solucion**:
+**Solución**:
 
 Cuando hay fila de encabezado:
 
@@ -534,32 +534,32 @@ Cuando no hay fila de encabezado:
 No se obtienen datos
 --------------------
 
-**Sintoma**: El crawl tiene exito pero el conteo es 0
+**Síntoma**: El crawl tiene éxito pero el conteo es 0
 
 **Verificaciones**:
 
-1. Verificar que el archivo CSV no este vacio
-2. Verificar que la configuracion del script sea correcta (comprobar que las referencias a nombres de columna o ``cell<N>`` no llevan el prefijo ``data.``)
+1. Verificar que el archivo CSV no esté vacío
+2. Verificar que la configuración del script sea correcta (comprobar que las referencias a nombres de columna o ``cell<N>`` no llevan el prefijo ``data.``)
 3. Verificar que los nombres de columna sean correctos (cuando has_header_line=true)
 4. Revisar los mensajes de error en el log
 
 Archivo CSV grande
 ------------------
 
-**Sintoma**: Memoria insuficiente o timeout
+**Síntoma**: Memoria insuficiente o timeout
 
-**Solucion**:
+**Solución**:
 
 1. Dividir el archivo CSV en varios
 2. Usar solo las columnas necesarias en el script
-3. Aumentar el tamano del heap de |Fess|
+3. Aumentar el tamaño del heap de |Fess|
 4. Filtrar filas innecesarias
 
-Campo con saltos de linea
+Campo con saltos de línea
 --------------------------
 
-En formato RFC 4180, los campos con saltos de linea pueden manejarse entrecomillandolos.
-Como el procesamiento de comillas esta deshabilitado por defecto, es necesario especificar ``quote_disabled=false``:
+En formato RFC 4180, los campos con saltos de línea pueden manejarse entrecomillándolos.
+Como el procesamiento de comillas está deshabilitado por defecto, es necesario especificar ``quote_disabled=false``:
 
 ::
 
@@ -569,7 +569,7 @@ Como el procesamiento de comillas esta deshabilitado por defecto, es necesario e
     description"
     2,"Product B","Single line"
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -583,17 +583,17 @@ Parametros:
 CsvListDataStore
 =================
 
-El plugin ``fess-ds-csv`` incluye, ademas de ``CsvDataStore``, el handler ``CsvListDataStore``.
+El plugin ``fess-ds-csv`` incluye, además de ``CsvDataStore``, el handler ``CsvListDataStore``.
 
 ``CsvListDataStore`` extiende ``CsvDataStore`` y proporciona las siguientes funciones adicionales:
 
-- Procesamiento multihilo (controlado mediante el parametro ``numOfThreads``)
-- Eliminacion automatica de archivos CSV procesados
-- Filtrado de archivos basado en marca de tiempo (omite archivos que aun se estan escribiendo)
+- Procesamiento multihilo (controlado mediante el parámetro ``numOfThreads``)
+- Eliminación automática de archivos CSV procesados
+- Filtrado de archivos basado en marca de tiempo (omite archivos que aún se están escribiendo)
 
-Todos los parametros y configuraciones de script de ``CsvDataStore`` pueden utilizarse sin cambios.
+Todos los parámetros y configuraciones de script de ``CsvDataStore`` pueden utilizarse sin cambios.
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -605,26 +605,26 @@ Configuracion basica
    * - Nombre del handler
      - CsvListDataStore
 
-Parametros adicionales
+Parámetros adicionales
 ----------------------
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``timestamp_margin``
      - No
-     - Tiempo transcurrido desde la ultima modificacion del archivo (milisegundos). Los archivos que no hayan superado este tiempo se consideran en proceso de escritura y son omitidos (predeterminado: 10000)
+     - Tiempo transcurrido desde la última modificación del archivo (milisegundos). Los archivos que no hayan superado este tiempo se consideran en proceso de escritura y son omitidos (predeterminado: 10000)
    * - ``numOfThreads``
      - No
-     - Numero de hilos de procesamiento (predeterminado: 1)
+     - Número de hilos de procesamiento (predeterminado: 1)
 
 .. note::
 
-   ``CsvListDataStore`` elimina automaticamente los archivos CSV tras procesarlos. Si se produce un error durante el procesamiento, el archivo se renombra con extension ``.txt`` (si el renombrado falla, el archivo se elimina).
+   ``CsvListDataStore`` elimina automáticamente los archivos CSV tras procesarlos. Si se produce un error durante el procesamiento, el archivo se renombra con extensión ``.txt`` (si el renombrado falla, el archivo se elimina).
 
 Ejemplos avanzados de scripts
 ==============================
@@ -651,7 +651,7 @@ Indexado condicional
     content=Integer.parseInt(price) >= 10000 ? description : null
     price=Integer.parseInt(price) >= 10000 ? price : null
 
-Concatenacion de multiples columnas
+Concatenación de múltiples columnas
 ------------------------------------
 
 ::
@@ -672,11 +672,11 @@ Formato de fecha
     created=created_date
     // Si se necesita conversion de formato de fecha, agregar procesamiento adicional
 
-Informacion de referencia
+Información de referencia
 =========================
 
-- :doc:`ds-overview` - Descripcion general de conectores de Data Store
+- :doc:`ds-overview` - Descripción general de conectores de Data Store
 - :doc:`ds-json` - Conector JSON
 - :doc:`ds-database` - Conector de base de datos
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de Data Store
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de Data Store
 - `RFC 4180 - Formato CSV <https://datatracker.ietf.org/doc/html/rfc4180>`_

--- a/es/15.7/config/datastore/ds-dropbox.rst
+++ b/es/15.7/config/datastore/ds-dropbox.rst
@@ -2,11 +2,11 @@
 Conector de Dropbox
 ==================================
 
-Descripcion General
+Descripción General
 ===================
 
 El conector de Dropbox proporciona funcionalidad para obtener archivos del almacenamiento
-en la nube Dropbox y registrarlos en el indice de |Fess|.
+en la nube Dropbox y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-dropbox``.
 
@@ -19,27 +19,27 @@ Servicios Compatibles
 Requisitos Previos
 ==================
 
-1. Se requiere instalacion del plugin
-2. Se requiere una cuenta de desarrollador de Dropbox y la creacion de una aplicacion
+1. Se requiere instalación del plugin
+2. Se requiere una cuenta de desarrollador de Dropbox y la creación de una aplicación
 3. Se requiere obtener un token de acceso
 
-Instalacion del Plugin
+Instalación del Plugin
 ----------------------
 
-Instale desde la consola de administracion en "Sistema" -> "Plugins":
+Instale desde la consola de administración en "Sistema" -> "Plugins":
 
 1. Descargue ``fess-ds-dropbox-X.X.X.jar`` de Maven Central
-2. Cargue e instale desde la pantalla de administracion de plugins
+2. Cargue e instale desde la pantalla de administración de plugins
 3. Reinicie |Fess|
 
-O consulte :doc:`../../admin/plugin-guide` para mas detalles.
+O consulte :doc:`../../admin/plugin-guide` para más detalles.
 
-Metodo de Configuracion
+Método de Configuración
 =======================
 
-Configure desde la consola de administracion en "Rastreador" -> "Almacen de Datos" -> "Crear Nuevo".
+Configure desde la consola de administración en "Rastreador" -> "Almacén de Datos" -> "Crear Nuevo".
 
-Configuracion Basica
+Configuración Básica
 --------------------
 
 .. list-table::
@@ -47,7 +47,7 @@ Configuracion Basica
    :widths: 25 75
 
    * - Elemento
-     - Ejemplo de Configuracion
+     - Ejemplo de Configuración
    * - Nombre
      - Company Dropbox
    * - Nombre del Manejador
@@ -55,7 +55,7 @@ Configuracion Basica
    * - Habilitado
      - Activado
 
-Configuracion de Parametros
+Configuración de Parámetros
 ----------------------------
 
 ::
@@ -63,54 +63,54 @@ Configuracion de Parametros
     access_token=sl.your-dropbox-token-here
     basic_plan=false
 
-Lista de Parametros
+Lista de Parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``access_token``
-     - Si
+     - Sí
      - Token de acceso de Dropbox (generado en App Console)
    * - ``basic_plan``
      - No
      - ``true`` para cuenta individual, ``false`` para cuenta de equipo (predeterminado: ``false``)
    * - ``max_size``
      - No
-     - Tamano maximo de archivo para indexacion en bytes (predeterminado: ``10000000``)
+     - Tamaño máximo de archivo para indexación en bytes (predeterminado: ``10000000``)
    * - ``number_of_threads``
      - No
-     - Numero de hilos para rastreo (predeterminado: ``1``)
+     - Número de hilos para rastreo (predeterminado: ``1``)
    * - ``ignore_folder``
      - No
      - Indica si se omiten los metadatos de carpetas (predeterminado: ``true``)
    * - ``ignore_error``
      - No
-     - Indica si se ignoran los errores durante la extraccion de contenido (predeterminado: ``true``)
+     - Indica si se ignoran los errores durante la extracción de contenido (predeterminado: ``true``)
    * - ``supported_mimetypes``
      - No
      - Patrones regex para tipos MIME permitidos, separados por comas (predeterminado: ``.*``)
    * - ``include_pattern``
      - No
-     - Patron de URL a incluir en el rastreo
+     - Patrón de URL a incluir en el rastreo
    * - ``exclude_pattern``
      - No
-     - Patron de URL a excluir del rastreo
+     - Patrón de URL a excluir del rastreo
    * - ``default_permissions``
      - No
      - Permisos predeterminados para documentos indexados, separados por comas
    * - ``max_cached_content_size``
      - No
-     - Tamano maximo de contenido almacenado en cache en memoria en bytes. El contenido que supere este limite se escribe en un archivo temporal (predeterminado: ``1048576``)
+     - Tamaño máximo de contenido almacenado en cache en memoria en bytes. El contenido que supere este límite se escribe en un archivo temporal (predeterminado: ``1048576``)
    * - ``readInterval``
      - No
      - Tiempo de espera en milisegundos entre el procesamiento de cada registro (predeterminado: ``0``)
 
-Configuracion de Script
+Configuración de Script
 -----------------------
 
 Para Archivos de Dropbox
@@ -135,7 +135,7 @@ Campos disponibles:
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``file.url``
      - Enlace de vista previa del archivo
    * - ``file.contents``
@@ -149,23 +149,23 @@ Campos disponibles:
    * - ``file.path_display``
      - Ruta del archivo
    * - ``file.size``
-     - Tamano del archivo (bytes)
+     - Tamaño del archivo (bytes)
    * - ``file.client_modified``
-     - Fecha de ultima modificacion del lado del cliente
+     - Fecha de última modificación del lado del cliente
    * - ``file.server_modified``
-     - Fecha de ultima modificacion del lado del servidor
+     - Fecha de última modificación del lado del servidor
    * - ``file.roles``
      - Permisos de acceso del archivo
    * - ``file.id``
      - ID del archivo de Dropbox
    * - ``file.path_lower``
-     - Ruta del archivo en minusculas
+     - Ruta del archivo en minúsculas
    * - ``file.parent_shared_folder_id``
      - ID de la carpeta compartida principal
    * - ``file.content_hash``
      - Hash del contenido
    * - ``file.rev``
-     - Revision del archivo
+     - Revisión del archivo
 
 Para Dropbox Paper
 ~~~~~~~~~~~~~~~~~~
@@ -186,7 +186,7 @@ Campos disponibles:
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``paper.url``
      - Enlace de vista previa del documento Paper
    * - ``paper.contents``
@@ -196,22 +196,22 @@ Campos disponibles:
    * - ``paper.filetype``
      - Tipo de archivo
    * - ``paper.title``
-     - Titulo del documento Paper
+     - Título del documento Paper
    * - ``paper.owner``
      - Propietario del documento Paper
    * - ``paper.roles``
      - Permisos de acceso del documento
    * - ``paper.revision``
-     - Revision del documento Paper
+     - Revisión del documento Paper
 
-Configuracion de Autenticacion de Dropbox
+Configuración de Autenticación de Dropbox
 ==========================================
 
 Tipo de Cuenta y Token de Acceso
 ---------------------------------
 
-Este conector alterna entre dos modos de operacion segun el parametro ``basic_plan``.
-Dado que el tipo de aplicacion y de token de acceso que se debe crear difiere, verifiquelo primero.
+Este conector alterna entre dos modos de operación según el parámetro ``basic_plan``.
+Dado que el tipo de aplicación y de token de acceso que se debe crear difiere, verifíquelo primero.
 
 .. list-table::
    :header-rows: 1
@@ -219,24 +219,24 @@ Dado que el tipo de aplicacion y de token de acceso que se debe crear difiere, v
 
    * - Modo
      - ``basic_plan``
-     - Descripcion
+     - Descripción
    * - Cuenta de equipo (predeterminado)
      - ``false``
      - Destinado a cuentas Dropbox Business (equipo). Requiere un token de acceso con permisos de administrador del equipo, y rastrea archivos de los miembros del equipo y carpetas de equipo de forma transversal.
    * - Cuenta individual
      - ``true``
-     - Destinado a cuentas individuales (no de equipo). Utiliza un token de acceso con alcance estandar y rastrea directamente los archivos dentro de esa cuenta.
+     - Destinado a cuentas individuales (no de equipo). Utiliza un token de acceso con alcance estándar y rastrea directamente los archivos dentro de esa cuenta.
 
 .. note::
-   Con la configuracion predeterminada (``basic_plan=false``), se utilizan las API de administracion de equipos
+   Con la configuración predeterminada (``basic_plan=false``), se utilizan las API de administración de equipos
    (lista de miembros, acceso a archivos por miembro, carpetas de equipo), por lo que es obligatorio
    disponer de una cuenta Dropbox Business y un token con permisos de administrador del equipo.
-   Si utiliza una cuenta individual, asegurese de configurar ``basic_plan=true``.
+   Si utiliza una cuenta individual, asegúrese de configurar ``basic_plan=true``.
 
 Pasos para Obtener el Token de Acceso
 --------------------------------------
 
-1. Crear una aplicacion en Dropbox App Console
+1. Crear una aplicación en Dropbox App Console
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Acceda a https://www.dropbox.com/developers/apps:
@@ -244,18 +244,18 @@ Acceda a https://www.dropbox.com/developers/apps:
 1. Haga clic en "Create app"
 2. Seleccione "Scoped access" para el tipo de API
 3. Seleccione el tipo de acceso (se recomienda "Full Dropbox" para rastrear cuentas de equipo de forma transversal)
-4. Ingrese el nombre de la aplicacion y cree
+4. Ingrese el nombre de la aplicación y cree
 
-2. Configuracion de Permisos
+2. Configuración de Permisos
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-En la pestana "Permissions", seleccione los permisos requeridos:
+En la pestaña "Permissions", seleccione los permisos requeridos:
 
 **Permisos necesarios para el rastreo de archivos y Paper**:
 
 - ``files.metadata.read`` - Lectura de metadatos de archivos
 - ``files.content.read`` - Lectura de contenido de archivos y documentos Paper
-- ``sharing.read`` - Lectura de informacion de uso compartido
+- ``sharing.read`` - Lectura de información de uso compartido
 
 **Permisos adicionales requeridos para cuentas de equipo (``basic_plan=false``)**:
 
@@ -264,15 +264,15 @@ En la pestana "Permissions", seleccione los permisos requeridos:
 
 .. note::
    En el modo de cuenta de equipo, se accede a cada miembro y carpeta de equipo como administrador del equipo.
-   Habilite los permisos de equipo mencionados en la pestana Permissions y genere un token de administrador del equipo.
+   Habilite los permisos de equipo mencionados en la pestaña Permissions y genere un token de administrador del equipo.
 
 3. Generar Token de Acceso
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-En la pestana "Settings":
+En la pestaña "Settings":
 
-1. Desplacese hasta la seccion "Generated access token"
-2. Haga clic en el boton "Generate"
+1. Desplácese hasta la sección "Generated access token"
+2. Haga clic en el botón "Generate"
 3. Copie el token generado (este token se muestra solo una vez)
 
 .. warning::
@@ -282,20 +282,20 @@ En la pestana "Settings":
 4. Configurar el Token
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Configure el token obtenido en los parametros:
+Configure el token obtenido en los parámetros:
 
 ::
 
     access_token=sl.your-dropbox-token-here
 
-Configuracion para Cuenta Individual
+Configuración para Cuenta Individual
 =====================================
 
 Uso con Cuentas Individuales
 -----------------------------
 
 Para cuentas individuales (no cuentas de equipo),
-configure el parametro ``basic_plan`` como ``true``:
+configure el parámetro ``basic_plan`` como ``true``:
 
 ::
 
@@ -311,7 +311,7 @@ Ejemplos de Uso
 Rastrear Todos los Archivos de Dropbox
 ---------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -334,7 +334,7 @@ Script:
 Rastrear Documentos de Dropbox Paper
 --------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -354,7 +354,7 @@ Script:
 Rastrear con Permisos
 ----------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -386,18 +386,18 @@ Script (Dropbox Paper):
     filetype=paper.filetype
     role=paper.roles
 
-Rastrear Solo Tipos de Archivo Especificos
+Rastrear Solo Tipos de Archivo Específicos
 -------------------------------------------
 
-Para indexar unicamente tipos MIME especificos, especifique en el parametro ``supported_mimetypes``
+Para indexar únicamente tipos MIME específicos, especifique en el parámetro ``supported_mimetypes``
 las expresiones regulares de los tipos MIME permitidos, separadas por comas.
 
 .. note::
-   Los scripts del almacen de datos evaluan cada linea como una expresion independiente con el formato ``campo=expresion``.
-   Por ello, no es posible asignar multiples campos en un bloque ``if`` de varias lineas.
-   El filtrado por tipo MIME debe realizarse mediante el parametro ``supported_mimetypes``, no con scripts.
+   Los scripts del almacén de datos evalúan cada línea como una expresión independiente con el formato ``campo=expresion``.
+   Por ello, no es posible asignar múltiples campos en un bloque ``if`` de varias líneas.
+   El filtrado por tipo MIME debe realizarse mediante el parámetro ``supported_mimetypes``, no con scripts.
 
-Parametros (solo PDF y archivos Word):
+Parámetros (solo PDF y archivos Word):
 
 ::
 
@@ -416,34 +416,34 @@ Script:
     filename=file.name
     last_modified=file.client_modified
 
-Solucion de Problemas
+Solución de Problemas
 ======================
 
-Errores de Autenticacion
+Errores de Autenticación
 -------------------------
 
-**Sintoma**: ``Invalid access token`` o ``401 Unauthorized``
+**Síntoma**: ``Invalid access token`` o ``401 Unauthorized``
 
 **Verifique**:
 
 1. Verifique que el token de acceso se haya copiado correctamente
-2. Verifique que el token no haya expirado (use token de larga duracion)
-3. Verifique que los permisos requeridos esten otorgados en Dropbox App Console
-4. Verifique que la aplicacion no este desactivada
+2. Verifique que el token no haya expirado (use token de larga duración)
+3. Verifique que los permisos requeridos estén otorgados en Dropbox App Console
+4. Verifique que la aplicación no esté desactivada
 
 No Se Pueden Obtener Archivos
 ------------------------------
 
-**Sintoma**: El rastreo tiene exito pero hay 0 archivos
+**Síntoma**: El rastreo tiene éxito pero hay 0 archivos
 
 **Verifique**:
 
-1. Verifique que el "Access type" de la aplicacion sea apropiado:
+1. Verifique que el "Access type" de la aplicación sea apropiado:
 
    - "Full Dropbox": Puede acceder a todo Dropbox
-   - "App folder": Solo puede acceder a una carpeta especifica
+   - "App folder": Solo puede acceder a una carpeta específica
 
-2. Verifique que los permisos requeridos esten otorgados:
+2. Verifique que los permisos requeridos estén otorgados:
 
    - ``files.metadata.read``
    - ``files.content.read``
@@ -451,25 +451,25 @@ No Se Pueden Obtener Archivos
 
 3. Verifique que existan archivos en la cuenta de Dropbox
 
-Errores de Limite de Tasa de API
+Errores de Límite de Tasa de API
 ----------------------------------
 
-**Sintoma**: Error ``429 Too Many Requests``
+**Síntoma**: Error ``429 Too Many Requests``
 
-**Solucion**:
+**Solución**:
 
 1. Configure ``readInterval`` para aumentar el intervalo de procesamiento entre archivos
-2. Reduzca ``number_of_threads`` para disminuir el numero de solicitudes simultaneas
-3. Divida el almacen de datos en varios (por carpeta u otro criterio) y escalone los horarios de ejecucion
+2. Reduzca ``number_of_threads`` para disminuir el número de solicitudes simultáneas
+3. Divida el almacén de datos en varios (por carpeta u otro criterio) y escalone los horarios de ejecución
 
 .. note::
-   ``basic_plan`` es un parametro que alterna el tipo de cuenta (equipo/individual)
-   y no afecta al ajuste de los limites de tasa. Configurelo correctamente segun su cuenta.
+   ``basic_plan`` es un parámetro que alterna el tipo de cuenta (equipo/individual)
+   y no afecta al ajuste de los límites de tasa. Configúrelo correctamente según su cuenta.
 
 No Se Pueden Obtener Documentos Paper
 ---------------------------------------
 
-**Sintoma**: Los documentos Paper no se rastrean
+**Síntoma**: Los documentos Paper no se rastrean
 
 **Verifique**:
 
@@ -477,16 +477,16 @@ No Se Pueden Obtener Documentos Paper
 2. Verifique que se incluya el permiso ``files.content.read``
 3. Verifique que realmente existan documentos Paper
 
-Cuando Hay un Gran Numero de Archivos
+Cuando Hay un Gran Número de Archivos
 ---------------------------------------
 
-**Sintoma**: El rastreo toma mucho tiempo o se agota el tiempo
+**Síntoma**: El rastreo toma mucho tiempo o se agota el tiempo
 
-**Solucion**:
+**Solución**:
 
-1. Divida los almacenes de datos en multiples (por unidad de carpeta, etc.)
-2. Distribuya la carga con configuracion de programacion
-3. En el plan Basic, tenga en cuenta los limites de tasa de API
+1. Divida los almacenes de datos en múltiples (por unidad de carpeta, etc.)
+2. Distribuya la carga con configuración de programación
+3. En el plan Basic, tenga en cuenta los límites de tasa de API
 
 Permisos y Control de Acceso
 ==============================
@@ -494,9 +494,9 @@ Permisos y Control de Acceso
 Reflejar Permisos de Uso Compartido de Dropbox
 ------------------------------------------------
 
-Puede reflejar la configuracion de uso compartido de Dropbox en los permisos de Fess:
+Puede reflejar la configuración de uso compartido de Dropbox en los permisos de Fess:
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -515,14 +515,14 @@ Script:
     filename=file.name
     last_modified=file.client_modified
 
-``file.roles`` o ``paper.roles`` contienen informacion de uso compartido de Dropbox.
+``file.roles`` o ``paper.roles`` contienen información de uso compartido de Dropbox.
 
-Informacion de Referencia
+Información de Referencia
 ==========================
 
-- :doc:`ds-overview` - Descripcion General de Conectores de Almacen de Datos
+- :doc:`ds-overview` - Descripción General de Conectores de Almacén de Datos
 - :doc:`ds-box` - Conector de Box
 - :doc:`ds-gsuite` - Conector de Google Workspace
-- :doc:`../../admin/dataconfig-guide` - Guia de Configuracion de Almacen de Datos
+- :doc:`../../admin/dataconfig-guide` - Guía de Configuración de Almacén de Datos
 - `Desarrolladores de Dropbox <https://www.dropbox.com/developers>`_
-- `Documentacion de API de Dropbox <https://www.dropbox.com/developers/documentation>`_
+- `Documentación de API de Dropbox <https://www.dropbox.com/developers/documentation>`_

--- a/es/15.7/config/datastore/ds-elasticsearch.rst
+++ b/es/15.7/config/datastore/ds-elasticsearch.rst
@@ -2,11 +2,11 @@
 Conector Elasticsearch/OpenSearch
 ==================================
 
-Descripcion general
+Descripción general
 ===================
 
 El conector Elasticsearch/OpenSearch proporciona la funcionalidad para obtener datos
-de un cluster de Elasticsearch u OpenSearch y registrarlos en el indice de |Fess|.
+de un cluster de Elasticsearch u OpenSearch y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-elasticsearch``.
 
@@ -23,10 +23,10 @@ Requisitos previos
 2. Se requiere acceso de lectura al cluster de Elasticsearch/OpenSearch
 3. Se necesitan permisos para ejecutar consultas
 
-Instalacion del plugin
+Instalación del plugin
 ----------------------
 
-Metodo 1: Colocar el archivo JAR directamente
+Método 1: Colocar el archivo JAR directamente
 
 ::
 
@@ -38,18 +38,18 @@ Metodo 1: Colocar el archivo JAR directamente
     # o
     cp fess-ds-elasticsearch-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Metodo 2: Instalar desde la pantalla de administracion
+Método 2: Instalar desde la pantalla de administración
 
 1. Abrir "Sistema" -> "Plugins"
 2. Subir el archivo JAR
 3. Reiniciar |Fess|
 
-Configuracion
+Configuración
 =============
 
-Configure desde la pantalla de administracion en "Crawler" -> "Data Store" -> "Crear nuevo".
+Configure desde la pantalla de administración en "Crawler" -> "Data Store" -> "Crear nuevo".
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -66,13 +66,13 @@ Configuracion basica
      - Activado
 
 .. note::
-   ``ElasticsearchListDataStore`` es una extension de ``ElasticsearchDataStore`` que procesa los datos obtenidos como una lista de archivos y soporta el registro en el indice con multiples hilos.
-   El numero de hilos se puede especificar con el parametro ``numOfThreads`` (predeterminado: 1).
+   ``ElasticsearchListDataStore`` es una extensión de ``ElasticsearchDataStore`` que procesa los datos obtenidos como una lista de archivos y soporta el registro en el índice con múltiples hilos.
+   El número de hilos se puede especificar con el parámetro ``numOfThreads`` (predeterminado: 1).
 
-Configuracion de parametros
+Configuración de parámetros
 ---------------------------
 
-Conexion basica:
+Conexión básica:
 
 ::
 
@@ -81,7 +81,7 @@ Conexion basica:
     size=100
     scroll=1m
 
-Conexion con autenticacion:
+Conexión con autenticación:
 
 ::
 
@@ -92,28 +92,28 @@ Conexion con autenticacion:
     size=100
     scroll=1m
 
-Lista de parametros
+Lista de parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``settings.http.hosts``
      - No
-     - URL del host de Elasticsearch/OpenSearch. Se pueden especificar multiples hosts separados por comas (ej: ``http://host1:9200,http://host2:9200``). Si no se especifica, se produce un error de conexion
+     - URL del host de Elasticsearch/OpenSearch. Se pueden especificar múltiples hosts separados por comas (ej: ``http://host1:9200,http://host2:9200``). Si no se especifica, se produce un error de conexión
    * - ``settings.fesen.username``
      - No
-     - Nombre de usuario para autenticacion
+     - Nombre de usuario para autenticación
    * - ``settings.fesen.password``
      - No
-     - Contrasena para autenticacion
+     - Contraseña para autenticación
    * - ``index``
      - No
-     - Nombre del indice objetivo (predeterminado: ``_all``). Se pueden especificar multiples indices separados por comas
+     - Nombre del índice objetivo (predeterminado: ``_all``). Se pueden especificar múltiples índices separados por comas
    * - ``size``
      - No
      - Cantidad de registros obtenidos por scroll (si no se especifica, se usa el valor predeterminado del servidor Elasticsearch/OpenSearch)
@@ -131,46 +131,46 @@ Lista de parametros
      - Campos a obtener (separados por comas)
    * - ``preference``
      - No
-     - Preferencia de replica de shard para la ejecucion de busqueda (predeterminado: ``_local``)
+     - Preferencia de replica de shard para la ejecución de búsqueda (predeterminado: ``_local``)
    * - ``delete.processed.doc``
      - No
-     - Si se eliminan los documentos procesados del indice fuente (predeterminado: false)
+     - Si se eliminan los documentos procesados del índice fuente (predeterminado: false)
    * - ``readInterval``
      - No
      - Tiempo de espera entre el procesamiento de cada documento en milisegundos (predeterminado: 0)
    * - ``numOfThreads``
      - No
-     - Numero de hilos para el registro en el indice (valido solo para ``ElasticsearchListDataStore``, predeterminado: 1)
+     - Número de hilos para el registro en el índice (válido solo para ``ElasticsearchListDataStore``, predeterminado: 1)
 
-Parametros adicionales de conexion
+Parámetros adicionales de conexión
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Los parametros con el prefijo ``settings.`` se pasan como configuracion del cliente interno de Elasticsearch/OpenSearch (cliente HTTP de fesen).
+Los parámetros con el prefijo ``settings.`` se pasan como configuración del cliente interno de Elasticsearch/OpenSearch (cliente HTTP de fesen).
 Las principales configuraciones adicionales son las siguientes.
 
 .. list-table::
    :header-rows: 1
    :widths: 40 60
 
-   * - Parametro
-     - Descripcion
+   * - Parámetro
+     - Descripción
    * - ``settings.http.ssl.certificate_authorities``
      - Ruta al archivo de certificado CA de confianza (formato X.509) para conexiones HTTPS
    * - ``settings.http.compression``
-     - Si se habilita la compresion HTTP (predeterminado: true)
+     - Si se habilita la compresión HTTP (predeterminado: true)
    * - ``settings.http.proxy_host``
-     - Nombre de host del servidor proxy (tambien se puede especificar ``settings.https.proxy_host``)
+     - Nombre de host del servidor proxy (también se puede especificar ``settings.https.proxy_host``)
    * - ``settings.http.proxy_port``
-     - Numero de puerto del servidor proxy (tambien se puede especificar ``settings.https.proxy_port``)
+     - Número de puerto del servidor proxy (también se puede especificar ``settings.https.proxy_port``)
    * - ``settings.http.proxy_username``
-     - Nombre de usuario para autenticacion del proxy (tambien se puede especificar ``settings.https.proxy_username``)
+     - Nombre de usuario para autenticación del proxy (también se puede especificar ``settings.https.proxy_username``)
    * - ``settings.http.proxy_password``
-     - Contrasena para autenticacion del proxy (tambien se puede especificar ``settings.https.proxy_password``)
+     - Contraseña para autenticación del proxy (también se puede especificar ``settings.https.proxy_password``)
 
-Configuracion de scripts
+Configuración de scripts
 ------------------------
 
-Mapeo basico:
+Mapeo básico:
 
 ::
 
@@ -195,50 +195,50 @@ Campos disponibles
 
 - ``source.<field_name>`` - Campo ``_source`` del documento de Elasticsearch
 - ``id`` - ID del documento
-- ``index`` - Nombre del indice
-- ``score`` - Puntuacion de busqueda
-- ``version`` - Version del documento
-- ``seqNo`` - Numero de secuencia
+- ``index`` - Nombre del índice
+- ``score`` - Puntuación de búsqueda
+- ``version`` - Versión del documento
+- ``seqNo`` - Número de secuencia
 - ``primaryTerm`` - Termino primario
-- ``clusterAlias`` - Alias del cluster (para busqueda entre clusters)
+- ``clusterAlias`` - Alias del cluster (para búsqueda entre clusters)
 - ``hit`` - Objeto SearchHit (uso avanzado)
 
-Configuracion de consultas
+Configuración de consultas
 ==========================
 
 Obtener todos los documentos
 ----------------------------
 
 Por defecto se obtienen todos los documentos.
-Si no se especifica el parametro ``query``, se usa ``match_all``.
+Si no se especifica el parámetro ``query``, se usa ``match_all``.
 
-Filtrado con condiciones especificas
+Filtrado con condiciones específicas
 ------------------------------------
 
 ::
 
     query={"term":{"status":"published"}}
 
-Especificacion de rango:
+Especificación de rango:
 
 ::
 
     query={"range":{"timestamp":{"gte":"2024-01-01","lte":"2024-12-31"}}}
 
-Multiples condiciones:
+Múltiples condiciones:
 
 ::
 
     query={"bool":{"must":[{"term":{"category":"news"}},{"range":{"views":{"gte":100}}}]}}
 
 .. note::
-   El parametro ``query`` solo acepta el cuerpo de la query. El wrapper externo ``{"query":...}`` no es necesario.
-   Las opciones a nivel de busqueda como ordenamiento no pueden especificarse en este parametro.
+   El parámetro ``query`` solo acepta el cuerpo de la query. El wrapper externo ``{"query":...}`` no es necesario.
+   Las opciones a nivel de búsqueda como ordenamiento no pueden especificarse en este parámetro.
 
-Obtener solo campos especificos
+Obtener solo campos específicos
 ===============================
 
-Limitar campos a obtener con el parametro fields
+Limitar campos a obtener con el parámetro fields
 -------------------------------------------------
 
 ::
@@ -248,15 +248,15 @@ Limitar campos a obtener con el parametro fields
     fields=title,content,url,timestamp
     size=100
 
-Para obtener todos los campos, no especifique ``fields`` o dejelo vacio.
+Para obtener todos los campos, no especifique ``fields`` o déjelo vacío.
 
 Ejemplos de uso
 ===============
 
-Crawl basico de indice
+Crawl básico de índice
 ----------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -275,10 +275,10 @@ Script:
     created=source.created_at
     last_modified=source.updated_at
 
-Crawl desde cluster con autenticacion
+Crawl desde cluster con autenticación
 --------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -299,10 +299,10 @@ Script:
     digest=source.category
     last_modified=source.updated_at
 
-Crawl desde multiples indices
+Crawl desde múltiples índices
 ------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -324,7 +324,7 @@ Script:
 Crawl de cluster OpenSearch
 ----------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -347,7 +347,7 @@ Script:
 Crawl con campos limitados
 ---------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -365,12 +365,12 @@ Script:
     content=source.content
     last_modified=source.timestamp
 
-Balanceo de carga con multiples hosts
+Balanceo de carga con múltiples hosts
 --------------------------------------
 
-Al especificar multiples hosts separados por comas en ``settings.http.hosts``, las solicitudes se distribuyen entre cada host.
+Al especificar múltiples hosts separados por comas en ``settings.http.hosts``, las solicitudes se distribuyen entre cada host.
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -388,61 +388,61 @@ Script:
     content=source.content
     last_modified=source.timestamp
 
-Solucion de problemas
+Solución de problemas
 =====================
 
-Error de conexion
+Error de conexión
 -----------------
 
-**Sintoma**: ``Connection refused`` o ``No route to host``
+**Síntoma**: ``Connection refused`` o ``No route to host``
 
 **Verificaciones**:
 
 1. Verificar que la URL del host sea correcta (protocolo, nombre de host, puerto)
-2. Confirmar que Elasticsearch/OpenSearch este ejecutandose
-3. Verificar la configuracion del firewall
-4. En caso de HTTPS, verificar que el certificado sea valido
+2. Confirmar que Elasticsearch/OpenSearch este ejecutándose
+3. Verificar la configuración del firewall
+4. En caso de HTTPS, verificar que el certificado sea válido
 
-Error de autenticacion
+Error de autenticación
 ----------------------
 
-**Sintoma**: ``401 Unauthorized`` o ``403 Forbidden``
+**Síntoma**: ``401 Unauthorized`` o ``403 Forbidden``
 
 **Verificaciones**:
 
-1. Verificar que el nombre de usuario y contrasena sean correctos
+1. Verificar que el nombre de usuario y contraseña sean correctos
 2. Confirmar que el usuario tenga los permisos apropiados:
 
-   - Permisos de lectura en el indice
+   - Permisos de lectura en el índice
    - Permisos para usar la API de scroll
 
-3. Si Elasticsearch Security (X-Pack) esta habilitado, verificar la configuracion correcta
+3. Si Elasticsearch Security (X-Pack) está habilitado, verificar la configuración correcta
 
-Indice no encontrado
+Índice no encontrado
 --------------------
 
-**Sintoma**: ``index_not_found_exception``
+**Síntoma**: ``index_not_found_exception``
 
 **Verificaciones**:
 
-1. Verificar que el nombre del indice sea correcto (incluyendo mayusculas/minusculas)
-2. Confirmar que el indice existe:
+1. Verificar que el nombre del índice sea correcto (incluyendo mayúsculas/minúsculas)
+2. Confirmar que el índice existe:
 
    ::
 
        GET /_cat/indices
 
-3. Verificar que el patron de comodin sea correcto (ej: ``logs-*``)
+3. Verificar que el patrón de comodín sea correcto (ej: ``logs-*``)
 
 Error de consulta
 -----------------
 
-**Sintoma**: ``parsing_exception`` o ``search_phase_execution_exception``
+**Síntoma**: ``parsing_exception`` o ``search_phase_execution_exception``
 
 **Verificaciones**:
 
 1. Verificar que el JSON de la consulta sea correcto
-2. Confirmar que la consulta sea compatible con la version de Elasticsearch/OpenSearch
+2. Confirmar que la consulta sea compatible con la versión de Elasticsearch/OpenSearch
 3. Verificar que los nombres de campo sean correctos
 4. Probar ejecutando la consulta directamente en Elasticsearch/OpenSearch:
 
@@ -456,9 +456,9 @@ Error de consulta
 Timeout de scroll
 -----------------
 
-**Sintoma**: ``No search context found`` o ``Scroll timeout``
+**Síntoma**: ``No search context found`` o ``Scroll timeout``
 
-**Solucion**:
+**Solución**:
 
 1. Aumentar el ``scroll``:
 
@@ -474,12 +474,12 @@ Timeout de scroll
 
 3. Verificar los recursos del cluster
 
-Crawl de grandes volumenes de datos
+Crawl de grandes volúmenes de datos
 ------------------------------------
 
-**Sintoma**: El crawl es lento o tiene timeout
+**Síntoma**: El crawl es lento o tiene timeout
 
-**Solucion**:
+**Solución**:
 
 1. Ajustar ``size`` (demasiado grande puede hacerlo lento):
 
@@ -490,32 +490,32 @@ Crawl de grandes volumenes de datos
 
 2. Limitar los campos a obtener con ``fields``
 3. Filtrar solo los documentos necesarios con ``query``
-4. Dividir en multiples data stores (por indice, por rango de tiempo, etc.)
+4. Dividir en múltiples data stores (por índice, por rango de tiempo, etc.)
 
 Memoria insuficiente
 --------------------
 
-**Sintoma**: OutOfMemoryError
+**Síntoma**: OutOfMemoryError
 
-**Solucion**:
+**Solución**:
 
 1. Reducir ``size``
 2. Limitar los campos a obtener con ``fields``
-3. Aumentar el tamano del heap de |Fess|
+3. Aumentar el tamaño del heap de |Fess|
 4. Excluir campos grandes (datos binarios, etc.)
 
-Conexion SSL/TLS
+Conexión SSL/TLS
 ================
 
 En caso de certificado autofirmado
 ------------------------------------
 
 .. warning::
-   Use certificados firmados adecuadamente en entornos de produccion.
+   Use certificados firmados adecuadamente en entornos de producción.
 
-Metodo 1: Especificar el certificado CA con el parametro ``settings.http.ssl.certificate_authorities`` (recomendado)
+Método 1: Especificar el certificado CA con el parámetro ``settings.http.ssl.certificate_authorities`` (recomendado)
 
-Especifique la ruta al archivo de certificado CA de confianza (formato X.509). Este metodo no afecta al keystore global de |Fess|.
+Especifique la ruta al archivo de certificado CA de confianza (formato X.509). Este método no afecta al keystore global de |Fess|.
 
 ::
 
@@ -523,18 +523,18 @@ Especifique la ruta al archivo de certificado CA de confianza (formato X.509). E
     settings.http.ssl.certificate_authorities=/path/to/es-cert.crt
     index=myindex
 
-Metodo 2: Agregar el certificado al keystore de Java
+Método 2: Agregar el certificado al keystore de Java
 
-Agregue el certificado al almacen de confianza de la JVM que inicia |Fess|.
+Agregue el certificado al almacén de confianza de la JVM que inicia |Fess|.
 
 ::
 
     keytool -import -alias es-cert -file es-cert.crt -keystore $JAVA_HOME/lib/security/cacerts
 
-Conexion a traves de proxy
+Conexión a través de proxy
 ---------------------------
 
-Para conectarse a traves de un servidor proxy, especifique ``settings.http.proxy_host`` y ``settings.http.proxy_port``.
+Para conectarse a través de un servidor proxy, especifique ``settings.http.proxy_host`` y ``settings.http.proxy_port``.
 
 ::
 
@@ -546,27 +546,27 @@ Para conectarse a traves de un servidor proxy, especifique ``settings.http.proxy
 Ejemplos de consultas avanzadas
 ================================
 
-Consulta con agregacion
+Consulta con agregación
 ------------------------
 
 .. note::
-   El parametro ``query`` solo acepta el cuerpo de la query. Agregaciones (aggs), ordenamiento y otras
-   opciones a nivel de busqueda no pueden especificarse. Solo se obtienen los documentos.
+   El parámetro ``query`` solo acepta el cuerpo de la query. Agregaciones (aggs), ordenamiento y otras
+   opciones a nivel de búsqueda no pueden especificarse. Solo se obtienen los documentos.
 
 Campos de script
 -----------------
 
 .. note::
-   Los campos de script de Elasticsearch/OpenSearch no estan incluidos en ``_source``, por lo que no se
+   Los campos de script de Elasticsearch/OpenSearch no están incluidos en ``_source``, por lo que no se
    puede acceder a ellos mediante el prefijo ``source.*``. Para usar campos de script, acceda a ellos
    mediante el objeto ``hit`` usando ``hit.getFields()``.
 
-Informacion de referencia
+Información de referencia
 ==========================
 
-- :doc:`ds-overview` - Descripcion general de conectores de Data Store
+- :doc:`ds-overview` - Descripción general de conectores de Data Store
 - :doc:`ds-database` - Conector de base de datos
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de Data Store
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de Data Store
 - `Elasticsearch Documentation <https://www.elastic.co/guide/>`_
 - `OpenSearch Documentation <https://opensearch.org/docs/>`_
 - `Elasticsearch Query DSL <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html>`_

--- a/es/15.7/config/datastore/ds-gsuite.rst
+++ b/es/15.7/config/datastore/ds-gsuite.rst
@@ -2,11 +2,11 @@
 Conector de Google Workspace
 ==================================
 
-Vision General
+Visión General
 ==============
 
 El conector de Google Workspace proporciona funcionalidad para obtener archivos de Google Drive
-(anteriormente G Suite) y registrarlos en el indice de |Fess|.
+(anteriormente G Suite) y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-gsuite``.
 
@@ -14,20 +14,20 @@ Servicios Soportados
 ====================
 
 - Google Drive (Mi unidad, Unidades compartidas)
-- Documentos de Google, Hojas de calculo, Presentaciones, Formularios, etc.
+- Documentos de Google, Hojas de cálculo, Presentaciones, Formularios, etc.
 
 Requisitos Previos
 ==================
 
-1. Se requiere la instalacion del plugin
-2. Se requiere la creacion de un proyecto en Google Cloud Platform
-3. Se requiere la creacion de una cuenta de servicio y la obtencion de credenciales
-4. Se requiere la configuracion de delegacion de dominio de Google Workspace
+1. Se requiere la instalación del plugin
+2. Se requiere la creación de un proyecto en Google Cloud Platform
+3. Se requiere la creación de una cuenta de servicio y la obtención de credenciales
+4. Se requiere la configuración de delegación de dominio de Google Workspace
 
-Instalacion del Plugin
+Instalación del Plugin
 ----------------------
 
-Metodo 1: Colocar el archivo JAR directamente
+Método 1: Colocar el archivo JAR directamente
 
 ::
 
@@ -39,18 +39,18 @@ Metodo 1: Colocar el archivo JAR directamente
     # o
     cp fess-ds-gsuite-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Metodo 2: Instalar desde la pantalla de administracion
+Método 2: Instalar desde la pantalla de administración
 
 1. Abra "Sistema" -> "Plugins"
 2. Cargue el archivo JAR
 3. Reinicie |Fess|
 
-Metodo de Configuracion
+Método de Configuración
 =======================
 
-Configure desde la pantalla de administracion en "Rastreador" -> "Almacen de datos" -> "Nuevo".
+Configure desde la pantalla de administración en "Rastreador" -> "Almacén de datos" -> "Nuevo".
 
-Configuracion Basica
+Configuración Básica
 --------------------
 
 .. list-table::
@@ -66,7 +66,7 @@ Configuracion Basica
    * - Habilitado
      - Activado
 
-Configuracion de Parametros
+Configuración de Parámetros
 ---------------------------
 
 ::
@@ -75,28 +75,28 @@ Configuracion de Parametros
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project.iam.gserviceaccount.com
 
-Lista de Parametros
+Lista de Parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``private_key``
-     - Si
-     - Clave privada de la cuenta de servicio (formato PEM, saltos de linea como ``\n``)
+     - Sí
+     - Clave privada de la cuenta de servicio (formato PEM, saltos de línea como ``\n``)
    * - ``private_key_id``
-     - Si
+     - Sí
      - ID de la clave privada
    * - ``client_email``
-     - Si
-     - Direccion de correo de la cuenta de servicio
+     - Sí
+     - Dirección de correo de la cuenta de servicio
    * - ``max_size``
      - No
-     - Tamano maximo de archivo a indexar (en bytes). Predeterminado: ``10000000`` (aprox. 10MB)
+     - Tamaño máximo de archivo a indexar (en bytes). Predeterminado: ``10000000`` (aprox. 10MB)
    * - ``ignore_folder``
      - No
      - Si se deben omitir las carpetas. Predeterminado: ``true``
@@ -105,28 +105,28 @@ Lista de Parametros
      - Si se debe continuar el procesamiento cuando ocurre un error. Predeterminado: ``true``
    * - ``supported_mimetypes``
      - No
-     - Tipos MIME a indexar (expresion regular, separados por comas). Predeterminado: ``.*`` (todos los tipos)
+     - Tipos MIME a indexar (expresión regular, separados por comas). Predeterminado: ``.*`` (todos los tipos)
    * - ``include_pattern``
      - No
-     - Patron de expresion regular para las URL que se incluyen en el indice
+     - Patrón de expresión regular para las URL que se incluyen en el índice
    * - ``exclude_pattern``
      - No
-     - Patron de expresion regular para las URL que se excluyen
+     - Patrón de expresión regular para las URL que se excluyen
    * - ``default_permissions``
      - No
      - Permisos predeterminados (separados por comas, p. ej. ``{role}drive-users``)
    * - ``number_of_threads``
      - No
-     - Numero de hilos de procesamiento en paralelo. Predeterminado: ``1``
+     - Número de hilos de procesamiento en paralelo. Predeterminado: ``1``
    * - ``query``
      - No
-     - Cadena de consulta de busqueda de la API de Google Drive
+     - Cadena de consulta de búsqueda de la API de Google Drive
    * - ``corpora``
      - No
      - Corpora a buscar. Predeterminado: ``allDrives``
    * - ``spaces``
      - No
-     - Espacios a buscar (parametro ``spaces`` de la API de Google Drive, p. ej. ``drive``, ``appDataFolder``). Predeterminado: sin especificar (valor predeterminado de la API).
+     - Espacios a buscar (parámetro ``spaces`` de la API de Google Drive, p. ej. ``drive``, ``appDataFolder``). Predeterminado: sin especificar (valor predeterminado de la API).
    * - ``fields``
      - No
      - Campos de archivo que se solicitan a la API de Google Drive. Predeterminado: ``*`` (todos los campos).
@@ -135,21 +135,21 @@ Lista de Parametros
      - Tiempo de espera de lectura HTTP (en milisegundos). Predeterminado: ``20000``
    * - ``connect_timeout``
      - No
-     - Tiempo de espera de conexion HTTP (en milisegundos). Predeterminado: ``20000``
+     - Tiempo de espera de conexión HTTP (en milisegundos). Predeterminado: ``20000``
    * - ``refresh_token_interval``
      - No
      - Intervalo (en segundos) para renovar el token de acceso OAuth. Predeterminado: ``3540`` (59 minutos).
    * - ``max_cached_content_size``
      - No
-     - Tamano maximo (en bytes) del contenido mantenido en memoria; el contenido mayor se vuelca a un archivo temporal. Predeterminado: ``1048576`` (1MB).
+     - Tamaño máximo (en bytes) del contenido mantenido en memoria; el contenido mayor se vuelca a un archivo temporal. Predeterminado: ``1048576`` (1MB).
    * - ``proxy_host``
      - No
      - Nombre de host del servidor proxy
    * - ``proxy_port``
      - No
-     - Numero de puerto del servidor proxy
+     - Número de puerto del servidor proxy
 
-Configuracion de Script
+Configuración de Script
 -----------------------
 
 ::
@@ -174,11 +174,11 @@ Campos Disponibles
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``file.name``
      - Nombre del archivo
    * - ``file.description``
-     - Descripcion del archivo
+     - Descripción del archivo
    * - ``file.contents``
      - Contenido de texto del archivo
    * - ``file.mimetype``
@@ -186,23 +186,23 @@ Campos Disponibles
    * - ``file.filetype``
      - Tipo de archivo
    * - ``file.created_time``
-     - Fecha de creacion
+     - Fecha de creación
    * - ``file.modified_time``
-     - Ultima fecha de modificacion
+     - Última fecha de modificación
    * - ``file.web_view_link``
      - Enlace para abrir en el navegador
    * - ``file.url``
      - URL del archivo
    * - ``file.thumbnail_link``
-     - Enlace de miniatura (valido por tiempo limitado)
+     - Enlace de miniatura (válido por tiempo limitado)
    * - ``file.size``
-     - Tamano del archivo (bytes)
+     - Tamaño del archivo (bytes)
    * - ``file.roles``
      - Permisos de acceso
 
-Para mas detalles, consulte `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_.
+Para más detalles, consulte `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_.
 
-Configuracion de Google Cloud Platform
+Configuración de Google Cloud Platform
 ======================================
 
 1. Crear Proyecto
@@ -212,7 +212,7 @@ Acceda a https://console.cloud.google.com/:
 
 1. Cree un nuevo proyecto
 2. Ingrese el nombre del proyecto
-3. Seleccione la organizacion y la ubicacion
+3. Seleccione la organización y la ubicación
 
 2. Habilitar Google Drive API
 -----------------------------
@@ -239,30 +239,30 @@ En "APIs y servicios" -> "Credenciales":
 En la cuenta de servicio creada:
 
 1. Haga clic en la cuenta de servicio
-2. Abra la pestana "Claves"
+2. Abra la pestaña "Claves"
 3. "Agregar clave" -> "Crear nueva clave"
 4. Seleccione el formato JSON
 5. Guarde el archivo JSON descargado
 
-5. Habilitar Delegacion de Dominio
+5. Habilitar Delegación de Dominio
 ----------------------------------
 
-En la configuracion de la cuenta de servicio:
+En la configuración de la cuenta de servicio:
 
-1. Marque "Habilitar delegacion de dominio"
+1. Marque "Habilitar delegación de dominio"
 2. Haga clic en "Guardar"
 3. Copie el "ID de cliente OAuth 2"
 
-6. Autorizar en la Consola de Administracion de Google Workspace
+6. Autorizar en la Consola de Administración de Google Workspace
 ----------------------------------------------------------------
 
 Acceda a https://admin.google.com/:
 
 1. Abra "Seguridad" -> "Acceso y control de datos" -> "Controles de API"
-2. Seleccione "Delegacion de dominio"
+2. Seleccione "Delegación de dominio"
 3. Haga clic en "Agregar nuevo"
 4. Ingrese el ID de cliente
-5. Ingrese los ambitos OAuth:
+5. Ingrese los ámbitos OAuth:
 
    ::
 
@@ -270,10 +270,10 @@ Acceda a https://admin.google.com/:
 
 6. Haga clic en "Autorizar"
 
-Configuracion de Credenciales
+Configuración de Credenciales
 =============================
 
-Obtener Informacion del Archivo JSON
+Obtener Información del Archivo JSON
 ------------------------------------
 
 Archivo JSON descargado:
@@ -293,75 +293,75 @@ Archivo JSON descargado:
       "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/..."
     }
 
-Configure la siguiente informacion en los parametros:
+Configure la siguiente información en los parámetros:
 
 - ``private_key_id`` -> ``private_key_id``
-- ``private_key`` -> ``private_key`` (los saltos de linea permanecen como ``\n``)
+- ``private_key`` -> ``private_key`` (los saltos de línea permanecen como ``\n``)
 - ``client_email`` -> ``client_email``
 
 Formato de Clave Privada
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-``private_key`` mantiene los saltos de linea como ``\n``:
+``private_key`` mantiene los saltos de línea como ``\n``:
 
 ::
 
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG...\n-----END PRIVATE KEY-----\n
 
-Solucion de Problemas
+Solución de Problemas
 =====================
 
-Error de Autenticacion
+Error de Autenticación
 ----------------------
 
-**Sintoma**: ``401 Unauthorized`` o ``403 Forbidden``
+**Síntoma**: ``401 Unauthorized`` o ``403 Forbidden``
 
 **Verificar**:
 
 1. Verificar que las credenciales de la cuenta de servicio sean correctas:
 
-   - Los saltos de linea de ``private_key`` estan como ``\n``
+   - Los saltos de línea de ``private_key`` están como ``\n``
    - ``private_key_id`` es correcto
    - ``client_email`` es correcto
 
-2. Verificar que Google Drive API este habilitada
-3. Verificar que la delegacion de dominio este configurada
-4. Verificar que este autorizado en la consola de administracion de Google Workspace
-5. Verificar que el ambito OAuth sea correcto (``https://www.googleapis.com/auth/drive``)
+2. Verificar que Google Drive API esté habilitada
+3. Verificar que la delegación de dominio esté configurada
+4. Verificar que esté autorizado en la consola de administración de Google Workspace
+5. Verificar que el ámbito OAuth sea correcto (``https://www.googleapis.com/auth/drive``)
 
-Error de Delegacion de Dominio
+Error de Delegación de Dominio
 ------------------------------
 
-**Sintoma**: ``Not Authorized to access this resource/api``
+**Síntoma**: ``Not Authorized to access this resource/api``
 
-**Solucion**:
+**Solución**:
 
-1. Verificar la autorizacion en la consola de administracion de Google Workspace:
+1. Verificar la autorización en la consola de administración de Google Workspace:
 
-   - El ID de cliente esta registrado correctamente
-   - El ambito OAuth es correcto (``https://www.googleapis.com/auth/drive``)
+   - El ID de cliente está registrado correctamente
+   - El ámbito OAuth es correcto (``https://www.googleapis.com/auth/drive``)
 
-2. Verificar que la delegacion de dominio este habilitada en la cuenta de servicio
+2. Verificar que la delegación de dominio esté habilitada en la cuenta de servicio
 
 No se Pueden Obtener Archivos
 -----------------------------
 
-**Sintoma**: El rastreo tiene exito pero hay 0 archivos
+**Síntoma**: El rastreo tiene éxito pero hay 0 archivos
 
 **Verificar**:
 
 1. Verificar que existan archivos en Google Drive
 2. Verificar que la cuenta de servicio tenga permisos de lectura
-3. Verificar que la delegacion de dominio este configurada correctamente
+3. Verificar que la delegación de dominio esté configurada correctamente
 4. Verificar que se pueda acceder al Drive del usuario objetivo
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`ds-overview` - Vision general de conectores de almacen de datos
+- :doc:`ds-overview` - Visión general de conectores de almacén de datos
 - :doc:`ds-microsoft365` - Conector de Microsoft 365
 - :doc:`ds-box` - Conector de Box
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de almacen de datos
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de almacén de datos
 - `Google Drive API <https://developers.google.com/drive/api>`_
 - `Google Cloud Platform <https://console.cloud.google.com/>`_
 - `Google Workspace Admin <https://admin.google.com/>`_

--- a/es/15.7/config/datastore/ds-json.rst
+++ b/es/15.7/config/datastore/ds-json.rst
@@ -2,11 +2,11 @@
 Conector JSON
 ==============================
 
-Descripcion general
+Descripción general
 ===================
 
 El conector JSON proporciona la funcionalidad para obtener datos de archivos JSONL
-locales (formato JSON Lines) y registrarlos en el indice de |Fess|.
+locales (formato JSON Lines) y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-json``.
 
@@ -17,10 +17,10 @@ Requisitos previos
 2. Se requiere permiso de acceso a los archivos JSON
 3. Es necesario comprender la estructura del JSON
 
-Instalacion del plugin
+Instalación del plugin
 ----------------------
 
-Metodo 1: Colocar el archivo JAR directamente
+Método 1: Colocar el archivo JAR directamente
 
 ::
 
@@ -32,18 +32,18 @@ Metodo 1: Colocar el archivo JAR directamente
     # o
     cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Metodo 2: Instalar desde la pantalla de administracion
+Método 2: Instalar desde la pantalla de administración
 
 1. Abrir "Sistema" -> "Plugins"
 2. Subir el archivo JAR
 3. Reiniciar |Fess|
 
-Metodo de configuracion
+Método de configuración
 =======================
 
-Configure desde la pantalla de administracion en "Crawler" -> "Data Store" -> "Crear nuevo".
+Configure desde la pantalla de administración en "Crawler" -> "Data Store" -> "Crear nuevo".
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -51,7 +51,7 @@ Configuracion basica
    :widths: 25 75
 
    * - Campo
-     - Ejemplo de configuracion
+     - Ejemplo de configuración
    * - Nombre
      - Products JSON
    * - Nombre del handler
@@ -59,7 +59,7 @@ Configuracion basica
    * - Habilitado
      - Activado
 
-Configuracion de parametros
+Configuración de parámetros
 ----------------------------
 
 Archivo local:
@@ -69,66 +69,66 @@ Archivo local:
     files=/path/to/data.json
     fileEncoding=UTF-8
 
-Multiples archivos:
+Múltiples archivos:
 
 ::
 
     files=/path/to/data1.json,/path/to/data2.json
     fileEncoding=UTF-8
 
-Especificacion de directorio:
+Especificación de directorio:
 
 ::
 
     directories=/path/to/json_dir/
     fileEncoding=UTF-8
 
-Lista de parametros
+Lista de parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 10 70
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``files``
      - No
-     - Ruta de los archivos JSON a procesar (se pueden especificar varios separados por comas). Solo se procesan archivos con extension ``.json`` o ``.jsonl``.
+     - Ruta de los archivos JSON a procesar (se pueden especificar varios separados por comas). Solo se procesan archivos con extensión ``.json`` o ``.jsonl``.
    * - ``directories``
      - No
      - Ruta de los directorios que contienen archivos JSON (se pueden especificar varios separados por comas)
    * - ``fileEncoding``
      - No
-     - Codificacion de caracteres (predeterminado: UTF-8)
+     - Codificación de caracteres (predeterminado: UTF-8)
 
 .. warning::
    Es necesario especificar ``files`` o ``directories``.
-   Si no se especifica ninguno (ambos vacios), se producira una ``DataStoreException``.
+   Si no se especifica ninguno (ambos vacíos), se producirá una ``DataStoreException``.
    Si se especifican ambos, ``files`` tiene prioridad y ``directories`` se ignora.
 
 .. note::
-   El nombre del parametro usa camelCase: ``fileEncoding`` (no snake_case ``file_encoding``).
+   El nombre del parámetro usa camelCase: ``fileEncoding`` (no snake_case ``file_encoding``).
 
 Comportamiento al especificar directorios
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Cuando se especifica ``directories``, los archivos ubicados directamente en cada directorio se procesan segun las siguientes reglas.
+Cuando se especifica ``directories``, los archivos ubicados directamente en cada directorio se procesan según las siguientes reglas.
 
-- **Los subdirectorios no se recorren** (no se realiza busqueda recursiva).
-- Solo se procesan archivos con extension ``.json`` o ``.jsonl`` (sin distinguir mayusculas de minusculas).
-- Los archivos se procesan en orden ascendente por fecha de modificacion (hora de ultima modificacion).
+- **Los subdirectorios no se recorren** (no se realiza búsqueda recursiva).
+- Solo se procesan archivos con extensión ``.json`` o ``.jsonl`` (sin distinguir mayúsculas de minúsculas).
+- Los archivos se procesan en orden ascendente por fecha de modificación (hora de última modificación).
 
 .. note::
-   Este conector solo admite archivos JSON en el sistema de archivos local. No es compatible con acceso HTTP ni funciones de autenticacion de API.
+   Este conector solo admite archivos JSON en el sistema de archivos local. No es compatible con acceso HTTP ni funciones de autenticación de API.
 
-Configuracion de scripts
+Configuración de scripts
 -------------------------
 
 Los valores de cada campo se construyen referenciando los valores de los campos del objeto JSON.
 Los campos del nivel superior del objeto JSON se pueden referenciar directamente dentro del script
-como **variables sin prefijo** (no se usa ningun prefijo como ``data.``).
+como **variables sin prefijo** (no se usa ningún prefijo como ``data.``).
 
 Objeto JSON simple:
 
@@ -166,11 +166,11 @@ Campos disponibles
 - ``<nombre_campo>`` - Referencia directa a un campo del nivel superior del objeto JSON por nombre
 - ``<padre>.<hijo>`` - Campo de un objeto anidado
 - ``<array>[<indice>]`` - Elemento de array
-- ``<array>.<metodo>`` - Metodos de array (``join``, ``collect``, ``size``, etc.)
+- ``<array>.<metodo>`` - Métodos de array (``join``, ``collect``, ``size``, etc.)
 
 .. note::
 
-   Si el nombre de un campo contiene caracteres invalidos como identificador de Groovy (espacios,
+   Si el nombre de un campo contiene caracteres inválidos como identificador de Groovy (espacios,
    guiones, etc.), ese campo no puede referenciarse directamente como nombre de variable.
 
 Detalles del formato JSON
@@ -180,14 +180,14 @@ Formato de archivo JSON
 ------------------------
 
 El conector JSON lee archivos en formato JSONL (JSON Lines).
-Es un formato en el que se escribe un objeto JSON por linea. El archivo se lee linea a linea
-y cada linea se analiza como un objeto JSON independiente.
+Es un formato en el que se escribe un objeto JSON por línea. El archivo se lee línea a línea
+y cada línea se analiza como un objeto JSON independiente.
 
 .. note::
-   Los archivos con extension ``.json`` tambien son procesados, pero su contenido debe estar
-   en formato JSONL (un objeto por linea).
-   Los archivos JSON en formato de array ( ``[{...}, {...}]`` ) o con formato de varias lineas
-   (pretty-printed) no se pueden leer directamente. Conviertelos al formato JSONL.
+   Los archivos con extensión ``.json`` también son procesados, pero su contenido debe estar
+   en formato JSONL (un objeto por línea).
+   Los archivos JSON en formato de array ( ``[{...}, {...}]`` ) o con formato de varias líneas
+   (pretty-printed) no se pueden leer directamente. Conviértelos al formato JSONL.
 
 Archivo en formato JSONL:
 
@@ -199,10 +199,10 @@ Archivo en formato JSONL:
 Ejemplos de uso
 ===============
 
-Catalogo de productos
+Catálogo de productos
 ----------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -219,10 +219,10 @@ Scripts:
     digest=category
     price=price
 
-Integracion de multiples archivos JSON
+Integración de múltiples archivos JSON
 ---------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -237,67 +237,67 @@ Scripts:
     title=title
     content=content
 
-Solucion de problemas
+Solución de problemas
 ======================
 
 Archivo no encontrado
 ----------------------
 
-**Sintoma**: El registro muestra ``... is not found.`` o ``Source file ... does not exist.``
+**Síntoma**: El registro muestra ``... is not found.`` o ``Source file ... does not exist.``
 
 **Puntos a verificar**:
 
 1. Verificar que la ruta del archivo sea correcta
 2. Verificar que el archivo exista
-3. Verificar que la extension del archivo sea ``.json`` o ``.jsonl``
+3. Verificar que la extensión del archivo sea ``.json`` o ``.jsonl``
 4. Verificar que el archivo tenga permisos de lectura
 
-Error de analisis JSON
+Error de análisis JSON
 -----------------------
 
-**Sintoma**: El registro muestra ``Crawling Access Exception`` y ``JsonParseException``, entre otros
+**Síntoma**: El registro muestra ``Crawling Access Exception`` y ``JsonParseException``, entre otros
 
-Si una linea contiene datos invalidos, solo esa linea se omite y se registra como URL fallida,
-y el crawling continua desde la siguiente linea.
+Si una línea contiene datos inválidos, solo esa línea se omite y se registra como URL fallida,
+y el crawling continúa desde la siguiente línea.
 
 **Puntos a verificar**:
 
-1. Verificar que el archivo JSON tenga el formato correcto (JSONL: un objeto por linea):
+1. Verificar que el archivo JSON tenga el formato correcto (JSONL: un objeto por línea):
 
    ::
 
        # Validar que cada linea sea un objeto JSON valido
        cat data.json | jq -c .
 
-2. Verificar la codificacion de caracteres
-3. Verificar que un mismo objeto no este dividido en varias lineas
-4. Verificar que no contenga comentarios (no permitidos en el estandar JSON)
+2. Verificar la codificación de caracteres
+3. Verificar que un mismo objeto no esté dividido en varias líneas
+4. Verificar que no contenga comentarios (no permitidos en el estándar JSON)
 
 No se obtienen datos
 ---------------------
 
-**Sintoma**: El crawling se completa con exito pero el recuento es 0
+**Síntoma**: El crawling se completa con éxito pero el recuento es 0
 
 **Puntos a verificar**:
 
 1. Verificar la estructura JSON
-2. Verificar que la configuracion de scripts sea correcta (que las referencias a campos no tengan el prefijo ``data.``)
-3. Verificar los nombres de campo (incluyendo mayusculas y minusculas)
+2. Verificar que la configuración de scripts sea correcta (que las referencias a campos no tengan el prefijo ``data.``)
+3. Verificar los nombres de campo (incluyendo mayúsculas y minúsculas)
 4. Verificar los mensajes de error en los registros
 
 Archivos JSON grandes
 ----------------------
 
-**Sintoma**: Falta de memoria o tiempo de espera agotado
+**Síntoma**: Falta de memoria o tiempo de espera agotado
 
-El archivo se lee linea a linea, por lo que el tamano total del archivo no afecta directamente
-al uso de memoria. Sin embargo, pueden surgir problemas si una sola linea (un objeto) es
-extremadamente grande o si la carga de indexacion es elevada.
+El archivo se lee línea a línea, por lo que el tamaño total del archivo no afecta directamente
+al uso de memoria. Sin embargo, pueden surgir problemas si una sola línea (un objeto) es
+extremadamente grande o si la carga de indexación es elevada.
 
-**Solucion**:
+**Solución**:
 
 1. Dividir el archivo JSON en varios archivos
-2. Aumentar el tamano del heap de |Fess|
+2. Aumentar el tamaño del heap de |Fess|
 
 Uso avanzado de scripts
 ========================
@@ -305,7 +305,7 @@ Uso avanzado de scripts
 Procesamiento condicional
 --------------------------
 
-Cada campo se evalua como una expresion independiente. Para valores condicionales, utilice el operador ternario:
+Cada campo se evalúa como una expresión independiente. Para valores condicionales, utilice el operador ternario:
 
 ::
 
@@ -314,7 +314,7 @@ Cada campo se evalua como una expresion independiente. Para valores condicionale
     content=status == "published" ? description : null
     price=status == "published" ? price : null
 
-Union de arrays
+Unión de arrays
 ----------------
 
 ::
@@ -325,7 +325,7 @@ Union de arrays
     tags=tags ? tags.join(", ") : ""
     categories=categories.collect { it.name }.join(", ")
 
-Configuracion de valores predeterminados
+Configuración de valores predeterminados
 -----------------------------------------
 
 ::
@@ -346,7 +346,7 @@ Formato de fechas
     created=created_at
     last_modified=updated_at
 
-Procesamiento de numeros
+Procesamiento de números
 -------------------------
 
 ::
@@ -357,13 +357,13 @@ Procesamiento de numeros
     price=price as Float
     stock=stock_quantity as Integer
 
-Informacion de referencia
+Información de referencia
 ==========================
 
-- :doc:`ds-overview` - Descripcion general de conectores de Data Store
+- :doc:`ds-overview` - Descripción general de conectores de Data Store
 - :doc:`ds-csv` - Conector CSV
 - :doc:`ds-database` - Conector de base de datos
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de Data Store
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de Data Store
 - `JSON (JavaScript Object Notation) <https://www.json.org/>`_
 - `JSON Lines <https://jsonlines.org/>`_
 - `jq - JSON processor <https://stedolan.github.io/jq/>`_

--- a/es/15.7/config/datastore/ds-overview.rst
+++ b/es/15.7/config/datastore/ds-overview.rst
@@ -1,17 +1,17 @@
 ==================================
-Descripcion General de los Conectores de Almacen de Datos
+Descripción General de los Conectores de Almacén de Datos
 ==================================
 
-Descripcion General
+Descripción General
 ===================
 
-Los conectores de almacen de datos de |Fess| proporcionan funcionalidad para obtener contenido
+Los conectores de almacén de datos de |Fess| proporcionan funcionalidad para obtener contenido
 de fuentes de datos distintas a sitios web o sistemas de archivos y indexarlo.
 
-Al utilizar conectores de almacen de datos, puede hacer que los datos de las siguientes fuentes sean buscables:
+Al utilizar conectores de almacén de datos, puede hacer que los datos de las siguientes fuentes sean buscables:
 
 - Almacenamiento en la nube (Box, Dropbox, Google Drive, OneDrive)
-- Herramientas de colaboracion (Confluence, Jira, Slack)
+- Herramientas de colaboración (Confluence, Jira, Slack)
 - Bases de datos (MySQL, PostgreSQL, Oracle, etc.)
 - Otros sistemas (Git, Salesforce, Elasticsearch, etc.)
 
@@ -19,7 +19,7 @@ Conectores Disponibles
 ======================
 
 |Fess| proporciona conectores para diversas fuentes de datos.
-Muchos conectores se proporcionan como plugins y pueden instalarse segun sea necesario.
+Muchos conectores se proporcionan como plugins y pueden instalarse según sea necesario.
 
 Almacenamiento en la Nube
 -------------------------
@@ -30,7 +30,7 @@ Almacenamiento en la Nube
 
    * - Conector
      - Plugin
-     - Descripcion
+     - Descripción
    * - :doc:`ds-box`
      - fess-ds-box
      - Rastrea archivos y carpetas de Box.com
@@ -44,7 +44,7 @@ Almacenamiento en la Nube
      - fess-ds-microsoft365
      - Rastrea OneDrive, SharePoint, etc.
 
-Herramientas de Colaboracion
+Herramientas de Colaboración
 ----------------------------
 
 .. list-table::
@@ -53,7 +53,7 @@ Herramientas de Colaboracion
 
    * - Conector
      - Plugin
-     - Descripcion
+     - Descripción
    * - :doc:`ds-atlassian`
      - fess-ds-atlassian
      - Rastrea Confluence y Jira
@@ -70,10 +70,10 @@ Herramientas de Desarrollo y Operaciones
 
    * - Conector
      - Plugin
-     - Descripcion
+     - Descripción
    * - :doc:`ds-git`
      - fess-ds-git
-     - Rastrea codigo fuente de repositorios Git
+     - Rastrea código fuente de repositorios Git
    * - :doc:`ds-elasticsearch`
      - fess-ds-elasticsearch
      - Obtiene datos de Elasticsearch/OpenSearch
@@ -90,7 +90,7 @@ Bases de Datos y Archivos
 
    * - Conector
      - Plugin
-     - Descripcion
+     - Descripción
    * - :doc:`ds-database`
      - fess-ds-db
      - Obtiene datos de bases de datos compatibles con JDBC
@@ -101,65 +101,65 @@ Bases de Datos y Archivos
      - fess-ds-json
      - Obtiene datos de archivos JSON
 
-Instalacion de Conectores
+Instalación de Conectores
 =========================
 
-Instalacion de Plugins
+Instalación de Plugins
 ----------------------
 
-Los plugins de conectores de almacen de datos pueden instalarse desde la consola de administracion.
+Los plugins de conectores de almacén de datos pueden instalarse desde la consola de administración.
 
-Desde la Consola de Administracion
+Desde la Consola de Administración
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Inicie sesion en la consola de administracion
+1. Inicie sesión en la consola de administración
 2. Vaya a "Sistema" -> "Plugin"
-3. Haga clic en el boton "Instalar"
-4. Seleccione el plugin en la pestana "Remoto" (o suba un archivo JAR desde la pestana "Local")
+3. Haga clic en el botón "Instalar"
+4. Seleccione el plugin en la pestaña "Remoto" (o suba un archivo JAR desde la pestaña "Local")
 5. Haga clic en "Instalar"
 6. Reinicie |Fess|
 
-Conceptos Basicos de Configuracion del Almacen de Datos
+Conceptos Básicos de Configuración del Almacén de Datos
 =======================================================
 
-La configuracion de los conectores de almacen de datos se realiza en la consola de administracion bajo "Rastreador" -> "Almacen de Datos".
+La configuración de los conectores de almacén de datos se realiza en la consola de administración bajo "Rastreador" -> "Almacén de Datos".
 
-Elementos de Configuracion Comunes
+Elementos de Configuración Comunes
 ----------------------------------
 
-Elementos de configuracion comunes a todos los conectores de almacen de datos:
+Elementos de configuración comunes a todos los conectores de almacén de datos:
 
 .. list-table::
    :header-rows: 1
    :widths: 25 75
 
    * - Elemento
-     - Descripcion
+     - Descripción
    * - Nombre
-     - Nombre identificador de la configuracion
-   * - Descripcion
-     - Texto descriptivo de la configuracion
+     - Nombre identificador de la configuración
+   * - Descripción
+     - Texto descriptivo de la configuración
    * - Nombre del Manejador
      - Nombre del manejador del conector a utilizar (ej., ``CsvDataStore``)
-   * - Parametros
-     - Parametros de configuracion especificos del conector (formato key=value)
+   * - Parámetros
+     - Parámetros de configuración específicos del conector (formato key=value)
    * - Script
-     - Script de mapeo de campos del indice
+     - Script de mapeo de campos del índice
    * - Boost
-     - Prioridad en los resultados de busqueda
+     - Prioridad en los resultados de búsqueda
    * - Permisos
-     - Permisos de acceso para los documentos obtenidos de este almacen de datos
+     - Permisos de acceso para los documentos obtenidos de este almacén de datos
    * - Hosts virtuales
-     - Host virtual al que se aplica esta configuracion
-   * - Orden de visualizacion
-     - Orden de visualizacion en la lista de configuraciones
+     - Host virtual al que se aplica esta configuración
+   * - Orden de visualización
+     - Orden de visualización en la lista de configuraciones
    * - Habilitado
-     - Si esta configuracion esta activa o no
+     - Si esta configuración está activa o no
 
-Configuracion de Parametros
+Configuración de Parámetros
 ---------------------------
 
-Los parametros se especifican en formato ``key=value`` separados por saltos de linea:
+Los parámetros se especifican en formato ``key=value`` separados por saltos de línea:
 
 ::
 
@@ -167,11 +167,11 @@ Los parametros se especifican en formato ``key=value`` separados por saltos de l
     folder.id=0
     max.depth=3
 
-Configuracion de Script
+Configuración de Script
 -----------------------
 
-Los scripts mapean los datos obtenidos a los campos del indice de |Fess|.
-El lado izquierdo de cada linea es el campo del indice de |Fess|; el lado derecho es el campo obtenido del conector.
+Los scripts mapean los datos obtenidos a los campos del índice de |Fess|.
+El lado izquierdo de cada línea es el campo del índice de |Fess|; el lado derecho es el campo obtenido del conector.
 
 El siguiente es un ejemplo para el conector CSV con columnas de encabezado ``link``, ``subject`` y ``body``:
 
@@ -183,73 +183,73 @@ El siguiente es un ejemplo para el conector CSV con columnas de encabezado ``lin
 
 .. note::
 
-   Los nombres de campo utilizables en los scripts difieren segun el conector.
+   Los nombres de campo utilizables en los scripts difieren según el conector.
    Box/Dropbox/Google Drive/OneDrive referencian el objeto obtenido con el prefijo ``file.*``; Slack utiliza ``message.*``; Jira utiliza ``issue.*``.
    Los conectores CSV, JSON y de base de datos NO utilizan prefijo; los campos se referencian directamente:
 
-   - CSV: nombres de columna del encabezado (si ``has_header_line=true``), o ``cell1``, ``cell2``, ... (indice basado en 1); ademas de ``csvfile`` y ``csvfilename``.
+   - CSV: nombres de columna del encabezado (si ``has_header_line=true``), o ``cell1``, ``cell2``, ... (índice basado en 1); además de ``csvfile`` y ``csvfilename``.
    - JSON: nombres de campo del objeto JSON.
    - Base de datos: nombres de columna (alias) del resultado del SELECT.
 
-   Consulte la documentacion individual de cada conector para mas detalles.
+   Consulte la documentación individual de cada conector para más detalles.
 
-Configuracion de Autenticacion
+Configuración de Autenticación
 ==============================
 
-Muchos conectores de almacen de datos requieren autenticacion mediante OAuth 2.0, claves API, cuentas de servicio, etc.
+Muchos conectores de almacén de datos requieren autenticación mediante OAuth 2.0, claves API, cuentas de servicio, etc.
 
-Los parametros de autenticacion varian segun el conector.
-Consulte la documentacion individual de cada conector para los detalles de configuracion de autenticacion.
+Los parámetros de autenticación varían según el conector.
+Consulte la documentación individual de cada conector para los detalles de configuración de autenticación.
 
-Parametros Comunes
+Parámetros Comunes
 ==================
 
-Parametros comunes disponibles para todos los conectores de almacen de datos:
+Parámetros comunes disponibles para todos los conectores de almacén de datos:
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 65
 
-   * - Parametro
+   * - Parámetro
      - Valor por defecto
-     - Descripcion
+     - Descripción
    * - ``readInterval``
      - ``0``
      - Tiempo de espera entre el procesamiento de cada registro (milisegundos). Se utiliza para reducir la carga del servidor al procesar grandes cantidades de datos.
    * - ``script_type``
      - ``groovy``
-     - Tipo de motor de scripts usado para el mapeo de campos del indice. De forma predeterminada solo esta disponible ``groovy``.
+     - Tipo de motor de scripts usado para el mapeo de campos del índice. De forma predeterminada solo está disponible ``groovy``.
 
-Solucion de Problemas
+Solución de Problemas
 =====================
 
 El Conector No Aparece
 ----------------------
 
-1. Verifique que el plugin este instalado correctamente
+1. Verifique que el plugin esté instalado correctamente
 2. Reinicie |Fess|
 3. Revise los logs en busca de errores
 
-Errores de Autenticacion
+Errores de Autenticación
 ------------------------
 
-1. Verifique que las credenciales de autenticacion sean correctas
-2. Verifique la fecha de expiracion del token
+1. Verifique que las credenciales de autenticación sean correctas
+2. Verifique la fecha de expiración del token
 3. Confirme que se hayan otorgado los permisos necesarios
-4. Verifique que el acceso a la API este permitido en el servicio
+4. Verifique que el acceso a la API esté permitido en el servicio
 
 No Se Pueden Obtener Datos
 --------------------------
 
-1. Verifique que el formato de los parametros sea correcto
+1. Verifique que el formato de los parámetros sea correcto
 2. Verifique los permisos de acceso a las carpetas/archivos de destino
-3. Revise la configuracion de filtros
+3. Revise la configuración de filtros
 4. Revise los logs para mensajes de error detallados
 
-Configuracion de Depuracion
+Configuración de Depuración
 ---------------------------
 
-Al investigar problemas, ajuste el nivel de log. El rastreo de almacenes de datos se ejecuta en el proceso del rastreador, por lo que debe editar el archivo de configuracion de log del rastreador:
+Al investigar problemas, ajuste el nivel de log. El rastreo de almacenes de datos se ejecuta en el proceso del rastreador, por lo que debe editar el archivo de configuración de log del rastreador:
 
 ``app/WEB-INF/env/crawler/resources/log4j2.xml``:
 
@@ -257,9 +257,9 @@ Al investigar problemas, ajuste el nivel de log. El rastreo de almacenes de dato
 
     <Logger name="org.codelibs.fess.ds" level="DEBUG"/>
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`../../admin/dataconfig-guide` - Guia de Configuracion de Almacen de Datos
-- :doc:`../../admin/plugin-guide` - Guia de Administracion de Plugins
-- :doc:`../../api/admin/api-admin-dataconfig` - API de Configuracion de Almacen de Datos
+- :doc:`../../admin/dataconfig-guide` - Guía de Configuración de Almacén de Datos
+- :doc:`../../admin/plugin-guide` - Guía de Administración de Plugins
+- :doc:`../../api/admin/api-admin-dataconfig` - API de Configuración de Almacén de Datos

--- a/es/15.7/config/datastore/ds-salesforce.rst
+++ b/es/15.7/config/datastore/ds-salesforce.rst
@@ -2,28 +2,28 @@
 Conector Salesforce
 ==================================
 
-Descripcion general
+Descripción general
 ===================
 
 El conector Salesforce proporciona la funcionalidad para obtener datos de objetos de Salesforce
-(objetos estandar, objetos personalizados) y registrarlos en el indice de |Fess|.
+(objetos estándar, objetos personalizados) y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-salesforce``.
 
 Objetos compatibles
 ===================
 
-- **Objetos estandar**: objetos estandar predefinidos (Account, Contact, Lead, Opportunity, Case, Solution, etc.). El conjunto de objetos estandar es fijo y todos ellos se recuperan en cada crawl.
-- **Objetos personalizados**: objetos definidos por el usuario y especificados mediante el parametro ``custom`` (objetos cuyos nombres de API terminan en ``__c``).
+- **Objetos estándar**: objetos estándar predefinidos (Account, Contact, Lead, Opportunity, Case, Solution, etc.). El conjunto de objetos estándar es fijo y todos ellos se recuperan en cada crawl.
+- **Objetos personalizados**: objetos definidos por el usuario y especificados mediante el parámetro ``custom`` (objetos cuyos nombres de API terminan en ``__c``).
 
 .. note::
 
-   Los objetos estandar se crawlean siempre en su totalidad (no es posible seleccionar individualmente cuales se crawlean). Para excluir objetos no deseados, utilice el filtrado por URL mediante ``include_pattern`` / ``exclude_pattern``.
+   Los objetos estándar se crawlean siempre en su totalidad (no es posible seleccionar individualmente cuales se crawlean). Para excluir objetos no deseados, utilice el filtrado por URL mediante ``include_pattern`` / ``exclude_pattern``.
 
-Lista de objetos estandar
+Lista de objetos estándar
 -------------------------
 
-Los siguientes objetos estandar son crawleados. El "Nombre de objeto" es el identificador que se usa en el mapeo de campos (p. ej. ``<NombreObjeto>.title``); ``object.type`` es el valor del tipo de objeto al que puede hacer referencia en los scripts.
+Los siguientes objetos estándar son crawleados. El "Nombre de objeto" es el identificador que se usa en el mapeo de campos (p. ej. ``<NombreObjeto>.title``); ``object.type`` es el valor del tipo de objeto al que puede hacer referencia en los scripts.
 
 .. list-table::
    :header-rows: 1
@@ -31,7 +31,7 @@ Los siguientes objetos estandar son crawleados. El "Nombre de objeto" es el iden
 
    * - Nombre de objeto
      - ``object.type``
-     - Descripcion
+     - Descripción
    * - ``ACCOUNT``
      - ``Account``
      - Account
@@ -106,23 +106,23 @@ Requisitos previos
 ==================
 
 1. Es necesario instalar el plugin
-2. Es necesario crear una aplicacion conectada (Connected App) en Salesforce
-3. Es necesario configurar la autenticacion OAuth
+2. Es necesario crear una aplicación conectada (Connected App) en Salesforce
+3. Es necesario configurar la autenticación OAuth
 4. Se requiere acceso de lectura a los objetos
 
-Instalacion del plugin
+Instalación del plugin
 ----------------------
 
-Instale desde la pantalla de administracion en "Sistema" -> "Plugins".
+Instale desde la pantalla de administración en "Sistema" -> "Plugins".
 
-O consulte :doc:`../../admin/plugin-guide` para mas detalles.
+O consulte :doc:`../../admin/plugin-guide` para más detalles.
 
-Configuracion
+Configuración
 =============
 
-Configure desde la pantalla de administracion en "Crawler" -> "Data Store" -> "Crear nuevo".
+Configure desde la pantalla de administración en "Crawler" -> "Data Store" -> "Crear nuevo".
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -138,10 +138,10 @@ Configuracion basica
    * - Habilitado
      - Activado
 
-Configuracion de parametros
+Configuración de parámetros
 ---------------------------
 
-Autenticacion OAuth Token (recomendada):
+Autenticación OAuth Token (recomendada):
 
 ::
 
@@ -158,7 +158,7 @@ Autenticacion OAuth Token (recomendada):
     CustomProduct.title=Product_Name__c
     CustomProduct.contents=Product_Name__c,Product_Description__c
 
-Autenticacion OAuth Password:
+Autenticación OAuth Password:
 
 ::
 
@@ -172,43 +172,43 @@ Autenticacion OAuth Password:
     number_of_threads=1
     ignore_error=true
 
-Lista de parametros
+Lista de parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``base_url``
      - No
      - URL de Salesforce (predeterminado: ``https://login.salesforce.com``; Sandbox: ``https://test.salesforce.com``)
    * - ``auth_type``
-     - Si
-     - Tipo de autenticacion (``oauth_token`` o ``oauth_password``)
+     - Sí
+     - Tipo de autenticación (``oauth_token`` o ``oauth_password``)
    * - ``username``
-     - Si
+     - Sí
      - Nombre de usuario de Salesforce
    * - ``client_id``
-     - Si
-     - Consumer Key de la aplicacion conectada
+     - Sí
+     - Consumer Key de la aplicación conectada
    * - ``password``
      - Para oauth_password
-     - Contrasena de Salesforce
+     - Contraseña de Salesforce
    * - ``private_key``
      - Para oauth_token
-     - Clave privada (formato PEM, saltos de linea como ``\n``)
+     - Clave privada (formato PEM, saltos de línea como ``\n``)
    * - ``client_secret``
      - Para oauth_password
-     - Consumer Secret de la aplicacion conectada
+     - Consumer Secret de la aplicación conectada
    * - ``security_token``
      - Para oauth_password
      - Token de seguridad del usuario
    * - ``number_of_threads``
      - No
-     - Numero de hilos de procesamiento paralelo (predeterminado: 1)
+     - Número de hilos de procesamiento paralelo (predeterminado: 1)
    * - ``ignore_error``
      - No
      - Continuar procesando en caso de error (predeterminado: true)
@@ -217,33 +217,33 @@ Lista de parametros
      - Nombres de objetos personalizados (separados por comas)
    * - ``<objeto>.title``
      - No
-     - Nombre del campo a usar para el titulo
+     - Nombre del campo a usar para el título
    * - ``<objeto>.contents``
      - No
      - Nombres de campos a usar para el contenido (separados por comas)
    * - ``<objeto>.descriptions``
      - No
-     - Nombres de campos para descripcion (separados por comas)
+     - Nombres de campos para descripción (separados por comas)
    * - ``<objeto>.thumbnail``
      - No
      - Nombre del campo para miniatura
    * - ``include_pattern``
      - No
-     - Patron de inclusion del filtro URL (regex)
+     - Patrón de inclusión del filtro URL (regex)
    * - ``exclude_pattern``
      - No
-     - Patron de exclusion del filtro URL (regex)
+     - Patrón de exclusión del filtro URL (regex)
    * - ``refresh_token_interval``
      - No
-     - Intervalo de actualizacion del token en segundos (predeterminado: 3540)
+     - Intervalo de actualización del token en segundos (predeterminado: 3540)
    * - ``proxy_host``
      - No
      - Nombre del host del proxy HTTP
    * - ``proxy_port``
-     - Si proxy_host esta configurado
-     - Numero de puerto del proxy HTTP
+     - Si proxy_host está configurado
+     - Número de puerto del proxy HTTP
 
-Configuracion de scripts
+Configuración de scripts
 ------------------------
 
 ::
@@ -263,13 +263,13 @@ Campos disponibles
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``object.type``
      - Tipo del objeto (ej: Case, User, Solution)
    * - ``object.title``
      - Nombre del objeto
    * - ``object.description``
-     - Descripcion del objeto
+     - Descripción del objeto
    * - ``object.content``
      - Contenido de texto del objeto
    * - ``object.id``
@@ -277,39 +277,39 @@ Campos disponibles
    * - ``object.content_length``
      - Longitud del contenido
    * - ``object.created``
-     - Fecha y hora de creacion
+     - Fecha y hora de creación
    * - ``object.last_modified``
-     - Fecha y hora de ultima modificacion
+     - Fecha y hora de última modificación
    * - ``object.url``
      - URL del objeto
    * - ``object.thumbnail``
      - URL del thumbnail
 
-Configuracion de aplicacion conectada de Salesforce
+Configuración de aplicación conectada de Salesforce
 ===================================================
 
-1. Crear aplicacion conectada
+1. Crear aplicación conectada
 -----------------------------
 
 En Salesforce Setup:
 
 1. Abrir "Application Manager"
 2. Hacer clic en "New Connected App"
-3. Ingresar informacion basica:
+3. Ingresar información básica:
 
-   - Nombre de aplicacion conectada: Fess Crawler
+   - Nombre de aplicación conectada: Fess Crawler
    - Nombre de API: Fess_Crawler
    - Email de contacto: your-email@example.com
 
 4. Marcar "Enable OAuth Settings"
 
-2. Configuracion de autenticacion OAuth Token (recomendada)
+2. Configuración de autenticación OAuth Token (recomendada)
 -----------------------------------------------------------
 
-En configuracion OAuth:
+En configuración OAuth:
 
 1. Marcar "Use digital signatures"
-2. Subir el certificado (crear segun los pasos a continuacion)
+2. Subir el certificado (crear según los pasos a continuación)
 3. OAuth Scopes seleccionados:
 
    - Full access (full)
@@ -318,7 +318,7 @@ En configuracion OAuth:
 4. Hacer clic en "Save"
 5. Copiar el Consumer Key
 
-Creacion del certificado:
+Creación del certificado:
 
 ::
 
@@ -332,12 +332,12 @@ Creacion del certificado:
     cat private_key.pem
 
 Suba el certificado (certificate.crt) a Salesforce y
-configure el contenido de la clave privada (private_key.pem) en los parametros.
+configure el contenido de la clave privada (private_key.pem) en los parámetros.
 
-3. Configuracion de autenticacion OAuth Password
+3. Configuración de autenticación OAuth Password
 ------------------------------------------------
 
-En configuracion OAuth:
+En configuración OAuth:
 
 1. URL de callback: ``https://localhost`` (no se usa pero es requerido)
 2. OAuth Scopes seleccionados:
@@ -350,27 +350,27 @@ En configuracion OAuth:
 
 Obtener el token de seguridad:
 
-1. Abrir configuracion personal en Salesforce
+1. Abrir configuración personal en Salesforce
 2. Hacer clic en "Reset My Security Token"
 3. Copiar el token enviado por email
 
-4. Aprobacion de aplicacion conectada
+4. Aprobación de aplicación conectada
 -------------------------------------
 
 En "Manage" -> "Manage Connected Apps":
 
-1. Seleccionar la aplicacion conectada creada
+1. Seleccionar la aplicación conectada creada
 2. Hacer clic en "Edit"
 3. Cambiar "Permitted Users" a "Admin approved users are pre-authorized"
 4. Asignar perfiles o conjuntos de permisos
 
-Configuracion de objetos personalizados
+Configuración de objetos personalizados
 =======================================
 
 Crawl de objetos personalizados
 -------------------------------
 
-Especifique los nombres de objetos personalizados en el parametro ``custom``:
+Especifique los nombres de objetos personalizados en el parámetro ``custom``:
 
 ::
 
@@ -392,25 +392,25 @@ Mapeo de campos para cada objeto:
 Reglas de mapeo de campos
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``<nombre_objeto>.title`` - Campo a usar para el titulo (campo unico)
-- ``<nombre_objeto>.contents`` - Campos a usar para el contenido (multiples separados por comas)
-- ``<nombre_objeto>.descriptions`` - Campos a usar para la descripcion (multiples separados por comas)
-- ``<nombre_objeto>.thumbnail`` - Campo a usar para la miniatura (campo unico)
+- ``<nombre_objeto>.title`` - Campo a usar para el título (campo único)
+- ``<nombre_objeto>.contents`` - Campos a usar para el contenido (múltiples separados por comas)
+- ``<nombre_objeto>.descriptions`` - Campos a usar para la descripción (múltiples separados por comas)
+- ``<nombre_objeto>.thumbnail`` - Campo a usar para la miniatura (campo único)
 
 .. note::
 
-   En el mapeo de campos de objetos estandar, el nombre de objeto usa UPPER_SNAKE_CASE
-   (el valor de la columna "Nombre de objeto" de la seccion `Lista de objetos estandar`_)
+   En el mapeo de campos de objetos estándar, el nombre de objeto usa UPPER_SNAKE_CASE
+   (el valor de la columna "Nombre de objeto" de la sección `Lista de objetos estándar`_)
    (p. ej. ``ACCOUNT.title=Name``, ``DAND_B_COMPANY.title=Name``).
    Para objetos personalizados, se usa el nombre de referencia de la API tal cual (p. ej. ``Product__c.title=Name``).
 
 Ejemplos de uso
 ===============
 
-Crawl de objetos estandar
+Crawl de objetos estándar
 -------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -436,7 +436,7 @@ Script:
 Crawl de objetos personalizados
 -------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -466,7 +466,7 @@ Script:
 Crawl de entorno Sandbox
 ------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -489,38 +489,38 @@ Script:
     timestamp=object.last_modified
     url=object.url
 
-Solucion de problemas
+Solución de problemas
 =====================
 
-Error de autenticacion
+Error de autenticación
 ----------------------
 
-**Sintoma**: ``Authentication failed`` o ``invalid_grant``
+**Síntoma**: ``Authentication failed`` o ``invalid_grant``
 
 **Verificaciones**:
 
-1. Para autenticacion OAuth Token:
+1. Para autenticación OAuth Token:
 
    - Verificar que el Consumer Key sea correcto
-   - Verificar que la clave privada este copiada correctamente (saltos de linea como ``\n``)
-   - Confirmar que el certificado este subido a Salesforce
+   - Verificar que la clave privada esté copiada correctamente (saltos de línea como ``\n``)
+   - Confirmar que el certificado esté subido a Salesforce
    - Verificar que el nombre de usuario sea correcto
 
-2. Para autenticacion OAuth Password:
+2. Para autenticación OAuth Password:
 
    - Verificar que Consumer Key y Consumer Secret sean correctos
    - Verificar que el token de seguridad sea correcto
-   - Confirmar que la contrasena y el token de seguridad no esten concatenados (configurar por separado)
+   - Confirmar que la contraseña y el token de seguridad no estén concatenados (configurar por separado)
 
-3. Comun:
+3. Común:
 
-   - Verificar que base_url sea correcta (entorno de produccion o Sandbox)
-   - Confirmar que la aplicacion conectada este aprobada
+   - Verificar que base_url sea correcta (entorno de producción o Sandbox)
+   - Confirmar que la aplicación conectada esté aprobada
 
 No se obtienen objetos
 ----------------------
 
-**Sintoma**: El crawl tiene exito pero hay 0 objetos
+**Síntoma**: El crawl tiene éxito pero hay 0 objetos
 
 **Verificaciones**:
 
@@ -543,7 +543,7 @@ Ejemplo:
 - Label: Product
 - API Name: Product__c (usar este)
 
-Verificacion de nombres de campo
+Verificación de nombres de campo
 --------------------------------
 
 Verificar el API Name del campo personalizado:
@@ -557,26 +557,26 @@ Ejemplo:
 - Field Label: Product Description
 - Field Name: Product_Description__c (usar este)
 
-Limite de tasa de API
+Límite de tasa de API
 ---------------------
 
-**Sintoma**: ``REQUEST_LIMIT_EXCEEDED``
+**Síntoma**: ``REQUEST_LIMIT_EXCEEDED``
 
-**Solucion**:
+**Solución**:
 
 1. Reducir ``number_of_threads`` (configurar a 1)
 2. Aumentar el intervalo de crawl
 3. Verificar el uso de la API de Salesforce
-4. Comprar limite de API adicional si es necesario
+4. Comprar límite de API adicional si es necesario
 
 Gran volumen de datos
 ---------------------
 
-**Sintoma**: El crawl toma mucho tiempo o tiene timeout
+**Síntoma**: El crawl toma mucho tiempo o tiene timeout
 
-**Solucion**:
+**Solución**:
 
-1. Dividir objetos en multiples data stores
+1. Dividir objetos en múltiples data stores
 2. Ajustar ``number_of_threads`` (aproximadamente 2-4)
 3. Distribuir el horario de crawl
 4. Mapear solo los campos necesarios
@@ -584,11 +584,11 @@ Gran volumen de datos
 Error de formato de clave privada
 ---------------------------------
 
-**Sintoma**: ``Invalid private key format``
+**Síntoma**: ``Invalid private key format``
 
-**Solucion**:
+**Solución**:
 
-Verificar que los saltos de linea en la clave privada sean correctamente ``\n``:
+Verificar que los saltos de línea en la clave privada sean correctamente ``\n``:
 
 ::
 
@@ -600,12 +600,12 @@ Verificar que los saltos de linea en la clave privada sean correctamente ``\n``:
     MIIEvgIBADANBgkqhkiG9w0BAQE...
     -----END PRIVATE KEY-----
 
-Informacion de referencia
+Información de referencia
 =========================
 
-- :doc:`ds-overview` - Descripcion general de conectores de Data Store
+- :doc:`ds-overview` - Descripción general de conectores de Data Store
 - :doc:`ds-database` - Conector de base de datos
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de Data Store
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de Data Store
 - `Salesforce REST API <https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/>`_
 - `Salesforce OAuth 2.0 JWT Bearer Flow <https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm>`_
 - `Salesforce Connected Apps <https://help.salesforce.com/s/articleView?id=sf.connected_app_overview.htm>`_

--- a/es/15.7/config/datastore/index.rst
+++ b/es/15.7/config/datastore/index.rst
@@ -1,12 +1,12 @@
 ===================================
-Guia de Conectores de Almacen de Datos
+Guía de Conectores de Almacén de Datos
 ===================================
 
-Los conectores de almacen de datos de |Fess| permiten obtener contenido de diversas fuentes de datos y hacerlo buscable.
+Los conectores de almacén de datos de |Fess| permiten obtener contenido de diversas fuentes de datos y hacerlo buscable.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Descripcion General
+   :caption: Descripción General
 
    ds-overview
 
@@ -21,7 +21,7 @@ Los conectores de almacen de datos de |Fess| permiten obtener contenido de diver
 
 .. toctree::
    :maxdepth: 2
-   :caption: Herramientas de Colaboracion
+   :caption: Herramientas de Colaboración
 
    ds-atlassian
    ds-slack

--- a/es/15.7/config/index.rst
+++ b/es/15.7/config/index.rst
@@ -1,17 +1,17 @@
-Guia de Configuracion de |Fess|
+Guía de Configuración de |Fess|
 ================================
 
-Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por proposito.
+Guía integral sobre la configuración de |Fess|. Cada sección está organizada por propósito.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Introduccion
+   :caption: Introducción
 
    intro
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion Basica
+   :caption: Configuración Básica
 
    setup-port-network
    setup-memory
@@ -19,7 +19,7 @@ Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion del Rastreador
+   :caption: Configuración del Rastreador
 
    crawler-basic
    crawler-advanced
@@ -33,7 +33,7 @@ Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion de Funciones de Busqueda
+   :caption: Configuración de Funciones de Búsqueda
 
    search-basic
    search-advanced
@@ -44,7 +44,7 @@ Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion de Seguridad
+   :caption: Configuración de Seguridad
 
    security-role
    security-virtual-host
@@ -53,7 +53,7 @@ Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion SSO
+   :caption: Configuración SSO
 
    sso-saml
    sso-oidc
@@ -62,7 +62,7 @@ Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion LLM/Modo de busqueda IA
+   :caption: Configuración LLM/Modo de búsqueda IA
 
    llm-overview
    llm-ollama
@@ -79,14 +79,14 @@ Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por
 
 .. toctree::
    :maxdepth: 2
-   :caption: Rendimiento y Operacion
+   :caption: Rendimiento y Operación
 
    rate-limiting
    load-control
 
 .. toctree::
    :maxdepth: 2
-   :caption: Administracion del Sistema
+   :caption: Administración del Sistema
 
    admin-logging
    admin-log-notification

--- a/es/15.7/config/llm-ollama.rst
+++ b/es/15.7/config/llm-ollama.rst
@@ -1,47 +1,47 @@
 ==========================
-Configuracion de Ollama
+Configuración de Ollama
 ==========================
 
-Descripcion general
+Descripción general
 ===================
 
-Ollama es una plataforma de codigo abierto para ejecutar modelos de lenguaje grandes (LLM) en entorno local.
-La funcionalidad de integracion con Ollama de |Fess| se proporciona como plugin ``fess-llm-ollama`` y es adecuada para uso en entornos privados.
+Ollama es una plataforma de código abierto para ejecutar modelos de lenguaje grandes (LLM) en entorno local.
+La funcionalidad de integración con Ollama de |Fess| se proporciona como plugin ``fess-llm-ollama`` y es adecuada para uso en entornos privados.
 
-Al usar Ollama, puede utilizar la funcionalidad del modo de busqueda IA sin enviar datos al exterior.
+Al usar Ollama, puede utilizar la funcionalidad del modo de búsqueda IA sin enviar datos al exterior.
 
-Caracteristicas principales
+Características principales
 ----------------------------
 
-- **Ejecucion local**: Los datos no se envian externamente, asegurando privacidad
+- **Ejecución local**: Los datos no se envían externamente, asegurando privacidad
 - **Modelos diversos**: Compatible con muchos modelos como Llama, Mistral, Gemma, CodeLlama
 - **Eficiencia de costos**: Sin costos de API (solo costos de hardware)
-- **Personalizacion**: Tambien puede usar modelos con ajuste fino personalizado
+- **Personalización**: También puede usar modelos con ajuste fino personalizado
 
 Modelos compatibles
 --------------------
 
 Principales modelos disponibles en Ollama:
 
-- ``llama3.3:70b`` - Llama 3.3 de Meta (70B parametros)
-- ``gemma4:e4b`` - Gemma 4 de Google (E4B parametros, predeterminado)
-- ``mistral:7b`` - Mistral de Mistral AI (7B parametros)
-- ``codellama:13b`` - Code Llama de Meta (13B parametros)
-- ``phi3:3.8b`` - Phi-3 de Microsoft (3.8B parametros)
+- ``llama3.3:70b`` - Llama 3.3 de Meta (70B parámetros)
+- ``gemma4:e4b`` - Gemma 4 de Google (E4B parámetros, predeterminado)
+- ``mistral:7b`` - Mistral de Mistral AI (7B parámetros)
+- ``codellama:13b`` - Code Llama de Meta (13B parámetros)
+- ``phi3:3.8b`` - Phi-3 de Microsoft (3.8B parámetros)
 
 .. note::
-   Para la lista mas reciente de modelos disponibles, consulte `Ollama Library <https://ollama.com/library>`__.
+   Para la lista más reciente de modelos disponibles, consulte `Ollama Library <https://ollama.com/library>`__.
 
 Requisitos previos
 ==================
 
 Antes de usar Ollama, verifique lo siguiente.
 
-1. **Instalacion de Ollama**: Descargue e instale desde `https://ollama.com/ <https://ollama.com/>`__
+1. **Instalación de Ollama**: Descargue e instale desde `https://ollama.com/ <https://ollama.com/>`__
 2. **Descarga de modelo**: Descargue el modelo a usar en Ollama
-3. **Inicio del servidor Ollama**: Confirme que Ollama este ejecutandose
+3. **Inicio del servidor Ollama**: Confirme que Ollama este ejecutándose
 
-Instalacion de Ollama
+Instalación de Ollama
 ---------------------
 
 Linux/macOS
@@ -77,14 +77,14 @@ Descarga de modelos
     # Verificar funcionamiento del modelo
     ollama run gemma4:e4b "Hello, how are you?"
 
-Instalacion del plugin
+Instalación del plugin
 ======================
 
-La funcionalidad de integracion con Ollama se proporciona como plugin.
+La funcionalidad de integración con Ollama se proporciona como plugin.
 Para usar Ollama es necesario instalar el plugin ``fess-llm-ollama``.
 
 1. Descargue `fess-llm-ollama-15.7.0.jar`.
-2. Coloquelo en el directorio ``app/WEB-INF/plugin/`` del directorio de instalacion de |Fess|.
+2. Colóquelo en el directorio ``app/WEB-INF/plugin/`` del directorio de instalación de |Fess|.
 
 ::
 
@@ -93,17 +93,17 @@ Para usar Ollama es necesario instalar el plugin ``fess-llm-ollama``.
 3. Reinicie |Fess|.
 
 .. note::
-   La version del plugin debe coincidir con la version de |Fess|.
+   La versión del plugin debe coincidir con la versión de |Fess|.
 
-Configuracion basica
+Configuración básica
 ====================
 
-La configuracion relacionada con LLM se divide en multiples archivos de configuracion.
+La configuración relacionada con LLM se divide en múltiples archivos de configuración.
 
-Configuracion minima
+Configuración mínima
 --------------------
 
-``system.properties`` (tambien configurable en Administracion > Sistema > General):
+``system.properties`` (también configurable en Administración > Sistema > General):
 
 ::
 
@@ -124,12 +124,12 @@ Configuracion minima
     rag.llm.ollama.model=gemma4:e4b
 
 .. note::
-   La configuracion del proveedor LLM tambien se puede configurar desde la pantalla de administracion (Administracion > Sistema > General) estableciendo ``rag.llm.name``.
+   La configuración del proveedor LLM también se puede configurar desde la pantalla de administración (Administración > Sistema > General) estableciendo ``rag.llm.name``.
 
-Configuracion recomendada (entorno de produccion)
+Configuración recomendada (entorno de producción)
 -------------------------------------------------
 
-``system.properties`` (tambien configurable en Administracion > Sistema > General):
+``system.properties`` (también configurable en Administración > Sistema > General):
 
 ::
 
@@ -155,17 +155,17 @@ Configuracion recomendada (entorno de produccion)
     # Control del numero de solicitudes simultaneas
     rag.llm.ollama.max.concurrent.requests=5
 
-Elementos de configuracion
+Elementos de configuración
 ==========================
 
-Todos los elementos de configuracion disponibles para el cliente de Ollama. Todos excepto ``rag.llm.name`` se configuran en ``fess_config.properties``.
+Todos los elementos de configuración disponibles para el cliente de Ollama. Todos excepto ``rag.llm.name`` se configuran en ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
    * - ``rag.llm.ollama.api.url``
      - URL base del servidor Ollama
@@ -177,83 +177,83 @@ Todos los elementos de configuracion disponibles para el cliente de Ollama. Todo
      - Timeout de solicitud (milisegundos)
      - ``60000``
    * - ``rag.llm.ollama.availability.check.interval``
-     - Intervalo de verificacion de disponibilidad (segundos). Si se especifica ``0`` o un valor menor, se deshabilita la verificacion periodica de disponibilidad
+     - Intervalo de verificación de disponibilidad (segundos). Si se especifica ``0`` o un valor menor, se deshabilita la verificación periódica de disponibilidad
      - ``60``
    * - ``rag.llm.ollama.max.concurrent.requests``
-     - Numero maximo de solicitudes simultaneas
+     - Número máximo de solicitudes simultáneas
      - ``5``
    * - ``rag.llm.ollama.chat.evaluation.max.relevant.docs``
-     - Numero maximo de documentos relevantes en la evaluacion
+     - Número máximo de documentos relevantes en la evaluación
      - ``3``
    * - ``rag.llm.ollama.concurrency.wait.timeout``
-     - Timeout de espera para la obtencion del permiso de control de concurrencia (milisegundos)
+     - Timeout de espera para la obtención del permiso de control de concurrencia (milisegundos)
      - ``30000``
    * - ``rag.llm.ollama.connect.timeout``
-     - Timeout de conexion TCP (milisegundos). Se puede especificar de forma independiente a ``rag.llm.ollama.timeout``
+     - Timeout de conexión TCP (milisegundos). Se puede especificar de forma independiente a ``rag.llm.ollama.timeout``
      - ``5000``
    * - ``rag.llm.ollama.retry.max``
-     - Numero maximo de reintentos HTTP (en errores ``429`` y de la familia ``5xx``)
+     - Número máximo de reintentos HTTP (en errores ``429`` y de la familia ``5xx``)
      - ``3``
    * - ``rag.llm.ollama.retry.base.delay.ms``
      - Retardo base del backoff exponencial (milisegundos)
      - ``2000``
 
-Configuracion detallada
+Configuración detallada
 -----------------------
 
-Elementos de configuracion detallados relacionados con el historial y el tamano del contexto.
+Elementos de configuración detallados relacionados con el historial y el tamaño del contexto.
 
 .. list-table::
    :header-rows: 1
    :widths: 45 35 20
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
    * - ``rag.llm.ollama.chat.evaluation.description.max.chars``
-     - Numero maximo de caracteres de la descripcion en la evaluacion
+     - Número máximo de caracteres de la descripción en la evaluación
      - ``500``
    * - ``rag.llm.ollama.history.max.chars``
-     - Numero maximo de caracteres del historial de conversacion
+     - Número máximo de caracteres del historial de conversación
      - ``4000``
    * - ``rag.llm.ollama.intent.history.max.messages``
-     - Numero maximo de mensajes del historial en la determinacion de intencion
+     - Número máximo de mensajes del historial en la determinación de intención
      - ``6``
    * - ``rag.llm.ollama.intent.history.max.chars``
-     - Numero maximo de caracteres del historial en la determinacion de intencion
+     - Número máximo de caracteres del historial en la determinación de intención
      - ``3000``
    * - ``rag.llm.ollama.history.assistant.max.chars``
-     - Numero maximo de caracteres del historial de respuestas del asistente
+     - Número máximo de caracteres del historial de respuestas del asistente
      - ``500``
    * - ``rag.llm.ollama.history.assistant.summary.max.chars``
-     - Numero maximo de caracteres del historial de resumenes del asistente
+     - Número máximo de caracteres del historial de resúmenes del asistente
      - ``500``
 
 Control de concurrencia
 -----------------------
 
-Usando ``rag.llm.ollama.max.concurrent.requests``, puede controlar el numero de solicitudes simultaneas a Ollama.
-El valor predeterminado es 5. Ajustelo segun los recursos del servidor Ollama.
-Si el numero de solicitudes simultaneas es demasiado alto, puede sobrecargar el servidor Ollama y reducir la velocidad de respuesta.
+Usando ``rag.llm.ollama.max.concurrent.requests``, puede controlar el número de solicitudes simultáneas a Ollama.
+El valor predeterminado es 5. Ajústelo según los recursos del servidor Ollama.
+Si el número de solicitudes simultáneas es demasiado alto, puede sobrecargar el servidor Ollama y reducir la velocidad de respuesta.
 
-Configuracion por tipo de prompt
+Configuración por tipo de prompt
 =================================
 
-En |Fess|, se pueden personalizar los parametros del LLM por tipo de prompt.
-La configuracion se escribe en ``fess_config.properties``.
+En |Fess|, se pueden personalizar los parámetros del LLM por tipo de prompt.
+La configuración se escribe en ``fess_config.properties``.
 
-Se pueden configurar los siguientes parametros por tipo de prompt:
+Se pueden configurar los siguientes parámetros por tipo de prompt:
 
-- ``rag.llm.ollama.{promptType}.temperature`` - Temperature en la generacion
-- ``rag.llm.ollama.{promptType}.max.tokens`` - Numero maximo de tokens (mapeado a ``num_predict`` en la API de Ollama)
-- ``rag.llm.ollama.{promptType}.context.max.chars`` - Numero maximo de caracteres del contexto
-- ``rag.llm.ollama.{promptType}.thinking.budget`` - Presupuesto de pensamiento (control de pensamiento en formato booleano; consulte "Soporte de modelo de pensamiento" para mas detalles)
-- ``rag.llm.ollama.{promptType}.thinking.level`` - Nivel de pensamiento (formato de cadena ``high`` / ``medium`` / ``low``; consulte "Soporte de modelo de pensamiento" para mas detalles)
+- ``rag.llm.ollama.{promptType}.temperature`` - Temperature en la generación
+- ``rag.llm.ollama.{promptType}.max.tokens`` - Número máximo de tokens (mapeado a ``num_predict`` en la API de Ollama)
+- ``rag.llm.ollama.{promptType}.context.max.chars`` - Número máximo de caracteres del contexto
+- ``rag.llm.ollama.{promptType}.thinking.budget`` - Presupuesto de pensamiento (control de pensamiento en formato booleano; consulte "Soporte de modelo de pensamiento" para más detalles)
+- ``rag.llm.ollama.{promptType}.thinking.level`` - Nivel de pensamiento (formato de cadena ``high`` / ``medium`` / ``low``; consulte "Soporte de modelo de pensamiento" para más detalles)
 - ``rag.llm.ollama.{promptType}.top.p`` - Valor de muestreo Top-P
 - ``rag.llm.ollama.{promptType}.top.k`` - Valor de muestreo Top-K
-- ``rag.llm.ollama.{promptType}.num.ctx`` - Tamano de la ventana de contexto
+- ``rag.llm.ollama.{promptType}.num.ctx`` - Tamaño de la ventana de contexto
 
-Cada parametro se resuelve en el siguiente orden: ``rag.llm.ollama.{promptType}.<param>`` (configuracion especifica por tipo de prompt) → ``rag.llm.ollama.default.<param>`` (valor de reserva comun para todos los tipos de prompt) → valor predeterminado codificado por tipo de prompt. Los valores especificados explicitamente en la solicitud siempre tienen prioridad.
+Cada parámetro se resuelve en el siguiente orden: ``rag.llm.ollama.{promptType}.<param>`` (configuración específica por tipo de prompt) → ``rag.llm.ollama.default.<param>`` (valor de reserva común para todos los tipos de prompt) → valor predeterminado codificado por tipo de prompt. Los valores especificados explícitamente en la solicitud siempre tienen prioridad.
 
 Tipos de prompt disponibles:
 
@@ -262,29 +262,29 @@ Tipos de prompt disponibles:
    :widths: 20 80
 
    * - Tipo de prompt
-     - Descripcion
+     - Descripción
    * - ``intent``
-     - Prompt para determinar la intencion del usuario
+     - Prompt para determinar la intención del usuario
    * - ``evaluation``
-     - Prompt de evaluacion de resultados de busqueda
+     - Prompt de evaluación de resultados de búsqueda
    * - ``unclear``
      - Prompt de respuesta para consultas no claras
    * - ``noresults``
-     - Prompt para cuando no hay resultados de busqueda
+     - Prompt para cuando no hay resultados de búsqueda
    * - ``docnotfound``
      - Prompt para cuando no se encuentra el documento
    * - ``answer``
-     - Prompt de generacion de respuesta
+     - Prompt de generación de respuesta
    * - ``summary``
-     - Prompt de generacion de resumen
+     - Prompt de generación de resumen
    * - ``faq``
-     - Prompt de generacion de FAQ
+     - Prompt de generación de FAQ
    * - ``direct``
      - Prompt de respuesta directa
    * - ``queryregeneration``
-     - Prompt de regeneracion de consulta
+     - Prompt de regeneración de consulta
 
-Cada tipo de prompt tiene valores predeterminados codificados que se aplican cuando se omite la configuracion.
+Cada tipo de prompt tiene valores predeterminados codificados que se aplican cuando se omite la configuración.
 
 .. list-table::
    :header-rows: 1
@@ -346,7 +346,7 @@ Cada tipo de prompt tiene valores predeterminados codificados que se aplican cua
      - ``0``
      - ``6000``
 
-Ejemplo de configuracion::
+Ejemplo de configuración::
 
     # Configurar la temperature en la generacion de respuestas
     rag.llm.ollama.answer.temperature=0.7
@@ -360,16 +360,16 @@ Ejemplo de configuracion::
 Opciones de modelo Ollama
 ==========================
 
-Los parametros del modelo Ollama se pueden configurar en ``fess_config.properties``.
-Al especificarlos con el formato ``rag.llm.ollama.default.<param>``, se usan como valor de reserva comun para todos los tipos de prompt.
-El mecanismo de reserva mediante ``default`` se aplica no solo a ``top.p`` / ``top.k`` / ``num.ctx``, sino tambien a ``temperature`` / ``max.tokens`` / ``thinking.budget`` / ``thinking.level``.
+Los parámetros del modelo Ollama se pueden configurar en ``fess_config.properties``.
+Al especificarlos con el formato ``rag.llm.ollama.default.<param>``, se usan como valor de reserva común para todos los tipos de prompt.
+El mecanismo de reserva mediante ``default`` se aplica no solo a ``top.p`` / ``top.k`` / ``num.ctx``, sino también a ``temperature`` / ``max.tokens`` / ``thinking.budget`` / ``thinking.level``.
 
 .. list-table::
    :header-rows: 1
    :widths: 40 40 20
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
    * - ``rag.llm.ollama.default.top.p``
      - Valor de muestreo Top-P (0.0 a 1.0). Se puede sobrescribir por tipo de prompt con ``rag.llm.ollama.{promptType}.top.p``
@@ -378,13 +378,13 @@ El mecanismo de reserva mediante ``default`` se aplica no solo a ``top.p`` / ``t
      - Valor de muestreo Top-K. Se puede sobrescribir por tipo de prompt con ``rag.llm.ollama.{promptType}.top.k``
      - (sin definir)
    * - ``rag.llm.ollama.default.num.ctx``
-     - Tamano de la ventana de contexto. Se puede sobrescribir por tipo de prompt con ``rag.llm.ollama.{promptType}.num.ctx``
+     - Tamaño de la ventana de contexto. Se puede sobrescribir por tipo de prompt con ``rag.llm.ollama.{promptType}.num.ctx``
      - (sin definir)
    * - ``rag.llm.ollama.default.temperature``
-     - Valor de reserva de temperature en la generacion. Se puede sobrescribir por tipo de prompt con ``rag.llm.ollama.{promptType}.temperature``
+     - Valor de reserva de temperature en la generación. Se puede sobrescribir por tipo de prompt con ``rag.llm.ollama.{promptType}.temperature``
      - (sin definir)
    * - ``rag.llm.ollama.default.max.tokens``
-     - Valor de reserva del numero maximo de tokens. Se puede sobrescribir por tipo de prompt con ``rag.llm.ollama.{promptType}.max.tokens``
+     - Valor de reserva del número máximo de tokens. Se puede sobrescribir por tipo de prompt con ``rag.llm.ollama.{promptType}.max.tokens``
      - (sin definir)
    * - ``rag.llm.ollama.default.thinking.budget``
      - Valor de reserva del presupuesto de pensamiento. Se puede sobrescribir por tipo de prompt con ``rag.llm.ollama.{promptType}.thinking.budget``
@@ -393,10 +393,10 @@ El mecanismo de reserva mediante ``default`` se aplica no solo a ``top.p`` / ``t
      - Valor de reserva del nivel de pensamiento (``high`` / ``medium`` / ``low``). Se puede sobrescribir por tipo de prompt con ``rag.llm.ollama.{promptType}.thinking.level``
      - (sin definir)
    * - ``rag.llm.ollama.options.*``
-     - Opciones globales pasadas directamente a la API de Ollama. El sufijo se usa como nombre de opcion (ejemplo: ``rag.llm.ollama.options.repeat_penalty=1.1``). Los valores se convierten automaticamente a Integer, Double, Boolean o String
+     - Opciones globales pasadas directamente a la API de Ollama. El sufijo se usa como nombre de opción (ejemplo: ``rag.llm.ollama.options.repeat_penalty=1.1``). Los valores se convierten automáticamente a Integer, Double, Boolean o String
      - (sin definir)
 
-Ejemplo de configuracion::
+Ejemplo de configuración::
 
     # Muestreo Top-P predeterminado (comun para todos los tipos de prompt)
     rag.llm.ollama.default.top.p=0.9
@@ -416,7 +416,7 @@ Ejemplo de configuracion::
 Soporte de modelo de pensamiento
 ==================================
 
-Cuando se usa un modelo de pensamiento (thinking model) como gemma4 o qwen3, |Fess| soporta la configuracion del presupuesto de pensamiento (thinking budget).
+Cuando se usa un modelo de pensamiento (thinking model) como gemma4 o qwen3, |Fess| soporta la configuración del presupuesto de pensamiento (thinking budget).
 
 El presupuesto de pensamiento se configura por tipo de prompt en ``fess_config.properties``:
 
@@ -428,15 +428,15 @@ El presupuesto de pensamiento se configura por tipo de prompt en ``fess_config.p
     # Configuracion del presupuesto de pensamiento en la generacion de resumenes
     rag.llm.ollama.summary.thinking.budget=1024
 
-Al configurar el presupuesto de pensamiento, puede controlar el numero de tokens asignados al paso de "pensar" antes de que el modelo genere una respuesta.
+Al configurar el presupuesto de pensamiento, puede controlar el número de tokens asignados al paso de "pensar" antes de que el modelo genere una respuesta.
 
 .. note::
-   En Ollama, el presupuesto de pensamiento se convierte a un flag booleano (si el valor es mayor que 0, se usa ``think: true``; si es 0, se usa ``think: false``). El control detallado por numero de tokens no esta disponible debido a las restricciones de la API de Ollama.
+   En Ollama, el presupuesto de pensamiento se convierte a un flag booleano (si el valor es mayor que 0, se usa ``think: true``; si es 0, se usa ``think: false``). El control detallado por número de tokens no está disponible debido a las restricciones de la API de Ollama.
 
 Nivel de pensamiento (thinking level)
 --------------------------------------
 
-Algunos modelos como gpt-oss ignoran el flag ``think`` en formato booleano y requieren la especificacion del nivel de pensamiento mediante el formato de cadena ``high`` / ``medium`` / ``low``.
+Algunos modelos como gpt-oss ignoran el flag ``think`` en formato booleano y requieren la especificación del nivel de pensamiento mediante el formato de cadena ``high`` / ``medium`` / ``low``.
 Para este tipo de modelos, use ``rag.llm.ollama.{promptType}.thinking.level``.
 
 ::
@@ -447,25 +447,25 @@ Para este tipo de modelos, use ``rag.llm.ollama.{promptType}.thinking.level``.
     # Configuracion del nivel de pensamiento en la generacion de resumenes
     rag.llm.ollama.summary.thinking.level=medium
 
-Los valores que se pueden establecer en ``thinking.level`` son ``high`` / ``medium`` / ``low`` (sin distincion de mayusculas y minusculas). Si se especifica un valor no valido, se ignora y se emite un log de advertencia.
+Los valores que se pueden establecer en ``thinking.level`` son ``high`` / ``medium`` / ``low`` (sin distinción de mayúsculas y minúsculas). Si se especifica un valor no válido, se ignora y se emite un log de advertencia.
 
 .. note::
-   Si tanto ``thinking.level`` (formato de cadena) como ``thinking.budget`` (formato booleano) estan configurados, ``thinking.level`` tiene prioridad. Use ``thinking.level`` para modelos de la familia GPT-OSS y ``thinking.budget`` para otros modelos de pensamiento.
+   Si tanto ``thinking.level`` (formato de cadena) como ``thinking.budget`` (formato booleano) están configurados, ``thinking.level`` tiene prioridad. Use ``thinking.level`` para modelos de la familia GPT-OSS y ``thinking.budget`` para otros modelos de pensamiento.
 
-Configuracion de red
+Configuración de red
 ====================
 
-Configuracion con Docker
+Configuración con Docker
 ------------------------
 
-El repositorio oficial `docker-fess <https://github.com/codelibs/docker-fess>`__ de |Fess| incluye un overlay para Ollama ``compose-ollama.yaml``. Los pasos minimos son los siguientes.
+El repositorio oficial `docker-fess <https://github.com/codelibs/docker-fess>`__ de |Fess| incluye un overlay para Ollama ``compose-ollama.yaml``. Los pasos mínimos son los siguientes.
 
 ::
 
     docker compose -f compose.yaml -f compose-opensearch3.yaml -f compose-ollama.yaml up -d
     docker exec -it ollama01 ollama pull gemma4:e4b
 
-``compose-ollama.yaml`` esta configurado para usar GPU NVIDIA (se requiere NVIDIA Container Toolkit). Su contenido es el siguiente.
+``compose-ollama.yaml`` está configurado para usar GPU NVIDIA (se requiere NVIDIA Container Toolkit). Su contenido es el siguiente.
 
 .. code-block:: yaml
 
@@ -501,14 +501,14 @@ El repositorio oficial `docker-fess <https://github.com/codelibs/docker-fess>`__
 
 Puntos clave:
 
-- ``FESS_PLUGINS=fess-llm-ollama:15.7.0`` hace que el script de inicio obtenga automaticamente el JAR del plugin y lo coloque en ``app/WEB-INF/plugin/`` (ajuste la version a la de su |Fess|)
-- ``-Dfess.config.rag.chat.enabled=true`` habilita el modo de busqueda IA
+- ``FESS_PLUGINS=fess-llm-ollama:15.7.0`` hace que el script de inicio obtenga automáticamente el JAR del plugin y lo coloque en ``app/WEB-INF/plugin/`` (ajuste la versión a la de su |Fess|)
+- ``-Dfess.config.rag.chat.enabled=true`` habilita el modo de búsqueda IA
 - ``-Dfess.config.rag.llm.ollama.api.url=...`` especifica la URL del servidor Ollama (dentro de la red de Docker Compose se resuelve por el nombre del servicio, como ``ollama01``)
-- El valor predeterminado del proveedor LLM (``rag.llm.name``) es ``ollama``, por lo que si solo se usa Ollama no es necesaria una especificacion explicita. Si se cambia desde otro proveedor, agregue ``-Dfess.system.rag.llm.name=ollama`` a ``FESS_JAVA_OPTS`` o configurelo despues del inicio en la pantalla de administracion "Sistema > General", seccion RAG
-- El bloque ``deploy.resources.reservations.devices`` es la configuracion para usar GPU. Si no se usa GPU (ejecutando solo con CPU), elimine este bloque
+- El valor predeterminado del proveedor LLM (``rag.llm.name``) es ``ollama``, por lo que si solo se usa Ollama no es necesaria una especificación explícita. Si se cambia desde otro proveedor, agregue ``-Dfess.system.rag.llm.name=ollama`` a ``FESS_JAVA_OPTS`` o configúrelo después del inicio en la pantalla de administración "Sistema > General", sección RAG
+- El bloque ``deploy.resources.reservations.devices`` es la configuración para usar GPU. Si no se usa GPU (ejecutando solo con CPU), elimine este bloque
 
 .. note::
-   Las variables de entorno en formato snake_case en mayusculas como ``RAG_CHAT_ENABLED`` o ``RAG_LLM_NAME`` no son reconocidas directamente por |Fess|. Los valores de configuracion deben pasarse siempre dentro de ``FESS_JAVA_OPTS`` como ``-Dfess.config.<key>`` (familia ``fess_config.properties``) o ``-Dfess.system.<key>`` (familia ``system.properties``).
+   Las variables de entorno en formato snake_case en mayúsculas como ``RAG_CHAT_ENABLED`` o ``RAG_LLM_NAME`` no son reconocidas directamente por |Fess|. Los valores de configuración deben pasarse siempre dentro de ``FESS_JAVA_OPTS`` como ``-Dfess.config.<key>`` (familia ``fess_config.properties``) o ``-Dfess.system.<key>`` (familia ``system.properties``).
 
 Servidor Ollama remoto
 ----------------------
@@ -520,57 +520,57 @@ Cuando se ejecuta Ollama en un servidor diferente a Fess:
     rag.llm.ollama.api.url=http://ollama-server.example.com:11434
 
 .. warning::
-   Ollama no tiene funcionalidad de autenticacion por defecto, por lo que si lo hace accesible externamente,
+   Ollama no tiene funcionalidad de autenticación por defecto, por lo que si lo hace accesible externamente,
    considere medidas de seguridad a nivel de red (firewall, VPN, etc.).
 
-Uso a traves de proxy HTTP
+Uso a través de proxy HTTP
 ==========================
 
-El cliente de Ollama comparte la configuracion de proxy HTTP comun de |Fess|. Si necesita pasar por un proxy para conectarse al servidor Ollama (por ejemplo al usar un servidor Ollama remoto), especifique las siguientes propiedades en ``fess_config.properties``.
+El cliente de Ollama comparte la configuración de proxy HTTP común de |Fess|. Si necesita pasar por un proxy para conectarse al servidor Ollama (por ejemplo al usar un servidor Ollama remoto), especifique las siguientes propiedades en ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
    * - ``http.proxy.host``
-     - Nombre del host del proxy (si la cadena esta vacia, no se usa proxy)
+     - Nombre del host del proxy (si la cadena está vacía, no se usa proxy)
      - ``""``
    * - ``http.proxy.port``
-     - Numero de puerto del proxy
+     - Número de puerto del proxy
      - ``8080``
    * - ``http.proxy.username``
-     - Nombre de usuario para autenticacion del proxy (opcional; al especificarlo se habilita la autenticacion Basic)
+     - Nombre de usuario para autenticación del proxy (opcional; al especificarlo se habilita la autenticación Basic)
      - ``""``
    * - ``http.proxy.password``
-     - Contrasena para autenticacion del proxy
+     - Contraseña para autenticación del proxy
      - ``""``
 
 .. note::
-   Como Ollama normalmente se ejecuta en local o dentro de la red interna, la configuracion de proxy solo es necesaria en casos limitados (por ejemplo, cuando se usa un servidor Ollama remoto al que solo se puede llegar a traves del proxy corporativo).
-   Esta configuracion tambien afecta el acceso HTTP de todo |Fess|, incluido el crawler.
+   Como Ollama normalmente se ejecuta en local o dentro de la red interna, la configuración de proxy solo es necesaria en casos limitados (por ejemplo, cuando se usa un servidor Ollama remoto al que solo se puede llegar a través del proxy corporativo).
+   Esta configuración también afecta el acceso HTTP de todo |Fess|, incluido el crawler.
 
-Guia de seleccion de modelos
+Guía de selección de modelos
 ============================
 
-Guia para la seleccion de modelos segun el proposito de uso.
+Guía para la selección de modelos según el propósito de uso.
 
 .. list-table::
    :header-rows: 1
    :widths: 25 20 20 35
 
    * - Modelo
-     - Tamano
+     - Tamaño
      - VRAM requerida
      - Uso
    * - ``phi3:3.8b``
-     - Pequeno
+     - Pequeño
      - 4GB+
      - Entornos ligeros, respuestas simples
    * - ``gemma4:e4b``
-     - Pequeno-Medio
+     - Pequeño-Medio
      - 8GB+
      - Uso general equilibrado, soporte de thinking (predeterminado)
    * - ``mistral:7b``
@@ -580,12 +580,12 @@ Guia para la seleccion de modelos segun el proposito de uso.
    * - ``llama3.3:70b``
      - Grande
      - 48GB+
-     - Respuestas de maxima calidad, razonamiento complejo
+     - Respuestas de máxima calidad, razonamiento complejo
 
 Soporte de GPU
 --------------
 
-Ollama soporta aceleracion por GPU. El uso de GPUs NVIDIA mejora significativamente
+Ollama soporta aceleración por GPU. El uso de GPUs NVIDIA mejora significativamente
 la velocidad de inferencia.
 
 ::
@@ -593,34 +593,34 @@ la velocidad de inferencia.
     # Verificar soporte de GPU
     ollama run gemma4:e4b --verbose
 
-Solucion de problemas
+Solución de problemas
 =====================
 
-Error de conexion
+Error de conexión
 -----------------
 
-**Sintoma**: Errores en la funcionalidad de chat, LLM mostrado como no disponible
+**Síntoma**: Errores en la funcionalidad de chat, LLM mostrado como no disponible
 
 **Verificaciones**:
 
-1. Verificar que Ollama este ejecutandose::
+1. Verificar que Ollama este ejecutándose::
 
     curl http://localhost:11434/api/tags
 
-2. Verificar que el modelo este descargado::
+2. Verificar que el modelo esté descargado::
 
     ollama list
 
-3. Verificar la configuracion del firewall
+3. Verificar la configuración del firewall
 
-4. Verificar que el plugin ``fess-llm-ollama`` este colocado en ``app/WEB-INF/plugin/``
+4. Verificar que el plugin ``fess-llm-ollama`` esté colocado en ``app/WEB-INF/plugin/``
 
 Modelo no encontrado
 --------------------
 
-**Sintoma**: Se muestra en el log "Configured model not found"
+**Síntoma**: Se muestra en el log "Configured model not found"
 
-**Solucion**:
+**Solución**:
 
 1. Verificar que el nombre del modelo sea exacto (puede incluir el tag ``:latest``)::
 
@@ -634,17 +634,17 @@ Modelo no encontrado
 Timeout
 -------
 
-**Sintoma**: Las solicitudes tienen timeout
+**Síntoma**: Las solicitudes tienen timeout
 
-**Solucion**:
+**Solución**:
 
 1. Extender el tiempo de timeout::
 
     rag.llm.ollama.timeout=120000
 
-2. Usar un modelo mas pequeno o considerar un entorno con GPU
+2. Usar un modelo más pequeño o considerar un entorno con GPU
 
-Configuracion de depuracion
+Configuración de depuración
 ---------------------------
 
 Para investigar problemas, puede ajustar el nivel de log de |Fess| para obtener logs detallados relacionados con Ollama.
@@ -655,11 +655,11 @@ Para investigar problemas, puede ajustar el nivel de log de |Fess| para obtener 
 
     <Logger name="org.codelibs.fess.llm.ollama" level="DEBUG"/>
 
-Informacion de referencia
+Información de referencia
 =========================
 
 - `Sitio oficial de Ollama <https://ollama.com/>`__
 - `Biblioteca de modelos Ollama <https://ollama.com/library>`__
 - `Ollama GitHub <https://github.com/ollama/ollama>`__
-- :doc:`llm-overview` - Descripcion general de integracion LLM
-- :doc:`rag-chat` - Detalles de la funcionalidad de modo de busqueda IA
+- :doc:`llm-overview` - Descripción general de integración LLM
+- :doc:`rag-chat` - Detalles de la funcionalidad de modo de búsqueda IA

--- a/es/15.7/config/load-control.rst
+++ b/es/15.7/config/load-control.rst
@@ -1,28 +1,28 @@
 ====================================
-Configuracion de control de carga
+Configuración de control de carga
 ====================================
 
-Descripcion general
+Descripción general
 ===================
 
-|Fess| incluye dos tipos de funciones de control de carga que protegen la estabilidad del sistema en funcion del uso de CPU.
+|Fess| incluye dos tipos de funciones de control de carga que protegen la estabilidad del sistema en función del uso de CPU.
 
 **Control de carga de solicitudes HTTP** (``web.load.control`` / ``api.load.control``):
 
 - Monitoreo en tiempo real del uso de CPU del cluster de OpenSearch
 - Umbrales independientes para solicitudes web y solicitudes API
 - Devuelve HTTP 429 (Too Many Requests) cuando se superan los umbrales
-- El panel de administracion, el inicio de sesion y los recursos estaticos estan excluidos del control
+- El panel de administración, el inicio de sesión y los recursos estáticos están excluidos del control
 - Deshabilitado por defecto (umbral=100)
 
 **Control de carga adaptativo** (``adaptive.load.control``):
 
 - Monitorea el uso de CPU del sistema del propio servidor Fess
-- Regula automaticamente las tareas en segundo plano como rastreo, indexacion, actualizaciones de sugerencias y generacion de miniaturas
+- Regula automáticamente las tareas en segundo plano como rastreo, indexación, actualizaciones de sugerencias y generación de miniaturas
 - Cuando el uso de CPU alcanza o supera el umbral, los hilos de procesamiento se pausan y se reanudan cuando desciende por debajo del umbral
 - Habilitado por defecto (umbral=50)
 
-Configuracion del control de carga de solicitudes HTTP
+Configuración del control de carga de solicitudes HTTP
 ======================================================
 
 Configure las siguientes propiedades en ``fess_config.properties``:
@@ -45,7 +45,7 @@ Configure las siguientes propiedades en ``fess_config.properties``:
     load.control.monitor.interval=1
 
 .. note::
-   Cuando tanto ``web.load.control`` como ``api.load.control`` estan establecidos en 100 (predeterminado),
+   Cuando tanto ``web.load.control`` como ``api.load.control`` están establecidos en 100 (predeterminado),
    el monitoreo de CPU de OpenSearch no se inicia.
 
 Como funciona
@@ -54,24 +54,24 @@ Como funciona
 Mecanismo de monitoreo
 ----------------------
 
-Cuando el control de carga esta habilitado (algun umbral es inferior a 100), LoadControlMonitorTarget monitorea periodicamente el uso de CPU del cluster de OpenSearch.
+Cuando el control de carga está habilitado (algún umbral es inferior a 100), LoadControlMonitorTarget monitorea periódicamente el uso de CPU del cluster de OpenSearch.
 
-- Obtiene estadisticas del SO de todos los nodos del cluster de OpenSearch
-- Registra el uso de CPU mas alto entre todos los nodos
+- Obtiene estadísticas del SO de todos los nodos del cluster de OpenSearch
+- Registra el uso de CPU más alto entre todos los nodos
 - Monitorea en el intervalo especificado por ``load.control.monitor.interval`` (predeterminado: 1 segundo)
 - El monitoreo se inicia de forma diferida en la primera solicitud
 
 .. note::
-   Si falla la obtencion de informacion de monitoreo, el uso de CPU se restablece a 0.
+   Si falla la obtención de información de monitoreo, el uso de CPU se restablece a 0.
    Hasta el tercer fallo consecutivo, el nivel de log es WARNING; a partir del cuarto fallo, cambia a DEBUG
-   (para evitar que los fallos continuos hinchen los logs). El contador de fallos se reinicia cuando el monitoreo tiene exito al menos una vez.
+   (para evitar que los fallos continuos hinchen los logs). El contador de fallos se reinicia cuando el monitoreo tiene éxito al menos una vez.
 
 Control de solicitudes
 ----------------------
 
 Cuando llega una solicitud, LoadControlFilter la procesa en el siguiente orden:
 
-1. Verificar si la ruta esta excluida (si esta excluida, dejar pasar)
+1. Verificar si la ruta está excluida (si está excluida, dejar pasar)
 2. Determinar el tipo de solicitud (Web / API)
 3. Obtener el umbral correspondiente
 4. Si el umbral es 100 o superior, no controlar (dejar pasar)
@@ -80,19 +80,19 @@ Cuando llega una solicitud, LoadControlFilter la procesa en el siguiente orden:
 
 **Solicitudes excluidas:**
 
-- Rutas que comienzan con ``/admin`` (panel de administracion)
-- Rutas que comienzan con ``/error`` (paginas de error)
-- Rutas que comienzan con ``/login`` (paginas de inicio de sesion)
-- Recursos estaticos (``.css``, ``.js``, ``.png``, ``.jpg``, ``.gif``, ``.ico``, ``.svg``, ``.woff``, ``.woff2``, ``.ttf``, ``.eot``)
+- Rutas que comienzan con ``/admin`` (panel de administración)
+- Rutas que comienzan con ``/error`` (páginas de error)
+- Rutas que comienzan con ``/login`` (páginas de inicio de sesión)
+- Recursos estáticos (``.css``, ``.js``, ``.png``, ``.jpg``, ``.gif``, ``.ico``, ``.svg``, ``.woff``, ``.woff2``, ``.ttf``, ``.eot``)
 
 **Para solicitudes web:**
 
-- Devuelve el codigo de estado HTTP 429
-- Muestra la pagina de error (``busy.jsp``)
+- Devuelve el código de estado HTTP 429
+- Muestra la página de error (``busy.jsp``)
 
 **Para solicitudes API:**
 
-- Devuelve el codigo de estado HTTP 429
+- Devuelve el código de estado HTTP 429
 - Adjunta el encabezado de respuesta HTTP ``Retry-After: 60``
 - Devuelve una respuesta JSON:
 
@@ -111,13 +111,13 @@ Cuando llega una solicitud, LoadControlFilter la procesa en el siguiente orden:
    ``Rejecting request due to high CPU load: path=..., cpu=...%, threshold=...%``.
    Esto permite verificar que rutas fueron rechazadas y con que umbral.
 
-Ejemplos de configuracion
+Ejemplos de configuración
 =========================
 
 Limitar solo solicitudes web
 -----------------------------
 
-Configuracion que limita solo las solicitudes de busqueda web sin restringir la API:
+Configuración que limita solo las solicitudes de búsqueda web sin restringir la API:
 
 ::
 
@@ -147,14 +147,14 @@ Ejemplo con diferentes umbrales para web y API:
     load.control.monitor.interval=2
 
 .. note::
-   Al establecer el umbral de API mas alto que el de web, puede lograr un control escalonado
-   donde las solicitudes web se restringen primero durante alta carga, y las solicitudes API tambien
-   se restringen cuando la carga aumenta aun mas.
+   Al establecer el umbral de API más alto que el de web, puede lograr un control escalonado
+   donde las solicitudes web se restringen primero durante alta carga, y las solicitudes API también
+   se restringen cuando la carga aumenta aún más.
 
-Diferencia con el limite de tasa
+Diferencia con el límite de tasa
 =================================
 
-|Fess| tiene una funcion de :doc:`rate-limiting` separada del control de carga.
+|Fess| tiene una función de :doc:`rate-limiting` separada del control de carga.
 Estas protegen el sistema usando enfoques diferentes.
 
 .. list-table::
@@ -162,33 +162,33 @@ Estas protegen el sistema usando enfoques diferentes.
    :widths: 20 40 40
 
    * - Aspecto
-     - Limite de tasa
+     - Límite de tasa
      - Control de carga
    * - Base de control
-     - Numero de solicitudes (por unidad de tiempo)
+     - Número de solicitudes (por unidad de tiempo)
      - Uso de CPU de OpenSearch
-   * - Proposito
-     - Prevencion de solicitudes excesivas
-     - Proteccion del motor de busqueda contra alta carga
-   * - Unidad de limite
-     - Por direccion IP
+   * - Propósito
+     - Prevención de solicitudes excesivas
+     - Protección del motor de búsqueda contra alta carga
+   * - Unidad de límite
+     - Por dirección IP
      - Todo el sistema
    * - Respuesta
      - HTTP 429
      - HTTP 429
    * - Alcance
      - Todas las solicitudes HTTP
-     - Solicitudes web / Solicitudes API (panel de administracion etc. excluido)
+     - Solicitudes web / Solicitudes API (panel de administración etc. excluido)
 
-Combinar ambas funciones permite una proteccion del sistema mas robusta.
+Combinar ambas funciones permite una protección del sistema más robusta.
 
 Control de carga adaptativo
 ===========================
 
-El control de carga adaptativo ajusta automaticamente la velocidad de procesamiento de las tareas
-en segundo plano en funcion del uso de CPU del sistema del servidor Fess.
+El control de carga adaptativo ajusta automáticamente la velocidad de procesamiento de las tareas
+en segundo plano en función del uso de CPU del sistema del servidor Fess.
 
-Configuracion
+Configuración
 -------------
 
 ``fess_config.properties``:
@@ -205,19 +205,19 @@ Comportamiento
 
 - Monitorea el uso de CPU del sistema del servidor donde se ejecuta Fess
 - Cuando el uso de CPU alcanza o supera el umbral, los hilos de procesamiento afectados esperan hasta que el uso de CPU descienda por debajo del umbral
-- Cuando el uso de CPU desciende por debajo del umbral, el procesamiento se reanuda automaticamente
+- Cuando el uso de CPU desciende por debajo del umbral, el procesamiento se reanuda automáticamente
 
 **Tareas en segundo plano afectadas:**
 
 - Rastreo (Web / Sistema de archivos)
-- Indexacion (registro de documentos)
-- Procesamiento de almacen de datos
+- Indexación (registro de documentos)
+- Procesamiento de almacén de datos
 - Actualizaciones de sugerencias
-- Generacion de miniaturas
-- Respaldo y restauracion
+- Generación de miniaturas
+- Respaldo y restauración
 
 .. note::
-   El control de carga adaptativo esta habilitado por defecto (umbral=50).
+   El control de carga adaptativo está habilitado por defecto (umbral=50).
    Opera de forma independiente del control de carga de solicitudes HTTP (``web.load.control`` / ``api.load.control``).
 
 .. list-table::
@@ -233,33 +233,33 @@ Comportamiento
    * - Objetivo de control
      - Solicitudes HTTP (Web / API)
      - Tareas en segundo plano
-   * - Metodo de control
+   * - Método de control
      - Rechaza solicitudes devolviendo HTTP 429
      - Pausa temporalmente los hilos de procesamiento
    * - Predeterminado
      - Deshabilitado (umbral=100)
      - Habilitado (umbral=50)
 
-Solucion de problemas
+Solución de problemas
 =====================
 
 El control de carga no se activa
 ---------------------------------
 
-**Causa**: La configuracion no se refleja correctamente
+**Causa**: La configuración no se refleja correctamente
 
 **Verificaciones**:
 
-1. Si ``web.load.control`` o ``api.load.control`` esta establecido por debajo de 100
-2. Si el archivo de configuracion se esta leyendo correctamente
+1. Si ``web.load.control`` o ``api.load.control`` está establecido por debajo de 100
+2. Si el archivo de configuración se está leyendo correctamente
 3. Si |Fess| fue reiniciado
 
-Solicitudes legitimas son rechazadas
+Solicitudes legítimas son rechazadas
 --------------------------------------
 
 **Causa**: Los umbrales son demasiado bajos
 
-**Solucion**:
+**Solución**:
 
 1. Aumentar los valores de ``web.load.control`` o ``api.load.control``
 2. Ajustar ``load.control.monitor.interval`` para cambiar la frecuencia de monitoreo
@@ -272,20 +272,20 @@ Solicitudes legitimas son rechazadas
 El rastreo es lento
 -------------------
 
-**Causa**: Los hilos estan en estado de espera debido al control de carga adaptativo
+**Causa**: Los hilos están en estado de espera debido al control de carga adaptativo
 
 **Verificaciones**:
 
 1. Si ``Cpu Load XX% is greater than YY%`` aparece en los logs
 2. Si el umbral de ``adaptive.load.control`` es demasiado bajo
 
-**Solucion**:
+**Solución**:
 
 1. Aumentar el valor de ``adaptive.load.control`` (ej: 70)
 2. Aumentar los recursos de CPU del servidor Fess
 3. Establecer en 0 para deshabilitar el control de carga adaptativo (no recomendado)
 
-Informacion de referencia
+Información de referencia
 =========================
 
-- :doc:`rate-limiting` - Configuracion de limite de tasa
+- :doc:`rate-limiting` - Configuración de límite de tasa

--- a/es/15.7/config/multitenancy.rst
+++ b/es/15.7/config/multitenancy.rst
@@ -1,52 +1,52 @@
 =====================================
-Configuracion de multitenencia
+Configuración de multitenencia
 =====================================
 
-Descripcion general
+Descripción general
 ===================
 
 La funcionalidad de multitenencia de |Fess| permite operar
-multiples inquilinos (organizaciones, departamentos, clientes, etc.) de forma separada con una sola instancia de |Fess|.
+múltiples inquilinos (organizaciones, departamentos, clientes, etc.) de forma separada con una sola instancia de |Fess|.
 
 Al usar la funcionalidad de host virtual, puede proporcionar para cada inquilino:
 
-- Interfaz de busqueda independiente
+- Interfaz de búsqueda independiente
 - Contenido separado
-- Diseno personalizado
+- Diseño personalizado
 
-El host virtual actual se refleja en las funciones de filtrado de resultados de busqueda, etiquetas, contenido relacionado,
-consultas relacionadas y diseno (tema), entre otras funciones de |Fess|.
+El host virtual actual se refleja en las funciones de filtrado de resultados de búsqueda, etiquetas, contenido relacionado,
+consultas relacionadas y diseño (tema), entre otras funciones de |Fess|.
 
 Funcionalidad de host virtual
 ==============================
 
-El host virtual es una funcionalidad que proporciona diferentes entornos de busqueda basados en el nombre de host de la solicitud HTTP.
+El host virtual es una funcionalidad que proporciona diferentes entornos de búsqueda basados en el nombre de host de la solicitud HTTP.
 
 Mecanismo
 ---------
 
 1. El usuario accede a ``tenant1.example.com``
 2. |Fess| identifica el nombre de host
-3. Se aplica la configuracion de host virtual correspondiente
-4. Se muestra el contenido y la UI especificos del inquilino
+3. Se aplica la configuración de host virtual correspondiente
+4. Se muestra el contenido y la UI específicos del inquilino
 
-Configuracion de encabezados de host virtual
+Configuración de encabezados de host virtual
 =============================================
 
 Para habilitar la funcionalidad de host virtual, configure la correspondencia entre los encabezados de la solicitud HTTP
-y las claves de host virtual. Existen dos metodos de configuracion:
+y las claves de host virtual. Existen dos métodos de configuración:
 
-- **Pantalla de administracion (recomendado)**: Configure el campo "Host Virtual" en "Sistema" -> "General".
-  Este valor se guarda como configuracion del sistema y se conserva tras el reinicio. Tiene prioridad sobre
+- **Pantalla de administración (recomendado)**: Configure el campo "Host Virtual" en "Sistema" -> "General".
+  Este valor se guarda como configuración del sistema y se conserva tras el reinicio. Tiene prioridad sobre
   ``virtual.host.headers`` en ``fess_config.properties``.
-- **Archivo de configuracion**: Configure la propiedad ``virtual.host.headers`` en ``fess_config.properties``.
+- **Archivo de configuración**: Configure la propiedad ``virtual.host.headers`` en ``fess_config.properties``.
 
-Ambos metodos utilizan el mismo formato de valor de configuracion.
+Ambos métodos utilizan el mismo formato de valor de configuración.
 
-Formato de configuracion
+Formato de configuración
 ------------------------
 
-Especifique cada entrada en el formato ``NombreEncabezado:ValorEncabezado=ClaveHostVirtual``, una por linea:
+Especifique cada entrada en el formato ``NombreEncabezado:ValorEncabezado=ClaveHostVirtual``, una por línea:
 
 ::
 
@@ -54,55 +54,55 @@ Especifique cada entrada en el formato ``NombreEncabezado:ValorEncabezado=ClaveH
     virtual.host.headers=Host:tenant1.example.com=tenant1\n\
     Host:tenant2.example.com=tenant2
 
-Para multiples hosts virtuales, separe las entradas con saltos de linea.
+Para múltiples hosts virtuales, separe las entradas con saltos de línea.
 
 Comportamiento de coincidencia
 ------------------------------
 
 Cada vez que |Fess| recibe una solicitud, compara el valor del encabezado de solicitud correspondiente al
-"NombreEncabezado" de cada linea configurada con el "ValorEncabezado" configurado.
+"NombreEncabezado" de cada línea configurada con el "ValorEncabezado" configurado.
 
-- La comparacion de valores de encabezado no distingue entre mayusculas y minusculas.
-- Las lineas configuradas se evaluan en orden de arriba a abajo; se aplica la clave de host virtual de la primera linea que coincida.
-- Si no hay coincidencia, la solicitud se trata sin host virtual (entorno comun).
-- El resultado de la evaluacion se almacena en cache por solicitud.
+- La comparación de valores de encabezado no distingue entre mayúsculas y minúsculas.
+- Las líneas configuradas se evalúan en orden de arriba a abajo; se aplica la clave de host virtual de la primera línea que coincida.
+- Si no hay coincidencia, la solicitud se trata sin host virtual (entorno común).
+- El resultado de la evaluación se almacena en cache por solicitud.
 
 Restricciones de claves de host virtual
 ----------------------------------------
 
 Las claves de host virtual tienen las siguientes restricciones:
 
-- Solo se permiten caracteres alfanumericos y guiones bajos (``a-zA-Z0-9_``). Otros caracteres se eliminan automaticamente.
-- Los siguientes nombres de clave estan reservados y no se pueden usar: ``admin``, ``common``, ``error``, ``login``, ``profile``
+- Solo se permiten caracteres alfanuméricos y guiones bajos (``a-zA-Z0-9_``). Otros caracteres se eliminan automáticamente.
+- Los siguientes nombres de clave están reservados y no se pueden usar: ``admin``, ``common``, ``error``, ``login``, ``profile``
 
-Configuracion desde la pantalla de administracion
+Configuración desde la pantalla de administración
 ==================================================
 
-Configuracion de crawl
+Configuración de crawl
 ----------------------
 
-Puede separar el contenido especificando el host virtual en la configuracion de crawl web:
+Puede separar el contenido especificando el host virtual en la configuración de crawl web:
 
-1. Iniciar sesion en la pantalla de administracion
-2. Crear configuracion de crawl en "Crawler" -> "Web"
-3. Seleccionar la clave de host virtual configurada en el campo "Host Virtual" (se admite seleccion multiple)
-4. El contenido crawleado con esta configuracion solo sera buscable en el host virtual especificado
+1. Iniciar sesión en la pantalla de administración
+2. Crear configuración de crawl en "Crawler" -> "Web"
+3. Seleccionar la clave de host virtual configurada en el campo "Host Virtual" (se admite selección múltiple)
+4. El contenido crawleado con esta configuración solo será buscable en el host virtual especificado
 
 .. note::
-   El campo "Host Virtual" esta disponible en las configuraciones de crawl de web, sistema de archivos y almacen de datos.
-   La clave de host virtual seleccionada aqui se asigna a cada documento crawleado y se usa para filtrar
-   por el host virtual actual en el momento de la busqueda.
+   El campo "Host Virtual" está disponible en las configuraciones de crawl de web, sistema de archivos y almacén de datos.
+   La clave de host virtual seleccionada aquí se asigna a cada documento crawleado y se usa para filtrar
+   por el host virtual actual en el momento de la búsqueda.
 
 Control de acceso
 =================
 
-Combinacion de host virtual y roles
+Combinación de host virtual y roles
 -------------------------------------
 
 Al combinar hosts virtuales con control de acceso basado en roles,
-es posible un control de acceso mas detallado.
+es posible un control de acceso más detallado.
 
-Configure el host virtual y los permisos juntos en la configuracion de crawl:
+Configure el host virtual y los permisos juntos en la configuración de crawl:
 
 ::
 
@@ -112,43 +112,43 @@ Configure el host virtual y los permisos juntos en la configuracion de crawl:
     # Permisos en la configuracion de crawl
     {role}tenant1_user
 
-Busqueda basada en roles
+Búsqueda basada en roles
 ------------------------
 
-Para mas detalles, consulte :doc:`security-role`.
+Para más detalles, consulte :doc:`security-role`.
 
-Personalizacion de UI
+Personalización de UI
 =====================
 
 Puede personalizar la UI para cada host virtual.
 
-Aplicacion de tema
+Aplicación de tema
 ------------------
 
 Aplicar un tema diferente para cada host virtual:
 
-1. Configurar tema en "Sistema" -> "Diseno"
-2. Especificar tema en la configuracion del host virtual
+1. Configurar tema en "Sistema" -> "Diseño"
+2. Especificar tema en la configuración del host virtual
 
 CSS personalizado
 -----------------
 
-Para aplicar CSS personalizado por host virtual, edite los archivos CSS en la pantalla de administracion en "Sistema" -> "Diseno". Tambien puede colocar plantillas personalizadas en el directorio de vista correspondiente a la clave del host virtual.
+Para aplicar CSS personalizado por host virtual, edite los archivos CSS en la pantalla de administración en "Sistema" -> "Diseño". También puede colocar plantillas personalizadas en el directorio de vista correspondiente a la clave del host virtual.
 
-Configuracion de etiquetas
+Configuración de etiquetas
 --------------------------
 
 Limitar etiquetas mostradas para cada host virtual:
 
-1. Especificar host virtual en la configuracion del tipo de etiqueta
+1. Especificar host virtual en la configuración del tipo de etiqueta
 2. La etiqueta solo se muestra en el host virtual especificado
 
 Acceso mediante API
 ===================
 
-Las solicitudes a la API de busqueda tambien determinan el host virtual por el nombre de host de la solicitud
+Las solicitudes a la API de búsqueda también determinan el host virtual por el nombre de host de la solicitud
 (el encabezado configurado, normalmente el encabezado ``Host``), igual que la UI. Por ejemplo,
-una solicitud dirigida a ``tenant1.example.com`` se limita automaticamente al host virtual ``tenant1``
+una solicitud dirigida a ``tenant1.example.com`` se limita automáticamente al host virtual ``tenant1``
 y solo se busca en el contenido de ese host virtual.
 
 Solicitud de API
@@ -158,7 +158,7 @@ Solicitud de API
 
     curl "https://tenant1.example.com/api/v2/search?q=keyword"
 
-Para autenticarse con un token de acceso, especifiquelo en el encabezado ``Authorization``
+Para autenticarse con un token de acceso, especifíquelo en el encabezado ``Authorization``
 en formato ``Bearer``:
 
 ::
@@ -167,16 +167,16 @@ en formato ``Bearer``:
          "https://tenant1.example.com/api/v2/search?q=keyword"
 
 .. note::
-   Los tokens de acceso no estan vinculados a un host virtual especifico. Un token es valido para
+   Los tokens de acceso no están vinculados a un host virtual específico. Un token es válido para
    cualquier host virtual; el host virtual de destino se determina por el nombre de host al que se
-   envia la solicitud. Si se envia el mismo token a un nombre de host diferente, se aplica al
+   envía la solicitud. Si se envía el mismo token a un nombre de host diferente, se aplica al
    host virtual correspondiente. Si desea controlar el alcance del acceso independientemente del
    host virtual, combinen con el control de acceso basado en roles (:doc:`security-role`).
 
-Configuracion de DNS
+Configuración de DNS
 ====================
 
-Ejemplo de configuracion de DNS para implementar multitenencia:
+Ejemplo de configuración de DNS para implementar multitenencia:
 
 Subdominios al mismo servidor
 ------------------------------
@@ -190,10 +190,10 @@ Subdominios al mismo servidor
     # O comodin
     *.example.com          A    192.168.1.100
 
-Configuracion de proxy inverso
+Configuración de proxy inverso
 --------------------------------
 
-Ejemplo de configuracion de proxy inverso con Nginx:
+Ejemplo de configuración de proxy inverso con Nginx:
 
 ::
 
@@ -217,15 +217,15 @@ Ejemplo de configuracion de proxy inverso con Nginx:
         }
     }
 
-Separacion de datos
+Separación de datos
 ===================
 
-Si se requiere separacion completa de datos, considere los siguientes enfoques:
+Si se requiere separación completa de datos, considere los siguientes enfoques:
 
-Separacion a nivel de indice
+Separación a nivel de índice
 ------------------------------
 
-Usar instancias e indices separados de |Fess| para cada inquilino:
+Usar instancias e índices separados de |Fess| para cada inquilino:
 
 ::
 
@@ -237,27 +237,27 @@ Usar instancias e indices separados de |Fess| para cada inquilino:
 
 .. note::
    ``index.document.search.index`` solo puede establecerse en un valor por instancia.
-   Para una separacion completa a nivel de indice, necesita ejecutar instancias separadas de |Fess| por inquilino
-   o implementar codigo personalizado. Para multitenencia tipica, la separacion logica mediante la funcionalidad de host virtual es suficiente.
+   Para una separación completa a nivel de índice, necesita ejecutar instancias separadas de |Fess| por inquilino
+   o implementar código personalizado. Para multitenencia típica, la separación lógica mediante la funcionalidad de host virtual es suficiente.
 
-Mejores practicas
+Mejores prácticas
 =================
 
-1. **Convencion de nombres clara**: Usar una convencion de nombres consistente para hosts virtuales y roles
+1. **Convención de nombres clara**: Usar una convención de nombres consistente para hosts virtuales y roles
 2. **Pruebas**: Probar exhaustivamente el funcionamiento en cada inquilino
 3. **Monitoreo**: Monitorear el uso de recursos por inquilino
-4. **Documentacion**: Documentar la configuracion de inquilinos
+4. **Documentación**: Documentar la configuración de inquilinos
 
 Limitaciones
 ============
 
-- La pantalla de administracion es compartida por todos los inquilinos
-- La configuracion del sistema afecta a todos los inquilinos
+- La pantalla de administración es compartida por todos los inquilinos
+- La configuración del sistema afecta a todos los inquilinos
 - Algunas funcionalidades pueden no ser compatibles con hosts virtuales
 
-Informacion de referencia
+Información de referencia
 =========================
 
 - :doc:`security-role` - Control de acceso basado en roles
-- :doc:`security-virtual-host` - Detalles de configuracion de host virtual
-- :doc:`../admin/design-guide` - Personalizacion de diseno
+- :doc:`security-virtual-host` - Detalles de configuración de host virtual
+- :doc:`../admin/design-guide` - Personalización de diseño

--- a/es/15.7/config/scripting-groovy.rst
+++ b/es/15.7/config/scripting-groovy.rst
@@ -1,18 +1,18 @@
 ==================================
-Guia de scripting Groovy
+Guía de scripting Groovy
 ==================================
 
-Descripcion general
+Descripción general
 ===================
 
 Groovy es el lenguaje de scripting predeterminado de |Fess|.
-Se ejecuta en la maquina virtual Java (JVM) y permite escribir scripts con una sintaxis mas concisa
+Se ejecuta en la máquina virtual Java (JVM) y permite escribir scripts con una sintaxis más concisa
 mientras mantiene alta compatibilidad con Java.
 
-Sintaxis basica
+Sintaxis básica
 ===============
 
-Declaracion de variables
+Declaración de variables
 ------------------------
 
 ::
@@ -110,15 +110,15 @@ Bucles
 Scripts de Data Store
 =====================
 
-Ejemplos de scripts en configuracion de data store.
+Ejemplos de scripts en configuración de data store.
 
 .. note::
-   En los scripts de data store, cada linea ``campo=expresion`` se evalua de forma independiente como una unica expresion.
-   Por lo tanto, no se pueden usar sentencias ``import``, declaraciones ``def`` multilinea ni estructuras de control multilinea que establezcan varios campos a la vez (como bloques ``if``).
-   Al usar clases Java, escribalas como una unica expresion con el nombre de clase completamente calificado (FQCN), y use el operador ternario por campo para los valores condicionales (por ejemplo, ``url=data.published ? data.url : null`` ).
-   Ademas, el nombre de variable ``data`` usado aqui es solo un ejemplo; el nombre de variable real depende del conector de data store utilizado. Consulte :doc:`../admin/dataconfig-guide` para mas detalles.
+   En los scripts de data store, cada línea ``campo=expresion`` se evalúa de forma independiente como una única expresión.
+   Por lo tanto, no se pueden usar sentencias ``import``, declaraciones ``def`` multilínea ni estructuras de control multilínea que establezcan varios campos a la vez (como bloques ``if``).
+   Al usar clases Java, escríbalas como una única expresión con el nombre de clase completamente calificado (FQCN), y use el operador ternario por campo para los valores condicionales (por ejemplo, ``url=data.published ? data.url : null`` ).
+   Además, el nombre de variable ``data`` usado aquí es solo un ejemplo; el nombre de variable real depende del conector de data store utilizado. Consulte :doc:`../admin/dataconfig-guide` para más detalles.
 
-Mapeo basico
+Mapeo básico
 ------------
 
 ::
@@ -128,7 +128,7 @@ Mapeo basico
     content=data.content
     lastModified=data.updated_at
 
-Generacion de URL
+Generación de URL
 -----------------
 
 ::
@@ -170,7 +170,7 @@ Procesamiento de fechas
 Objetos disponibles
 ===================
 
-Los objetos disponibles en los scripts varian segun el contexto de ejecucion.
+Los objetos disponibles en los scripts varían según el contexto de ejecución.
 
 .. list-table::
    :header-rows: 1
@@ -178,36 +178,36 @@ Los objetos disponibles en los scripts varian segun el contexto de ejecucion.
 
    * - Contexto
      - Objeto
-     - Descripcion
+     - Descripción
    * - Todos los contextos
      - ``container``
      - Contenedor DI. Se usa para acceder a los componentes mediante ``container.getComponent("...")``
    * - Trabajos programados
      - ``executor``
-     - Control de ejecucion de trabajos ( ``JobExecutor`` ). Necesario para el soporte de detencion de trabajos
+     - Control de ejecución de trabajos ( ``JobExecutor`` ). Necesario para el soporte de detención de trabajos
    * - Data Store
-     - (especifico del conector)
+     - (específico del conector)
      - Variables de registro de datos proporcionadas por cada data store. El nombre de la variable depende del conector
    * - Mapeo de rutas
      - ``url`` , ``matcher``
-     - La cadena de URL a convertir y el resultado de coincidencia de expresion regular ( ``Matcher`` ). Disponible en configuraciones de reemplazo con el prefijo ``groovy:``
+     - La cadena de URL a convertir y el resultado de coincidencia de expresión regular ( ``Matcher`` ). Disponible en configuraciones de reemplazo con el prefijo ``groovy:``
    * - Boost de documento
      - (campos del documento)
-     - Cada campo del documento objetivo esta disponible como variable (se usa en expresiones de condicion y de valor de boost)
+     - Cada campo del documento objetivo está disponible como variable (se usa en expresiones de condición y de valor de boost)
 
 Scripts de trabajos programados
 ===============================
 
 Ejemplos de scripts Groovy para trabajos programados.
-En los trabajos programados, ``container`` y ``executor`` estan disponibles.
-Pasar ``executor`` al metodo ``execute()`` del trabajo habilita el control de detencion del trabajo.
+En los trabajos programados, ``container`` y ``executor`` están disponibles.
+Pasar ``executor`` al método ``execute()`` del trabajo habilita el control de detención del trabajo.
 
 .. note::
-   Un script de trabajo programado se evalua como un unico script Groovy completo.
-   Por lo tanto, a diferencia de los scripts de data store, puede usar sentencias ``import``, declaraciones ``def`` multilinea y estructuras de control multilinea.
-   Los ejemplos de "Uso de clases Java", "Acceso a componentes de Fess", "Manejo de errores" y "Depuracion y salida de logs" que aparecen a continuacion tambien asumen este contexto de script completo.
+   Un script de trabajo programado se evalúa como un único script Groovy completo.
+   Por lo tanto, a diferencia de los scripts de data store, puede usar sentencias ``import``, declaraciones ``def`` multilínea y estructuras de control multilínea.
+   Los ejemplos de "Uso de clases Java", "Acceso a componentes de Fess", "Manejo de errores" y "Depuración y salida de logs" que aparecen a continuación también asumen este contexto de script completo.
 
-Ejecucion de trabajo de crawl
+Ejecución de trabajo de crawl
 -----------------------------
 
 ::
@@ -230,7 +230,7 @@ Crawl condicional
     }
     return "Skipped during business hours"
 
-Ejecucion secuencial de multiples trabajos
+Ejecución secuencial de múltiples trabajos
 ------------------------------------------
 
 ::
@@ -248,7 +248,7 @@ Ejecucion secuencial de multiples trabajos
 Uso de clases Java
 ==================
 
-Dentro de los scripts Groovy, puede usar la biblioteca estandar de Java y las clases de Fess.
+Dentro de los scripts Groovy, puede usar la biblioteca estándar de Java y las clases de Fess.
 
 Fecha y hora
 ------------
@@ -271,7 +271,7 @@ Operaciones de archivo
 
     def content = new String(Files.readAllBytes(Paths.get("/path/to/file.txt")))
 
-Comunicacion HTTP
+Comunicación HTTP
 -----------------
 
 ::
@@ -283,7 +283,7 @@ Comunicacion HTTP
 
 .. warning::
    El acceso a recursos externos afecta el rendimiento,
-   mantengalo al minimo necesario.
+   manténgalo al mínimo necesario.
 
 Acceso a componentes de Fess
 ============================
@@ -298,7 +298,7 @@ System Helper
     def systemHelper = container.getComponent("systemHelper")
     def currentTime = systemHelper.getCurrentTimeAsLong()
 
-Obtencion de valores de configuracion
+Obtención de valores de configuración
 -------------------------------------
 
 ::
@@ -306,7 +306,7 @@ Obtencion de valores de configuracion
     def fessConfig = container.getComponent("fessConfig")
     def indexName = fessConfig.getIndexDocumentUpdateIndex()
 
-Ejecucion de busqueda
+Ejecución de búsqueda
 ---------------------
 
 ::
@@ -333,7 +333,7 @@ Puede capturar excepciones con ``try-catch`` para controlar los errores del trab
         return "Error: " + e.message
     }
 
-Depuracion y salida de logs
+Depuración y salida de logs
 ===========================
 
 Salida de logs
@@ -350,7 +350,7 @@ Salida de logs
     logger.warn("Warning: {}", message)
     logger.error("Error: {}", e.message, e)
 
-Salida de depuracion
+Salida de depuración
 --------------------
 
 ::
@@ -359,19 +359,19 @@ Salida de depuracion
     println "data.id = ${data.id}"
     println "data.title = ${data.title}"
 
-Mejores practicas
+Mejores prácticas
 =================
 
-1. **Mantenerlo simple**: Evitar logica compleja, escribir codigo legible
-2. **Verificacion de null**: Usar operadores ``?.`` y ``?:``
+1. **Mantenerlo simple**: Evitar lógica compleja, escribir código legible
+2. **Verificación de null**: Usar operadores ``?.`` y ``?:``
 3. **Manejo de excepciones**: Manejar errores inesperados con try-catch apropiado
-4. **Salida de logs**: Registrar logs para facilitar la depuracion
+4. **Salida de logs**: Registrar logs para facilitar la depuración
 5. **Rendimiento**: Minimizar acceso a recursos externos
 
-Informacion de referencia
+Información de referencia
 =========================
 
-- `Documentacion oficial de Groovy <https://groovy-lang.org/documentation.html>`__
-- :doc:`scripting-overview` - Descripcion general de scripting
-- :doc:`../admin/dataconfig-guide` - Guia de configuracion de Data Store
-- :doc:`../admin/scheduler-guide` - Guia de configuracion del programador
+- `Documentación oficial de Groovy <https://groovy-lang.org/documentation.html>`__
+- :doc:`scripting-overview` - Descripción general de scripting
+- :doc:`../admin/dataconfig-guide` - Guía de configuración de Data Store
+- :doc:`../admin/scheduler-guide` - Guía de configuración del programador

--- a/es/15.7/config/scripting-overview.rst
+++ b/es/15.7/config/scripting-overview.rst
@@ -1,13 +1,13 @@
 =======================================
-Descripcion general del scripting
+Descripción general del scripting
 =======================================
 
-Descripcion general
+Descripción general
 ===================
 
-En |Fess|, puede implementar logica personalizada usando scripts en diversos escenarios.
+En |Fess|, puede implementar lógica personalizada usando scripts en diversos escenarios.
 Al aprovechar los scripts, puede controlar de manera flexible el procesamiento de datos
-durante el crawl, la transformacion de URLs y la ejecucion de trabajos programados.
+durante el crawl, la transformación de URLs y la ejecución de trabajos programados.
 
 Lenguajes de scripting compatibles
 ===================================
@@ -20,25 +20,25 @@ Lenguajes de scripting compatibles
 
    * - Lenguaje
      - Identificador
-     - Descripcion
+     - Descripción
    * - Groovy
      - ``groovy``
      - Lenguaje de scripting registrado de forma predeterminada. Compatible con Java y proporciona funcionalidades potentes
 
 .. note::
-   El unico motor de scripting registrado de forma predeterminada en |Fess| es Groovy.
+   El único motor de scripting registrado de forma predeterminada en |Fess| es Groovy.
    El lenguaje de scripting por defecto es ``groovy`` ( ``Constants.DEFAULT_SCRIPT`` ).
-   Todos los ejemplos de scripts de este documento estan escritos en sintaxis Groovy.
+   Todos los ejemplos de scripts de este documento están escritos en sintaxis Groovy.
 
 Casos de uso del scripting
 ===========================
 
-Configuracion de data store
+Configuración de data store
 ----------------------------
 
 En los conectores de data store, se usan scripts para mapear los datos obtenidos
-a los campos del indice. La configuracion se escribe en formato ``nombre_de_campo=expresion``
-una linea por entrada, y cada linea se evalua como una expresion Groovy independiente.
+a los campos del índice. La configuración se escribe en formato ``nombre_de_campo=expresion``
+una línea por entrada, y cada línea se evalúa como una expresión Groovy independiente.
 
 ::
 
@@ -47,31 +47,31 @@ una linea por entrada, y cada linea se evalua como una expresion Groovy independ
     content=description
     last_modified=updated_at
 
-Los nombres de variables disponibles en los scripts de data store varian segun el tipo de conector.
+Los nombres de variables disponibles en los scripts de data store varían según el tipo de conector.
 Por ejemplo, en el data store CSV y en el data store JSON, cada nombre de columna o campo
-puede usarse directamente como variable (sin prefijo comun como ``data``).
+puede usarse directamente como variable (sin prefijo común como ``data``).
 En los conectores de tipo archivo (Box, Google Drive, OneDrive, etc.) se usa el prefijo ``file.*``,
 en Slack se usa ``message.*``, y cada conector tiene su propio prefijo.
-Consulte la documentacion de cada conector de data store para conocer las variables disponibles.
+Consulte la documentación de cada conector de data store para conocer las variables disponibles.
 
 .. note::
-   Cada linea de un data store se evalua como una expresion unica, por lo que no es posible
-   usar bloques ``if`` de varias lineas, sentencias ``import`` ni declaraciones de variables
-   con ``def``. Para cambiar un valor segun una condicion, use el operador ternario por campo
+   Cada línea de un data store se evalúa como una expresión única, por lo que no es posible
+   usar bloques ``if`` de varias líneas, sentencias ``import`` ni declaraciones de variables
+   con ``def``. Para cambiar un valor según una condición, use el operador ternario por campo
    (por ejemplo: ``title=enabled == "true" ? name : null`` ). Para referenciar clases,
-   escriba el nombre completamente cualificado (FQCN) en linea.
+   escriba el nombre completamente cualificado (FQCN) en línea.
 
 Mapeo de rutas
 --------------
 
-El mapeo de rutas es una funcion para normalizar y transformar las URLs a crawlear.
-De forma predeterminada, se configura mediante un par de "expresion regular" y "cadena de
+El mapeo de rutas es una función para normalizar y transformar las URLs a crawlear.
+De forma predeterminada, se configura mediante un par de "expresión regular" y "cadena de
 reemplazo", y no es un script Groovy. Por ejemplo, si se especifica ``http://`` como
-expresion regular y ``https://`` como cadena de reemplazo, se sustituye el esquema de la URL.
+expresión regular y ``https://`` como cadena de reemplazo, se sustituye el esquema de la URL.
 
 Solo cuando la cadena de reemplazo comienza con el prefijo ``groovy:``, la cadena restante
-se evalua como un script Groovy. Dentro de este script, se puede usar ``url`` para la cadena
-de URL a transformar y ``matcher`` para el ``java.util.regex.Matcher`` de la expresion regular.
+se evalúa como un script Groovy. Dentro de este script, se puede usar ``url`` para la cadena
+de URL a transformar y ``matcher`` para el ``java.util.regex.Matcher`` de la expresión regular.
 
 ::
 
@@ -80,24 +80,24 @@ de URL a transformar y ``matcher`` para el ``java.util.regex.Matcher`` de la exp
 Trabajos programados
 --------------------
 
-En los trabajos programados, puede escribir logica de procesamiento personalizada en scripts
-Groovy. El script completo se evalua como un unico script Groovy, por lo que es posible
-usar multiples lineas, sentencias ``import`` y declaraciones de variables con ``def``.
+En los trabajos programados, puede escribir lógica de procesamiento personalizada en scripts
+Groovy. El script completo se evalúa como un único script Groovy, por lo que es posible
+usar múltiples líneas, sentencias ``import`` y declaraciones de variables con ``def``.
 
 ::
 
     return container.getComponent("crawlJob").logLevel("info").gcLogging().execute(executor);
 
-Los metodos como ``logLevel("info")`` son metodos de la clase del trabajo ( ``ExecJob`` y sus
-subclases) y pueden encadenarse. Consulte "Contexto de ejecucion y objetos disponibles" para
-obtener informacion sobre la variable ``executor``.
+Los métodos como ``logLevel("info")`` son métodos de la clase del trabajo ( ``ExecJob`` y sus
+subclases) y pueden encadenarse. Consulte "Contexto de ejecución y objetos disponibles" para
+obtener información sobre la variable ``executor``.
 
-Sintaxis basica
+Sintaxis básica
 ===============
 
-A continuacion se muestran ejemplos de sintaxis basica de Groovy. Los comentarios se escriben
-con ``//`` (comentario de linea) o ``/* */`` (comentario de bloque). Tenga en cuenta que los
-comentarios que comienzan con ``#`` no son validos en Groovy.
+A continuación se muestran ejemplos de sintaxis básica de Groovy. Los comentarios se escriben
+con ``//`` (comentario de línea) o ``/* */`` (comentario de bloque). Tenga en cuenta que los
+comentarios que comienzan con ``#`` no son válidos en Groovy.
 
 Acceso a variables
 ------------------
@@ -146,52 +146,52 @@ Operaciones de fecha
     // Formato
     new java.text.SimpleDateFormat("yyyy-MM-dd").format(updated_at)
 
-Contexto de ejecucion y objetos disponibles
+Contexto de ejecución y objetos disponibles
 ============================================
 
-Los objetos disponibles dentro de un script varian segun el contexto en que se ejecuta.
-Solo ``container`` esta disponible en todos los contextos.
+Los objetos disponibles dentro de un script varían según el contexto en que se ejecuta.
+Solo ``container`` está disponible en todos los contextos.
 
 .. list-table::
    :header-rows: 1
    :widths: 30 25 45
 
-   * - Contexto de ejecucion
+   * - Contexto de ejecución
      - Objetos disponibles
-     - Descripcion
+     - Descripción
    * - Todos los contextos
      - ``container``
      - Contenedor DI. Acceso a componentes mediante
        ``container.getComponent("systemHelper")`` o
        ``container.getComponent("fessConfig")``
    * - Script de data store
-     - Variables de campo especificas del conector
-     - Cada campo obtenido del data store esta disponible como variable
-       (los nombres de variable y prefijos varian segun el conector; en CSV/JSON el nombre del campo se usa directamente como variable)
+     - Variables de campo específicas del conector
+     - Cada campo obtenido del data store está disponible como variable
+       (los nombres de variable y prefijos varían según el conector; en CSV/JSON el nombre del campo se usa directamente como variable)
    * - Mapeo de rutas
      - ``url`` ``matcher``
-     - La cadena de URL a transformar y el ``Matcher`` de la expresion regular (solo cuando se usa el prefijo ``groovy:``)
+     - La cadena de URL a transformar y el ``Matcher`` de la expresión regular (solo cuando se usa el prefijo ``groovy:``)
    * - Trabajos programados
      - ``executor``
-     - Instancia de ejecucion del trabajo ( ``JobExecutor`` ). Se usa para controlar el apagado del trabajo
+     - Instancia de ejecución del trabajo ( ``JobExecutor`` ). Se usa para controlar el apagado del trabajo
 
 .. note::
-   Los objetos distintos de ``container`` solo se inyectan en contextos especificos.
-   Por ejemplo, ``executor`` solo esta disponible en trabajos programados y no puede
+   Los objetos distintos de ``container`` solo se inyectan en contextos específicos.
+   Por ejemplo, ``executor`` solo está disponible en trabajos programados y no puede
    usarse en scripts de data store ni en mapeo de rutas.
 
 Seguridad
 =========
 
 .. warning::
-   Los scripts tienen funcionalidades muy potentes; uselos unicamente desde fuentes de confianza.
+   Los scripts tienen funcionalidades muy potentes; úselos únicamente desde fuentes de confianza.
 
 - Los scripts se ejecutan en el servidor
 - Es posible acceder al sistema de archivos y a la red
-- Asegurese de que solo los usuarios con privilegios de administrador puedan editar scripts
-- La ejecucion de scripts se registra en el log de auditoria ( ``audit.log`` ).
-  El registro puede controlarse con ``script.audit.log.enabled`` y esta activado por defecto ( ``true`` ).
-  La longitud maxima de la cadena de script registrada se controla con ``script.audit.log.max.length``
+- Asegúrese de que solo los usuarios con privilegios de administrador puedan editar scripts
+- La ejecución de scripts se registra en el log de auditoría ( ``audit.log`` ).
+  El registro puede controlarse con ``script.audit.log.enabled`` y está activado por defecto ( ``true`` ).
+  La longitud máxima de la cadena de script registrada se controla con ``script.audit.log.max.length``
   y el valor por defecto es ``100`` caracteres.
 
 Rendimiento
@@ -203,13 +203,13 @@ Consejos para optimizar el rendimiento de los scripts:
 2. **Minimizar el acceso a recursos externos**: Las llamadas de red son una fuente de latencia
 3. **Aprovechar la cache**: Considere usar cache para valores que se usan repetidamente
 
-Depuracion
+Depuración
 ==========
 
-En los scripts de trabajos programados, el script completo se evalua como un unico script
+En los scripts de trabajos programados, el script completo se evalúa como un único script
 Groovy, por lo que puede usar la salida de logs para depurar.
-(En los scripts de data store, cada linea se evalua como una expresion individual, por lo que
-no es posible usar sentencias ``import`` ni procesamiento en varias lineas.)
+(En los scripts de data store, cada línea se evalúa como una expresión individual, por lo que
+no es posible usar sentencias ``import`` ni procesamiento en varias líneas.)
 
 ::
 
@@ -218,23 +218,23 @@ no es posible usar sentencias ``import`` ni procesamiento en varias lineas.)
     logger.info("executor = {}", executor)
 
 El ejemplo anterior usa un logger denominado ``fess.script``.
-Para que este log se emita, agregue la configuracion del logger correspondiente
+Para que este log se emita, agregue la configuración del logger correspondiente
 en ``app/WEB-INF/classes/log4j2.xml``.
 
 ::
 
     <Logger name="fess.script" level="DEBUG"/>
 
-Ademas, para activar los logs de depuracion del propio motor de scripting, establezca
+Además, para activar los logs de depuración del propio motor de scripting, establezca
 el nivel de log del paquete ``org.codelibs.fess.script`` en ``DEBUG``.
 
 ::
 
     <Logger name="org.codelibs.fess.script" level="DEBUG"/>
 
-Informacion de referencia
+Información de referencia
 ==========================
 
-- :doc:`scripting-groovy` - Guia de scripting Groovy
-- :doc:`../admin/dataconfig-guide` - Guia de configuracion de data store
-- :doc:`../admin/scheduler-guide` - Guia de configuracion del planificador
+- :doc:`scripting-groovy` - Guía de scripting Groovy
+- :doc:`../admin/dataconfig-guide` - Guía de configuración de data store
+- :doc:`../admin/scheduler-guide` - Guía de configuración del planificador

--- a/es/15.7/dev/datastore-plugin.rst
+++ b/es/15.7/dev/datastore-plugin.rst
@@ -1,19 +1,19 @@
 ==================================
-Desarrollo de Plugins de Almacen de Datos
+Desarrollo de Plugins de Almacén de Datos
 ==================================
 
-Vision General
+Visión General
 ==============
 
-Al desarrollar un plugin de almacen de datos, puede agregar funcionalidad a |Fess|
+Al desarrollar un plugin de almacén de datos, puede agregar funcionalidad a |Fess|
 para obtener contenido desde nuevas fuentes de datos.
 
-Estructura Basica
+Estructura Básica
 =================
 
-El plugin de almacen de datos se implementa heredando de ``AbstractDataStore``.
+El plugin de almacén de datos se implementa heredando de ``AbstractDataStore``.
 
-Implementacion Minima
+Implementación Mínima
 ---------------------
 
 .. code-block:: java
@@ -48,37 +48,37 @@ Implementacion Minima
 AbstractDataStore
 =================
 
-Metodos Principales
+Métodos Principales
 -------------------
 
 .. list-table::
    :header-rows: 1
    :widths: 30 70
 
-   * - Metodo
-     - Descripcion
+   * - Método
+     - Descripción
    * - ``getName()``
-     - Devuelve el nombre del almacen de datos (obligatorio)
+     - Devuelve el nombre del almacén de datos (obligatorio)
    * - ``storeData()``
-     - Realiza la obtencion de datos y registro en el indice (obligatorio)
+     - Realiza la obtención de datos y registro en el índice (obligatorio)
    * - ``register()``
      - Registra el plugin
 
-Parametros
+Parámetros
 ----------
 
-Parametros pasados al metodo ``storeData()``:
+Parámetros pasados al método ``storeData()``:
 
-- ``dataConfig``: Configuracion del almacen de datos
-- ``callback``: Callback para actualizacion del indice
-- ``paramMap``: Parametros configurados en la pantalla de administracion
-- ``scriptMap``: Configuracion de scripts
+- ``dataConfig``: Configuración del almacén de datos
+- ``callback``: Callback para actualización del índice
+- ``paramMap``: Parámetros configurados en la pantalla de administración
+- ``scriptMap``: Configuración de scripts
 - ``defaultDataMap``: Mapa de datos predeterminado
 
-Ejemplo de Implementacion
+Ejemplo de Implementación
 =========================
 
-Almacen de Datos Simple
+Almacén de Datos Simple
 -----------------------
 
 .. code-block:: java
@@ -126,7 +126,7 @@ Almacen de Datos Simple
         }
     }
 
-Soporte de Paginacion
+Soporte de Paginación
 ---------------------
 
 .. code-block:: java
@@ -151,7 +151,7 @@ Soporte de Paginacion
         }
     }
 
-Implementacion de Autenticacion
+Implementación de Autenticación
 ===============================
 
 OAuth 2.0
@@ -181,7 +181,7 @@ OAuth 2.0
         }
     }
 
-Autenticacion con Clave API
+Autenticación con Clave API
 ---------------------------
 
 .. code-block:: java
@@ -245,12 +245,12 @@ Pruebas Unitarias
         }
     }
 
-Ejemplo de Configuracion
+Ejemplo de Configuración
 ========================
 
-Ejemplo de configuracion en la pantalla de administracion:
+Ejemplo de configuración en la pantalla de administración:
 
-Parametros
+Parámetros
 ----------
 
 ::
@@ -271,9 +271,9 @@ Script
     lastModified=data.updated_at
     mimetype=data.content_type
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
 - :doc:`plugin-architecture` - Arquitectura de plugins
-- :doc:`../config/datastore/ds-overview` - Vision general de conectores de almacen de datos
-- `GitHub: fess-ds-* <https://github.com/codelibs?q=fess-ds>`__ - Ejemplos de plugins publicos
+- :doc:`../config/datastore/ds-overview` - Visión general de conectores de almacén de datos
+- `GitHub: fess-ds-* <https://github.com/codelibs?q=fess-ds>`__ - Ejemplos de plugins públicos

--- a/es/15.7/dev/ingest-plugin.rst
+++ b/es/15.7/dev/ingest-plugin.rst
@@ -2,21 +2,21 @@
 Plugin Ingest
 ==================================
 
-Vision General
+Visión General
 ==============
 
 Los plugins Ingest proporcionan funcionalidad para procesar y transformar
-datos antes de que los documentos se registren en el indice.
+datos antes de que los documentos se registren en el índice.
 
 Casos de Uso
 ============
 
-- Normalizacion de texto (conversion de ancho completo/medio, etc.)
-- Adicion de metadatos
-- Enmascaramiento de informacion sensible
-- Adicion de campos personalizados
+- Normalización de texto (conversión de ancho completo/medio, etc.)
+- Adición de metadatos
+- Enmascaramiento de información sensible
+- Adición de campos personalizados
 
-Implementacion Basica
+Implementación Básica
 =====================
 
 Implemente la interfaz ``IngestHandler``:
@@ -63,7 +63,7 @@ Registro
         <postConstruct name="register"/>
     </component>
 
-Configuracion
+Configuración
 =============
 
 ``fess_config.properties``:
@@ -72,7 +72,7 @@ Configuracion
 
     ingest.handler.example.enabled=true
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
 - :doc:`plugin-architecture` - Arquitectura de plugins

--- a/es/15.7/dev/overview.rst
+++ b/es/15.7/dev/overview.rst
@@ -1,26 +1,26 @@
 ==================================
-Vision General de Documentacion para Desarrolladores
+Visión General de Documentación para Desarrolladores
 ==================================
 
-Vision General
+Visión General
 ==============
 
-Esta seccion explica el desarrollo de extensiones de |Fess|.
-Proporciona informacion para extender |Fess|, incluyendo desarrollo de plugins,
-creacion de conectores personalizados y personalizacion de temas.
+Esta sección explica el desarrollo de extensiones de |Fess|.
+Proporciona información para extender |Fess|, incluyendo desarrollo de plugins,
+creación de conectores personalizados y personalización de temas.
 
 Audiencia Objetivo
 ==================
 
 - Desarrolladores que desean crear funciones personalizadas para |Fess|
 - Desarrolladores que desean crear plugins
-- Desarrolladores que desean entender el codigo fuente de |Fess|
+- Desarrolladores que desean entender el código fuente de |Fess|
 
 Conocimientos Previos
 ---------------------
 
-- Conocimientos basicos de Java 21
-- Conceptos basicos de Maven (sistema de construccion)
+- Conocimientos básicos de Java 21
+- Conceptos básicos de Maven (sistema de construcción)
 - Experiencia en desarrollo de aplicaciones web
 
 Entorno de Desarrollo
@@ -31,13 +31,13 @@ Entorno Recomendado
 
 - **JDK**: OpenJDK 21 o superior
 - **IDE**: IntelliJ IDEA / Eclipse / VS Code
-- **Herramienta de construccion**: Maven 3.9 o superior
+- **Herramienta de construcción**: Maven 3.9 o superior
 - **Git**: Control de versiones
 
-Configuracion
+Configuración
 -------------
 
-1. Obtener el codigo fuente:
+1. Obtener el código fuente:
 
 ::
 
@@ -56,10 +56,10 @@ Configuracion
 
     ./bin/fess
 
-Vision General de la Arquitectura
+Visión General de la Arquitectura
 =================================
 
-|Fess| esta compuesto por los siguientes componentes principales:
+|Fess| está compuesto por los siguientes componentes principales:
 
 Estructura de Componentes
 -------------------------
@@ -69,24 +69,24 @@ Estructura de Componentes
    :widths: 25 75
 
    * - Componente
-     - Descripcion
+     - Descripción
    * - Capa Web
-     - Implementacion MVC con el framework LastaFlute
+     - Implementación MVC con el framework LastaFlute
    * - Capa de Servicios
-     - Logica de negocio
+     - Lógica de negocio
    * - Capa de Acceso a Datos
-     - Integracion con OpenSearch mediante DBFlute
+     - Integración con OpenSearch mediante DBFlute
    * - Rastreador
-     - Recoleccion de contenido con la biblioteca fess-crawler
-   * - Motor de Busqueda
-     - Busqueda de texto completo con OpenSearch
+     - Recolección de contenido con la biblioteca fess-crawler
+   * - Motor de Búsqueda
+     - Búsqueda de texto completo con OpenSearch
 
 Frameworks Principales
 ----------------------
 
-- **LastaFlute**: Framework web (Acciones, Formularios, Validacion)
-- **DBFlute**: Framework de acceso a datos (integracion con OpenSearch)
-- **Lasta Di**: Contenedor de inyeccion de dependencias
+- **LastaFlute**: Framework web (Acciones, Formularios, Validación)
+- **DBFlute**: Framework de acceso a datos (integración con OpenSearch)
+- **Lasta Di**: Contenedor de inyección de dependencias
 
 Estructura de Directorios
 =========================
@@ -111,31 +111,31 @@ Estructura de Directorios
     └── src/main/webapp/
         └── WEB-INF/view/    # Plantillas JSP
 
-Puntos de Extension
+Puntos de Extensión
 ===================
 
-|Fess| proporciona los siguientes puntos de extension:
+|Fess| proporciona los siguientes puntos de extensión:
 
 Plugins
 -------
 
 Puede agregar funcionalidad utilizando plugins.
 
-- **Plugin de almacen de datos**: Rastreo desde nuevas fuentes de datos
+- **Plugin de almacén de datos**: Rastreo desde nuevas fuentes de datos
 - **Plugin de motor de scripts**: Soporte para nuevos lenguajes de script
-- **Plugin de aplicacion web**: Extension de la interfaz web
-- **Plugin Ingest**: Procesamiento de datos durante la indexacion
+- **Plugin de aplicación web**: Extensión de la interfaz web
+- **Plugin Ingest**: Procesamiento de datos durante la indexación
 
 Detalles: :doc:`plugin-architecture`
 
 Temas
 -----
 
-Puede personalizar el diseno de la pantalla de busqueda.
+Puede personalizar el diseño de la pantalla de búsqueda.
 
 Detalles: :doc:`theme-development`
 
-Configuracion
+Configuración
 -------------
 
 Puede personalizar muchos comportamientos en ``fess_config.properties``.
@@ -148,38 +148,38 @@ Desarrollo de Plugins
 Para detalles sobre el desarrollo de plugins, consulte lo siguiente:
 
 - :doc:`plugin-architecture` - Arquitectura de plugins
-- :doc:`datastore-plugin` - Desarrollo de plugins de almacen de datos
+- :doc:`datastore-plugin` - Desarrollo de plugins de almacén de datos
 - :doc:`script-engine-plugin` - Plugins de motor de scripts
-- :doc:`webapp-plugin` - Plugins de aplicacion web
+- :doc:`webapp-plugin` - Plugins de aplicación web
 - :doc:`ingest-plugin` - Plugins Ingest
 
 Desarrollo de Temas
 ===================
 
-- :doc:`theme-development` - Personalizacion de temas
+- :doc:`theme-development` - Personalización de temas
 
-Mejores Practicas
+Mejores Prácticas
 =================
 
-Convenciones de Codificacion
+Convenciones de Codificación
 ----------------------------
 
-- Seguir el estilo de codigo existente de |Fess|
-- Formatear codigo con ``mvn formatter:format``
+- Seguir el estilo de código existente de |Fess|
+- Formatear código con ``mvn formatter:format``
 - Agregar encabezados de licencia con ``mvn license:format``
 
 Pruebas
 -------
 
 - Escribir pruebas unitarias (``*Test.java``)
-- Las pruebas de integracion son ``*Tests.java``
+- Las pruebas de integración son ``*Tests.java``
 
 Registro
 --------
 
 - Usar Log4j2
 - ``logger.debug()`` / ``logger.info()`` / ``logger.warn()`` / ``logger.error()``
-- No registrar informacion sensible
+- No registrar información sensible
 
 Recursos
 ========

--- a/es/15.7/dev/plugin-architecture.rst
+++ b/es/15.7/dev/plugin-architecture.rst
@@ -2,11 +2,11 @@
 Arquitectura de Plugins
 ==================================
 
-Vision General
+Visión General
 ==============
 
 El sistema de plugins de |Fess| permite extender la funcionalidad principal.
-Los plugins se distribuyen como archivos JAR y se cargan dinamicamente.
+Los plugins se distribuyen como archivos JAR y se cargan dinámicamente.
 
 Tipos de Plugins
 ================
@@ -18,20 +18,20 @@ Tipos de Plugins
    :widths: 25 75
 
    * - Tipo
-     - Descripcion
-   * - Almacen de datos
-     - Obtencion de contenido desde nuevas fuentes de datos (Box, Slack, etc.)
+     - Descripción
+   * - Almacén de datos
+     - Obtención de contenido desde nuevas fuentes de datos (Box, Slack, etc.)
    * - Motor de scripts
      - Soporte para nuevos lenguajes de script
-   * - Aplicacion web
-     - Extension de la interfaz web
+   * - Aplicación web
+     - Extensión de la interfaz web
    * - Ingest
-     - Procesamiento de datos durante la indexacion
+     - Procesamiento de datos durante la indexación
 
 Estructura de un Plugin
 =======================
 
-Estructura Basica
+Estructura Básica
 -----------------
 
 ::
@@ -83,7 +83,7 @@ Registro de Plugins
 Registro en el Contenedor DI
 ----------------------------
 
-Los plugins se registran en archivos de configuracion como ``fess_ds.xml``:
+Los plugins se registran en archivos de configuración como ``fess_ds.xml``:
 
 .. code-block:: xml
 
@@ -91,10 +91,10 @@ Los plugins se registran en archivos de configuracion como ``fess_ds.xml``:
         <postConstruct name="register"/>
     </component>
 
-Registro Automatico
+Registro Automático
 -------------------
 
-Muchos plugins se registran automaticamente con la anotacion ``@PostConstruct``:
+Muchos plugins se registran automáticamente con la anotación ``@PostConstruct``:
 
 .. code-block:: java
 
@@ -106,18 +106,18 @@ Muchos plugins se registran automaticamente con la anotacion ``@PostConstruct``:
 Ciclo de Vida del Plugin
 ========================
 
-Inicializacion
+Inicialización
 --------------
 
 1. Se carga el archivo JAR
 2. El contenedor DI inicializa los componentes
-3. Se llama al metodo ``@PostConstruct``
+3. Se llama al método ``@PostConstruct``
 4. El plugin se registra en el gestor
 
-Finalizacion
+Finalización
 ------------
 
-1. Se llama al metodo ``@PreDestroy`` (si esta definido)
+1. Se llama al método ``@PreDestroy`` (si está definido)
 2. Limpieza de recursos
 
 Dependencias
@@ -151,7 +151,7 @@ Los plugins pueden incluir sus propias bibliotecas de dependencia:
 Las bibliotecas de dependencia se distribuyen junto con el JAR del plugin o
 se crea un fat JAR usando Maven Shade Plugin.
 
-Obtencion de Configuracion
+Obtención de Configuración
 ==========================
 
 Obtener desde FessConfig
@@ -180,25 +180,25 @@ Obtener desde FessConfig
         }
     }
 
-Construccion e Instalacion
+Construcción e Instalación
 ==========================
 
-Construccion
+Construcción
 ------------
 
 ::
 
     mvn clean package
 
-Instalacion
+Instalación
 -----------
 
-1. **Desde la pantalla de administracion**:
+1. **Desde la pantalla de administración**:
 
    - "Sistema" -> "Plugins" -> "Instalar"
    - Ingrese el nombre del plugin e instale
 
-2. **Linea de comandos**:
+2. **Línea de comandos**:
 
    ::
 
@@ -209,7 +209,7 @@ Instalacion
    - Copie el archivo JAR al directorio ``plugins/``
    - Reinicie |Fess|
 
-Depuracion
+Depuración
 ==========
 
 Salida de Registros
@@ -229,11 +229,11 @@ Modo de Desarrollo
 
 Durante el desarrollo, puede depurar iniciando |Fess| desde el IDE:
 
-1. Ejecute la clase ``FessBoot`` en modo de depuracion
-2. Incluya el codigo fuente del plugin en el proyecto
-3. Establezca puntos de interrupcion
+1. Ejecute la clase ``FessBoot`` en modo de depuración
+2. Incluya el código fuente del plugin en el proyecto
+3. Establezca puntos de interrupción
 
-Lista de Plugins Publicos
+Lista de Plugins Públicos
 =========================
 
 Principales plugins publicados por el proyecto |Fess|:
@@ -243,7 +243,7 @@ Principales plugins publicados por el proyecto |Fess|:
    :widths: 30 70
 
    * - Plugin
-     - Descripcion
+     - Descripción
    * - fess-ds-box
      - Conector de Box.com
    * - fess-ds-dropbox
@@ -257,13 +257,13 @@ Principales plugins publicados por el proyecto |Fess|:
    * - fess-theme-\*
      - Temas personalizados
 
-Estos plugins estan disponibles como referencia de desarrollo en
+Estos plugins están disponibles como referencia de desarrollo en
 `GitHub <https://github.com/codelibs>`__.
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`datastore-plugin` - Desarrollo de plugins de almacen de datos
+- :doc:`datastore-plugin` - Desarrollo de plugins de almacén de datos
 - :doc:`script-engine-plugin` - Plugins de motor de scripts
-- :doc:`webapp-plugin` - Plugins de aplicacion web
+- :doc:`webapp-plugin` - Plugins de aplicación web
 - :doc:`ingest-plugin` - Plugins Ingest

--- a/es/15.7/dev/script-engine-plugin.rst
+++ b/es/15.7/dev/script-engine-plugin.rst
@@ -2,13 +2,13 @@
 Plugin de Motor de Scripts
 ==================================
 
-Vision General
+Visión General
 ==============
 
 Al desarrollar un plugin de motor de scripts, puede agregar soporte para
 nuevos lenguajes de script a |Fess|.
 
-Implementacion Basica
+Implementación Básica
 =====================
 
 Implemente la interfaz ``ScriptEngine``:
@@ -47,15 +47,15 @@ Registro
 Ejemplo de Uso
 ==============
 
-Seleccione como tipo de script en la pantalla de administracion:
+Seleccione como tipo de script en la pantalla de administración:
 
 ::
 
     scriptType=example
     scriptData=your script here
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
 - :doc:`plugin-architecture` - Arquitectura de plugins
-- :doc:`../config/scripting-overview` - Vision general de scripting
+- :doc:`../config/scripting-overview` - Visión general de scripting

--- a/es/15.7/dev/theme-development.rst
+++ b/es/15.7/dev/theme-development.rst
@@ -1,12 +1,12 @@
 ==================================
-Guia de Desarrollo de Temas
+Guía de Desarrollo de Temas
 ==================================
 
-Vision General
+Visión General
 ==============
 
-Usando el sistema de temas de |Fess|, puede personalizar el diseno de la pantalla de busqueda.
-Los temas se pueden distribuir como plugins y puede alternar entre multiples temas.
+Usando el sistema de temas de |Fess|, puede personalizar el diseño de la pantalla de búsqueda.
+Los temas se pueden distribuir como plugins y puede alternar entre múltiples temas.
 
 Estructura del Tema
 ===================
@@ -27,10 +27,10 @@ Estructura del Tema
             └── templates/
                 └── search.html
 
-Creacion Basica de Temas
+Creación Básica de Temas
 ========================
 
-Personalizacion de CSS
+Personalización de CSS
 ----------------------
 
 ``css/style.css``:
@@ -67,10 +67,10 @@ Cambio de Logo
         max-height: 40px;
     }
 
-Personalizacion de Plantillas
+Personalización de Plantillas
 -----------------------------
 
-Las plantillas estan en formato JSP.
+Las plantillas están en formato JSP.
 
 ``templates/search.html`` (parcial):
 
@@ -94,7 +94,7 @@ pom.xml
     <version>15.7.0</version>
     <packaging>jar</packaging>
 
-Archivo de Configuracion
+Archivo de Configuración
 ------------------------
 
 ``src/main/resources/theme.properties``:
@@ -105,16 +105,16 @@ Archivo de Configuracion
     theme.display.name=Example Theme
     theme.version=1.0.0
 
-Instalacion
+Instalación
 ===========
 
 ::
 
     ./bin/fess-plugin install fess-theme-example
 
-Seleccione el tema desde la pantalla de administracion:
+Seleccione el tema desde la pantalla de administración:
 
-1. "Sistema" -> "Diseno"
+1. "Sistema" -> "Diseño"
 2. Seleccione el tema
 3. Guarde y aplique
 
@@ -124,8 +124,8 @@ Ejemplos de Temas Existentes
 - `fess-theme-simple <https://github.com/codelibs/fess-theme-simple>`__
 - `fess-theme-minimal <https://github.com/codelibs/fess-theme-minimal>`__
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
 - :doc:`plugin-architecture` - Arquitectura de plugins
-- :doc:`../admin/design-guide` - Guia de configuracion de diseno
+- :doc:`../admin/design-guide` - Guía de configuración de diseño

--- a/es/15.7/dev/webapp-plugin.rst
+++ b/es/15.7/dev/webapp-plugin.rst
@@ -1,14 +1,14 @@
 ==================================
-Plugin de Aplicacion Web
+Plugin de Aplicación Web
 ==================================
 
-Vision General
+Visión General
 ==============
 
-Con los plugins de aplicacion web puede extender la interfaz web de Fess.
-Es posible agregar nuevas paginas, personalizar la pantalla de administracion, etc.
+Con los plugins de aplicación web puede extender la interfaz web de Fess.
+Es posible agregar nuevas páginas, personalizar la pantalla de administración, etc.
 
-Estructura Basica
+Estructura Básica
 =================
 
 ::
@@ -21,7 +21,7 @@ Estructura Basica
         └── webapp/WEB-INF/view/example/
             └── index.jsp
 
-Implementacion de Action
+Implementación de Action
 ========================
 
 .. code-block:: java
@@ -59,7 +59,7 @@ Plantilla JSP
     </body>
     </html>
 
-Extension de API
+Extensión de API
 ================
 
 .. code-block:: java
@@ -74,8 +74,8 @@ Extension de API
         }
     }
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
 - :doc:`plugin-architecture` - Arquitectura de plugins
-- :doc:`overview` - Vision general de documentacion para desarrolladores
+- :doc:`overview` - Visión general de documentación para desarrolladores

--- a/es/15.8/api/admin/api-admin-accesstoken.rst
+++ b/es/15.8/api/admin/api-admin-accesstoken.rst
@@ -2,16 +2,16 @@
 AccessToken API
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de AccessToken es una API para gestionar los tokens de acceso a la API de |Fess|.
-Permite ejecutar la creacion, obtencion, actualizacion y eliminacion de tokens.
+Permite ejecutar la creación, obtención, actualización y eliminación de tokens.
 
-Los tokens de acceso se utilizan para la autenticacion al invocar la API de busqueda
-o la Admin API de |Fess| de forma programatica.
-Para conocer las especificaciones comunes de la Admin API (metodo de autenticacion, formato de respuesta,
-valores de ``status``, respuestas de error y codigos de estado HTTP), incluyendo esta API,
+Los tokens de acceso se utilizan para la autenticación al invocar la API de búsqueda
+o la Admin API de |Fess| de forma programática.
+Para conocer las especificaciones comunes de la Admin API (método de autenticación, formato de respuesta,
+valores de ``status``, respuestas de error y códigos de estado HTTP), incluyendo esta API,
 consulte :doc:`api-admin-overview`.
 
 .. note::
@@ -34,9 +34,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de tokens de acceso
@@ -63,29 +63,29 @@ Solicitud
 
     GET /api/admin/accesstoken/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25; puede cambiarse con ``paging.page.size``)
+     - Número de elementos por página (predeterminado: 25; puede cambiarse con ``paging.page.size``)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1; predeterminado: 1)
+     - Número de página (comienza en 1; predeterminado: 1)
    * - ``id``
      - String
      - No
-     - Filtro para obtener unicamente el token con el ID especificado
+     - Filtro para obtener únicamente el token con el ID especificado
 
 Respuesta
 ---------
@@ -117,11 +117,11 @@ Respuesta
 
 .. note::
 
-   Cada objeto de token incluye tambien informacion de auditoria y version:
+   Cada objeto de token incluye también información de auditoría y versión:
    ``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime`` y ``versionNo``.
-   ``createdTime`` y ``updatedTime`` se expresan en milisegundos desde la epoca (valor numerico).
+   ``createdTime`` y ``updatedTime`` se expresan en milisegundos desde la época (valor numérico).
    Los campos con valor ``null`` se excluyen de la respuesta.
-   ``permissions`` se devuelve como una cadena separada por saltos de linea (``\n``).
+   ``permissions`` se devuelve como una cadena separada por saltos de línea (``\n``).
 
 Obtener Token de Acceso
 =======================
@@ -179,7 +179,7 @@ Cuerpo de la Solicitud
       "expires": "2026-01-01T00:00:00"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -188,24 +188,24 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre del token (maximo 1000 caracteres)
+     - Sí
+     - Nombre del token (máximo 1000 caracteres)
    * - ``permissions``
      - No
-     - Permisos otorgados a este token. Se pueden especificar multiples valores separados por saltos de linea (``\n``) (ejemplo: ``{role}admin-api``). Los tokens que invocan la Admin API deben tener un permiso que coincida con ``api.admin.access.permissions`` (valor predeterminado: ``{role}admin-api``).
+     - Permisos otorgados a este token. Se pueden especificar múltiples valores separados por saltos de línea (``\n``) (ejemplo: ``{role}admin-api``). Los tokens que invocan la Admin API deben tener un permiso que coincida con ``api.admin.access.permissions`` (valor predeterminado: ``{role}admin-api``).
    * - ``parameterName``
      - No
-     - Nombre del parametro de solicitud para pasar permisos adicionales. Si una solicitud autenticada con este token incluye un parametro con el nombre aqui especificado, su valor se agrega a ``permissions``. Si se omite, no se configura.
+     - Nombre del parámetro de solicitud para pasar permisos adicionales. Si una solicitud autenticada con este token incluye un parámetro con el nombre aquí especificado, su valor se agrega a ``permissions``. Si se omite, no se configura.
    * - ``expires``
      - No
-     - Fecha de expiracion. Se especifica como cadena en formato ``YYYY-MM-DDTHH:MM:SS`` (ejemplo: ``2026-01-01T00:00:00``). Si se omite, el token no tiene fecha de expiracion.
+     - Fecha de expiración. Se especifica como cadena en formato ``YYYY-MM-DDTHH:MM:SS`` (ejemplo: ``2026-01-01T00:00:00``). Si se omite, el token no tiene fecha de expiración.
 
 .. note::
 
-   La cadena del token (``token``) se genera automaticamente en el servidor. Si se especifica
-   ``token`` en el cuerpo de la solicitud, sera ignorado. Como la respuesta de creacion no incluye
+   La cadena del token (``token``) se genera automáticamente en el servidor. Si se especifica
+   ``token`` en el cuerpo de la solicitud, será ignorado. Como la respuesta de creación no incluye
    la cadena del token generada, obtenga el token mediante "Obtener Token de Acceso"
    (``GET /setting/{id}``).
 
@@ -246,10 +246,10 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
-En la actualizacion se utilizan los mismos campos que en la creacion, mas los siguientes campos adicionales.
+En la actualización se utilizan los mismos campos que en la creación, más los siguientes campos adicionales.
 
 .. list-table::
    :header-rows: 1
@@ -257,18 +257,18 @@ En la actualizacion se utilizan los mismos campos que en la creacion, mas los si
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
+     - Sí
      - ID del token a actualizar
    * - ``versionNo``
-     - Si
-     - Numero de version para el bloqueo optimista. Especifique el ``versionNo`` del token obtenido previamente.
+     - Sí
+     - Número de versión para el bloqueo optimista. Especifique el ``versionNo`` del token obtenido previamente.
 
 .. note::
 
    La cadena del token (``token``) no puede actualizarse. Si se especifica ``token``
-   en el cuerpo de la solicitud, sera ignorado y se mantendra el valor existente.
+   en el cuerpo de la solicitud, será ignorado y se mantendrá el valor existente.
 
 Respuesta
 ---------
@@ -323,7 +323,7 @@ Crear Token API
 Llamada a la API Usando el Token
 ---------------------------------
 
-El token creado se utiliza para la autenticacion al invocar la API de busqueda u otras APIs.
+El token creado se utiliza para la autenticación al invocar la API de búsqueda u otras APIs.
 
 .. code-block:: bash
 
@@ -334,9 +334,9 @@ El token creado se utiliza para la autenticacion al invocar la API de busqueda u
     # Usar el token como parametro de consulta (requiere configurar api.access.token.request.parameter)
     curl "http://localhost:8080/api/v2/search?q=test&token=your_token_here"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API (autenticacion, formato de respuesta y errores)
-- :doc:`../api-search` - API de busqueda
-- :doc:`../../admin/accesstoken-guide` - Guia de gestion de tokens de acceso
+- :doc:`api-admin-overview` - Visión general de Admin API (autenticación, formato de respuesta y errores)
+- :doc:`../api-search` - API de búsqueda
+- :doc:`../../admin/accesstoken-guide` - Guía de gestión de tokens de acceso

--- a/es/15.8/api/admin/api-admin-backup.rst
+++ b/es/15.8/api/admin/api-admin-backup.rst
@@ -2,13 +2,13 @@
 API de Backup
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Backup es una API para consultar y descargar los datos objetivo de copia de seguridad de |Fess|.
-Permite obtener la lista de objetivos de copia de seguridad y descargar archivos de copia de seguridad individuales (propiedades del sistema, datos masivos de cada indice, datos NDJSON de registros).
+Permite obtener la lista de objetivos de copia de seguridad y descargar archivos de copia de seguridad individuales (propiedades del sistema, datos masivos de cada índice, datos NDJSON de registros).
 
-Esta API es exclusivamente de consulta y descarga (solo lectura). La funcionalidad de restauracion para subir archivos de copia de seguridad no esta disponible a traves de la API; si necesita restaurar, utilice Informacion del sistema → Copia de seguridad en la pantalla de administracion.
+Esta API es exclusivamente de consulta y descarga (solo lectura). La funcionalidad de restauración para subir archivos de copia de seguridad no está disponible a través de la API; si necesita restaurar, utilice Información del sistema → Copia de seguridad en la pantalla de administración.
 
 URL Base
 ========
@@ -17,17 +17,17 @@ URL Base
 
     /api/admin/backup
 
-Autenticacion
+Autenticación
 =============
 
-Al igual que con el resto de Admin APIs, se requiere autenticacion mediante token de acceso. El token de acceso debe tener el permiso ``Radmin-api`` (configurado en ``api.admin.access.permissions``; el valor predeterminado es ``Radmin-api``).
+Al igual que con el resto de Admin APIs, se requiere autenticación mediante token de acceso. El token de acceso debe tener el permiso ``Radmin-api`` (configurado en ``api.admin.access.permissions``; el valor predeterminado es ``Radmin-api``).
 El token de acceso se especifica en el encabezado de la solicitud.
 
 ::
 
     Authorization: Bearer <token de acceso>
 
-Para mas detalles sobre la autenticacion y como obtener el token de acceso, consulte :doc:`api-admin-overview`.
+Para más detalles sobre la autenticación y cómo obtener el token de acceso, consulte :doc:`api-admin-overview`.
 
 Lista de Endpoints
 ==================
@@ -36,9 +36,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /files
      - Obtener lista de objetivos de copia de seguridad
@@ -49,7 +49,7 @@ Lista de Endpoints
 Obtener Lista de Objetivos de Copia de Seguridad
 ================================================
 
-Devuelve la lista de objetivos de copia de seguridad. Los objetivos se determinan en funcion de la configuracion de ``index.backup.targets`` e ``index.backup.log.targets``, y se devuelve una lista combinada de ambos.
+Devuelve la lista de objetivos de copia de seguridad. Los objetivos se determinan en función de la configuración de ``index.backup.targets`` e ``index.backup.log.targets``, y se devuelve una lista combinada de ambos.
 
 Solicitud
 ---------
@@ -61,10 +61,10 @@ Solicitud
 Respuesta
 ---------
 
-En ``files`` se almacena un arreglo de objetos que representan los objetivos de copia de seguridad, y en ``total`` el numero de elementos.
+En ``files`` se almacena un arreglo de objetos que representan los objetivos de copia de seguridad, y en ``total`` el número de elementos.
 Cada objeto tiene ``id`` y ``name``, y en ambos se establece el nombre del objetivo (``fess_config.bulk``, ``system.properties``, ``search_log.ndjson``, etc.).
 
-A continuacion se muestra un ejemplo con la configuracion predeterminada (cuando ``index.backup.targets`` e ``index.backup.log.targets`` tienen sus valores por defecto).
+A continuación se muestra un ejemplo con la configuración predeterminada (cuando ``index.backup.targets`` e ``index.backup.log.targets`` tienen sus valores por defecto).
 
 .. code-block:: json
 
@@ -90,15 +90,15 @@ A continuacion se muestra un ejemplo con la configuracion predeterminada (cuando
 
 .. note::
 
-   En ``version`` se establece la version del producto de |Fess| en ejecucion. El contenido de ``files`` varia
-   segun la configuracion de ``index.backup.targets`` / ``index.backup.log.targets``, por lo que
+   En ``version`` se establece la versión del producto de |Fess| en ejecución. El contenido de ``files`` varía
+   según la configuración de ``index.backup.targets`` / ``index.backup.log.targets``, por lo que
    el ejemplo anterior corresponde a los valores por defecto.
 
 Descargar Archivo de Copia de Seguridad
 =======================================
 
 Descarga el contenido del archivo de copia de seguridad especificado. En ``{id}`` se especifica el ``id`` (nombre del objetivo) obtenido en la lista.
-Segun el tipo de ``{id}``, el contenido de la respuesta cambia de la siguiente manera.
+Según el tipo de ``{id}``, el contenido de la respuesta cambia de la siguiente manera.
 
 .. list-table::
    :header-rows: 1
@@ -108,18 +108,18 @@ Segun el tipo de ``{id}``, el contenido de la respuesta cambia de la siguiente m
      - Contenido
    * - ``system.properties``
      - Contenido de las propiedades del sistema (``application/octet-stream``)
-   * - ``*.bulk`` o nombre de indice sin extension
-     - Datos masivos generados al recorrer el indice con el mismo nombre que el objetivo (``application/octet-stream``). El nombre sin ``.bulk`` se trata como nombre del indice.
+   * - ``*.bulk`` o nombre de índice sin extensión
+     - Datos masivos generados al recorrer el índice con el mismo nombre que el objetivo (``application/octet-stream``). El nombre sin ``.bulk`` se trata como nombre del índice.
    * - ``*.ndjson`` (``search_log`` / ``user_info`` / ``click_log`` / ``favorite_log``)
      - Datos NDJSON del registro correspondiente (``application/x-ndjson``)
 
 .. note::
 
-   ``fess.json`` y ``doc.json`` son archivos de definicion de mapeo (esquema) del indice.
+   ``fess.json`` y ``doc.json`` son archivos de definición de mapeo (esquema) del índice.
    Se incluyen en la lista de objetivos (``/files``), pero en la descarga de esta API se tratan
-   como procesamiento de desplazamiento del indice, al igual que ``.bulk``. Para realizar copias de
-   seguridad y restauraciones que incluyan la definicion de mapeo, utilice
-   Informacion del sistema → Copia de seguridad en la pantalla de administracion.
+   como procesamiento de desplazamiento del índice, al igual que ``.bulk``. Para realizar copias de
+   seguridad y restauraciones que incluyan la definición de mapeo, utilice
+   Información del sistema → Copia de seguridad en la pantalla de administración.
 
 Si se especifica un ``{id}`` que no existe entre los objetivos de copia de seguridad, se devuelve una respuesta de error con un valor distinto de 0 en ``status`` y el mensaje de error (``Could not find any backup index.``).
 
@@ -133,11 +133,11 @@ Solicitud
 Respuesta
 ---------
 
-El flujo del archivo de copia de seguridad. En formato NDJSON se devuelve con ``Content-Type: application/x-ndjson``, y en los demas casos con ``application/octet-stream``.
+El flujo del archivo de copia de seguridad. En formato NDJSON se devuelve con ``Content-Type: application/x-ndjson``, y en los demás casos con ``application/octet-stream``.
 
 .. note::
 
-   La exportacion de registros (``*.ndjson``) esta sujeta a la restriccion de ``index.backup.log.load.timeout`` (valor predeterminado ``60000`` milisegundos).
+   La exportación de registros (``*.ndjson``) está sujeta a la restricción de ``index.backup.log.load.timeout`` (valor predeterminado ``60000`` milisegundos).
    Si la salida tarda demasiado, los datos del registro pueden quedar truncados.
 
 Ejemplos de Uso
@@ -151,7 +151,7 @@ Obtener Lista de Objetivos de Copia de Seguridad
     curl -X GET "http://localhost:8080/api/admin/backup/files" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Descargar Indice de Configuracion
+Descargar Índice de Configuración
 ---------------------------------
 
 .. code-block:: bash
@@ -160,7 +160,7 @@ Descargar Indice de Configuracion
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o fess_config.bulk
 
-Descargar Registro de Busqueda
+Descargar Registro de Búsqueda
 ------------------------------
 
 .. code-block:: bash
@@ -169,8 +169,8 @@ Descargar Registro de Busqueda
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o search_log.ndjson
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-log` - API de registros

--- a/es/15.8/api/admin/api-admin-badword.rst
+++ b/es/15.8/api/admin/api-admin-badword.rst
@@ -2,11 +2,11 @@
 API de BadWord
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de BadWord es para gestionar las palabras prohibidas (exclusion de palabras de sugerencia inapropiadas) de |Fess|.
-Puede configurar palabras clave que no desea mostrar en la funcion de sugerencias.
+La API de BadWord es para gestionar las palabras prohibidas (exclusión de palabras de sugerencia inapropiadas) de |Fess|.
+Puede configurar palabras clave que no desea mostrar en la función de sugerencias.
 
 URL Base
 ========
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de palabras prohibidas
@@ -57,25 +57,25 @@ Solicitud
 
     GET /api/admin/badword/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Número de elementos por página (predeterminado: 20)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``id``
      - String
      - No
@@ -144,7 +144,7 @@ Cuerpo de la Solicitud
       "suggestWord": "spam_keyword"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -153,9 +153,9 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``suggestWord``
-     - Si
+     - Sí
      - Palabra clave a excluir (no puede contener espacios en blanco)
 
 Respuesta
@@ -232,7 +232,7 @@ Respuesta
 Subir CSV de Palabras Prohibidas
 ================================
 
-Registra palabras prohibidas en bloque a partir de un archivo CSV. El archivo se envia como ``multipart/form-data``. La importacion se ejecuta de forma asincrona en el servidor.
+Registra palabras prohibidas en bloque a partir de un archivo CSV. El archivo se envía como ``multipart/form-data``. La importación se ejecuta de forma asíncrona en el servidor.
 
 Solicitud
 ---------
@@ -242,33 +242,33 @@ Solicitud
     PUT /api/admin/badword/upload
     Content-Type: multipart/form-data
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``badWordFile``
-     - Si
+     - Sí
      - Archivo CSV de palabras prohibidas a subir
 
 Formato CSV
 ~~~~~~~~~~~
 
-- La primera linea se omite como fila de encabezado (el nombre de la columna es arbitrario; al descargar se escribe ``BadWord``).
-- A partir de la segunda linea, escriba una palabra prohibida por linea como ``suggestWord``.
-- Las lineas cuyo valor esta en blanco se ignoran.
+- La primera línea se omite como fila de encabezado (el nombre de la columna es arbitrario; al descargar se escribe ``BadWord``).
+- A partir de la segunda línea, escriba una palabra prohibida por línea como ``suggestWord``.
+- Las líneas cuyo valor está en blanco se ignoran.
 - Anteponga ``--`` a una palabra para eliminarla (por ejemplo, ``--spam`` elimina ``spam``).
-- Especificar una palabra ya registrada se trata como una actualizacion (se restablecen el usuario y la fecha de actualizacion).
+- Especificar una palabra ya registrada se trata como una actualización (se restablecen el usuario y la fecha de actualización).
 
 .. note::
 
-   Dado que la importacion se ejecuta de forma asincrona en el servidor, una respuesta ``status: 0``
-   indica que la solicitud fue aceptada, no que la importacion se haya completado.
+   Dado que la importación se ejecuta de forma asíncrona en el servidor, una respuesta ``status: 0``
+   indica que la solicitud fue aceptada, no que la importación se haya completado.
 
 Respuesta
 ---------
@@ -285,7 +285,7 @@ Descargar CSV de Palabras Prohibidas
 ====================================
 
 Descarga las palabras prohibidas registradas como archivo CSV (``badword.csv``). La respuesta es un flujo ``application/octet-stream``.
-El CSV tiene una fila de encabezado ``BadWord`` en la primera linea, seguida de una palabra prohibida registrada por linea.
+El CSV tiene una fila de encabezado ``BadWord`` en la primera línea, seguida de una palabra prohibida registrada por línea.
 
 Solicitud
 ---------
@@ -327,10 +327,10 @@ Descargar Archivo CSV
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o badword.csv
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-suggest` - API de gestion de sugerencias
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-suggest` - API de gestión de sugerencias
 - :doc:`api-admin-elevateword` - API de palabras elevadas
-- :doc:`../../admin/badword-guide` - Guia de gestion de palabras prohibidas
+- :doc:`../../admin/badword-guide` - Guía de gestión de palabras prohibidas

--- a/es/15.8/api/admin/api-admin-boostdoc.rst
+++ b/es/15.8/api/admin/api-admin-boostdoc.rst
@@ -2,24 +2,24 @@
 BoostDoc API
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de BoostDoc es para gestionar la configuracion de impulso de documentos de |Fess|.
-Al configurar el impulso de documentos, puede elevar la puntuacion de los documentos que
+La API de BoostDoc es para gestionar la configuración de impulso de documentos de |Fess|.
+Al configurar el impulso de documentos, puede elevar la puntuación de los documentos que
 coincidan con ciertas condiciones y hacer que aparezcan con mayor facilidad en las posiciones
-superiores de los resultados de busqueda.
+superiores de los resultados de búsqueda.
 
-El impulso se aplica a cada documento en el momento de la indexacion (durante el rastreo).
-La condicion (``urlExpr``) y el valor de impulso (``boostExpr``) se evaluan ambos como expresiones Groovy.
-Las reglas multiples se evaluan en orden ascendente segun ``sortOrder``, y solo se aplica el valor de
-impulso de la primera regla cuya condicion coincida (una vez encontrada una regla que coincida,
-las reglas siguientes no se evaluan).
+El impulso se aplica a cada documento en el momento de la indexación (durante el rastreo).
+La condición (``urlExpr``) y el valor de impulso (``boostExpr``) se evalúan ambos como expresiones Groovy.
+Las reglas múltiples se evalúan en orden ascendente según ``sortOrder``, y solo se aplica el valor de
+impulso de la primera regla cuya condición coincida (una vez encontrada una regla que coincida,
+las reglas siguientes no se evalúan).
 
 .. note::
 
-   En el panel de administracion, ``urlExpr`` se muestra como "Condicion" y ``boostExpr`` como "Expresion de valor de impulso".
-   Para mas detalles sobre los elementos de configuracion, consulte :doc:`../../admin/boostdoc-guide`.
+   En el panel de administración, ``urlExpr`` se muestra como "Condición" y ``boostExpr`` como "Expresión de valor de impulso".
+   Para más detalles sobre los elementos de configuración, consulte :doc:`../../admin/boostdoc-guide`.
 
 URL Base
 ========
@@ -28,11 +28,11 @@ URL Base
 
     /api/admin/boostdoc
 
-Autenticacion
+Autenticación
 =============
 
 Para usar esta API, se requiere un token de acceso con el permiso ``Radmin-api``.
-Consulte :doc:`api-admin-overview` para conocer como obtener y especificar el token de acceso.
+Consulte :doc:`api-admin-overview` para conocer cómo obtener y especificar el token de acceso.
 
 Lista de Endpoints
 ==================
@@ -41,9 +41,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de impulsos de documentos
@@ -70,33 +70,33 @@ Solicitud
 
     GET /api/admin/boostdoc/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25)
+     - Número de elementos por página (predeterminado: 25)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1. Predeterminado: 1)
+     - Número de página (comienza en 1. Predeterminado: 1)
    * - ``urlExpr``
      - String
      - No
-     - Filtrado por expresion de condicion (coincidencia parcial)
+     - Filtrado por expresión de condición (coincidencia parcial)
    * - ``boostExpr``
      - String
      - No
-     - Filtrado por expresion de valor de impulso (coincidencia parcial)
+     - Filtrado por expresión de valor de impulso (coincidencia parcial)
 
 Respuesta
 ---------
@@ -121,8 +121,8 @@ Respuesta
 
 .. note::
 
-   Ademas de los campos mostrados anteriormente, cada objeto de configuracion en la respuesta incluye tambien metadatos de creacion/actualizacion (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``).
-   ``versionNo`` es obligatorio al actualizar (PUT), por lo que debe obtener su valor actual mediante la API de obtencion individual o de lista antes de actualizar.
+   Además de los campos mostrados anteriormente, cada objeto de configuración en la respuesta incluye también metadatos de creación/actualización (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``).
+   ``versionNo`` es obligatorio al actualizar (PUT), por lo que debe obtener su valor actual mediante la API de obtención individual o de lista antes de actualizar.
 
 Obtener Impulso de Documento
 =============================
@@ -174,7 +174,7 @@ Cuerpo de la Solicitud
       "sortOrder": 0
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -183,16 +183,16 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``urlExpr``
-     - Si
-     - Expresion de condicion. Expresion Groovy que determina los documentos objetivo del impulso y devuelve ``Boolean``. Corresponde a "Condicion" en el panel de administracion (maximo 10000 caracteres).
+     - Sí
+     - Expresión de condición. Expresión Groovy que determina los documentos objetivo del impulso y devuelve ``Boolean``. Corresponde a "Condición" en el panel de administración (máximo 10000 caracteres).
    * - ``boostExpr``
-     - Si
-     - Expresion de valor de impulso. Expresion Groovy que devuelve el valor de impulso (numerico). Tambien se puede especificar un valor fijo como ``3.0``. Corresponde a "Expresion de valor de impulso" en el panel de administracion (maximo 10000 caracteres).
+     - Sí
+     - Expresión de valor de impulso. Expresión Groovy que devuelve el valor de impulso (numérico). También se puede especificar un valor fijo como ``3.0``. Corresponde a "Expresión de valor de impulso" en el panel de administración (máximo 10000 caracteres).
    * - ``sortOrder``
-     - Si
-     - Orden de aplicacion. Las reglas se evaluan en orden ascendente y se aplica el valor de impulso de la primera regla cuya condicion coincida (valor inicial del formulario: 0; entero mayor o igual a 0).
+     - Sí
+     - Orden de aplicación. Las reglas se evalúan en orden ascendente y se aplica el valor de impulso de la primera regla cuya condición coincida (valor inicial del formulario: 0; entero mayor o igual a 0).
 
 Respuesta
 ---------
@@ -231,7 +231,7 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Al actualizar, ademas de los campos utilizados al crear, ``id`` (el identificador de la regla objetivo, hasta 1000 caracteres) y ``versionNo`` (el numero de version para bloqueo optimista) son obligatorios. Especifique el numero de version actual obtenido desde la respuesta de la API de obtencion individual o de lista para ``versionNo``. La actualizacion falla si el numero de version no coincide.
+Al actualizar, además de los campos utilizados al crear, ``id`` (el identificador de la regla objetivo, hasta 1000 caracteres) y ``versionNo`` (el número de versión para bloqueo optimista) son obligatorios. Especifique el número de versión actual obtenido desde la respuesta de la API de obtención individual o de lista para ``versionNo``. La actualización falla si el número de versión no coincide.
 
 Respuesta
 ---------
@@ -267,58 +267,58 @@ Respuesta
       }
     }
 
-Acerca de las Expresiones de Condicion y de Valor de Impulso
+Acerca de las Expresiones de Condición y de Valor de Impulso
 =============================================================
 
-``urlExpr`` (condicion) y ``boostExpr`` (expresion de valor de impulso) se evaluan ambas como expresiones Groovy.
-Dentro de la expresion, se pueden referenciar los valores de campo del documento a indexar como variables con el nombre del campo.
+``urlExpr`` (condición) y ``boostExpr`` (expresión de valor de impulso) se evalúan ambas como expresiones Groovy.
+Dentro de la expresión, se pueden referenciar los valores de campo del documento a indexar como variables con el nombre del campo.
 
-- ``urlExpr`` debe devolver ``Boolean`` (ejemplo: ``url.startsWith("https://docs.example.com/")``). Una simple cadena de expresion regular (ejemplo: ``.*docs\.example\.com.*``) no devuelve ``Boolean`` como expresion Groovy y por lo tanto no funciona como condicion. Para usar expresiones regulares, utilice ``String#matches`` de Groovy.
-- ``boostExpr`` debe devolver un valor numerico. El resultado se convierte a ``float`` y el impulso se aplica solo si es mayor que 0.
+- ``urlExpr`` debe devolver ``Boolean`` (ejemplo: ``url.startsWith("https://docs.example.com/")``). Una simple cadena de expresión regular (ejemplo: ``.*docs\.example\.com.*``) no devuelve ``Boolean`` como expresión Groovy y por lo tanto no funciona como condición. Para usar expresiones regulares, utilice ``String#matches`` de Groovy.
+- ``boostExpr`` debe devolver un valor numérico. El resultado se convierte a ``float`` y el impulso se aplica solo si es mayor que 0.
 
 .. note::
 
-   Principales variables de campo disponibles dentro de la expresion: ``url``, ``title``, ``content``, ``content_length``, ``last_modified``, entre otros.
-   ``click_count`` y ``favorite_count`` estan disponibles cuando ``indexer.click.count.enabled`` /
-   ``indexer.favorite.count.enabled`` estan habilitados (ambos habilitados por defecto).
-   La sintaxis de calculo de fechas de OpenSearch como ``now - 7d`` no se puede usar en Groovy.
+   Principales variables de campo disponibles dentro de la expresión: ``url``, ``title``, ``content``, ``content_length``, ``last_modified``, entre otros.
+   ``click_count`` y ``favorite_count`` están disponibles cuando ``indexer.click.count.enabled`` /
+   ``indexer.favorite.count.enabled`` están habilitados (ambos habilitados por defecto).
+   La sintaxis de cálculo de fechas de OpenSearch como ``now - 7d`` no se puede usar en Groovy.
 
-Ejemplos de Expresion de Condicion (``urlExpr``)
+Ejemplos de Expresión de Condición (``urlExpr``)
 -------------------------------------------------
 
 .. list-table::
    :header-rows: 1
    :widths: 45 55
 
-   * - Expresion de condicion
-     - Descripcion
+   * - Expresión de condición
+     - Descripción
    * - ``url.startsWith("https://docs.example.com/")``
      - Aplica a documentos cuya URL comienza con la URL especificada
    * - ``url.matches("https://www\\.example\\.com/.*")``
-     - Evalua la URL mediante expresion regular (``String#matches`` de Groovy)
+     - Evalúa la URL mediante expresión regular (``String#matches`` de Groovy)
    * - ``title.contains("Notas de la version")``
-     - Aplica a documentos que contienen una palabra especifica en el titulo
+     - Aplica a documentos que contienen una palabra específica en el título
 
-Ejemplos de Expresion de Valor de Impulso (``boostExpr``)
+Ejemplos de Expresión de Valor de Impulso (``boostExpr``)
 ----------------------------------------------------------
 
 .. list-table::
    :header-rows: 1
    :widths: 45 55
 
-   * - Expresion de valor de impulso
-     - Descripcion
+   * - Expresión de valor de impulso
+     - Descripción
    * - ``3.0``
      - Impulso con valor fijo
    * - ``click_count * 0.1 + 1``
-     - Impulso segun el numero de clics
+     - Impulso según el número de clics
    * - ``Math.log(click_count + 1)``
-     - Impulso en escala logaritmica basado en el numero de clics
+     - Impulso en escala logarítmica basado en el número de clics
 
 Ejemplos de Uso
 ===============
 
-Impulso de Sitio de Documentacion
+Impulso de Sitio de Documentación
 ----------------------------------
 
 .. code-block:: bash
@@ -346,9 +346,9 @@ Impulso de Contenido con Muchos Clics
            "sortOrder": 10
          }'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-elevateword` - API de palabras elevadas
-- :doc:`../../admin/boostdoc-guide` - Guia de gestion de impulso de documentos
+- :doc:`../../admin/boostdoc-guide` - Guía de gestión de impulso de documentos

--- a/es/15.8/api/admin/api-admin-crawlinginfo.rst
+++ b/es/15.8/api/admin/api-admin-crawlinginfo.rst
@@ -2,10 +2,10 @@
 API de CrawlingInfo
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de CrawlingInfo es para consultar y gestionar la informacion de rastreo (sesiones de rastreo) de |Fess|.
+La API de CrawlingInfo es para consultar y gestionar la información de rastreo (sesiones de rastreo) de |Fess|.
 Permite operaciones como obtener la lista de sesiones de rastreo, obtenerlas individualmente y eliminarlas.
 
 URL Base
@@ -22,23 +22,23 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /logs
-     - Obtener lista de informacion de rastreo
+     - Obtener lista de información de rastreo
    * - GET
      - /log/{id}
-     - Obtener informacion de rastreo
+     - Obtener información de rastreo
    * - DELETE
      - /log/{id}
-     - Eliminar informacion de rastreo
+     - Eliminar información de rastreo
    * - DELETE
      - /all
      - Eliminar en lote sesiones de rastreo (excepto las activas)
 
-Obtener Lista de Informacion de Rastreo
+Obtener Lista de Información de Rastreo
 =======================================
 
 Solicitud
@@ -48,29 +48,29 @@ Solicitud
 
     GET /api/admin/crawlinginfo/logs
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Número de elementos por página (predeterminado: 20)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (basado en 1, predeterminado: 1)
+     - Número de página (basado en 1, predeterminado: 1)
    * - ``sessionId``
      - String
      - No
-     - Filtro por ID de sesion (coincidencia parcial)
+     - Filtro por ID de sesión (coincidencia parcial)
 
 Respuesta
 ---------
@@ -108,25 +108,25 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``id``
-     - ID de informacion de rastreo
+     - ID de información de rastreo
    * - ``sessionId``
-     - ID de sesion
+     - ID de sesión
    * - ``name``
-     - Nombre de sesion
+     - Nombre de sesión
    * - ``expiredTime``
-     - Fecha de expiracion (milisegundos epoch; devuelto como cadena de texto)
+     - Fecha de expiración (milisegundos epoch; devuelto como cadena de texto)
    * - ``createdTime``
-     - Hora de creacion (milisegundos epoch; devuelto como numero)
+     - Hora de creación (milisegundos epoch; devuelto como número)
 
 .. note::
 
-   Cada objeto de registro en la respuesta incluye tambien un campo interno ``crudMode``
-   (un entero que indica el modo de operacion CRUD, siempre ``0`` para operaciones de lectura).
+   Cada objeto de registro en la respuesta incluye también un campo interno ``crudMode``
+   (un entero que indica el modo de operación CRUD, siempre ``0`` para operaciones de lectura).
    Los clientes pueden ignorarlo sin problema.
 
-Obtener Informacion de Rastreo
+Obtener Información de Rastreo
 ==============================
 
 Solicitud
@@ -154,7 +154,7 @@ Respuesta
       }
     }
 
-Eliminar Informacion de Rastreo
+Eliminar Información de Rastreo
 ===============================
 
 Solicitud
@@ -178,7 +178,7 @@ Respuesta
 Eliminar en Lote Sesiones de Rastreo
 =====================================
 
-Elimina todas las sesiones de rastreo (y sus datos de parametros), excepto las que estan en ejecucion en ese momento. No existe umbral de antiguedad ni de tiempo; se eliminan todas las sesiones que no esten en ejecucion.
+Elimina todas las sesiones de rastreo (y sus datos de parámetros), excepto las que están en ejecución en ese momento. No existe umbral de antigüedad ni de tiempo; se eliminan todas las sesiones que no estén en ejecución.
 
 Solicitud
 ---------
@@ -201,7 +201,7 @@ Respuesta
 Ejemplos de Uso
 ===============
 
-Obtener Lista de Informacion de Rastreo
+Obtener Lista de Información de Rastreo
 ---------------------------------------
 
 .. code-block:: bash
@@ -209,7 +209,7 @@ Obtener Lista de Informacion de Rastreo
     curl -X GET "http://localhost:8080/api/admin/crawlinginfo/logs?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Filtrar por Sesion Especifica
+Filtrar por Sesión Específica
 -----------------------------
 
 .. code-block:: bash
@@ -217,7 +217,7 @@ Filtrar por Sesion Especifica
     curl -X GET "http://localhost:8080/api/admin/crawlinginfo/logs?sessionId=20250129100000" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Obtener Informacion de Rastreo
+Obtener Información de Rastreo
 ------------------------------
 
 .. code-block:: bash
@@ -225,7 +225,7 @@ Obtener Informacion de Rastreo
     curl -X GET "http://localhost:8080/api/admin/crawlinginfo/log/crawling_info_id_1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Eliminar Informacion de Rastreo
+Eliminar Información de Rastreo
 -------------------------------
 
 .. code-block:: bash
@@ -241,10 +241,10 @@ Eliminar en Lote Sesiones
     curl -X DELETE "http://localhost:8080/api/admin/crawlinginfo/all" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-failureurl` - API de URLs fallidas
 - :doc:`api-admin-joblog` - API de registro de trabajos
-- :doc:`../../admin/crawlinginfo-guide` - Guia de informacion de rastreo
+- :doc:`../../admin/crawlinginfo-guide` - Guía de información de rastreo

--- a/es/15.8/api/admin/api-admin-dataconfig.rst
+++ b/es/15.8/api/admin/api-admin-dataconfig.rst
@@ -2,10 +2,10 @@
 API de DataConfig
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de DataConfig es para gestionar la configuracion de almacen de datos de |Fess|.
+La API de DataConfig es para gestionar la configuración de almacén de datos de |Fess|.
 Puede operar configuraciones de rastreo para fuentes de datos como bases de datos, CSV y JSON.
 
 URL Base
@@ -22,26 +22,26 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
-     - Obtener lista de configuraciones de almacen de datos
+     - Obtener lista de configuraciones de almacén de datos
    * - GET
      - /setting/{id}
-     - Obtener configuracion de almacen de datos
+     - Obtener configuración de almacén de datos
    * - POST
      - /setting
-     - Crear configuracion de almacen de datos
+     - Crear configuración de almacén de datos
    * - PUT
      - /setting
-     - Actualizar configuracion de almacen de datos
+     - Actualizar configuración de almacén de datos
    * - DELETE
      - /setting/{id}
-     - Eliminar configuracion de almacen de datos
+     - Eliminar configuración de almacén de datos
 
-Obtener Lista de Configuraciones de Almacen de Datos
+Obtener Lista de Configuraciones de Almacén de Datos
 ====================================================
 
 Solicitud
@@ -51,29 +51,29 @@ Solicitud
 
     GET /api/admin/dataconfig/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25)
+     - Número de elementos por página (predeterminado: 25)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``name``
      - String
      - No
-     - Filtrar por nombre de configuracion
+     - Filtrar por nombre de configuración
    * - ``handlerName``
      - String
      - No
@@ -81,7 +81,7 @@ Parametros
    * - ``description``
      - String
      - No
-     - Filtrar por descripcion
+     - Filtrar por descripción
 
 Respuesta
 ---------
@@ -110,7 +110,7 @@ Respuesta
       }
     }
 
-Obtener Configuracion de Almacen de Datos
+Obtener Configuración de Almacén de Datos
 =========================================
 
 Solicitud
@@ -144,7 +144,7 @@ Respuesta
       }
     }
 
-Crear Configuracion de Almacen de Datos
+Crear Configuración de Almacén de Datos
 =======================================
 
 Solicitud
@@ -171,7 +171,7 @@ Cuerpo de la Solicitud
       "permissions": "{role}admin\n{role}user"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -180,37 +180,37 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre de la configuracion
+     - Sí
+     - Nombre de la configuración
    * - ``description``
      - No
-     - Descripcion de la configuracion
+     - Descripción de la configuración
    * - ``handlerName``
-     - Si
-     - Nombre del manejador de almacen de datos
+     - Sí
+     - Nombre del manejador de almacén de datos
    * - ``handlerParameter``
      - No
-     - Parametros del manejador (informacion de conexion, etc.)
+     - Parámetros del manejador (información de conexión, etc.)
    * - ``handlerScript``
      - No
-     - Script de transformacion de datos
+     - Script de transformación de datos
    * - ``boost``
-     - Si
-     - Valor de impulso en resultados de busqueda
+     - Sí
+     - Valor de impulso en resultados de búsqueda
    * - ``available``
-     - Si
+     - Sí
      - Habilitado/Deshabilitado (cadena ``"true"`` / ``"false"``)
    * - ``sortOrder``
-     - Si
-     - Orden de visualizacion
+     - Sí
+     - Orden de visualización
    * - ``permissions``
      - No
-     - Roles con permiso de acceso (separados por saltos de linea si son varios)
+     - Roles con permiso de acceso (separados por saltos de línea si son varios)
    * - ``virtualHosts``
      - No
-     - Hosts virtuales (separados por saltos de linea si son varios)
+     - Hosts virtuales (separados por saltos de línea si son varios)
 
 Respuesta
 ---------
@@ -225,7 +225,7 @@ Respuesta
       }
     }
 
-Actualizar Configuracion de Almacen de Datos
+Actualizar Configuración de Almacén de Datos
 ============================================
 
 Solicitud
@@ -253,7 +253,7 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Las solicitudes de actualizacion requieren los mismos campos obligatorios que la creacion (``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``), ademas de los siguientes campos:
+Las solicitudes de actualización requieren los mismos campos obligatorios que la creación (``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``), además de los siguientes campos:
 
 .. list-table::
    :header-rows: 1
@@ -261,13 +261,13 @@ Las solicitudes de actualizacion requieren los mismos campos obligatorios que la
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
-     - ID de la configuracion a actualizar
+     - Sí
+     - ID de la configuración a actualizar
    * - ``versionNo``
-     - Si
-     - Numero de version para el bloqueo optimista (especifique el valor obtenido al recuperar la configuracion)
+     - Sí
+     - Número de versión para el bloqueo optimista (especifique el valor obtenido al recuperar la configuración)
 
 Respuesta
 ---------
@@ -282,7 +282,7 @@ Respuesta
       }
     }
 
-Eliminar Configuracion de Almacen de Datos
+Eliminar Configuración de Almacén de Datos
 ==========================================
 
 Solicitud
@@ -311,27 +311,27 @@ Tipos de Manejador
    :widths: 30 70
 
    * - Nombre del Manejador
-     - Descripcion
+     - Descripción
    * - ``DatabaseDataStore``
-     - Conecta a base de datos via JDBC
+     - Conecta a base de datos vía JDBC
    * - ``CsvDataStore``
      - Lee datos de un archivo CSV (procesa cada fila como un documento)
    * - ``CsvListDataStore``
-     - Lee archivos CSV y elimina automaticamente los archivos procesados (una extension de ``CsvDataStore`` con filtrado basado en marcas de tiempo)
+     - Lee archivos CSV y elimina automáticamente los archivos procesados (una extensión de ``CsvDataStore`` con filtrado basado en marcas de tiempo)
    * - ``JsonDataStore``
      - Lee datos de archivos JSON o API JSON
 
 .. note::
 
-   Los tipos de manejador disponibles dependen de los plugins de almacen de datos instalados.
+   Los tipos de manejador disponibles dependen de los plugins de almacén de datos instalados.
    Los manejadores indicados arriba se incluyen de forma predeterminada. Al instalar plugins de
-   almacen de datos como SharePoint, Slack o Salesforce, los nombres de manejador correspondientes
+   almacén de datos como SharePoint, Slack o Salesforce, los nombres de manejador correspondientes
    quedan disponibles.
 
 Ejemplos de Uso
 ===============
 
-Configuracion de Rastreo de Base de Datos
+Configuración de Rastreo de Base de Datos
 -----------------------------------------
 
 .. code-block:: bash
@@ -349,10 +349,10 @@ Configuracion de Rastreo de Base de Datos
            "sortOrder": 0
          }'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-webconfig` - API de configuracion de rastreo web
-- :doc:`api-admin-fileconfig` - API de configuracion de rastreo de archivos
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de almacen de datos
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-webconfig` - API de configuración de rastreo web
+- :doc:`api-admin-fileconfig` - API de configuración de rastreo de archivos
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de almacén de datos

--- a/es/15.8/api/admin/api-admin-dict.rst
+++ b/es/15.8/api/admin/api-admin-dict.rst
@@ -2,12 +2,12 @@
 API de Dict
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Dict es para gestionar los diccionarios de |Fess|.
-En el endpoint raiz se puede obtener la lista de diccionarios disponibles.
-La referencia, creacion, actualizacion y eliminacion de elementos de diccionario individuales, asi como la carga y descarga de archivos de diccionario, se operan mediante los subendpoints por tipo de diccionario (synonym, kuromoji, mapping, protwords, stopwords, stemmeroverride).
+En el endpoint raíz se puede obtener la lista de diccionarios disponibles.
+La referencia, creación, actualización y eliminación de elementos de diccionario individuales, así como la carga y descarga de archivos de diccionario, se operan mediante los subendpoints por tipo de diccionario (synonym, kuromoji, mapping, protwords, stopwords, stemmeroverride).
 
 URL Base
 ========
@@ -19,16 +19,16 @@ URL Base
 Lista de Endpoints
 ==================
 
-Raiz del Diccionario
+Raíz del Diccionario
 --------------------
 
 .. list-table::
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /
      - Obtener lista de diccionarios
@@ -44,9 +44,9 @@ Estos valores coinciden con el valor del campo ``type`` incluido en la respuesta
    :header-rows: 1
    :widths: 15 50 35
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /{type}/settings/{dictId}
      - Obtener lista de elementos del diccionario
@@ -116,7 +116,7 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``settings[].id``
      - ID del diccionario (usado como ``{dictId}`` en las operaciones de diccionario individuales)
    * - ``settings[].type``
@@ -124,9 +124,9 @@ Campos de Respuesta
    * - ``settings[].path``
      - Ruta del archivo de diccionario
    * - ``settings[].timestamp``
-     - Fecha y hora de actualizacion del archivo de diccionario
+     - Fecha y hora de actualización del archivo de diccionario
    * - ``total``
-     - Numero total de archivos de diccionario
+     - Número total de archivos de diccionario
 
 Obtener Lista de Elementos del Diccionario
 ==========================================
@@ -140,34 +140,34 @@ Solicitud
 
     GET /api/admin/dict/{type}/settings/{dictId}
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametros
+   * - Parámetros
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``dictId``
      - String
-     - Si
-     - ID del diccionario (parametro de ruta)
+     - Sí
+     - ID del diccionario (parámetro de ruta)
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (por defecto: 25)
+     - Número de elementos por página (por defecto: 25)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, por defecto: 1)
+     - Número de página (comienza en 1, por defecto: 1)
 
 Respuesta
 ---------
 
-Los campos de cada elemento del arreglo ``settings`` de la respuesta varian segun el tipo de diccionario (consulte "Campos de Elementos por Tipo de Diccionario" mas adelante).
+Los campos de cada elemento del arreglo ``settings`` de la respuesta varían según el tipo de diccionario (consulte "Campos de Elementos por Tipo de Diccionario" más adelante).
 
 .. code-block:: json
 
@@ -192,7 +192,7 @@ El ejemplo anterior corresponde al diccionario ``synonym``.
 Obtener Elemento del Diccionario
 ================================
 
-Obtiene un elemento especifico dentro del diccionario.
+Obtiene un elemento específico dentro del diccionario.
 
 Solicitud
 ---------
@@ -201,25 +201,25 @@ Solicitud
 
     GET /api/admin/dict/{type}/setting/{dictId}/{id}
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametros
+   * - Parámetros
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``dictId``
      - String
-     - Si
-     - ID del diccionario (parametro de ruta)
+     - Sí
+     - ID del diccionario (parámetro de ruta)
    * - ``id``
      - Long
-     - Si
-     - ID del elemento (parametro de ruta)
+     - Sí
+     - ID del elemento (parámetro de ruta)
 
 Respuesta
 ---------
@@ -326,25 +326,25 @@ Solicitud
 
     DELETE /api/admin/dict/{type}/setting/{dictId}/{id}
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametros
+   * - Parámetros
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``dictId``
      - String
-     - Si
-     - ID del diccionario (parametro de ruta)
+     - Sí
+     - ID del diccionario (parámetro de ruta)
    * - ``id``
      - Long
-     - Si
-     - ID del elemento (parametro de ruta)
+     - Sí
+     - ID del elemento (parámetro de ruta)
 
 Respuesta
 ---------
@@ -373,7 +373,7 @@ Solicitud
     PUT /api/admin/dict/{type}/upload/{dictId}
     Content-Type: multipart/form-data
 
-El nombre del campo de archivo varia segun el tipo de diccionario (consulte "Campos de Elementos por Tipo de Diccionario" mas adelante).
+El nombre del campo de archivo varía según el tipo de diccionario (consulte "Campos de Elementos por Tipo de Diccionario" más adelante).
 
 Respuesta
 ---------
@@ -404,8 +404,8 @@ La respuesta es el binario del archivo de diccionario ( ``application/octet-stre
 Campos de Elementos por Tipo de Diccionario
 ===========================================
 
-Los campos del cuerpo de la solicitud de creacion y actualizacion de elementos del diccionario, asi como los de la respuesta, varian segun el tipo de diccionario.
-``id`` (ID del elemento) y ``dictId`` (ID del diccionario) se incluyen en comun en la respuesta.
+Los campos del cuerpo de la solicitud de creación y actualización de elementos del diccionario, así como los de la respuesta, varían según el tipo de diccionario.
+``id`` (ID del elemento) y ``dictId`` (ID del diccionario) se incluyen en común en la respuesta.
 
 .. list-table::
    :header-rows: 1
@@ -444,7 +444,7 @@ Obtener Lista de Diccionarios
     curl -X GET "http://localhost:8080/api/admin/dict" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Obtener Lista de Elementos del Diccionario de Sinonimos
+Obtener Lista de Elementos del Diccionario de Sinónimos
 -------------------------------------------------------
 
 .. code-block:: bash
@@ -452,7 +452,7 @@ Obtener Lista de Elementos del Diccionario de Sinonimos
     curl -X GET "http://localhost:8080/api/admin/dict/synonym/settings/{dictId}" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Agregar Elemento al Diccionario de Sinonimos
+Agregar Elemento al Diccionario de Sinónimos
 --------------------------------------------
 
 .. code-block:: bash
@@ -465,7 +465,7 @@ Agregar Elemento al Diccionario de Sinonimos
            "outputs": "busqueda,buscar,investigar"
          }'
 
-Cargar Archivo del Diccionario de Sinonimos
+Cargar Archivo del Diccionario de Sinónimos
 -------------------------------------------
 
 .. code-block:: bash
@@ -474,7 +474,7 @@ Cargar Archivo del Diccionario de Sinonimos
          -H "Authorization: Bearer YOUR_TOKEN" \
          -F "synonymFile=@synonym.txt"
 
-Descargar Archivo del Diccionario de Sinonimos
+Descargar Archivo del Diccionario de Sinónimos
 ----------------------------------------------
 
 .. code-block:: bash
@@ -483,8 +483,8 @@ Descargar Archivo del Diccionario de Sinonimos
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o synonym.txt
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`../../admin/dict-guide` - Guia de gestion de diccionarios
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`../../admin/dict-guide` - Guía de gestión de diccionarios

--- a/es/15.8/api/admin/api-admin-documents.rst
+++ b/es/15.8/api/admin/api-admin-documents.rst
@@ -2,11 +2,11 @@
 API de Documents
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de Documents es una Admin API de |Fess| para registrar documentos de forma masiva en el indice.
-Permite a sistemas externos agregar documentos generados directamente al indice sin necesidad de un rastreador.
+La API de Documents es una Admin API de |Fess| para registrar documentos de forma masiva en el índice.
+Permite a sistemas externos agregar documentos generados directamente al índice sin necesidad de un rastreador.
 Se pueden registrar varios documentos en una sola solicitud.
 
 URL Base
@@ -16,12 +16,12 @@ URL Base
 
     /api/admin/documents
 
-Autenticacion
+Autenticación
 =============
 
-Para llamar a esta API se requiere autenticacion mediante token de acceso, tal como se describe en :doc:`api-admin-overview`.
+Para llamar a esta API se requiere autenticación mediante token de acceso, tal como se describe en :doc:`api-admin-overview`.
 El token debe tener el permiso de acceso a Admin API (por defecto ``Radmin-api``).
-Este permiso se puede cambiar mediante la clave de configuracion ``api.admin.access.permissions``.
+Este permiso se puede cambiar mediante la clave de configuración ``api.admin.access.permissions``.
 
 Lista de Endpoints
 ==================
@@ -30,21 +30,21 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - PUT
      - /bulk
      - Registro masivo de documentos
 
 .. note::
 
-   Este endpoint acepta unicamente el metodo ``PUT``.
+   Este endpoint acepta únicamente el método ``PUT``.
 
 Registro Masivo de Documentos
 ==============================
 
-Registra varios documentos en el indice de forma masiva.
+Registra varios documentos en el índice de forma masiva.
 
 Solicitud
 ---------
@@ -74,7 +74,7 @@ Cuerpo de la Solicitud
       ]
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -83,20 +83,20 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``documents``
-     - Si
-     - Arreglo de documentos a registrar. Cada documento se especifica como un mapa de nombres de campo y valores. Si es ``null`` o un arreglo vacio, se devuelve un error (``status`` = ``1``).
+     - Sí
+     - Arreglo de documentos a registrar. Cada documento se especifica como un mapa de nombres de campo y valores. Si es ``null`` o un arreglo vacío, se devuelve un error (``status`` = ``1``).
 
 Campos del Documento
 ~~~~~~~~~~~~~~~~~~~~
 
-En cada documento se pueden especificar libremente los campos del indice como un mapa de nombres y valores.
-Como minimo, se deben especificar ``url`` y ``title`` (segun la configuracion de campos requeridos
+En cada documento se pueden especificar libremente los campos del índice como un mapa de nombres y valores.
+Como mínimo, se deben especificar ``url`` y ``title`` (según la configuración de campos requeridos
 ``index.admin.required.fields``; el valor predeterminado es ``url,title,role,boost``, y dado que
-``role`` y ``boost`` se autocompletan como se describe mas adelante, en la practica ``url`` y ``title`` son obligatorios).
+``role`` y ``boost`` se autocompletan como se describe más adelante, en la práctica ``url`` y ``title`` son obligatorios).
 
-Los siguientes campos se completan automaticamente si se omiten:
+Los siguientes campos se completan automáticamente si se omiten:
 
 .. list-table::
    :header-rows: 1
@@ -105,7 +105,7 @@ Los siguientes campos se completan automaticamente si se omiten:
    * - Campo
      - Valor predeterminado al omitir
    * - ``content_length``
-     - Suma del numero de caracteres de ``title`` y ``content``
+     - Suma del número de caracteres de ``title`` y ``content``
    * - ``favorite_count``
      - ``0``
    * - ``click_count``
@@ -113,13 +113,13 @@ Los siguientes campos se completan automaticamente si se omiten:
    * - ``boost``
      - ``1.0``
    * - ``role``
-     - Rol de busqueda para invitados (rol de busqueda configurado para usuarios invitados)
+     - Rol de búsqueda para invitados (rol de búsqueda configurado para usuarios invitados)
    * - ``last_modified``
      - Hora actual
    * - ``timestamp``
      - Hora actual
 
-Ademas, los siguientes campos se generan automaticamente al registrar:
+Además, los siguientes campos se generan automáticamente al registrar:
 
 - ``id`` - Se genera de forma determinista a partir de la ``url`` del documento (y de ``role`` y ``virtual_host``),
   y se utiliza como ID de documento en OpenSearch (``_id``). Este valor se devuelve en ``items[].id``
@@ -129,16 +129,16 @@ Ademas, los siguientes campos se generan automaticamente al registrar:
 .. note::
 
    Dado que ``id`` se genera de forma determinista a partir de ``url``, si se registra de nuevo
-   un documento con la misma ``url``, el documento existente sera actualizado
-   (``items[].result`` sera ``OK``).
+   un documento con la misma ``url``, el documento existente será actualizado
+   (``items[].result`` será ``OK``).
 
 Notas Adicionales
 ~~~~~~~~~~~~~~~~~
 
-- Si se incluye ``"auto"`` en el campo ``lang``, el idioma se detecta automaticamente a partir del cuerpo del documento.
-- Si se especifica ``config_id``, se aplica el pipeline de ingesta (ingest pipeline) de la configuracion de rastreo correspondiente.
-- Si la generacion de miniaturas esta habilitada (``thumbnail.crawler.enabled``), se intentara generar una miniatura al registrar.
-- Los valores de cada campo se validan segun la configuracion de tipo del campo (``index.admin.array.fields``,
+- Si se incluye ``"auto"`` en el campo ``lang``, el idioma se detecta automáticamente a partir del cuerpo del documento.
+- Si se especifica ``config_id``, se aplica el pipeline de ingesta (ingest pipeline) de la configuración de rastreo correspondiente.
+- Si la generación de miniaturas está habilitada (``thumbnail.crawler.enabled``), se intentará generar una miniatura al registrar.
+- Los valores de cada campo se validan según la configuración de tipo del campo (``index.admin.array.fields``,
   ``index.admin.date.fields``, ``index.admin.long.fields``, etc.).
   Si el tipo no coincide, se devuelve un error (``status`` = ``1``).
 
@@ -170,8 +170,8 @@ Los elementos exitosos incluyen ``result`` e ``id``, y los elementos fallidos in
 Cuando ``status`` es ``0``, indica que todos los documentos se registraron correctamente.
 En ``items[].result`` se establece ``CREATED`` para nuevos documentos y ``OK`` para documentos existentes actualizados.
 
-Si el registro falla en alguno de los elementos, ``status`` sera ``9`` (FAILED) y
-el elemento correspondiente incluira el campo ``message`` (en ``result`` se establecera
+Si el registro falla en alguno de los elementos, ``status`` será ``9`` (FAILED) y
+el elemento correspondiente incluirá el campo ``message`` (en ``result`` se establecerá
 el nombre del estado de error, como ``CONFLICT`` o ``BAD_REQUEST``). Los elementos exitosos devuelven su ``id`` normalmente.
 
 .. code-block:: json
@@ -195,7 +195,7 @@ el nombre del estado de error, como ``CONFLICT`` o ``BAD_REQUEST``). Los element
 
 .. note::
 
-   Si la solicitud en si es invalida (``documents`` no especificado o vacio, campos requeridos ausentes,
+   Si la solicitud en sí es inválida (``documents`` no especificado o vacío, campos requeridos ausentes,
    tipo de campo incorrecto, etc.), el proceso de registro de documentos no se ejecuta y
    se devuelve una respuesta de error con ``status`` = ``1`` (BAD_REQUEST) y ``message``.
    En este caso, no se devuelve el arreglo ``items``.
@@ -208,13 +208,13 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``items``
      - Arreglo de resultados de procesamiento de cada documento
    * - ``items[].result``
      - Nombre del estado del resultado de procesamiento. ``CREATED`` para nuevos documentos, ``OK`` para actualizaciones, o nombre del estado de error como ``BAD_REQUEST`` en caso de fallo
    * - ``items[].id``
-     - ID del documento registrado (solo en caso de exito)
+     - ID del documento registrado (solo en caso de éxito)
    * - ``items[].message``
      - Mensaje con el motivo del fallo (solo en caso de fallo)
 
@@ -239,10 +239,10 @@ Registro Masivo de Documentos
            ]
          }'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-searchlist` - API de busqueda y gestion de documentos
-- :doc:`api-admin-crawlinginfo` - API de informacion de rastreo
-- :doc:`../../admin/searchlist-guide` - Guia de gestion de lista de busqueda
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-searchlist` - API de búsqueda y gestión de documentos
+- :doc:`api-admin-crawlinginfo` - API de información de rastreo
+- :doc:`../../admin/searchlist-guide` - Guía de gestión de lista de búsqueda

--- a/es/15.8/api/admin/api-admin-elevateword.rst
+++ b/es/15.8/api/admin/api-admin-elevateword.rst
@@ -2,11 +2,11 @@
 API de ElevateWord
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de ElevateWord es para gestionar las palabras elevadas (manipulacion del orden de busqueda para palabras clave especificas) de |Fess|.
-Puede colocar documentos especificos en posiciones superiores o inferiores para ciertas consultas de busqueda.
+La API de ElevateWord es para gestionar las palabras elevadas (manipulación del orden de búsqueda para palabras clave específicas) de |Fess|.
+Puede colocar documentos específicos en posiciones superiores o inferiores para ciertas consultas de búsqueda.
 
 URL Base
 ========
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de palabras elevadas
@@ -57,25 +57,25 @@ Solicitud
 
     GET /api/admin/elevateword/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Número de elementos por página (predeterminado: 20)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``id``
      - String
      - No
@@ -156,7 +156,7 @@ Cuerpo de la Solicitud
       "labelTypeIds": ["label1"]
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -165,18 +165,18 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``suggestWord``
-     - Si
+     - Sí
      - Palabra clave a elevar
    * - ``reading``
      - No
-     - Lectura fonetica
+     - Lectura fonética
    * - ``permissions``
      - No
-     - Permisos de acceso (cadena separada por saltos de linea, uno por linea. Valor inicial del formulario: permisos de visualizacion predeterminados de la busqueda)
+     - Permisos de acceso (cadena separada por saltos de línea, uno por línea. Valor inicial del formulario: permisos de visualización predeterminados de la búsqueda)
    * - ``boost``
-     - Si
+     - Sí
      - Valor de impulso (valor inicial del formulario: 100.0)
    * - ``labelTypeIds``
      - No
@@ -223,10 +223,10 @@ Cuerpo de la Solicitud
 
 .. note::
 
-   Al actualizar, los siguientes campos son obligatorios ademas de los campos utilizados para la creacion:
+   Al actualizar, los siguientes campos son obligatorios además de los campos utilizados para la creación:
 
    - ``id`` - ID de la palabra elevada a actualizar
-   - ``versionNo`` - Numero de version para el bloqueo optimista. Especifique el valor obtenido de ``GET /setting/{id}``.
+   - ``versionNo`` - Número de versión para el bloqueo optimista. Especifique el valor obtenido de ``GET /setting/{id}``.
 
 Respuesta
 ---------
@@ -267,7 +267,7 @@ Respuesta
 Subir CSV de Palabras Elevadas
 ==============================
 
-Registra palabras elevadas en bloque a partir de un archivo CSV. El archivo se envia como ``multipart/form-data``. La importacion se ejecuta de forma asincrona en el servidor.
+Registra palabras elevadas en bloque a partir de un archivo CSV. El archivo se envía como ``multipart/form-data``. La importación se ejecuta de forma asíncrona en el servidor.
 
 Solicitud
 ---------
@@ -277,18 +277,18 @@ Solicitud
     PUT /api/admin/elevateword/upload
     Content-Type: multipart/form-data
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``elevateWordFile``
-     - Si
+     - Sí
      - Archivo CSV de palabras elevadas a subir
 
 Respuesta
@@ -331,7 +331,7 @@ Elevar Nombre de Producto
            "permissions": "{role}guest"
          }'
 
-Elevar a Etiqueta Especifica
+Elevar a Etiqueta Específica
 ----------------------------
 
 .. code-block:: bash
@@ -364,10 +364,10 @@ Descargar Archivo CSV
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o elevate.csv
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-keymatch` - API de coincidencia de claves
 - :doc:`api-admin-boostdoc` - API de impulso de documentos
-- :doc:`../../admin/elevateword-guide` - Guia de gestion de palabras elevadas
+- :doc:`../../admin/elevateword-guide` - Guía de gestión de palabras elevadas

--- a/es/15.8/api/admin/api-admin-failureurl.rst
+++ b/es/15.8/api/admin/api-admin-failureurl.rst
@@ -2,7 +2,7 @@
 API de FailureUrl
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de FailureUrl es para gestionar las URLs de rastreo fallidas de |Fess|.
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /logs
      - Obtener lista de URLs fallidas
@@ -48,25 +48,25 @@ Solicitud
 
     GET /api/admin/failureurl/logs
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Número de elementos por página (predeterminado: 20)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``url``
      - String
      - No
@@ -74,15 +74,15 @@ Parametros
    * - ``errorCountMin``
      - Integer
      - No
-     - Limite inferior del numero de errores (mayor o igual al valor especificado)
+     - Límite inferior del número de errores (mayor o igual al valor especificado)
    * - ``errorCountMax``
      - Integer
      - No
-     - Limite superior del numero de errores (menor o igual al valor especificado)
+     - Límite superior del número de errores (menor o igual al valor especificado)
    * - ``errorName``
      - String
      - No
-     - Filtro por nombre de error (coincidencia con comodin sobre el nombre de clase completamente calificado almacenado; se admiten ``*`` ``?``)
+     - Filtro por nombre de error (coincidencia con comodín sobre el nombre de clase completamente calificado almacenado; se admiten ``*`` ``?``)
 
 Respuesta
 ---------
@@ -126,27 +126,27 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``id``
      - ID de URL fallida
    * - ``url``
-     - URL que fallo
+     - URL que falló
    * - ``threadName``
      - Nombre del hilo
    * - ``errorName``
-     - Nombre del error (nombre de clase completamente calificado de la excepcion ocurrida; por ejemplo, ``java.net.ConnectException``)
+     - Nombre del error (nombre de clase completamente calificado de la excepción ocurrida; por ejemplo, ``java.net.ConnectException``)
    * - ``errorLog``
-     - Registro de error (mensaje de la excepcion o traza de pila)
+     - Registro de error (mensaje de la excepción o traza de pila)
    * - ``errorCount``
-     - Numero de ocurrencias del error (valor numerico representado como cadena)
+     - Número de ocurrencias del error (valor numérico representado como cadena)
    * - ``lastAccessTime``
-     - Hora del ultimo acceso (milisegundos epoch representados como cadena)
+     - Hora del último acceso (milisegundos epoch representados como cadena)
    * - ``configId``
-     - ID de configuracion de rastreo
+     - ID de configuración de rastreo
 
 .. note::
 
-   Todos los campos de respuesta se devuelven como cadenas (JSON string). ``errorCount`` es un valor numerico representado como cadena y ``lastAccessTime`` son milisegundos epoch representados como cadena.
+   Todos los campos de respuesta se devuelven como cadenas (JSON string). ``errorCount`` es un valor numérico representado como cadena y ``lastAccessTime`` son milisegundos epoch representados como cadena.
 
 Obtener URL Fallida
 ===================
@@ -203,7 +203,7 @@ Respuesta
 Eliminar Todas las URLs Fallidas
 ================================
 
-Elimina todas las URLs fallidas. No tiene parametros.
+Elimina todas las URLs fallidas. No tiene parámetros.
 
 Solicitud
 ---------
@@ -226,28 +226,28 @@ Respuesta
 Tipos de Error
 ==============
 
-``errorName`` almacena el nombre de clase completamente calificado de la excepcion ocurrida durante el rastreo, tal como fue capturado. No es una enumeracion fija; puede aparecer cualquier nombre de clase dependiendo de la excepcion que se haya producido. A continuacion se muestran ejemplos representativos.
+``errorName`` almacena el nombre de clase completamente calificado de la excepción ocurrida durante el rastreo, tal como fue capturado. No es una enumeración fija; puede aparecer cualquier nombre de clase dependiendo de la excepción que se haya producido. A continuación se muestran ejemplos representativos.
 
 .. list-table::
    :header-rows: 1
    :widths: 50 50
 
    * - Nombre de Error (ejemplo)
-     - Descripcion
+     - Descripción
    * - ``java.net.ConnectException``
-     - Conexion rechazada (no se puede conectar al servidor)
+     - Conexión rechazada (no se puede conectar al servidor)
    * - ``java.net.UnknownHostException``
      - No se pudo resolver el nombre de host (error de DNS)
    * - ``java.net.SocketTimeoutException``
-     - Tiempo de espera de conexion o lectura agotado
+     - Tiempo de espera de conexión o lectura agotado
    * - ``javax.net.ssl.SSLException``
      - Error en el protocolo de enlace SSL/TLS o en el certificado
    * - ``java.io.IOException``
      - Error de entrada/salida
    * - ``org.codelibs.fess.exception.ContentNotFoundException``
-     - URL que devolvio un codigo de estado HTTP configurado en ``crawler.failure.url.status.codes`` (predeterminado: 403, 404, 410)
+     - URL que devolvió un código de estado HTTP configurado en ``crawler.failure.url.status.codes`` (predeterminado: 403, 404, 410)
    * - ``org.codelibs.fess.crawler.exception.MaxLengthExceededException``
-     - El contenido supero la longitud maxima
+     - El contenido superó la longitud máxima
 
 Ejemplos de Uso
 ===============
@@ -260,7 +260,7 @@ Obtener Lista de URLs Fallidas
     curl -X GET "http://localhost:8080/api/admin/failureurl/logs?size=100&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Filtrar por Numero de Errores
+Filtrar por Número de Errores
 -----------------------------
 
 .. code-block:: bash
@@ -302,7 +302,7 @@ Eliminar Todas las URLs Fallidas
     curl -X DELETE "http://localhost:8080/api/admin/failureurl/all" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Agregacion por Tipo de Error
+Agregación por Tipo de Error
 ----------------------------
 
 .. code-block:: bash
@@ -312,10 +312,10 @@ Agregacion por Tipo de Error
          -H "Authorization: Bearer YOUR_TOKEN" | \
          jq '[.response.logs[].errorName] | group_by(.) | map({error: .[0], count: length})'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-crawlinginfo` - API de informacion de rastreo
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-crawlinginfo` - API de información de rastreo
 - :doc:`api-admin-joblog` - API de registro de trabajos
-- :doc:`../../admin/failureurl-guide` - Guia de gestion de URLs fallidas
+- :doc:`../../admin/failureurl-guide` - Guía de gestión de URLs fallidas

--- a/es/15.8/api/admin/api-admin-fileconfig.rst
+++ b/es/15.8/api/admin/api-admin-fileconfig.rst
@@ -2,10 +2,10 @@
 API de FileConfig
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de FileConfig es para gestionar la configuracion de rastreo de archivos de |Fess|.
+La API de FileConfig es para gestionar la configuración de rastreo de archivos de |Fess|.
 Puede operar configuraciones de rastreo para sistemas de archivos locales, carpetas compartidas SMB/CIFS, FTP y diversos almacenes de objetos.
 
 URL Base
@@ -17,8 +17,8 @@ URL Base
 
 .. note::
 
-   Todos los endpoints requieren privilegios de administrador y un token de acceso valido.
-   Consulte :doc:`api-admin-overview` para obtener informacion sobre la autenticacion.
+   Todos los endpoints requieren privilegios de administrador y un token de acceso válido.
+   Consulte :doc:`api-admin-overview` para obtener información sobre la autenticación.
 
 Lista de Endpoints
 ==================
@@ -27,24 +27,24 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de configuraciones de rastreo de archivos
    * - GET
      - /setting/{id}
-     - Obtener configuracion de rastreo de archivos
+     - Obtener configuración de rastreo de archivos
    * - POST
      - /setting
-     - Crear configuracion de rastreo de archivos
+     - Crear configuración de rastreo de archivos
    * - PUT
      - /setting
-     - Actualizar configuracion de rastreo de archivos
+     - Actualizar configuración de rastreo de archivos
    * - DELETE
      - /setting/{id}
-     - Eliminar configuracion de rastreo de archivos
+     - Eliminar configuración de rastreo de archivos
 
 Obtener Lista de Configuraciones de Rastreo de Archivos
 ========================================================
@@ -58,31 +58,31 @@ Solicitud
 
 .. note::
 
-   El endpoint de lista tambien acepta ``PUT`` ademas de ``GET``.
+   El endpoint de lista también acepta ``PUT`` además de ``GET``.
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 10 55
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25, segun la configuracion ``paging.page.size``)
+     - Número de elementos por página (predeterminado: 25, según la configuración ``paging.page.size``)
    * - ``name``
      - String
      - No
-     - Filtrar por nombre de configuracion
+     - Filtrar por nombre de configuración
    * - ``paths``
      - String
      - No
@@ -90,7 +90,7 @@ Parametros
    * - ``description``
      - String
      - No
-     - Filtrar por descripcion
+     - Filtrar por descripción
 
 Respuesta
 ---------
@@ -126,9 +126,9 @@ Respuesta
       }
     }
 
-``total`` indica el numero total de configuraciones que coinciden con los criterios de busqueda.
+``total`` indica el número total de configuraciones que coinciden con los criterios de búsqueda.
 
-Obtener Configuracion de Rastreo de Archivos
+Obtener Configuración de Rastreo de Archivos
 ============================================
 
 Solicitud
@@ -176,12 +176,12 @@ Respuesta
 
 .. note::
 
-   La respuesta incluye los campos de auditoria ``createdBy``, ``createdTime``,
-   ``updatedBy``, ``updatedTime`` y ``versionNo``, que son asignados automaticamente
-   en el momento del registro o la actualizacion.
-   ``versionNo`` es obligatorio al actualizar (consulte la seccion "Actualizar configuracion de rastreo de archivos" a continuacion).
+   La respuesta incluye los campos de auditoría ``createdBy``, ``createdTime``,
+   ``updatedBy``, ``updatedTime`` y ``versionNo``, que son asignados automáticamente
+   en el momento del registro o la actualización.
+   ``versionNo`` es obligatorio al actualizar (consulte la sección "Actualizar configuración de rastreo de archivos" a continuación).
 
-Crear Configuracion de Rastreo de Archivos
+Crear Configuración de Rastreo de Archivos
 ==========================================
 
 Solicitud
@@ -210,7 +210,7 @@ Cuerpo de la Solicitud
       "permissions": "{role}admin\n{role}user"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -219,63 +219,63 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre de la configuracion (maximo 200 caracteres)
+     - Sí
+     - Nombre de la configuración (máximo 200 caracteres)
    * - ``description``
      - No
-     - Descripcion de la configuracion (maximo 1000 caracteres)
+     - Descripción de la configuración (máximo 1000 caracteres)
    * - ``paths``
-     - Si
-     - Ruta de inicio de rastreo (separadas por salto de linea si son multiples). Se especifica con uno de los protocolos: ``file:``, ``smb:``, ``smb1:``, ``ftp:``, ``storage:``, ``s3:`` o ``gcs:``
+     - Sí
+     - Ruta de inicio de rastreo (separadas por salto de línea si son múltiples). Se especifica con uno de los protocolos: ``file:``, ``smb:``, ``smb1:``, ``ftp:``, ``storage:``, ``s3:`` o ``gcs:``
    * - ``includedPaths``
      - No
-     - Patron de expresion regular para rutas a rastrear
+     - Patrón de expresión regular para rutas a rastrear
    * - ``excludedPaths``
      - No
-     - Patron de expresion regular para rutas a excluir del rastreo
+     - Patrón de expresión regular para rutas a excluir del rastreo
    * - ``includedDocPaths``
      - No
-     - Patron de expresion regular para rutas a indexar
+     - Patrón de expresión regular para rutas a indexar
    * - ``excludedDocPaths``
      - No
-     - Patron de expresion regular para rutas a excluir del indice
+     - Patrón de expresión regular para rutas a excluir del índice
    * - ``configParameter``
      - No
-     - Parametros de configuracion adicionales (formato ``key=value``, un elemento por linea)
+     - Parámetros de configuración adicionales (formato ``key=value``, un elemento por línea)
    * - ``depth``
      - No
-     - Profundidad de rastreo (0 o mas)
+     - Profundidad de rastreo (0 o más)
    * - ``maxAccessCount``
      - No
-     - Numero maximo de accesos (0 o mas)
+     - Número máximo de accesos (0 o más)
    * - ``numOfThread``
-     - Si
-     - Numero de hilos paralelos (1 o mas)
+     - Sí
+     - Número de hilos paralelos (1 o más)
    * - ``intervalTime``
-     - Si
-     - Intervalo de acceso (milisegundos, 0 o mas)
+     - Sí
+     - Intervalo de acceso (milisegundos, 0 o más)
    * - ``boost``
-     - Si
-     - Valor de impulso en resultados de busqueda
+     - Sí
+     - Valor de impulso en resultados de búsqueda
    * - ``available``
-     - Si
+     - Sí
      - Habilitado/Deshabilitado (cadena ``"true"`` / ``"false"``)
    * - ``sortOrder``
-     - Si
-     - Orden de visualizacion (0 o mas)
+     - Sí
+     - Orden de visualización (0 o más)
    * - ``permissions``
      - No
-     - Roles con permiso de acceso (separados por saltos de linea si son varios)
+     - Roles con permiso de acceso (separados por saltos de línea si son varios)
    * - ``virtualHosts``
      - No
-     - Hosts virtuales (separados por saltos de linea si son varios)
+     - Hosts virtuales (separados por saltos de línea si son varios)
 
 .. note::
 
-   Los campos de auditoria como ``createdBy``, ``createdTime``, ``updatedBy`` y ``updatedTime``
-   son asignados automaticamente por el servidor, por lo que no es necesario incluirlos en el cuerpo de la solicitud.
+   Los campos de auditoría como ``createdBy``, ``createdTime``, ``updatedBy`` y ``updatedTime``
+   son asignados automáticamente por el servidor, por lo que no es necesario incluirlos en el cuerpo de la solicitud.
 
 Respuesta
 ---------
@@ -290,7 +290,7 @@ Respuesta
       }
     }
 
-Actualizar Configuracion de Rastreo de Archivos
+Actualizar Configuración de Rastreo de Archivos
 ===============================================
 
 Solicitud
@@ -304,8 +304,8 @@ Solicitud
 Cuerpo de la Solicitud
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Al actualizar, ademas de los campos de creacion, son obligatorios ``id`` para identificar
-el registro a actualizar y ``versionNo`` como numero de version.
+Al actualizar, además de los campos de creación, son obligatorios ``id`` para identificar
+el registro a actualizar y ``versionNo`` como número de versión.
 En ``versionNo`` se debe especificar el valor actual incluido en la respuesta de la API de consulta (GET).
 
 .. code-block:: json
@@ -326,7 +326,7 @@ En ``versionNo`` se debe especificar el valor actual incluido en la respuesta de
       "versionNo": 1
     }
 
-Campos Adicionales para la Actualizacion
+Campos Adicionales para la Actualización
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -335,13 +335,13 @@ Campos Adicionales para la Actualizacion
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
-     - ID de la configuracion a actualizar (maximo 1000 caracteres)
+     - Sí
+     - ID de la configuración a actualizar (máximo 1000 caracteres)
    * - ``versionNo``
-     - Si
-     - Numero de version actual del registro a actualizar. Se especifica el valor de ``versionNo`` incluido en la respuesta de la API de consulta (GET)
+     - Sí
+     - Número de versión actual del registro a actualizar. Se especifica el valor de ``versionNo`` incluido en la respuesta de la API de consulta (GET)
 
 Respuesta
 ---------
@@ -356,7 +356,7 @@ Respuesta
       }
     }
 
-Eliminar Configuracion de Rastreo de Archivos
+Eliminar Configuración de Rastreo de Archivos
 =============================================
 
 Solicitud
@@ -380,7 +380,7 @@ Respuesta
 Formato de Rutas
 ================
 
-En ``paths`` se pueden utilizar los siguientes protocolos (los protocolos disponibles pueden modificarse mediante la configuracion ``crawler.file.protocols``).
+En ``paths`` se pueden utilizar los siguientes protocolos (los protocolos disponibles pueden modificarse mediante la configuración ``crawler.file.protocols``).
 
 .. list-table::
    :header-rows: 1
@@ -405,14 +405,14 @@ En ``paths`` se pueden utilizar los siguientes protocolos (los protocolos dispon
 
 .. note::
 
-   Las credenciales de autenticacion (nombre de usuario y contrasena) para SMB/CIFS y FTP
-   no se incluyen en la ruta, sino que se configuran en la seccion "Autenticacion de archivos".
-   Consulte :doc:`../../admin/fileauth-guide` para mas informacion.
+   Las credenciales de autenticación (nombre de usuario y contraseña) para SMB/CIFS y FTP
+   no se incluyen en la ruta, sino que se configuran en la sección "Autenticación de archivos".
+   Consulte :doc:`../../admin/fileauth-guide` para más información.
 
 Ejemplos de Uso
 ===============
 
-Configuracion de Rastreo de Archivos Locales
+Configuración de Rastreo de Archivos Locales
 --------------------------------------------
 
 .. code-block:: bash
@@ -433,7 +433,7 @@ Configuracion de Rastreo de Archivos Locales
            "permissions": "{role}guest"
          }'
 
-Configuracion de Rastreo de Recurso Compartido SMB
+Configuración de Rastreo de Recurso Compartido SMB
 --------------------------------------------------
 
 .. code-block:: bash
@@ -457,14 +457,14 @@ Configuracion de Rastreo de Recurso Compartido SMB
 
 .. note::
 
-   Si el acceso al recurso compartido SMB requiere autenticacion, registre previamente
-   las credenciales del host de destino en la configuracion de "Autenticacion de archivos".
+   Si el acceso al recurso compartido SMB requiere autenticación, registre previamente
+   las credenciales del host de destino en la configuración de "Autenticación de archivos".
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-webconfig` - API de configuracion de rastreo web
-- :doc:`api-admin-dataconfig` - API de configuracion de almacen de datos
-- :doc:`../../admin/fileconfig-guide` - Guia de configuracion de rastreo de archivos
-- :doc:`../../admin/fileauth-guide` - Guia de configuracion de autenticacion de archivos
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-webconfig` - API de configuración de rastreo web
+- :doc:`api-admin-dataconfig` - API de configuración de almacén de datos
+- :doc:`../../admin/fileconfig-guide` - Guía de configuración de rastreo de archivos
+- :doc:`../../admin/fileauth-guide` - Guía de configuración de autenticación de archivos

--- a/es/15.8/api/admin/api-admin-general.rst
+++ b/es/15.8/api/admin/api-admin-general.rst
@@ -2,16 +2,16 @@
 API de General
 ==========================
 
-Descripcion General
+Descripción General
 ===================
 
-La API de General es una API para gestionar la configuracion general de |Fess|
-(configuracion de todo el sistema). Puede obtener y actualizar configuraciones
-relacionadas con el rastreo, el registro, la visualizacion de resultados de
-busqueda, las sugerencias, los periodos de retencion de registros, las
-notificaciones, la autenticacion (LDAP / SSO) y la integracion con
+La API de General es una API para gestionar la configuración general de |Fess|
+(configuración de todo el sistema). Puede obtener y actualizar configuraciones
+relacionadas con el rastreo, el registro, la visualización de resultados de
+búsqueda, las sugerencias, los períodos de retención de registros, las
+notificaciones, la autenticación (LDAP / SSO) y la integración con
 almacenamiento en la nube. Estas configuraciones corresponden a los ajustes
-"General" en la interfaz de administracion (:doc:`../../admin/general-guide`).
+"General" en la interfaz de administración (:doc:`../../admin/general-guide`).
 
 URL Base
 ========
@@ -22,7 +22,7 @@ URL Base
 
 Para acceder a esta API se requiere un token de acceso con el permiso
 ``Radmin-api``. Consulte :doc:`api-admin-overview` para obtener detalles sobre
-la autenticacion.
+la autenticación.
 
 Lista de Endpoints
 ==================
@@ -31,17 +31,17 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /
-     - Obtener configuracion general
+     - Obtener configuración general
    * - PUT
      - /
-     - Actualizar configuracion general
+     - Actualizar configuración general
 
-Obtener Configuracion General
+Obtener Configuración General
 ==============================
 
 Solicitud
@@ -51,17 +51,17 @@ Solicitud
 
     GET /api/admin/general
 
-Este endpoint no acepta parametros de consulta.
+Este endpoint no acepta parámetros de consulta.
 
 Respuesta
 ---------
 
-``response.setting`` contiene la configuracion general actual. La respuesta
-incluye todos los campos de configuracion actualizables; el ejemplo a
-continuacion muestra solo los campos representativos. Los ajustes de
-activacion/desactivacion se expresan como las cadenas ``"true"`` /
-``"false"``, mientras que valores como los dias de retencion y el numero de
-hilos se expresan como numeros.
+``response.setting`` contiene la configuración general actual. La respuesta
+incluye todos los campos de configuración actualizables; el ejemplo a
+continuación muestra solo los campos representativos. Los ajustes de
+activación/desactivación se expresan como las cadenas ``"true"`` /
+``"false"``, mientras que valores como los días de retención y el número de
+hilos se expresan como números.
 
 .. code-block:: json
 
@@ -108,24 +108,24 @@ hilos se expresan como numeros.
 .. note::
 
    Lo anterior muestra solo campos representativos a modo de ejemplo. El objeto ``setting``
-   real en la respuesta contiene todos los campos de configuracion general (rastreo, busqueda,
-   notificaciones, LDAP, SSO, almacenamiento, etc.). Consulte la pagina de ajustes "General"
-   en la interfaz de administracion para la lista completa.
+   real en la respuesta contiene todos los campos de configuración general (rastreo, búsqueda,
+   notificaciones, LDAP, SSO, almacenamiento, etc.). Consulte la página de ajustes "General"
+   en la interfaz de administración para la lista completa.
 
 .. note::
 
    Por razones de seguridad, los campos que contienen credenciales no se devuelven con sus
    valores reales.
 
-   - La contrasena del administrador LDAP ``ldapAdminSecurityCredentials`` siempre se
+   - La contraseña del administrador LDAP ``ldapAdminSecurityCredentials`` siempre se
      devuelve como ``null``.
    - Otros secretos (``storageAccessKey`` / ``storageSecretKey`` /
      ``oicClientId`` / ``oicClientSecret`` / ``spnegoPreauthPassword`` /
      ``entraidClientId`` / ``entraidClientSecret``) se devuelven enmascarados como
-     ``"**********"`` cuando estan configurados, o como una cadena vacia (``""``) cuando
-     no lo estan.
+     ``"**********"`` cuando están configurados, o como una cadena vacía (``""``) cuando
+     no lo están.
 
-Actualizar Configuracion General
+Actualizar Configuración General
 =================================
 
 Solicitud
@@ -139,8 +139,8 @@ Solicitud
 Cuerpo de la Solicitud
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Las actualizaciones se procesan como una actualizacion parcial (merge). El
-servidor carga la configuracion actual y luego sobreescribe unicamente los
+Las actualizaciones se procesan como una actualización parcial (merge). El
+servidor carga la configuración actual y luego sobreescribe únicamente los
 campos no nulos (no ``null``) incluidos en la solicitud. Los campos no
 incluidos en la solicitud, y los campos establecidos como ``null``, conservan
 sus valores existentes.
@@ -148,33 +148,33 @@ sus valores existentes.
 .. warning::
 
    Los siguientes cuatro campos son requeridos y DEBEN incluirse en CADA solicitud PUT,
-   incluso en una actualizacion parcial:
+   incluso en una actualización parcial:
 
    - ``dayForCleanup``
    - ``crawlingThreadCount``
    - ``failureCountThreshold``
    - ``csvFileEncoding``
 
-   Si falta alguno de ellos, la solicitud falla la validacion y la API devuelve HTTP 400
+   Si falta alguno de ellos, la solicitud falla la validación y la API devuelve HTTP 400
    con ``status: 1`` y un ``message`` de error. Dado que el valor enviado sobreescribe la
-   configuracion existente, para mantener un valor sin cambios primero recuperelo con
-   ``GET`` y envielo tal cual. Todos los demas campos son opcionales; los campos omitidos
+   configuración existente, para mantener un valor sin cambios primero recupérelo con
+   ``GET`` y envíelo tal cual. Todos los demás campos son opcionales; los campos omitidos
    conservan sus valores existentes.
 
 .. note::
 
-   Los campos numericos tienen validacion de tipo y rango. Enviar un valor que no pueda
-   interpretarse como un entero, o un valor fuera del rango permitido, falla la validacion
-   (HTTP 400 con ``status: 1``). El rango valido de cada campo numerico se indica en la
-   tabla de campos a continuacion.
+   Los campos numéricos tienen validación de tipo y rango. Enviar un valor que no pueda
+   interpretarse como un entero, o un valor fuera del rango permitido, falla la validación
+   (HTTP 400 con ``status: 1``). El rango válido de cada campo numérico se indica en la
+   tabla de campos a continuación.
 
 .. note::
 
-   Para los campos de activacion/desactivacion (tipo ``available``), solo ``"true"`` o
-   ``"on"`` (ambos sin distincion de mayusculas y minusculas) significan habilitado.
-   Cualquier otro valor (como ``"false"`` o una cadena vacia) se trata como deshabilitado
-   (``false``). El valor existente se mantiene unicamente cuando el campo se omite (no se
-   envia). En la respuesta GET, estos campos se devuelven como las cadenas ``"true"`` /
+   Para los campos de activación/desactivación (tipo ``available``), solo ``"true"`` o
+   ``"on"`` (ambos sin distinción de mayúsculas y minúsculas) significan habilitado.
+   Cualquier otro valor (como ``"false"`` o una cadena vacía) se trata como deshabilitado
+   (``false``). El valor existente se mantiene únicamente cuando el campo se omite (no se
+   envía). En la respuesta GET, estos campos se devuelven como las cadenas ``"true"`` /
    ``"false"``.
 
 .. code-block:: json
@@ -191,10 +191,10 @@ sus valores existentes.
 Campos Principales
 ~~~~~~~~~~~~~~~~~~
 
-Los elementos de configuracion son muy variados. A continuacion se muestran
+Los elementos de configuración son muy variados. A continuación se muestran
 los campos representativos (todos los campos corresponden a los ajustes
-"General" en la interfaz de administracion). Los ajustes de
-activacion/desactivacion se especifican como las cadenas ``"true"`` /
+"General" en la interfaz de administración). Los ajustes de
+activación/desactivación se especifican como las cadenas ``"true"`` /
 ``"false"``.
 
 .. list-table::
@@ -203,64 +203,64 @@ activacion/desactivacion se especifican como las cadenas ``"true"`` /
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``incrementalCrawling``
      - No
      - Habilitar/deshabilitar el rastreo incremental
    * - ``dayForCleanup``
-     - Si
-     - Numero de dias que se conservan los documentos rastreados (-1=limpieza deshabilitada; rango: -1 a 1000)
+     - Sí
+     - Número de días que se conservan los documentos rastreados (-1=limpieza deshabilitada; rango: -1 a 1000)
    * - ``crawlingThreadCount``
-     - Si
-     - Numero de hilos usados para el rastreo (rango: 0 a 100)
+     - Sí
+     - Número de hilos usados para el rastreo (rango: 0 a 100)
    * - ``failureCountThreshold``
-     - Si
-     - Umbral del numero de fallos para detener el rastreo de una URL (-1=deshabilitado; rango: -1 a 10000)
+     - Sí
+     - Umbral del número de fallos para detener el rastreo de una URL (-1=deshabilitado; rango: -1 a 10000)
    * - ``csvFileEncoding``
-     - Si
-     - Codificacion de la exportacion CSV
+     - Sí
+     - Codificación de la exportación CSV
    * - ``searchLog``
      - No
-     - Habilitar/deshabilitar el registro de consultas de busqueda
+     - Habilitar/deshabilitar el registro de consultas de búsqueda
    * - ``userInfo``
      - No
-     - Habilitar/deshabilitar el registro de informacion de usuario
+     - Habilitar/deshabilitar el registro de información de usuario
    * - ``userFavorite``
      - No
-     - Habilitar/deshabilitar la funcion de favoritos
+     - Habilitar/deshabilitar la función de favoritos
    * - ``webApiJson``
      - No
      - Habilitar/deshabilitar la Web API JSON
    * - ``appValue``
      - No
-     - Valor de configuracion adicional especifico de la aplicacion
+     - Valor de configuración adicional específico de la aplicación
    * - ``virtualHostValue``
      - No
-     - Configuracion de host virtual (para entornos multi-tenant)
+     - Configuración de host virtual (para entornos multi-tenant)
    * - ``popularWord``
      - No
-     - Habilitar/deshabilitar la agregacion y visualizacion de palabras populares
+     - Habilitar/deshabilitar la agregación y visualización de palabras populares
    * - ``defaultLabelValue``
      - No
      - Valor de etiqueta predeterminado
    * - ``defaultSortValue``
      - No
-     - Orden de clasificacion predeterminado
+     - Orden de clasificación predeterminado
    * - ``appendQueryParameter``
      - No
-     - Agregar parametros de consulta a la URL de los resultados de busqueda
+     - Agregar parámetros de consulta a la URL de los resultados de búsqueda
    * - ``loginRequired``
      - No
-     - Si se requiere inicio de sesion para buscar
+     - Si se requiere inicio de sesión para buscar
    * - ``loginLink``
      - No
-     - Habilitar o deshabilitar la visualizacion del enlace de inicio de sesion en la pantalla de busqueda
+     - Habilitar o deshabilitar la visualización del enlace de inicio de sesión en la pantalla de búsqueda
    * - ``thumbnail``
      - No
-     - Habilitar/deshabilitar la generacion de miniaturas
+     - Habilitar/deshabilitar la generación de miniaturas
    * - ``resultCollapsed``
      - No
-     - Habilitar o deshabilitar el colapso de documentos similares en los resultados de busqueda
+     - Habilitar o deshabilitar el colapso de documentos similares en los resultados de búsqueda
    * - ``ignoreFailureType``
      - No
      - Tipos de fallo de rastreo a ignorar
@@ -269,34 +269,34 @@ activacion/desactivacion se especifican como las cadenas ``"true"`` /
      - Cadena User-Agent enviada durante el rastreo
    * - ``purgeSearchLogDay``
      - No
-     - Numero de dias que se conservan los registros de busqueda (-1=deshabilitado; rango: -1 a 100000)
+     - Número de días que se conservan los registros de búsqueda (-1=deshabilitado; rango: -1 a 100000)
    * - ``purgeJobLogDay``
      - No
-     - Numero de dias que se conservan los registros de trabajos (-1=deshabilitado; rango: -1 a 100000)
+     - Número de días que se conservan los registros de trabajos (-1=deshabilitado; rango: -1 a 100000)
    * - ``purgeUserInfoDay``
      - No
-     - Numero de dias que se conserva la informacion de usuario (-1=deshabilitado; rango: -1 a 100000)
+     - Número de días que se conserva la información de usuario (-1=deshabilitado; rango: -1 a 100000)
    * - ``purgeSuggestSearchLogDay``
      - No
-     - Numero de dias que se conservan los registros de busqueda de sugerencias (0=deshabilitado; rango: 0 a 100000)
+     - Número de días que se conservan los registros de búsqueda de sugerencias (0=deshabilitado; rango: 0 a 100000)
    * - ``purgeByBots``
      - No
-     - User-Agent de bots cuyos registros de busqueda se descartan
+     - User-Agent de bots cuyos registros de búsqueda se descartan
    * - ``notificationTo``
      - No
-     - Direccion de correo electronico de destino de las notificaciones del sistema
+     - Dirección de correo electrónico de destino de las notificaciones del sistema
    * - ``notificationLogin``
      - No
-     - Mensaje de notificacion que se muestra en la pagina de inicio de sesion
+     - Mensaje de notificación que se muestra en la página de inicio de sesión
    * - ``notificationSearchTop``
      - No
-     - Mensaje de notificacion que se muestra en la pagina principal de busqueda
+     - Mensaje de notificación que se muestra en la página principal de búsqueda
    * - ``notificationAdvanceSearch``
      - No
-     - Mensaje de notificacion que se muestra en la pagina de busqueda avanzada
+     - Mensaje de notificación que se muestra en la página de búsqueda avanzada
    * - ``suggestSearchLog``
      - No
-     - Habilitar/deshabilitar las sugerencias a partir de los registros de busqueda
+     - Habilitar/deshabilitar las sugerencias a partir de los registros de búsqueda
    * - ``suggestDocuments``
      - No
      - Habilitar/deshabilitar las sugerencias a partir de los documentos
@@ -305,10 +305,10 @@ activacion/desactivacion se especifican como las cadenas ``"true"`` /
      - Nivel de registro del log del sistema
    * - ``logNotificationEnabled``
      - No
-     - Habilitar/deshabilitar la notificacion de logs ERROR/WARN
+     - Habilitar/deshabilitar la notificación de logs ERROR/WARN
    * - ``logNotificationLevel``
      - No
-     - Nivel de notificacion de logs
+     - Nivel de notificación de logs
    * - ``slackWebhookUrls``
      - No
      - URL de Slack Webhook para notificaciones
@@ -317,7 +317,7 @@ activacion/desactivacion se especifican como las cadenas ``"true"`` /
      - URL de Google Chat Webhook para notificaciones
    * - ``searchUseBrowserLocale``
      - No
-     - Si se utiliza el idioma del navegador para la busqueda
+     - Si se utiliza el idioma del navegador para la búsqueda
    * - ``ragLlmName``
      - No
      - Nombre del proveedor LLM utilizado para RAG
@@ -325,22 +325,22 @@ activacion/desactivacion se especifican como las cadenas ``"true"`` /
      - No
      - Nivel de registro para los paquetes relacionados con LLM
 
-Campos Relacionados con Autenticacion
+Campos Relacionados con Autenticación
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Las configuraciones relacionadas con LDAP y SSO (OpenID Connect, SAML,
-SPNEGO, Entra ID) tambien se gestionan con esta API. A continuacion se
+SPNEGO, Entra ID) también se gestionan con esta API. A continuación se
 muestran los campos representativos (todos los campos corresponden a los
-ajustes "General" en la interfaz de administracion).
+ajustes "General" en la interfaz de administración).
 
 .. list-table::
    :header-rows: 1
    :widths: 40 60
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``ldapProviderUrl``
-     - URL de conexion LDAP
+     - URL de conexión LDAP
    * - ``ldapBaseDn``
      - DN base de LDAP
    * - ``ldapSecurityPrincipal``
@@ -348,26 +348,26 @@ ajustes "General" en la interfaz de administracion).
    * - ``ldapAdminSecurityPrincipal``
      - Principal de seguridad para operaciones administrativas LDAP
    * - ``ldapAdminSecurityCredentials``
-     - Contrasena del administrador LDAP (se reemplaza por ``null`` en la respuesta)
+     - Contraseña del administrador LDAP (se reemplaza por ``null`` en la respuesta)
    * - ``ldapAccountFilter`` / ``ldapGroupFilter``
-     - Filtros de busqueda de usuarios/grupos
+     - Filtros de búsqueda de usuarios/grupos
    * - ``ldapMemberofAttribute``
      - Nombre del atributo LDAP que indica la pertenencia a un grupo
    * - ``ssoType``
      - Tipo de SSO (``none`` / ``oic`` / ``saml`` / ``spnego`` / ``entraid``)
    * - ``oicClientId`` / ``oicClientSecret`` / ``oicAuthServerUrl`` y otros
-     - Configuracion de OpenID Connect
+     - Configuración de OpenID Connect
    * - ``samlIdpEntityid`` / ``samlSpEntityid`` y otros
-     - Configuracion de SAML
+     - Configuración de SAML
    * - ``spnegoKrb5Conf`` / ``spnegoLoginConf`` y otros
-     - Configuracion de SPNEGO
+     - Configuración de SPNEGO
    * - ``entraidClientId`` / ``entraidTenant`` y otros
-     - Configuracion de Microsoft Entra ID
+     - Configuración de Microsoft Entra ID
 
 Campos Relacionados con Almacenamiento
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tambien se puede gestionar la configuracion de integracion con almacenamiento
+También se puede gestionar la configuración de integración con almacenamiento
 en la nube (S3 / GCS).
 
 .. list-table::
@@ -375,17 +375,17 @@ en la nube (S3 / GCS).
    :widths: 40 60
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``storageType``
      - Tipo de almacenamiento (``auto`` / ``s3`` / ``gcs``)
    * - ``storageEndpoint``
      - URL del endpoint del almacenamiento
    * - ``storageAccessKey`` / ``storageSecretKey``
-     - Clave de acceso/clave secreta para la autenticacion
+     - Clave de acceso/clave secreta para la autenticación
    * - ``storageBucket``
      - Nombre del bucket
    * - ``storageRegion``
-     - Region de S3
+     - Región de S3
    * - ``storageProjectId`` / ``storageCredentialsPath``
      - ID de proyecto de GCS / ruta del archivo de credenciales
 
@@ -394,18 +394,18 @@ en la nube (S3 / GCS).
    Los campos de tipo secreto como ``ldapAdminSecurityCredentials``,
    ``storageAccessKey`` / ``storageSecretKey``, ``oicClientId`` / ``oicClientSecret``,
    ``entraidClientId`` / ``entraidClientSecret`` y ``spnegoPreauthPassword`` conservan su
-   valor almacenado (no se actualizan) cuando se envia el valor enmascarado ``"**********"``
-   tal cual. Envie el valor real solo cuando desee cambiarlo.
+   valor almacenado (no se actualizan) cuando se envía el valor enmascarado ``"**********"``
+   tal cual. Envíe el valor real solo cuando desee cambiarlo.
 
-   Dado que esta comprobacion se basa en si la cadena queda vacia tras eliminar los
-   asteriscos, enviar una cadena vacia (``""``) o un valor compuesto unicamente de
+   Dado que esta comprobación se basa en si la cadena queda vacía tras eliminar los
+   asteriscos, enviar una cadena vacía (``""``) o un valor compuesto únicamente de
    asteriscos tampoco actualiza el valor. Por lo tanto, estos campos de tipo secreto no
-   pueden borrarse a un valor vacio mediante la API.
+   pueden borrarse a un valor vacío mediante la API.
 
 Respuesta
 ---------
 
-En caso de actualizacion exitosa, solo se devuelven ``version`` y ``status``
+En caso de actualización exitosa, solo se devuelven ``version`` y ``status``
 (no se incluyen ``id`` ni ``created``).
 
 .. code-block:: json
@@ -417,9 +417,9 @@ En caso de actualizacion exitosa, solo se devuelven ``version`` y ``status``
       }
     }
 
-Si la actualizacion falla (por ejemplo, debido a un error de validacion), la API
+Si la actualización falla (por ejemplo, debido a un error de validación), la API
 devuelve HTTP 400 y ``status`` se establece en un valor distinto de cero (``1``
-para un error de validacion), y ``message`` contiene los detalles del error.
+para un error de validación), y ``message`` contiene los detalles del error.
 Consulte :doc:`api-admin-overview` para la lista de valores de ``status``.
 
 Ejemplos de Uso
@@ -427,13 +427,13 @@ Ejemplos de Uso
 
 .. note::
 
-   Los ejemplos a continuacion incluyen los campos requeridos (``dayForCleanup``,
+   Los ejemplos a continuación incluyen los campos requeridos (``dayForCleanup``,
    ``crawlingThreadCount``, ``failureCountThreshold``, ``csvFileEncoding``). Como estos
    deben enviarse siempre independientemente de lo que se desee cambiar, recupere los
-   valores actuales con ``GET`` e incluyalos en la operacion real (los ejemplos a
-   continuacion usan los valores predeterminados).
+   valores actuales con ``GET`` e inclúyalos en la operación real (los ejemplos a
+   continuación usan los valores predeterminados).
 
-Actualizar la Configuracion de Rastreo
+Actualizar la Configuración de Rastreo
 ---------------------------------------
 
 .. code-block:: bash
@@ -449,7 +449,7 @@ Actualizar la Configuracion de Rastreo
            "csvFileEncoding": "UTF-8"
          }'
 
-Actualizar el Periodo de Retencion de Registros
+Actualizar el Período de Retención de Registros
 -------------------------------------------------
 
 .. code-block:: bash
@@ -467,7 +467,7 @@ Actualizar el Periodo de Retencion de Registros
            "purgeUserInfoDay": 90
          }'
 
-Actualizar la Configuracion de Sugerencias
+Actualizar la Configuración de Sugerencias
 -------------------------------------------
 
 .. code-block:: bash
@@ -484,9 +484,9 @@ Actualizar la Configuracion de Sugerencias
            "suggestDocuments": "true"
          }'
 
-Informacion de Referencia
+Información de Referencia
 ==========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-systeminfo` - API de informacion del sistema
-- :doc:`../../admin/general-guide` - Guia de configuracion general
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-systeminfo` - API de información del sistema
+- :doc:`../../admin/general-guide` - Guía de configuración general

--- a/es/15.8/api/admin/api-admin-group.rst
+++ b/es/15.8/api/admin/api-admin-group.rst
@@ -2,11 +2,11 @@
 API de Group
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Group es para gestionar grupos de |Fess|.
-Puede operar creacion, actualizacion y eliminacion de grupos.
+Puede operar creación, actualización y eliminación de grupos.
 
 URL Base
 ========
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de grupos
@@ -51,25 +51,25 @@ Solicitud
 
     GET /api/admin/group/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25)
+     - Número de elementos por página (predeterminado: 25)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``id``
      - String
      - No
@@ -157,7 +157,7 @@ Cuerpo de la Solicitud
       }
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -166,10 +166,10 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre del grupo (maximo 100 caracteres)
+     - Sí
+     - Nombre del grupo (máximo 100 caracteres)
    * - ``attributes``
      - No
      - Mapa de atributos (incluye atributos LDAP como ``gidNumber``). Los valores se especifican como cadenas
@@ -212,7 +212,7 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -221,19 +221,19 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
+     - Sí
      - ID del grupo a actualizar
    * - ``name``
-     - Si
-     - Nombre del grupo (maximo 100 caracteres)
+     - Sí
+     - Nombre del grupo (máximo 100 caracteres)
    * - ``attributes``
      - No
      - Mapa de atributos (incluye atributos LDAP como ``gidNumber``). Los valores se especifican como cadenas
    * - ``versionNo``
-     - Si
-     - Numero de version para el bloqueo optimista. Especifique el valor de ``versionNo`` obtenido al obtener el grupo
+     - Sí
+     - Número de versión para el bloqueo optimista. Especifique el valor de ``versionNo`` obtenido al obtener el grupo
 
 Respuesta
 ---------
@@ -297,10 +297,10 @@ Obtener Lista de Grupos
     curl -X GET "http://localhost:8080/api/admin/group/settings" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-user` - API de gestion de usuarios
-- :doc:`api-admin-role` - API de gestion de roles
-- :doc:`../../admin/group-guide` - Guia de gestion de grupos
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-user` - API de gestión de usuarios
+- :doc:`api-admin-role` - API de gestión de roles
+- :doc:`../../admin/group-guide` - Guía de gestión de grupos

--- a/es/15.8/api/admin/api-admin-joblog.rst
+++ b/es/15.8/api/admin/api-admin-joblog.rst
@@ -2,11 +2,11 @@
 API de JobLog
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de JobLog es para consultar y gestionar los registros de ejecucion de trabajos de |Fess|.
-Permite obtener y eliminar el historial de ejecucion, los resultados y la informacion de errores
+La API de JobLog es para consultar y gestionar los registros de ejecución de trabajos de |Fess|.
+Permite obtener y eliminar el historial de ejecución, los resultados y la información de errores
 de trabajos programados y de rastreo.
 
 URL Base
@@ -23,9 +23,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /logs
      - Obtener lista de registros de trabajos
@@ -46,25 +46,25 @@ Solicitud
 
     GET /api/admin/joblog/logs
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 20)
+     - Número de elementos por página (predeterminado: 20)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (basado en 1, predeterminado: 1)
+     - Número de página (basado en 1, predeterminado: 1)
    * - ``id``
      - String
      - No
@@ -114,30 +114,30 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``id``
      - ID del registro de trabajo
    * - ``jobName``
      - Nombre del trabajo
    * - ``jobStatus``
-     - Estado del trabajo (``ok``: exitoso, ``fail``: fallido, ``running``: en ejecucion)
+     - Estado del trabajo (``ok``: exitoso, ``fail``: fallido, ``running``: en ejecución)
    * - ``target``
-     - Objetivo de ejecucion (nombre del objetivo del programador; el valor predeterminado es ``all``)
+     - Objetivo de ejecución (nombre del objetivo del programador; el valor predeterminado es ``all``)
    * - ``scriptType``
      - Tipo de script (ejemplo: ``groovy``)
    * - ``scriptData``
      - Script ejecutado
    * - ``scriptResult``
-     - Resultado de la ejecucion
+     - Resultado de la ejecución
    * - ``startTime``
      - Hora de inicio (milisegundos epoch; devuelto como cadena de texto)
    * - ``endTime``
-     - Hora de finalizacion (milisegundos epoch; devuelto como cadena de texto). No se devuelve para trabajos en ejecucion.
+     - Hora de finalización (milisegundos epoch; devuelto como cadena de texto). No se devuelve para trabajos en ejecución.
 
 .. note::
 
-   Cada objeto de registro en la respuesta incluye tambien un campo interno ``crudMode``
-   (un entero que indica el modo de operacion CRUD, siempre ``0`` para operaciones de lectura).
+   Cada objeto de registro en la respuesta incluye también un campo interno ``crudMode``
+   (un entero que indica el modo de operación CRUD, siempre ``0`` para operaciones de lectura).
    Los clientes pueden ignorarlo sin problema.
 
 Obtener Registro de Trabajo
@@ -236,7 +236,7 @@ Eliminar Registro de Trabajo
     curl -X DELETE "http://localhost:8080/api/admin/joblog/log/joblog_id_1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Calcular Tasa de Exito de Trabajos
+Calcular Tasa de Éxito de Trabajos
 ------------------------------------
 
 .. code-block:: bash
@@ -245,10 +245,10 @@ Calcular Tasa de Exito de Trabajos
          -H "Authorization: Bearer YOUR_TOKEN" | \
          jq '.response.logs | {total: length, ok: [.[] | select(.jobStatus=="ok")] | length, fail: [.[] | select(.jobStatus=="fail")] | length}'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-scheduler` - API del programador
-- :doc:`api-admin-crawlinginfo` - API de informacion de rastreo
-- :doc:`../../admin/joblog-guide` - Guia de gestion de registros de trabajos
+- :doc:`api-admin-crawlinginfo` - API de información de rastreo
+- :doc:`../../admin/joblog-guide` - Guía de gestión de registros de trabajos

--- a/es/15.8/api/admin/api-admin-log.rst
+++ b/es/15.8/api/admin/api-admin-log.rst
@@ -2,7 +2,7 @@
 API de Log
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Log es para consultar y descargar los archivos de registro de |Fess|.
@@ -15,17 +15,17 @@ URL Base
 
     /api/admin/log
 
-Autenticacion
+Autenticación
 =============
 
-Al igual que con el resto de Admin APIs, se requiere autenticacion mediante token de acceso. El token de acceso debe tener el permiso ``Radmin-api`` (configurado en ``api.admin.access.permissions``; el valor predeterminado es ``Radmin-api``).
+Al igual que con el resto de Admin APIs, se requiere autenticación mediante token de acceso. El token de acceso debe tener el permiso ``Radmin-api`` (configurado en ``api.admin.access.permissions``; el valor predeterminado es ``Radmin-api``).
 El token de acceso se especifica en el encabezado de la solicitud.
 
 ::
 
     Authorization: Bearer <token de acceso>
 
-Para mas detalles sobre la autenticacion y como obtener el token de acceso, consulte :doc:`api-admin-overview`.
+Para más detalles sobre la autenticación y cómo obtener el token de acceso, consulte :doc:`api-admin-overview`.
 
 Lista de Endpoints
 ==================
@@ -34,9 +34,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /files
      - Obtener lista de archivos de registro
@@ -60,7 +60,7 @@ Solicitud
 Respuesta
 ---------
 
-En ``files`` se almacena un arreglo de objetos que representan la informacion de cada archivo de registro, y en ``total`` el numero de elementos.
+En ``files`` se almacena un arreglo de objetos que representan la información de cada archivo de registro, y en ``total`` el número de elementos.
 Cada objeto tiene los siguientes campos.
 
 .. list-table::
@@ -68,13 +68,13 @@ Cada objeto tiene los siguientes campos.
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``id``
      - Valor del nombre de archivo codificado en Base64 URL (se usa como ``{id}`` al descargar)
    * - ``name``
      - Nombre del archivo de registro
    * - ``lastModified``
-     - Fecha/hora de la ultima modificacion
+     - Fecha/hora de la última modificación
 
 .. code-block:: json
 
@@ -100,7 +100,7 @@ Cada objeto tiene los siguientes campos.
 
 .. note::
 
-   En ``version`` se establece la version del producto de |Fess| en ejecucion. El contenido y la cantidad de elementos en ``files`` dependen de los archivos de registro presentes en el servidor, por lo que el ejemplo anterior es solo una muestra.
+   En ``version`` se establece la versión del producto de |Fess| en ejecución. El contenido y la cantidad de elementos en ``files`` dependen de los archivos de registro presentes en el servidor, por lo que el ejemplo anterior es solo una muestra.
 
 Descargar Archivo de Registro
 =============================
@@ -109,7 +109,7 @@ Descarga el contenido del archivo de registro especificado.
 En ``{id}`` se especifica el ``id`` devuelto en la lista (el valor del nombre de archivo codificado en Base64 URL) tal cual.
 La respuesta se devuelve como un flujo ``application/octet-stream``.
 Por razones de seguridad, solo se aceptan nombres que terminen en ``.log`` o ``.log.gz``; los nombres que contienen operaciones de ruta como ``..`` no son aceptados.
-Si se especifica un nombre de archivo inexistente o un nombre no permitido como archivo de registro, se devuelve una respuesta vacia.
+Si se especifica un nombre de archivo inexistente o un nombre no permitido como archivo de registro, se devuelve una respuesta vacía.
 
 Solicitud
 ---------
@@ -143,8 +143,8 @@ Descargar Archivo de Registro
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o fess.log
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-backup` - API de respaldo

--- a/es/15.8/api/admin/api-admin-overview.rst
+++ b/es/15.8/api/admin/api-admin-overview.rst
@@ -1,14 +1,14 @@
 ===========================
-Vision General de Admin API
+Visión General de Admin API
 ===========================
 
-Vision General
+Visión General
 ==============
 
-|Fess| Admin API es una API RESTful para acceder programaticamente a las funciones de administracion.
-Puede ejecutar a traves de la API la mayoria de las operaciones disponibles en el panel de administracion, como la configuracion de rastreo, la gestion de usuarios y el control del programador.
+|Fess| Admin API es una API RESTful para acceder programáticamente a las funciones de administración.
+Puede ejecutar a través de la API la mayoría de las operaciones disponibles en el panel de administración, como la configuración de rastreo, la gestión de usuarios y el control del programador.
 
-Al utilizar esta API, puede automatizar la configuracion de |Fess| o integrarse con sistemas externos.
+Al utilizar esta API, puede automatizar la configuración de |Fess| o integrarse con sistemas externos.
 
 URL Base
 ========
@@ -25,15 +25,15 @@ Por ejemplo, en un entorno local:
 
     http://localhost:8080/api/admin/
 
-Autenticacion
+Autenticación
 =============
 
-Para acceder a Admin API, se requiere autenticacion mediante un token de acceso.
+Para acceder a Admin API, se requiere autenticación mediante un token de acceso.
 
-Obtencion del Token de Acceso
+Obtención del Token de Acceso
 -----------------------------
 
-1. Inicie sesion en el panel de administracion
+1. Inicie sesión en el panel de administración
 2. Vaya a "Sistema" -> "Tokens de Acceso"
 3. Haga clic en "Crear Nuevo"
 4. Ingrese el nombre del token y configure en el campo "Permisos" los permisos que desea otorgar al token (para usar Admin API, ingrese ``{role}admin-api``)
@@ -48,15 +48,15 @@ Incluya el token de acceso en el encabezado de la solicitud:
 
     Authorization: Bearer <token de acceso>
 
-Tambien puede omitir ``Bearer`` y especificar solo el token:
+También puede omitir ``Bearer`` y especificar solo el token:
 
 ::
 
     Authorization: <token de acceso>
 
-La especificacion mediante parametro de consulta tambien es posible, pero esta deshabilitada de forma predeterminada. Si configura un nombre de parametro en
-``api.access.token.request.parameter`` de ``fess_config.properties``, podra pasar el
-token con ese nombre (como el valor predeterminado esta vacio, solo es valida la especificacion mediante el encabezado).
+La especificación mediante parámetro de consulta también es posible, pero está deshabilitada de forma predeterminada. Si configura un nombre de parámetro en
+``api.access.token.request.parameter`` de ``fess_config.properties``, podrá pasar el
+token con ese nombre (como el valor predeterminado está vacío, solo es válida la especificación mediante el encabezado).
 Por ejemplo, si configura ``api.access.token.request.parameter=token``:
 
 ::
@@ -74,7 +74,7 @@ Ejemplo con cURL
 Permisos Requeridos
 -------------------
 
-El acceso a Admin API se controla mediante un unico conjunto de permisos, no por funcion. Para utilizar
+El acceso a Admin API se controla mediante un único conjunto de permisos, no por función. Para utilizar
 cualquiera de los endpoints de Admin API, el token de acceso debe tener otorgado alguno de los permisos
 configurados en ``api.admin.access.permissions`` de ``fess_config.properties``.
 
@@ -92,9 +92,9 @@ El valor predeterminado es ``Radmin-api``, que es la forma codificada del rol ``
 Patrones Comunes
 ================
 
-Los recursos que tienen configuraciones (webconfig, user, role, etc.) siguen el siguiente patron CRUD comun.
-Sin embargo, algunos recursos (systeminfo, stats, storage, plugin, log, backup, documents, suggest, la raiz de dict, etc.)
-tienen una estructura de endpoints propia distinta de este patron comun, por lo que debe consultar la pagina de cada recurso.
+Los recursos que tienen configuraciones (webconfig, user, role, etc.) siguen el siguiente patrón CRUD común.
+Sin embargo, algunos recursos (systeminfo, stats, storage, plugin, log, backup, documents, suggest, la raíz de dict, etc.)
+tienen una estructura de endpoints propia distinta de este patrón común, por lo que debe consultar la página de cada recurso.
 
 Obtener Lista (GET /settings)
 -----------------------------
@@ -108,21 +108,21 @@ Solicitud
 
     GET /api/admin/<recurso>/settings
 
-Parametros (paginacion):
+Parámetros (paginación):
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 65
 
-   * - Parametro
+   * - Parámetro
      - Tipo
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
-     - Numero de elementos por pagina (predeterminado: 25. Modificable mediante ``paging.page.size`` de ``fess_config.properties``)
+     - Número de elementos por página (predeterminado: 25. Modificable mediante ``paging.page.size`` de ``fess_config.properties``)
    * - ``page``
      - Integer
-     - Numero de pagina (comienza en 1. Predeterminado: 1. Si se especifica un valor menor o igual a 0, se trata como 1)
+     - Número de página (comienza en 1. Predeterminado: 1. Si se especifica un valor menor o igual a 0, se trata como 1)
 
 Respuesta
 ~~~~~~~~~
@@ -141,13 +141,13 @@ Respuesta
 .. note::
 
    El objeto ``response`` de todas las respuestas incluye siempre ``version``,
-   que indica la version del producto (por ejemplo, ``"15.8.0"``). En los ejemplos siguientes
+   que indica la versión del producto (por ejemplo, ``"15.8.0"``). En los ejemplos siguientes
    puede omitirse por brevedad.
 
-Obtener Configuracion Individual (GET /setting/{id})
+Obtener Configuración Individual (GET /setting/{id})
 ----------------------------------------------------
 
-Obtiene una configuracion individual especificando el ID.
+Obtiene una configuración individual especificando el ID.
 
 Solicitud
 ~~~~~~~~~
@@ -171,7 +171,7 @@ Respuesta
 Crear Nuevo (POST /setting)
 ---------------------------
 
-Crea una nueva configuracion.
+Crea una nueva configuración.
 
 Solicitud
 ~~~~~~~~~
@@ -202,7 +202,7 @@ Respuesta
 Actualizar (PUT /setting)
 -------------------------
 
-Actualiza una configuracion existente.
+Actualiza una configuración existente.
 
 Solicitud
 ~~~~~~~~~
@@ -234,7 +234,7 @@ Respuesta
 Eliminar (DELETE /setting/{id})
 -------------------------------
 
-Elimina una configuracion.
+Elimina una configuración.
 
 Solicitud
 ~~~~~~~~~
@@ -246,7 +246,7 @@ Solicitud
 Respuesta
 ~~~~~~~~~
 
-El formato de la respuesta de eliminacion difiere segun el recurso (accion). Muchos recursos
+El formato de la respuesta de eliminación difiere según el recurso (acción). Muchos recursos
 devuelven solo ``status``.
 
 .. code-block:: json
@@ -257,8 +257,8 @@ devuelven solo ``status``.
       }
     }
 
-En algunos recursos, el resultado de la eliminacion se devuelve como ``ApiUpdateResponse``, con
-el ``id`` de la configuracion eliminada y ``created`` (``false`` al eliminar).
+En algunos recursos, el resultado de la eliminación se devuelve como ``ApiUpdateResponse``, con
+el ``id`` de la configuración eliminada y ``created`` (``false`` al eliminar).
 
 .. code-block:: json
 
@@ -270,14 +270,14 @@ el ``id`` de la configuracion eliminada y ``created`` (``false`` al eliminar).
       }
     }
 
-Ademas, en los recursos que devuelven ``ApiDeleteResponse`` puede agregarse ``count``,
-que indica el numero de elementos eliminados (valor predeterminado ``1``). Consulte la pagina de cada recurso para conocer el formato real.
+Además, en los recursos que devuelven ``ApiDeleteResponse`` puede agregarse ``count``,
+que indica el número de elementos eliminados (valor predeterminado ``1``). Consulte la página de cada recurso para conocer el formato real.
 
 Formato de Respuesta
 ====================
 
 Todas las respuestas se envuelven en un objeto ``response`` que incluye siempre
-``version``, que indica la version del producto, y ``status``, que indica el resultado del procesamiento.
+``version``, que indica la versión del producto, y ``status``, que indica el resultado del procesamiento.
 
 Los valores de ``status`` son los siguientes.
 
@@ -286,15 +286,15 @@ Los valores de ``status`` son los siguientes.
    :widths: 15 85
 
    * - Valor
-     - Descripcion
+     - Descripción
    * - ``0``
-     - OK (exito)
+     - OK (éxito)
    * - ``1``
-     - BAD_REQUEST (solicitud invalida)
+     - BAD_REQUEST (solicitud inválida)
    * - ``2``
      - SYSTEM_ERROR (error del sistema)
    * - ``3``
-     - UNAUTHORIZED (error de autenticacion)
+     - UNAUTHORIZED (error de autenticación)
    * - ``9``
      - FAILED (procesamiento fallido)
 
@@ -311,7 +311,7 @@ Respuesta Exitosa
       }
     }
 
-``status: 0`` indica exito.
+``status: 0`` indica éxito.
 
 Respuesta de Error
 ------------------
@@ -329,36 +329,36 @@ contiene el mensaje de error.
       }
     }
 
-Codigos de Estado HTTP
+Códigos de Estado HTTP
 ----------------------
 
-Admin API devuelve en la mayoria de los casos el estado HTTP ``200``, y el resultado del procesamiento se indica
-en el campo ``status`` del cuerpo de la respuesta. Por lo tanto, no determine el exito o el fallo por el codigo de estado HTTP,
+Admin API devuelve en la mayoría de los casos el estado HTTP ``200``, y el resultado del procesamiento se indica
+en el campo ``status`` del cuerpo de la respuesta. Por lo tanto, no determine el éxito o el fallo por el código de estado HTTP,
 sino por el valor de ``status`` del cuerpo.
 
-Los codigos de estado HTTP que se devuelven realmente son los siguientes.
+Los códigos de estado HTTP que se devuelven realmente son los siguientes.
 
 .. list-table::
    :header-rows: 1
    :widths: 15 85
 
-   * - Codigo
-     - Descripcion
+   * - Código
+     - Descripción
    * - 200
-     - Respuesta normal. Ademas del caso de exito (``status: 0``), la mayoria de los errores tambien se
-       devuelven con este codigo. Por ejemplo, si el token de acceso no se especifica o es invalido, o si los permisos son insuficientes, se devuelve
+     - Respuesta normal. Además del caso de éxito (``status: 0``), la mayoría de los errores también se
+       devuelven con este código. Por ejemplo, si el token de acceso no se especifica o es inválido, o si los permisos son insuficientes, se devuelve
        ``status: 3``; y un error del sistema se devuelve como ``status: 2``, ambos con HTTP ``200``.
    * - 400
-     - Error de validacion de los parametros de la solicitud. El ``status`` del cuerpo de la respuesta sera ``1``.
-       Este codigo tambien se devuelve cuando se intenta obtener un recurso inexistente.
+     - Error de validación de los parámetros de la solicitud. El ``status`` del cuerpo de la respuesta será ``1``.
+       Este código también se devuelve cuando se intenta obtener un recurso inexistente.
    * - 401
-     - Cuando ocurre una excepcion relacionada con la autenticacion de inicio de sesion. El ``status`` del cuerpo de la respuesta sera ``3``.
-       Tenga en cuenta que, si el token de acceso no se especifica o es invalido, no se devuelve este codigo, sino HTTP ``200`` con
+     - Cuando ocurre una excepción relacionada con la autenticación de inicio de sesión. El ``status`` del cuerpo de la respuesta será ``3``.
+       Tenga en cuenta que, si el token de acceso no se especifica o es inválido, no se devuelve este código, sino HTTP ``200`` con
        ``status: 3``.
 
 .. note::
 
-   Admin API no devuelve codigos de estado HTTP como ``403``, ``404`` o ``500``.
+   Admin API no devuelve códigos de estado HTTP como ``403``, ``404`` o ``500``.
    Tanto los permisos insuficientes como la inexistencia de un recurso se indican mediante el
    ``status`` incluido en el cuerpo de la respuesta HTTP ``200`` o ``400``.
 
@@ -367,7 +367,7 @@ APIs Disponibles
 
 |Fess| proporciona las siguientes Admin APIs.
 
-Configuracion de Rastreo
+Configuración de Rastreo
 ------------------------
 
 .. list-table::
@@ -375,22 +375,22 @@ Configuracion de Rastreo
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-webconfig`
-     - Configuracion de rastreo web
+     - Configuración de rastreo web
    * - :doc:`api-admin-fileconfig`
-     - Configuracion de rastreo de archivos
+     - Configuración de rastreo de archivos
    * - :doc:`api-admin-dataconfig`
-     - Configuracion de almacen de datos
+     - Configuración de almacén de datos
 
 .. note::
 
-   Ademas, los siguientes recursos relacionados con credenciales de autenticacion y control de rastreo
-   tambien se ofrecen como API (actualmente no tienen una pagina propia): ``webauth`` (autenticacion web), ``fileauth`` (autenticacion de archivos),
+   Además, los siguientes recursos relacionados con credenciales de autenticación y control de rastreo
+   también se ofrecen como API (actualmente no tienen una página propia): ``webauth`` (autenticación web), ``fileauth`` (autenticación de archivos),
    ``reqheader`` (encabezados de solicitud), ``pathmap`` (mapeo de rutas),
-   ``duplicatehost`` (hosts duplicados), ``searchlist`` (operaciones de busqueda/lista de documentos).
+   ``duplicatehost`` (hosts duplicados), ``searchlist`` (operaciones de búsqueda/lista de documentos).
 
-Gestion de Indices
+Gestión de Índices
 ------------------
 
 .. list-table::
@@ -398,15 +398,15 @@ Gestion de Indices
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-documents`
      - Operaciones masivas de documentos
    * - :doc:`api-admin-crawlinginfo`
-     - Informacion de rastreo
+     - Información de rastreo
    * - :doc:`api-admin-failureurl`
-     - Gestion de URLs fallidas
+     - Gestión de URLs fallidas
    * - :doc:`api-admin-backup`
-     - Copia de seguridad/Restauracion
+     - Copia de seguridad/Restauración
 
 Programador
 -----------
@@ -416,13 +416,13 @@ Programador
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-scheduler`
-     - Programacion de trabajos
+     - Programación de trabajos
    * - :doc:`api-admin-joblog`
-     - Obtencion de registros de trabajos
+     - Obtención de registros de trabajos
 
-Gestion de Usuarios y Permisos
+Gestión de Usuarios y Permisos
 ------------------------------
 
 .. list-table::
@@ -430,17 +430,17 @@ Gestion de Usuarios y Permisos
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-user`
-     - Gestion de usuarios
+     - Gestión de usuarios
    * - :doc:`api-admin-role`
-     - Gestion de roles
+     - Gestión de roles
    * - :doc:`api-admin-group`
-     - Gestion de grupos
+     - Gestión de grupos
    * - :doc:`api-admin-accesstoken`
-     - Gestion de tokens API
+     - Gestión de tokens API
 
-Ajuste de Busqueda
+Ajuste de Búsqueda
 ------------------
 
 .. list-table::
@@ -448,7 +448,7 @@ Ajuste de Busqueda
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-labeltype`
      - Tipos de etiqueta
    * - :doc:`api-admin-keymatch`
@@ -464,7 +464,7 @@ Ajuste de Busqueda
    * - :doc:`api-admin-relatedquery`
      - Consultas relacionadas
    * - :doc:`api-admin-suggest`
-     - Gestion de sugerencias
+     - Gestión de sugerencias
 
 Sistema
 -------
@@ -474,21 +474,21 @@ Sistema
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-general`
-     - Configuracion general
+     - Configuración general
    * - :doc:`api-admin-systeminfo`
-     - Informacion del sistema
+     - Información del sistema
    * - :doc:`api-admin-stats`
-     - Estadisticas del sistema
+     - Estadísticas del sistema
    * - :doc:`api-admin-log`
-     - Obtencion de registros
+     - Obtención de registros
    * - :doc:`api-admin-searchlist`
-     - Busqueda y gestion de documentos
+     - Búsqueda y gestión de documentos
    * - :doc:`api-admin-storage`
-     - Gestion de almacenamiento
+     - Gestión de almacenamiento
    * - :doc:`api-admin-plugin`
-     - Gestion de plugins
+     - Gestión de plugins
 
 Diccionario
 -----------
@@ -498,14 +498,14 @@ Diccionario
    :widths: 30 70
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - :doc:`api-admin-dict`
-     - Gestion de diccionarios (sinonimos, palabras vacias, etc.)
+     - Gestión de diccionarios (sinónimos, palabras vacías, etc.)
 
 Ejemplos de Uso
 ===============
 
-Crear Configuracion de Rastreo Web
+Crear Configuración de Rastreo Web
 ----------------------------------
 
 .. code-block:: bash
@@ -530,9 +530,9 @@ Crear Configuracion de Rastreo Web
 
 .. note::
 
-   Al crear una configuracion de rastreo web, son obligatorios ``name``, ``urls``, ``userAgent``, ``numOfThread``,
+   Al crear una configuración de rastreo web, son obligatorios ``name``, ``urls``, ``userAgent``, ``numOfThread``,
    ``intervalTime``, ``boost``, ``available`` y ``sortOrder``. Si se omiten,
-   se produce un error de validacion (``status: 1``). ``available`` se especifica como una cadena de texto y
+   se produce un error de validación (``status: 1``). ``available`` se especifica como una cadena de texto y
    se establece en ``"true"`` o ``"false"``.
 
 Iniciar Trabajo Programado
@@ -551,8 +551,8 @@ Obtener Lista de Usuarios
     curl "http://localhost:8080/api/admin/user/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`../api-overview` - Vision general de API
-- :doc:`../../admin/accesstoken-guide` - Guia de gestion de tokens de acceso
+- :doc:`../api-overview` - Visión general de API
+- :doc:`../../admin/accesstoken-guide` - Guía de gestión de tokens de acceso

--- a/es/15.8/api/admin/api-admin-plugin.rst
+++ b/es/15.8/api/admin/api-admin-plugin.rst
@@ -2,11 +2,11 @@
 API de Plugin
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Plugin es para gestionar los plugins (artefactos) de |Fess|.
-Permite obtener la lista de plugins instalados y de plugins instalables, asi como instalar y eliminar plugins.
+Permite obtener la lista de plugins instalados y de plugins instalables, así como instalar y eliminar plugins.
 
 URL Base
 ========
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /installed
      - Obtener lista de plugins instalados
@@ -38,7 +38,7 @@ Lista de Endpoints
      - /
      - Eliminar plugin
 
-Campos de Informacion del Plugin
+Campos de Información del Plugin
 =================================
 
 Los endpoints de listado (``/installed`` y ``/available``) devuelven un arreglo ``plugins``
@@ -49,18 +49,18 @@ cuyos elementos son objetos con los siguientes campos.
    :widths: 15 85
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``type``
-     - ID de tipo del artefacto. Puede ser uno de: ``fess-ds`` (almacen de datos), ``fess-theme`` (tema),
-       ``fess-ingest`` (Ingest), ``fess-script`` (script), ``fess-webapp`` (aplicacion web),
+     - ID de tipo del artefacto. Puede ser uno de: ``fess-ds`` (almacén de datos), ``fess-theme`` (tema),
+       ``fess-ingest`` (Ingest), ``fess-script`` (script), ``fess-webapp`` (aplicación web),
        ``fess-thumbnail`` (miniatura), ``fess-crawler`` (crawler), ``fess-llm`` (LLM),
-       ``jar`` (JAR de proposito general no incluido en los anteriores).
+       ``jar`` (JAR de propósito general no incluido en los anteriores).
    * - ``id``
      - Identificador con formato ``{name}:{version}``.
    * - ``name``
      - Nombre del plugin.
    * - ``version``
-     - Version del plugin.
+     - Versión del plugin.
    * - ``url``
      - URL de descarga del artefacto. Solo se incluye en la respuesta de ``/available``. En ``/installed``
        el valor no existe, por lo que el campo se omite por completo.
@@ -86,8 +86,8 @@ Solicitud
 Respuesta
 ---------
 
-En ``plugins`` se almacena un arreglo de objetos que representan la informacion de los plugins.
-Consulte `Campos de Informacion del Plugin`_ para conocer los campos de cada objeto.
+En ``plugins`` se almacena un arreglo de objetos que representan la información de los plugins.
+Consulte `Campos de Información del Plugin`_ para conocer los campos de cada objeto.
 En los plugins instalados, ``url`` no se incluye en la salida.
 
 .. code-block:: json
@@ -112,7 +112,7 @@ Obtener Lista de Plugins Instalables
 
 Devuelve la lista de plugins instalables. Obtiene artefactos de todos los tipos desde los repositorios
 configurados en ``plugin.repositories`` de ``fess_config.properties``.
-Los resultados se almacenan en cache durante un tiempo determinado (5 minutos por defecto).
+Los resultados se almacenan en caché durante un tiempo determinado (5 minutos por defecto).
 
 Solicitud
 ---------
@@ -124,8 +124,8 @@ Solicitud
 Respuesta
 ---------
 
-En ``plugins`` se almacena un arreglo de objetos que representan la informacion de los plugins instalables.
-Consulte `Campos de Informacion del Plugin`_ para conocer los campos de cada objeto.
+En ``plugins`` se almacena un arreglo de objetos que representan la información de los plugins instalables.
+Consulte `Campos de Información del Plugin`_ para conocer los campos de cada objeto.
 Los plugins instalables incluyen el campo ``url`` con la URL de descarga.
 
 .. code-block:: json
@@ -149,7 +149,7 @@ Los plugins instalables incluyen el campo ``url`` con la URL de descarga.
 Instalar Plugin
 ===============
 
-Instala el plugin con el nombre y la version especificados.
+Instala el plugin con el nombre y la versión especificados.
 
 Solicitud
 ---------
@@ -169,7 +169,7 @@ Cuerpo de la Solicitud
       "version": "15.8.0"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -178,18 +178,18 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre del plugin (maximo 100 caracteres)
+     - Sí
+     - Nombre del plugin (máximo 100 caracteres)
    * - ``version``
-     - Si
-     - Version del plugin (maximo 100 caracteres)
+     - Sí
+     - Versión del plugin (máximo 100 caracteres)
 
 .. note::
 
    ``name`` y ``version`` deben coincidir con alguno de los plugins instalables obtenidos mediante ``/available``.
-   Si no existe un artefacto que coincida, se devolvera un error.
+   Si no existe un artefacto que coincida, se devolverá un error.
 
 Respuesta
 ---------
@@ -205,8 +205,8 @@ Cuando la solicitud es aceptada, se devuelve una respuesta con ``status`` igual 
       }
     }
 
-Si no existe un artefacto que corresponda a ``name`` o ``version``, ``status`` sera
-``1`` (BAD_REQUEST) y ``message`` se establecera con ``invalid name or version``.
+Si no existe un artefacto que corresponda a ``name`` o ``version``, ``status`` será
+``1`` (BAD_REQUEST) y ``message`` se establecerá con ``invalid name or version``.
 
 .. code-block:: json
 
@@ -220,16 +220,16 @@ Si no existe un artefacto que corresponda a ``name`` o ``version``, ``status`` s
 
 .. note::
 
-   El proceso de instalacion se ejecuta de forma asincrona en segundo plano. La respuesta con ``status: 0``
-   indica que la solicitud fue aceptada, pero no garantiza que la instalacion haya finalizado.
-   Una vez completada la instalacion, si ya existian plugins con el mismo nombre pero distinta version,
-   estos se eliminan automaticamente. Si la descarga o la instalacion fallan, el error se registra
+   El proceso de instalación se ejecuta de forma asíncrona en segundo plano. La respuesta con ``status: 0``
+   indica que la solicitud fue aceptada, pero no garantiza que la instalación haya finalizado.
+   Una vez completada la instalación, si ya existían plugins con el mismo nombre pero distinta versión,
+   estos se eliminan automáticamente. Si la descarga o la instalación fallan, el error se registra
    en el log del servidor, pero no se refleja en la respuesta de la API.
 
 Eliminar Plugin
 ===============
 
-Elimina el plugin con el nombre y la version especificados.
+Elimina el plugin con el nombre y la versión especificados.
 
 Solicitud
 ---------
@@ -249,7 +249,7 @@ Cuerpo de la Solicitud
       "version": "15.8.0"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -258,13 +258,13 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre del plugin (maximo 100 caracteres)
+     - Sí
+     - Nombre del plugin (máximo 100 caracteres)
    * - ``version``
      - No
-     - Version del plugin (maximo 100 caracteres). Se recomienda especificarlo para identificar de forma unica el artefacto a eliminar.
+     - Versión del plugin (máximo 100 caracteres). Se recomienda especificarlo para identificar de forma única el artefacto a eliminar.
 
 Respuesta
 ---------
@@ -282,9 +282,9 @@ Cuando la solicitud es aceptada, se devuelve una respuesta con ``status`` igual 
 
 .. note::
 
-   El proceso de eliminacion se ejecuta de forma asincrona en segundo plano. La respuesta con ``status: 0``
-   indica que la solicitud fue aceptada, pero no determina si el plugin existe ni si la eliminacion fue exitosa.
-   Si la eliminacion falla (por ejemplo, si el archivo no existe), el error se registra en el log del servidor,
+   El proceso de eliminación se ejecuta de forma asíncrona en segundo plano. La respuesta con ``status: 0``
+   indica que la solicitud fue aceptada, pero no determina si el plugin existe ni si la eliminación fue exitosa.
+   Si la eliminación falla (por ejemplo, si el archivo no existe), el error se registra en el log del servidor,
    pero no se refleja en la respuesta de la API.
 
 Ejemplos de Uso
@@ -324,7 +324,7 @@ Eliminar un Plugin
            "version": "15.8.0"
          }'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API

--- a/es/15.8/api/admin/api-admin-relatedquery.rst
+++ b/es/15.8/api/admin/api-admin-relatedquery.rst
@@ -2,17 +2,17 @@
 API de RelatedQuery
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de RelatedQuery es una API para gestionar las consultas relacionadas de |Fess|.
-Permite registrar y administrar candidatos de palabras clave de busqueda relacionadas
-(``queries``) para las palabras clave de busqueda (``term``) que introduce el usuario.
-Las consultas relacionadas registradas se muestran como sugerencias de busqueda relacionadas
-en la pantalla de busqueda.
+Permite registrar y administrar candidatos de palabras clave de búsqueda relacionadas
+(``queries``) para las palabras clave de búsqueda (``term``) que introduce el usuario.
+Las consultas relacionadas registradas se muestran como sugerencias de búsqueda relacionadas
+en la pantalla de búsqueda.
 
-Para obtener informacion detallada sobre la autenticacion, el formato de respuesta comun
-(el campo ``version`` y los codigos ``status``), la paginacion y las respuestas de error,
+Para obtener información detallada sobre la autenticación, el formato de respuesta común
+(el campo ``version`` y los códigos ``status``), la paginación y las respuestas de error,
 consulte :doc:`api-admin-overview`.
 
 URL Base
@@ -29,9 +29,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de consultas relacionadas
@@ -58,25 +58,25 @@ Solicitud
 
     GET /api/admin/relatedquery/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25. Modificable mediante ``paging.page.size`` de ``fess_config.properties``)
+     - Número de elementos por página (predeterminado: 25. Modificable mediante ``paging.page.size`` de ``fess_config.properties``)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1. Predeterminado: 1)
+     - Número de página (comienza en 1. Predeterminado: 1)
 
 Respuesta
 ---------
@@ -101,9 +101,9 @@ Respuesta
 
 .. note::
 
-   Cada configuracion incluye ``versionNo`` (numero de version para el bloqueo optimista). Los campos
-   ``virtualHost`` y los campos de auditoria (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``)
-   se incluyen unicamente cuando tienen un valor asignado. Un ``virtualHost`` vacio no se incluye
+   Cada configuración incluye ``versionNo`` (número de versión para el bloqueo optimista). Los campos
+   ``virtualHost`` y los campos de auditoría (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``)
+   se incluyen únicamente cuando tienen un valor asignado. Un ``virtualHost`` vacío no se incluye
    en la respuesta.
 
 Obtener Consulta Relacionada
@@ -157,7 +157,7 @@ Cuerpo de la Solicitud
       "virtualHost": ""
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -166,20 +166,20 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``term``
-     - Si
-     - Palabra clave de busqueda (maximo 10000 caracteres)
+     - Sí
+     - Palabra clave de búsqueda (máximo 10000 caracteres)
    * - ``queries``
-     - Si
-     - Consultas relacionadas. Cadena separada por saltos de linea, una por linea (las lineas vacias se ignoran; maximo 10000 caracteres)
+     - Sí
+     - Consultas relacionadas. Cadena separada por saltos de línea, una por línea (las líneas vacías se ignoran; máximo 10000 caracteres)
    * - ``virtualHost``
      - No
-     - Host virtual (maximo 1000 caracteres)
+     - Host virtual (máximo 1000 caracteres)
 
 .. note::
 
-   ``crudMode`` es configurado automaticamente por la API, por lo que no es necesario incluirlo en el cuerpo de la solicitud.
+   ``crudMode`` es configurado automáticamente por la API, por lo que no es necesario incluirlo en el cuerpo de la solicitud.
 
 Respuesta
 ---------
@@ -219,7 +219,7 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -228,22 +228,22 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
-     - ID de la consulta relacionada a actualizar (maximo 1000 caracteres)
+     - Sí
+     - ID de la consulta relacionada a actualizar (máximo 1000 caracteres)
    * - ``term``
-     - Si
-     - Palabra clave de busqueda (maximo 10000 caracteres)
+     - Sí
+     - Palabra clave de búsqueda (máximo 10000 caracteres)
    * - ``queries``
-     - Si
-     - Consultas relacionadas. Cadena separada por saltos de linea, una por linea (las lineas vacias se ignoran; maximo 10000 caracteres)
+     - Sí
+     - Consultas relacionadas. Cadena separada por saltos de línea, una por línea (las líneas vacías se ignoran; máximo 10000 caracteres)
    * - ``virtualHost``
      - No
-     - Host virtual (maximo 1000 caracteres)
+     - Host virtual (máximo 1000 caracteres)
    * - ``versionNo``
-     - Si
-     - Numero de version para el bloqueo optimista. Debe especificarse el valor incluido en la respuesta de la consulta de obtencion
+     - Sí
+     - Número de versión para el bloqueo optimista. Debe especificarse el valor incluido en la respuesta de la consulta de obtención
 
 Respuesta
 ---------
@@ -285,9 +285,9 @@ Respuesta de Error
 ==================
 
 Cuando una solicitud falla, ``status`` se establece en un valor distinto de 0 y ``message``
-contiene el detalle del error. Por ejemplo, en errores de validacion como la ausencia de campos
+contiene el detalle del error. Por ejemplo, en errores de validación como la ausencia de campos
 obligatorios, ``status`` toma el valor ``1``.
-Para consultar la lista de codigos de estado, vea :doc:`api-admin-overview`.
+Para consultar la lista de códigos de estado, vea :doc:`api-admin-overview`.
 
 .. code-block:: json
 
@@ -328,10 +328,10 @@ Consultas Relacionadas con Ayuda
            "queries": "help center\nhelp documentation\nhelp contact support"
          }'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-relatedcontent` - API de contenido relacionado
-- :doc:`api-admin-suggest` - API de gestion de sugerencias
-- :doc:`../../admin/relatedquery-guide` - Guia de gestion de consultas relacionadas
+- :doc:`api-admin-suggest` - API de gestión de sugerencias
+- :doc:`../../admin/relatedquery-guide` - Guía de gestión de consultas relacionadas

--- a/es/15.8/api/admin/api-admin-role.rst
+++ b/es/15.8/api/admin/api-admin-role.rst
@@ -2,11 +2,11 @@
 API de Role
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Role es para gestionar roles de |Fess|.
-Puede operar creacion, actualizacion y eliminacion de roles.
+Puede operar creación, actualización y eliminación de roles.
 
 URL Base
 ========
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de roles
@@ -51,25 +51,25 @@ Solicitud
 
     GET /api/admin/role/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25. Configurable mediante ``paging.page.size`` en ``fess_config.properties``)
+     - Número de elementos por página (predeterminado: 25. Configurable mediante ``paging.page.size`` en ``fess_config.properties``)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1. Los valores de 0 o menos se tratan como 1)
+     - Número de página (comienza en 1, predeterminado: 1. Los valores de 0 o menos se tratan como 1)
    * - ``id``
      - String
      - No
@@ -145,7 +145,7 @@ Cuerpo de la Solicitud
       "name": "editor"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -154,10 +154,10 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre del rol (maximo 100 caracteres)
+     - Sí
+     - Nombre del rol (máximo 100 caracteres)
    * - ``attributes``
      - No
      - Mapa de atributos. Los valores se especifican como cadenas
@@ -197,7 +197,7 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -206,19 +206,19 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
+     - Sí
      - ID del rol a actualizar
    * - ``name``
-     - Si
-     - Nombre del rol (maximo 100 caracteres)
+     - Sí
+     - Nombre del rol (máximo 100 caracteres)
    * - ``attributes``
      - No
      - Mapa de atributos. Los valores se especifican como cadenas
    * - ``versionNo``
-     - Si
-     - Numero de version para el bloqueo optimista. Especifique el valor de ``versionNo`` obtenido al obtener el rol
+     - Sí
+     - Número de versión para el bloqueo optimista. Especifique el valor de ``versionNo`` obtenido al obtener el rol
 
 Respuesta
 ---------
@@ -279,10 +279,10 @@ Obtener Lista de Roles
     curl -X GET "http://localhost:8080/api/admin/role/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-user` - API de gestion de usuarios
-- :doc:`api-admin-group` - API de gestion de grupos
-- :doc:`../../admin/role-guide` - Guia de gestion de roles
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-user` - API de gestión de usuarios
+- :doc:`api-admin-group` - API de gestión de grupos
+- :doc:`../../admin/role-guide` - Guía de gestión de roles

--- a/es/15.8/api/admin/api-admin-scheduler.rst
+++ b/es/15.8/api/admin/api-admin-scheduler.rst
@@ -2,11 +2,11 @@
 API de Scheduler
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Scheduler es para gestionar trabajos programados de |Fess|.
-Puede iniciar/detener trabajos de rastreo, crear/actualizar/eliminar configuraciones de programacion.
+Puede iniciar/detener trabajos de rastreo, crear/actualizar/eliminar configuraciones de programación.
 
 URL Base
 ========
@@ -22,9 +22,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de trabajos programados
@@ -57,25 +57,25 @@ Solicitud
 
     GET /api/admin/scheduler/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (por defecto: 25; configurable mediante ``paging.page.size`` en ``fess_config.properties``)
+     - Número de elementos por página (por defecto: 25; configurable mediante ``paging.page.size`` en ``fess_config.properties``)
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (a partir de 1; por defecto: 1)
+     - Número de página (a partir de 1; por defecto: 1)
 
 Respuesta
 ---------
@@ -108,11 +108,11 @@ Respuesta
 
 .. note::
 
-   El objeto ``response`` siempre incluye ``version`` (version del producto) y ``status`` (codigo de resultado). Consulte la descripcion general de Admin API (:doc:`api-admin-overview`) para conocer el formato de respuesta comun. Los ejemplos posteriores pueden omitir ``version`` por brevedad.
+   El objeto ``response`` siempre incluye ``version`` (versión del producto) y ``status`` (código de resultado). Consulte la descripción general de Admin API (:doc:`api-admin-overview`) para conocer el formato de respuesta común. Los ejemplos posteriores pueden omitir ``version`` por brevedad.
 
 .. note::
 
-   En las respuestas, ``jobLogging`` / ``crawler`` / ``available`` se devuelven como cadenas (``"true"`` / ``"false"``). ``running`` es un campo booleano exclusivo de respuesta que indica si el trabajo se esta ejecutando en ese momento (no puede especificarse en las solicitudes). ``total`` es el numero total de trabajos que coinciden con la consulta.
+   En las respuestas, ``jobLogging`` / ``crawler`` / ``available`` se devuelven como cadenas (``"true"`` / ``"false"``). ``running`` es un campo booleano exclusivo de respuesta que indica si el trabajo se está ejecutando en ese momento (no puede especificarse en las solicitudes). ``total`` es el número total de trabajos que coinciden con la consulta.
 
 Obtener Trabajo Programado
 ==========================
@@ -177,7 +177,7 @@ Cuerpo de la Solicitud
       "sortOrder": 1
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -186,22 +186,22 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
+     - Sí
      - Nombre del trabajo (max. 100 caracteres)
    * - ``target``
-     - Si
-     - Objetivo de ejecucion (max. 100 caracteres). Especifique ``all`` o un nombre de objetivo especifico
+     - Sí
+     - Objetivo de ejecución (max. 100 caracteres). Especifique ``all`` o un nombre de objetivo específico
    * - ``cronExpression``
      - No
-     - Expresion Cron (segundo minuto hora dia mes dia-semana). Max. 100 caracteres, validada como expresion cron. Si esta vacia, el trabajo no se ejecuta de forma programada y solo puede iniciarse manualmente
+     - Expresión Cron (segundo minuto hora día mes día-semana). Max. 100 caracteres, validada como expresión cron. Si está vacía, el trabajo no se ejecuta de forma programada y solo puede iniciarse manualmente
    * - ``scriptType``
-     - Si
+     - Sí
      - Tipo de script (max. 100 caracteres). Actualmente solo se admite ``groovy``
    * - ``scriptData``
      - No
-     - Script de ejecucion. El tamano maximo sigue ``form.admin.max.input.size`` en ``fess_config.properties``
+     - Script de ejecución. El tamaño máximo sigue ``form.admin.max.input.size`` en ``fess_config.properties``
    * - ``jobLogging``
      - No
      - Habilitar registro de trabajos (cadena)
@@ -212,16 +212,16 @@ Descripcion de Campos
      - No
      - Habilitado/Deshabilitado (cadena)
    * - ``sortOrder``
-     - Si
-     - Orden de visualizacion (entero entre 0 y 2147483647)
+     - Sí
+     - Orden de visualización (entero entre 0 y 2147483647)
 
 .. note::
 
-   ``jobLogging`` / ``crawler`` / ``available`` son campos de cadena. En las solicitudes, especificar ``"on"`` o ``"true"`` (sin distincion de mayusculas y minusculas) los habilita; cualquier otro valor (``"false"``, cadena vacia o no especificado) se trata como deshabilitado. En las respuestas se devuelven como ``"true"`` / ``"false"``.
+   ``jobLogging`` / ``crawler`` / ``available`` son campos de cadena. En las solicitudes, especificar ``"on"`` o ``"true"`` (sin distinción de mayúsculas y minúsculas) los habilita; cualquier otro valor (``"false"``, cadena vacía o no especificado) se trata como deshabilitado. En las respuestas se devuelven como ``"true"`` / ``"false"``.
 
 .. note::
 
-   ``crudMode`` se establece automaticamente en el servidor y no es necesario especificarlo en las solicitudes. Los campos de auditoria como ``createdBy`` / ``createdTime`` tambien se establecen en el servidor.
+   ``crudMode`` se establece automáticamente en el servidor y no es necesario especificarlo en las solicitudes. Los campos de auditoría como ``createdBy`` / ``createdTime`` también se establecen en el servidor.
 
 Respuesta
 ---------
@@ -243,8 +243,8 @@ Ejemplos de Expresiones Cron
    :header-rows: 1
    :widths: 40 60
 
-   * - Expresion Cron
-     - Descripcion
+   * - Expresión Cron
+     - Descripción
    * - ``0 0 2 * * ?``
      - Ejecutar diariamente a las 2 AM
    * - ``0 0 0/6 * * ?``
@@ -252,7 +252,7 @@ Ejemplos de Expresiones Cron
    * - ``0 0 2 * * MON``
      - Ejecutar cada lunes a las 2 AM
    * - ``0 0 2 1 * ?``
-     - Ejecutar el dia 1 de cada mes a las 2 AM
+     - Ejecutar el día 1 de cada mes a las 2 AM
 
 Actualizar Trabajo Programado
 =============================
@@ -286,7 +286,7 @@ Cuerpo de la Solicitud
 
 .. note::
 
-   Para las actualizaciones, ``id`` (max. 1000 caracteres) y ``versionNo`` son obligatorios. ``versionNo`` se utiliza para el bloqueo optimista; especifique el valor devuelto en la respuesta de obtencion. Si el valor no coincide, la actualizacion falla. Los demas campos obligatorios (``name`` / ``target`` / ``scriptType`` / ``sortOrder``) son los mismos que para la creacion.
+   Para las actualizaciones, ``id`` (max. 1000 caracteres) y ``versionNo`` son obligatorios. ``versionNo`` se utiliza para el bloqueo optimista; especifique el valor devuelto en la respuesta de obtención. Si el valor no coincide, la actualización falla. Los demás campos obligatorios (``name`` / ``target`` / ``scriptType`` / ``sortOrder``) son los mismos que para la creación.
 
 Respuesta
 ---------
@@ -356,21 +356,21 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``jobLogId``
-     - ID del registro del trabajo iniciado. Se emite cuando el registro de trabajos esta habilitado. Es ``null`` cuando el registro de trabajos esta deshabilitado.
+     - ID del registro del trabajo iniciado. Se emite cuando el registro de trabajos está habilitado. Es ``null`` cuando el registro de trabajos está deshabilitado.
 
 Notas
 -----
 
-- Si el trabajo ya esta en ejecucion, el inicio falla y se devuelve un error (``status`` distinto de ``0``).
-- Si el trabajo esta deshabilitado (``available`` no esta habilitado), el inicio tambien falla con un error.
-- ``jobLogId`` solo se emite cuando el registro de trabajos esta habilitado (``jobLogging`` esta habilitado).
+- Si el trabajo ya está en ejecución, el inicio falla y se devuelve un error (``status`` distinto de ``0``).
+- Si el trabajo está deshabilitado (``available`` no está habilitado), el inicio también falla con un error.
+- ``jobLogId`` solo se emite cuando el registro de trabajos está habilitado (``jobLogging`` está habilitado).
 
 Detener Trabajo
 ===============
 
-Detiene un trabajo en ejecucion.
+Detiene un trabajo en ejecución.
 
 Solicitud
 ---------
@@ -429,9 +429,9 @@ Verificar Estado del Trabajo
 
     # Puede verificar el estado de ejecucion con el campo running
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-joblog` - API de registro de trabajos
-- :doc:`../../admin/scheduler-guide` - Guia de gestion del programador
+- :doc:`../../admin/scheduler-guide` - Guía de gestión del programador

--- a/es/15.8/api/admin/api-admin-stats.rst
+++ b/es/15.8/api/admin/api-admin-stats.rst
@@ -2,16 +2,16 @@
 API de Stats
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de Stats es una API para obtener metricas del sistema del servidor donde se ejecuta |Fess|.
-Puede ver informacion estadistica de la JVM, el sistema operativo, el proceso, el cluster del motor de busqueda (OpenSearch) y el sistema de archivos.
+La API de Stats es una API para obtener métricas del sistema del servidor donde se ejecuta |Fess|.
+Puede ver información estadística de la JVM, el sistema operativo, el proceso, el cluster del motor de búsqueda (OpenSearch) y el sistema de archivos.
 
 .. note::
 
-   Esta API no devuelve datos de analisis de busqueda como consultas de busqueda o clics.
-   Para buscar y gestionar documentos del indice, consulte :doc:`api-admin-searchlist`.
+   Esta API no devuelve datos de análisis de búsqueda como consultas de búsqueda o clics.
+   Para buscar y gestionar documentos del índice, consulte :doc:`api-admin-searchlist`.
 
 URL Base
 ========
@@ -21,7 +21,7 @@ URL Base
     /api/admin/stats
 
 El acceso a esta API requiere un token de acceso con el permiso ``Radmin-api``.
-Para obtener detalles sobre la autenticacion, consulte :doc:`api-admin-overview`.
+Para obtener detalles sobre la autenticación, consulte :doc:`api-admin-overview`.
 
 Lista de Endpoints
 ==================
@@ -30,14 +30,14 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /
-     - Obtener informacion estadistica del sistema
+     - Obtener información estadística del sistema
 
-Obtener Informacion Estadistica del Sistema
+Obtener Información Estadística del Sistema
 ===========================================
 
 Solicitud
@@ -47,18 +47,18 @@ Solicitud
 
     GET /api/admin/stats
 
-Este endpoint no acepta parametros de consulta.
+Este endpoint no acepta parámetros de consulta.
 
 Respuesta
 ---------
 
-La respuesta incluye ``version``, que indica la version del producto, ``status``, que indica
-el resultado del procesamiento, y un objeto ``stats`` que almacena las metricas del sistema.
+La respuesta incluye ``version``, que indica la versión del producto, ``status``, que indica
+el resultado del procesamiento, y un objeto ``stats`` que almacena las métricas del sistema.
 ``stats`` tiene cinco claves: ``jvm`` / ``os`` / ``process`` / ``engine`` / ``fs``.
 
 .. note::
 
-   Los nombres de campo de los objetos bajo ``stats`` se presentan en snake_case (palabras en minusculas separadas por guiones bajos, por ejemplo ``non_heap``).
+   Los nombres de campo de los objetos bajo ``stats`` se presentan en snake_case (palabras en minúsculas separadas por guiones bajos, por ejemplo ``non_heap``).
    Los campos cuyo valor es ``null`` se omiten de la respuesta.
 
 .. code-block:: json
@@ -143,15 +143,15 @@ Campos de Respuesta (Nivel Superior)
    :widths: 20 80
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``version``
-     - La version del producto de |Fess| (por ejemplo, ``15.8.0``).
+     - La versión del producto de |Fess| (por ejemplo, ``15.8.0``).
    * - ``status``
-     - Codigo que indica el resultado del procesamiento. ``0`` indica que se completo correctamente.
+     - Código que indica el resultado del procesamiento. ``0`` indica que se completó correctamente.
    * - ``stats``
-     - Objeto que almacena las metricas del sistema. Tiene cinco claves: ``jvm`` / ``os`` / ``process`` / ``engine`` / ``fs``.
+     - Objeto que almacena las métricas del sistema. Tiene cinco claves: ``jvm`` / ``os`` / ``process`` / ``engine`` / ``fs``.
 
-``jvm``: Estadisticas de la JVM
+``jvm``: Estadísticas de la JVM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -159,13 +159,13 @@ Campos de Respuesta (Nivel Superior)
    :widths: 35 65
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``memory.heap.used``
      - Memoria heap utilizada (bytes).
    * - ``memory.heap.committed``
      - Memoria heap comprometida (bytes).
    * - ``memory.heap.max``
-     - Memoria heap maxima (bytes).
+     - Memoria heap máxima (bytes).
    * - ``memory.heap.percent``
      - Porcentaje de uso de la memoria heap (%).
    * - ``memory.non_heap.used``
@@ -173,27 +173,27 @@ Campos de Respuesta (Nivel Superior)
    * - ``memory.non_heap.committed``
      - Memoria no-heap comprometida (bytes).
    * - ``memory.non_heap.max``
-     - Memoria no-heap maxima (bytes). En la implementacion actual este valor no se establece y siempre devuelve ``0``.
+     - Memoria no-heap máxima (bytes). En la implementación actual este valor no se establece y siempre devuelve ``0``.
    * - ``memory.non_heap.percent``
-     - Porcentaje de uso de la memoria no-heap (%). En la implementacion actual este valor no se establece y siempre devuelve ``0``.
+     - Porcentaje de uso de la memoria no-heap (%). En la implementación actual este valor no se establece y siempre devuelve ``0``.
    * - ``pools``
-     - Arreglo de grupos de buffers. Cada elemento incluye ``key`` (nombre del grupo), ``count`` (numero de buffers), ``used`` (memoria utilizada, bytes) y ``capacity`` (capacidad total, bytes).
+     - Arreglo de grupos de buffers. Cada elemento incluye ``key`` (nombre del grupo), ``count`` (número de buffers), ``used`` (memoria utilizada, bytes) y ``capacity`` (capacidad total, bytes).
    * - ``gc``
-     - Arreglo de recolectores de basura. Cada elemento incluye ``key`` (nombre del recolector), ``count`` (numero de recolecciones) y ``time`` (tiempo acumulado de recoleccion, milisegundos).
+     - Arreglo de recolectores de basura. Cada elemento incluye ``key`` (nombre del recolector), ``count`` (número de recolecciones) y ``time`` (tiempo acumulado de recolección, milisegundos).
    * - ``threads.count``
-     - Numero actual de hilos.
+     - Número actual de hilos.
    * - ``threads.peak``
-     - Numero maximo de hilos alcanzado.
+     - Número máximo de hilos alcanzado.
    * - ``classes.loaded``
-     - Numero de clases cargadas actualmente.
+     - Número de clases cargadas actualmente.
    * - ``classes.total_loaded``
-     - Numero total de clases cargadas desde que se inicio la JVM.
+     - Número total de clases cargadas desde que se inició la JVM.
    * - ``classes.unloaded``
-     - Numero total de clases descargadas.
+     - Número total de clases descargadas.
    * - ``uptime``
      - Tiempo de actividad de la JVM (milisegundos).
 
-``os``: Estadisticas del Sistema Operativo
+``os``: Estadísticas del Sistema Operativo
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -201,11 +201,11 @@ Campos de Respuesta (Nivel Superior)
    :widths: 35 65
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``memory.physical.free``
-     - Memoria fisica libre (bytes).
+     - Memoria física libre (bytes).
    * - ``memory.physical.total``
-     - Memoria fisica total (bytes).
+     - Memoria física total (bytes).
    * - ``memory.swap_space.free``
      - Espacio de intercambio libre (bytes).
    * - ``memory.swap_space.total``
@@ -215,7 +215,7 @@ Campos de Respuesta (Nivel Superior)
    * - ``load_averages``
      - Arreglo de promedios de carga (1, 5 y 15 minutos). Los valores que no se pueden obtener pueden ser ``-1``.
 
-``process``: Estadisticas del Proceso
+``process``: Estadísticas del Proceso
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -223,77 +223,77 @@ Campos de Respuesta (Nivel Superior)
    :widths: 35 65
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``file_fescriptor.open``
-     - Numero de descriptores de archivo abiertos actualmente.
+     - Número de descriptores de archivo abiertos actualmente.
    * - ``file_fescriptor.max``
-     - Numero maximo de descriptores de archivo que se pueden abrir.
+     - Número máximo de descriptores de archivo que se pueden abrir.
    * - ``cpu.percent``
      - Porcentaje de uso de CPU del proceso (%).
    * - ``cpu.total``
      - Tiempo de CPU acumulado utilizado por el proceso (milisegundos).
    * - ``virtual_memory.total``
-     - Tamano total de la memoria virtual del proceso (bytes).
+     - Tamaño total de la memoria virtual del proceso (bytes).
 
 .. note::
 
-   El nombre de clave ``process.file_fescriptor`` es la conversion a snake_case del nombre de campo del codigo fuente
-   ``fileFescriptor`` (que se origina de una falta de ortografia de ``fileDescriptor``). Coincide con
-   la implementacion y no es un error tipografico en este documento.
+   El nombre de clave ``process.file_fescriptor`` es la conversión a snake_case del nombre de campo del código fuente
+   ``fileFescriptor`` (que se origina de una falta de ortografía de ``fileDescriptor``). Coincide con
+   la implementación y no es un error tipográfico en este documento.
 
-``engine``: Estadisticas del Cluster del Motor de Busqueda
+``engine``: Estadísticas del Cluster del Motor de Búsqueda
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Informacion de salud del cluster del motor de busqueda (OpenSearch).
+Información de salud del cluster del motor de búsqueda (OpenSearch).
 
 .. list-table::
    :header-rows: 1
    :widths: 35 65
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``cluster_name``
      - Nombre del cluster.
    * - ``number_of_nodes``
-     - Numero total de nodos en el cluster.
+     - Número total de nodos en el cluster.
    * - ``number_of_data_nodes``
-     - Numero de nodos de datos.
+     - Número de nodos de datos.
    * - ``active_primary_shards``
-     - Numero de shards primarios activos.
+     - Número de shards primarios activos.
    * - ``active_shards``
-     - Numero de shards activos.
+     - Número de shards activos.
    * - ``active_shards_percent``
      - Porcentaje de shards activos (%).
    * - ``relocating_shards``
-     - Numero de shards en reubicacion.
+     - Número de shards en reubicación.
    * - ``initializing_shards``
-     - Numero de shards en inicializacion.
+     - Número de shards en inicialización.
    * - ``unassigned_shards``
-     - Numero de shards sin asignar.
+     - Número de shards sin asignar.
    * - ``delayed_unassigned_shards``
-     - Numero de shards sin asignar con retraso.
+     - Número de shards sin asignar con retraso.
    * - ``number_of_pending_tasks``
-     - Numero de tareas pendientes.
+     - Número de tareas pendientes.
    * - ``number_of_in_flight_fetch``
-     - Numero de operaciones de recuperacion en curso.
+     - Número de operaciones de recuperación en curso.
    * - ``status``
      - Estado de salud del cluster (``green`` / ``yellow`` / ``red``).
    * - ``exception``
      - Mensaje de error que se incluye solo cuando ocurre un error, como cuando no se puede alcanzar el cluster. En este caso, ``status`` se vuelve ``red``.
 
-``fs``: Estadisticas del Sistema de Archivos
+``fs``: Estadísticas del Sistema de Archivos
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Arreglo de estadisticas para cada raiz (las raices obtenidas de ``File.listRoots()``).
+Arreglo de estadísticas para cada raíz (las raíces obtenidas de ``File.listRoots()``).
 
 .. list-table::
    :header-rows: 1
    :widths: 35 65
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``path``
-     - Ruta absoluta de la raiz.
+     - Ruta absoluta de la raíz.
    * - ``total``
      - Capacidad total (bytes).
    * - ``free``
@@ -308,7 +308,7 @@ Arreglo de estadisticas para cada raiz (las raices obtenidas de ``File.listRoots
 Ejemplos de Uso
 ===============
 
-Obtener Informacion Estadistica del Sistema
+Obtener Información Estadística del Sistema
 -------------------------------------------
 
 .. code-block:: bash
@@ -325,7 +325,7 @@ Verificar el Uso del Heap de la JVM
          -H "Authorization: Bearer YOUR_TOKEN" \
          | jq '.response.stats.jvm.memory.heap.percent'
 
-Verificar el Estado del Cluster del Motor de Busqueda
+Verificar el Estado del Cluster del Motor de Búsqueda
 ------------------------------------------------------
 
 .. code-block:: bash
@@ -334,9 +334,9 @@ Verificar el Estado del Cluster del Motor de Busqueda
          -H "Authorization: Bearer YOUR_TOKEN" \
          | jq '.response.stats.engine.status'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-systeminfo` - API de informacion del sistema
-- :doc:`api-admin-searchlist` - API de busqueda y gestion de documentos
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-systeminfo` - API de información del sistema
+- :doc:`api-admin-searchlist` - API de búsqueda y gestión de documentos

--- a/es/15.8/api/admin/api-admin-storage.rst
+++ b/es/15.8/api/admin/api-admin-storage.rst
@@ -2,11 +2,11 @@
 Storage API
 ===========
 
-Vision General
+Visión General
 ==============
 
 Storage API es una API para gestionar el almacenamiento de objetos de |Fess|.
-Permite obtener el listado de archivos y directorios en el almacenamiento, asi como descargar, eliminar y subir archivos.
+Permite obtener el listado de archivos y directorios en el almacenamiento, así como descargar, eliminar y subir archivos.
 
 URL Base
 ========
@@ -15,17 +15,17 @@ URL Base
 
     /api/admin/storage
 
-Autenticacion
+Autenticación
 =============
 
-Todos los endpoints de Admin API, incluida Storage API, requieren autenticacion mediante un token de acceso.
+Todos los endpoints de Admin API, incluida Storage API, requieren autenticación mediante un token de acceso.
 Especifique el token de acceso en el encabezado ``Authorization`` de la solicitud.
 
 ::
 
     Authorization: Bearer <token de acceso>
 
-Para obtener informacion sobre como obtener el token de acceso y los permisos necesarios (de forma predeterminada, el rol ``admin-api``),
+Para obtener información sobre cómo obtener el token de acceso y los permisos necesarios (de forma predeterminada, el rol ``admin-api``),
 consulte :doc:`api-admin-overview`.
 
 Lista de Endpoints
@@ -35,9 +35,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /list/{id}
      - Obtener listado de archivos y directorios
@@ -55,7 +55,7 @@ Obtener Listado de Archivos y Directorios
 =========================================
 
 Devuelve el listado de archivos y directorios ubicados bajo el directorio especificado.
-En ``{id}`` especifique el ``id`` del directorio obtenido en el listado. Si se omite ``{id}``, se obtiene el listado del directorio raiz.
+En ``{id}`` especifique el ``id`` del directorio obtenido en el listado. Si se omite ``{id}``, se obtiene el listado del directorio raíz.
 
 Solicitud
 ---------
@@ -67,7 +67,7 @@ Solicitud
 Respuesta
 ---------
 
-En ``items`` se almacena un array de objetos que representan la informacion de archivos y directorios (primero los directorios, luego los archivos).
+En ``items`` se almacena un array de objetos que representan la información de archivos y directorios (primero los directorios, luego los archivos).
 Cada objeto tiene los siguientes campos.
 
 .. list-table::
@@ -75,7 +75,7 @@ Cada objeto tiene los siguientes campos.
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``id``
      - Identificador codificado. Cadena que representa la ruta del objeto codificada en Base64 seguro para URL, utilizada como ``{id}`` al descargar o eliminar.
    * - ``path``
@@ -85,11 +85,11 @@ Cada objeto tiene los siguientes campos.
    * - ``hashCode``
      - Valor de hash utilizado en el procesamiento interno (no es un valor estable que represente el contenido del objeto)
    * - ``size``
-     - Tamano (en bytes)
+     - Tamaño (en bytes)
    * - ``directory``
      - Indica si es un directorio (boolean)
    * - ``lastModified``
-     - Fecha y hora de la ultima modificacion (formato ISO 8601; incluido solo para archivos)
+     - Fecha y hora de la última modificación (formato ISO 8601; incluido solo para archivos)
 
 .. code-block:: json
 
@@ -140,7 +140,7 @@ Flujo binario del archivo (``Content-Type: application/octet-stream``).
 .. note::
 
    La respuesta de esta API no incluye el encabezado ``Content-Disposition``.
-   El nombre del archivo con el que se guarda debe especificarse en el lado del cliente (en cURL, utilice la opcion ``-o``).
+   El nombre del archivo con el que se guarda debe especificarse en el lado del cliente (en cURL, utilice la opción ``-o``).
 
 Eliminar un Archivo
 ===================
@@ -169,7 +169,7 @@ Respuesta
 Subir un Archivo
 ================
 
-Sube un archivo al almacenamiento. El envio se realiza en formato ``multipart/form-data``.
+Sube un archivo al almacenamiento. El envío se realiza en formato ``multipart/form-data``.
 El directorio de destino se especifica mediante el campo de formulario ``path``, no como parte de la ruta URL.
 
 Solicitud
@@ -180,7 +180,7 @@ Solicitud
     PUT /api/admin/storage/upload
     Content-Type: multipart/form-data
 
-Descripcion de los Campos
+Descripción de los Campos
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -189,12 +189,12 @@ Descripcion de los Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``path``
      - No
-     - Ruta del directorio de destino (sin barras al inicio ni al final). Si se omite, el archivo se guarda en el raiz (directamente bajo el bucket).
+     - Ruta del directorio de destino (sin barras al inicio ni al final). Si se omite, el archivo se guarda en el raíz (directamente bajo el bucket).
    * - ``file``
-     - Si
+     - Sí
      - Archivo a subir
 
 Respuesta
@@ -212,8 +212,8 @@ Respuesta
 Errores
 =======
 
-Cada endpoint devuelve una respuesta con ``status`` distinto de 0 (``1`` en caso de error de validacion) cuando el procesamiento falla.
-El campo ``message`` del cuerpo de la respuesta contiene el detalle del error. Para obtener informacion sobre los valores de status y los codigos de estado HTTP, consulte :doc:`api-admin-overview`.
+Cada endpoint devuelve una respuesta con ``status`` distinto de 0 (``1`` en caso de error de validación) cuando el procesamiento falla.
+El campo ``message`` del cuerpo de la respuesta contiene el detalle del error. Para obtener información sobre los valores de status y los códigos de estado HTTP, consulte :doc:`api-admin-overview`.
 
 Los principales casos de error son los siguientes.
 
@@ -224,18 +224,18 @@ Los principales casos de error son los siguientes.
    * - Endpoint
      - Principales casos en que se produce un error
    * - Obtener listado de archivos y directorios
-     - Cuando el numero de elementos supera el limite
+     - Cuando el número de elementos supera el límite
    * - Descargar un archivo
-     - Cuando el ``id`` es invalido o la descarga falla
+     - Cuando el ``id`` es inválido o la descarga falla
    * - Eliminar un archivo
-     - Cuando el ``id`` es invalido o la eliminacion falla
+     - Cuando el ``id`` es inválido o la eliminación falla
    * - Subir un archivo
      - Cuando no se especifica ``file`` o la subida falla
 
 Ejemplos de Uso
 ===============
 
-Obtener Listado del Directorio Raiz
+Obtener Listado del Directorio Raíz
 ------------------------------------
 
 .. code-block:: bash
@@ -270,7 +270,7 @@ Subir un Archivo
          -F "path=subdir" \
          -F "file=@sample.txt"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API

--- a/es/15.8/api/admin/api-admin-suggest.rst
+++ b/es/15.8/api/admin/api-admin-suggest.rst
@@ -2,20 +2,20 @@
 Suggest API
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de Suggest es una API para gestionar las palabras de sugerencia utilizadas por la funcionalidad de sugerencias de |Fess|.
-Permite obtener informacion estadistica sobre el numero de palabras de sugerencia y eliminar palabras de sugerencia.
+Permite obtener información estadística sobre el número de palabras de sugerencia y eliminar palabras de sugerencia.
 
 Las palabras de sugerencia incluyen las generadas a partir de documentos rastreados (derivadas de documentos) y
-las generadas a partir de las consultas de busqueda de los usuarios (derivadas de consultas de busqueda). Esta API permite
+las generadas a partir de las consultas de búsqueda de los usuarios (derivadas de consultas de búsqueda). Esta API permite
 eliminarlas por tipo o eliminarlas todas a la vez.
 
-Autenticacion
+Autenticación
 =============
 
-El acceso a esta API requiere autenticacion mediante un token de acceso. Especifique el token de acceso
+El acceso a esta API requiere autenticación mediante un token de acceso. Especifique el token de acceso
 en la cabecera de la solicitud.
 
 ::
@@ -23,7 +23,7 @@ en la cabecera de la solicitud.
     Authorization: Bearer <token de acceso>
 
 El token de acceso debe tener el permiso de Admin API (por defecto ``Radmin-api``).
-Para obtener informacion sobre como obtener un token de acceso y los detalles de los permisos, consulte :doc:`api-admin-overview`.
+Para obtener información sobre cómo obtener un token de acceso y los detalles de los permisos, consulte :doc:`api-admin-overview`.
 
 URL Base
 ========
@@ -39,12 +39,12 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /
-     - Obtener informacion estadistica de palabras de sugerencia
+     - Obtener información estadística de palabras de sugerencia
    * - DELETE
      - /all
      - Eliminar todas las palabras de sugerencia
@@ -53,12 +53,12 @@ Lista de Endpoints
      - Eliminar palabras de sugerencia derivadas de documentos
    * - DELETE
      - /query
-     - Eliminar palabras de sugerencia derivadas de consultas de busqueda
+     - Eliminar palabras de sugerencia derivadas de consultas de búsqueda
 
-Obtener Informacion Estadistica de Palabras de Sugerencia
+Obtener Información Estadística de Palabras de Sugerencia
 =========================================================
 
-Obtiene informacion estadistica sobre el numero de palabras de sugerencia.
+Obtiene información estadística sobre el número de palabras de sugerencia.
 
 Solicitud
 ---------
@@ -92,25 +92,25 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``setting.totalWordsNum``
-     - Numero total de palabras de sugerencia (numero de palabras de sugerencia registradas en el indice de sugerencias)
+     - Número total de palabras de sugerencia (número de palabras de sugerencia registradas en el índice de sugerencias)
    * - ``setting.documentWordsNum``
-     - Numero de palabras de sugerencia derivadas de documentos (numero de palabras de sugerencia con frecuencia de documento igual o superior a 1)
+     - Número de palabras de sugerencia derivadas de documentos (número de palabras de sugerencia con frecuencia de documento igual o superior a 1)
    * - ``setting.queryWordsNum``
-     - Numero de palabras de sugerencia derivadas de consultas de busqueda (numero de palabras de sugerencia con frecuencia de consulta igual o superior a 1)
+     - Número de palabras de sugerencia derivadas de consultas de búsqueda (número de palabras de sugerencia con frecuencia de consulta igual o superior a 1)
 
 .. note::
 
    ``documentWordsNum`` y ``queryWordsNum`` no son excluyentes entre si. Si una palabra de sugerencia tiene origen
-   tanto en documentos como en consultas de busqueda, se incluye en el recuento de ambos. Por este motivo,
+   tanto en documentos como en consultas de búsqueda, se incluye en el recuento de ambos. Por este motivo,
    la suma de ``documentWordsNum`` y ``queryWordsNum`` puede no coincidir con ``totalWordsNum``.
 
 Eliminar Todas las Palabras de Sugerencia
 =========================================
 
-Elimina todas las palabras de sugerencia. Se eliminan todas las palabras de sugerencia del indice de sugerencias,
-independientemente de si son derivadas de documentos o de consultas de busqueda.
+Elimina todas las palabras de sugerencia. Se eliminan todas las palabras de sugerencia del índice de sugerencias,
+independientemente de si son derivadas de documentos o de consultas de búsqueda.
 
 Solicitud
 ---------
@@ -155,10 +155,10 @@ Respuesta
       }
     }
 
-Eliminar Palabras de Sugerencia Derivadas de Consultas de Busqueda
+Eliminar Palabras de Sugerencia Derivadas de Consultas de Búsqueda
 ==================================================================
 
-Elimina las palabras de sugerencia generadas a partir de consultas de busqueda (palabras de sugerencia derivadas de consultas de busqueda).
+Elimina las palabras de sugerencia generadas a partir de consultas de búsqueda (palabras de sugerencia derivadas de consultas de búsqueda).
 
 Solicitud
 ---------
@@ -182,7 +182,7 @@ Respuesta
 Respuesta de Error
 ==================
 
-Si el proceso de eliminacion falla, se devuelve el estado HTTP ``400`` y el campo ``status`` del cuerpo de la
+Si el proceso de eliminación falla, se devuelve el estado HTTP ``400`` y el campo ``status`` del cuerpo de la
 respuesta se establece en ``1`` (BAD_REQUEST), con el campo ``message`` conteniendo el mensaje de error.
 
 .. code-block:: json
@@ -195,14 +195,14 @@ respuesta se establece en ``1`` (BAD_REQUEST), con el campo ``message`` contenie
       }
     }
 
-Si el token de acceso no se especifica, no es valido o los permisos son insuficientes, el campo ``status`` del
+Si el token de acceso no se especifica, no es válido o los permisos son insuficientes, el campo ``status`` del
 cuerpo de la respuesta se establece en ``3`` (UNAUTHORIZED). Para consultar la lista de valores de ``status``
-y codigos de estado HTTP, consulte :doc:`api-admin-overview`.
+y códigos de estado HTTP, consulte :doc:`api-admin-overview`.
 
 Ejemplos de Uso
 ===============
 
-Obtener Informacion Estadistica
+Obtener Información Estadística
 -------------------------------
 
 .. code-block:: bash
@@ -226,7 +226,7 @@ Eliminar Palabras de Sugerencia Derivadas de Documentos
     curl -X DELETE "http://localhost:8080/api/admin/suggest/document" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Eliminar Palabras de Sugerencia Derivadas de Consultas de Busqueda
+Eliminar Palabras de Sugerencia Derivadas de Consultas de Búsqueda
 ------------------------------------------------------------------
 
 .. code-block:: bash
@@ -234,10 +234,10 @@ Eliminar Palabras de Sugerencia Derivadas de Consultas de Busqueda
     curl -X DELETE "http://localhost:8080/api/admin/suggest/query" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
+- :doc:`api-admin-overview` - Visión general de Admin API
 - :doc:`api-admin-badword` - API de palabras prohibidas
 - :doc:`api-admin-elevateword` - API de palabras elevadas
-- :doc:`../../admin/suggest-guide` - Guia de gestion de sugerencias
+- :doc:`../../admin/suggest-guide` - Guía de gestión de sugerencias

--- a/es/15.8/api/admin/api-admin-systeminfo.rst
+++ b/es/15.8/api/admin/api-admin-systeminfo.rst
@@ -2,11 +2,11 @@
 API de SystemInfo
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de SystemInfo es para obtener informacion del sistema de |Fess|.
-Permite verificar las variables de entorno, las propiedades del sistema de Java, las propiedades de configuracion de |Fess| y la informacion para reportes de errores.
+La API de SystemInfo es para obtener información del sistema de |Fess|.
+Permite verificar las variables de entorno, las propiedades del sistema de Java, las propiedades de configuración de |Fess| y la información para reportes de errores.
 
 URL Base
 ========
@@ -16,7 +16,7 @@ URL Base
     /api/admin/systeminfo
 
 El acceso a esta API requiere un token de acceso con el permiso ``Radmin-api``.
-Para mas detalles sobre la autenticacion, consulte :doc:`api-admin-overview`.
+Para más detalles sobre la autenticación, consulte :doc:`api-admin-overview`.
 
 Lista de Endpoints
 ==================
@@ -25,14 +25,14 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /
-     - Obtener informacion del sistema
+     - Obtener información del sistema
 
-Obtener Informacion del Sistema
+Obtener Información del Sistema
 ===============================
 
 Solicitud
@@ -42,12 +42,12 @@ Solicitud
 
     GET /api/admin/systeminfo
 
-Este endpoint no acepta parametros de consulta.
+Este endpoint no acepta parámetros de consulta.
 
 Respuesta
 ---------
 
-La respuesta incluye ``version``, que indica la version del producto, ``status``, que indica el resultado del procesamiento, y los siguientes cuatro grupos de propiedades. Cada grupo de propiedades es un arreglo de objetos que tienen ``label`` y ``value``.
+La respuesta incluye ``version``, que indica la versión del producto, ``status``, que indica el resultado del procesamiento, y los siguientes cuatro grupos de propiedades. Cada grupo de propiedades es un arreglo de objetos que tienen ``label`` y ``value``.
 
 .. code-block:: json
 
@@ -85,36 +85,36 @@ Campos de Respuesta
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``version``
-     - Version del producto |Fess| (ejemplo: ``15.8.0``).
+     - Versión del producto |Fess| (ejemplo: ``15.8.0``).
    * - ``status``
-     - Codigo que indica el resultado del procesamiento. ``0`` significa finalizacion exitosa.
+     - Código que indica el resultado del procesamiento. ``0`` significa finalización exitosa.
    * - ``envProps``
-     - Lista de variables de entorno (arreglo de ``label`` / ``value``). Se devuelven los valores obtenidos mediante ``System.getenv()`` tal como estan.
+     - Lista de variables de entorno (arreglo de ``label`` / ``value``). Se devuelven los valores obtenidos mediante ``System.getenv()`` tal como están.
    * - ``systemProps``
-     - Lista de propiedades del sistema de Java (arreglo de ``label`` / ``value``). Se devuelven los valores obtenidos mediante ``System.getProperties()`` tal como estan.
+     - Lista de propiedades del sistema de Java (arreglo de ``label`` / ``value``). Se devuelven los valores obtenidos mediante ``System.getProperties()`` tal como están.
    * - ``fessProps``
-     - Lista de propiedades de configuracion de |Fess| (arreglo de ``label`` / ``value``). Incluye los valores de configuracion de ``fess_config.properties`` y las propiedades del sistema establecidas desde la pantalla de administracion. Los elementos sensibles son enmascarados (vease la nota a continuacion).
+     - Lista de propiedades de configuración de |Fess| (arreglo de ``label`` / ``value``). Incluye los valores de configuración de ``fess_config.properties`` y las propiedades del sistema establecidas desde la pantalla de administración. Los elementos sensibles son enmascarados (véase la nota a continuación).
    * - ``bugReportProps``
-     - Lista de informacion recopilada para reportes de errores (arreglo de ``label`` / ``value``). Incluye las principales propiedades del sistema relacionadas con el SO y el entorno de ejecucion de Java (``os.name``, ``os.version``, ``java.vm.version``, etc.) y los valores de propiedades del sistema de |Fess|.
+     - Lista de información recopilada para reportes de errores (arreglo de ``label`` / ``value``). Incluye las principales propiedades del sistema relacionadas con el SO y el entorno de ejecución de Java (``os.name``, ``os.version``, ``java.vm.version``, etc.) y los valores de propiedades del sistema de |Fess|.
 
 .. note::
 
-   En ``fessProps``, los siguientes valores de configuracion sensibles son enmascarados y se devuelven como ``XXXXXXXX``:
+   En ``fessProps``, los siguientes valores de configuración sensibles son enmascarados y se devuelven como ``XXXXXXXX``:
    ``http.proxy.password``, ``ldap.admin.security.credentials``, ``spnego.preauth.password``,
    ``app.cipher.key``, ``oic.client.id``, ``oic.client.secret``.
 
 .. warning::
 
    ``envProps`` (variables de entorno) y ``systemProps`` (propiedades del sistema de Java) no son enmascarados:
-   los valores configurados se devuelven tal como estan. Si las variables de entorno o las propiedades del sistema
-   contienen informacion confidencial como credenciales, esos valores apareceran en la respuesta.
+   los valores configurados se devuelven tal como están. Si las variables de entorno o las propiedades del sistema
+   contienen información confidencial como credenciales, esos valores aparecerán en la respuesta.
 
 Ejemplos de Uso
 ===============
 
-Obtener Informacion del Sistema
+Obtener Información del Sistema
 -------------------------------
 
 .. code-block:: bash
@@ -122,7 +122,7 @@ Obtener Informacion del Sistema
     curl -X GET "http://localhost:8080/api/admin/systeminfo" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Extraer una Propiedad del Sistema Especifica
+Extraer una Propiedad del Sistema Específica
 --------------------------------------------
 
 .. code-block:: bash
@@ -142,10 +142,10 @@ Mostrar la Lista de Variables de Entorno
          -H "Authorization: Bearer YOUR_TOKEN" \
          | jq -r '.response.envProps[] | "\(.label)=\(.value)"'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-stats` - API de estadisticas
-- :doc:`api-admin-general` - API de configuracion general
-- :doc:`../../admin/systeminfo-guide` - Guia de informacion del sistema
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-stats` - API de estadísticas
+- :doc:`api-admin-general` - API de configuración general
+- :doc:`../../admin/systeminfo-guide` - Guía de información del sistema

--- a/es/15.8/api/admin/api-admin-user.rst
+++ b/es/15.8/api/admin/api-admin-user.rst
@@ -2,19 +2,19 @@
 API de User
 ==========================
 
-Vision General
+Visión General
 ==============
 
 La API de User es una API REST para gestionar cuentas de usuario de |Fess|.
-Permite crear, obtener, actualizar y eliminar usuarios, ademas de asignar roles y grupos.
+Permite crear, obtener, actualizar y eliminar usuarios, además de asignar roles y grupos.
 
-Esta es una API de administracion, y el acceso requiere autenticacion con un token de acceso de administrador.
-Consulte :doc:`api-admin-overview` para conocer el metodo de autenticacion y las especificaciones comunes.
+Esta es una API de administración, y el acceso requiere autenticación con un token de acceso de administrador.
+Consulte :doc:`api-admin-overview` para conocer el método de autenticación y las especificaciones comunes.
 
-Cada respuesta esta envuelta en un objeto ``response`` e incluye los siguientes campos comunes:
+Cada respuesta está envuelta en un objeto ``response`` e incluye los siguientes campos comunes:
 
-- ``version`` : La cadena de version del producto |Fess|.
-- ``status`` : El codigo de estado del resultado (``0`` =exito, ``1`` =solicitud incorrecta, ``2`` =error del sistema, ``3`` =no autorizado, ``9`` =fallo).
+- ``version`` : La cadena de versión del producto |Fess|.
+- ``status`` : El código de estado del resultado (``0`` =éxito, ``1`` =solicitud incorrecta, ``2`` =error del sistema, ``3`` =no autorizado, ``9`` =fallo).
 
 URL Base
 ========
@@ -30,9 +30,9 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Listar usuarios
@@ -59,31 +59,31 @@ Solicitud
 
     GET /api/admin/user/settings
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 15 10 10 65
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina. El valor predeterminado es el valor configurado ``paging.page.size`` (predeterminado: 25).
+     - Número de elementos por página. El valor predeterminado es el valor configurado ``paging.page.size`` (predeterminado: 25).
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1). El valor predeterminado es 1.
+     - Número de página (comienza en 1). El valor predeterminado es 1.
 
 .. note::
 
-   En la implementacion actual, el endpoint de lista de usuarios no aplica los parametros ``size`` y ``page``.
-   Siempre devuelve la primera pagina, con el numero de elementos definido por la configuracion del servidor ``paging.page.size`` (predeterminado: 25), ordenado por nombre de usuario (``name``) en orden ascendente.
-   El numero total de usuarios coincidentes esta disponible en ``response.total``.
+   En la implementación actual, el endpoint de lista de usuarios no aplica los parámetros ``size`` y ``page``.
+   Siempre devuelve la primera página, con el número de elementos definido por la configuración del servidor ``paging.page.size`` (predeterminado: 25), ordenado por nombre de usuario (``name``) en orden ascendente.
+   El número total de usuarios coincidentes está disponible en ``response.total``.
 
 Respuesta
 ---------
@@ -112,8 +112,8 @@ Respuesta
       }
     }
 
-- ``settings`` : El array de usuarios en la pagina actual.
-- ``total`` : El numero total de usuarios coincidentes.
+- ``settings`` : El array de usuarios en la página actual.
+- ``total`` : El número total de usuarios coincidentes.
 
 Obtener Usuario
 ===============
@@ -189,7 +189,7 @@ Cuerpo de la Solicitud
       "groups": ["group_id_1"]
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -198,19 +198,19 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre de usuario (ID de inicio de sesion)
+     - Sí
+     - Nombre de usuario (ID de inicio de sesión)
    * - ``password``
      - No
-     - Contrasena
+     - Contraseña
    * - ``confirmPassword``
      - No
-     - Contrasena de confirmacion
+     - Contraseña de confirmación
    * - ``attributes``
      - No
-     - Mapa de atributos (vease mas adelante)
+     - Mapa de atributos (véase más adelante)
    * - ``roles``
      - No
      - Array de IDs de roles
@@ -220,23 +220,23 @@ Descripcion de Campos
 
 .. note::
 
-   La API REST no realiza la verificacion de contrasena obligatoria, la verificacion de coincidencia entre ``password`` y ``confirmPassword``, ni la validacion de politica de contrasenas (estas se aplican unicamente en la interfaz de administracion).
-   En la practica, se recomienda especificar una ``password`` valida cuyo valor coincida con ``confirmPassword``.
+   La API REST no realiza la verificación de contraseña obligatoria, la verificación de coincidencia entre ``password`` y ``confirmPassword``, ni la validación de política de contraseñas (éstas se aplican únicamente en la interfaz de administración).
+   En la práctica, se recomienda especificar una ``password`` válida cuyo valor coincida con ``confirmPassword``.
 
 Las claves de ``attributes`` son los nombres de atributos de la entidad de usuario (los nombres de elementos derivados del esquema LDAP).
-Las claves mas comunes son:
+Las claves más comunes son:
 
 - ``surname``, ``givenName``, ``displayName``, ``mail``
 - ``telephoneNumber``, ``mobile``, ``homePhone``
 - ``employeeNumber``, ``title``, ``description``, ``homeDirectory``
 - ``uidNumber``, ``gidNumber``
 
-``uidNumber`` y ``gidNumber`` deben ser numericos (su tipo se valida en la actualizacion).
-Tambien se pueden especificar muchas otras claves de atributos LDAP.
+``uidNumber`` y ``gidNumber`` deben ser numéricos (su tipo se valida en la actualización).
+También se pueden especificar muchas otras claves de atributos LDAP.
 
 .. note::
 
-   En la creacion, el ID de usuario (ID de documento) se genera automaticamente como el valor codificado en Base64 URL del nombre de usuario
+   En la creación, el ID de usuario (ID de documento) se genera automáticamente como el valor codificado en Base64 URL del nombre de usuario
    (por ejemplo, el nombre de usuario ``admin`` se convierte en ``YWRtaW4=``).
 
 Respuesta
@@ -287,7 +287,7 @@ Cuerpo de la Solicitud
       "versionNo": 1
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -296,25 +296,25 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
+     - Sí
      - El ID de documento del usuario a actualizar.
    * - ``name``
-     - Si
-     - Nombre de usuario (ID de inicio de sesion)
+     - Sí
+     - Nombre de usuario (ID de inicio de sesión)
    * - ``versionNo``
-     - Si
-     - Numero de version (para bloqueo optimista)
+     - Sí
+     - Número de versión (para bloqueo optimista)
    * - ``password``
      - No
-     - Nueva contrasena (se actualiza solo cuando se especifica)
+     - Nueva contraseña (se actualiza solo cuando se especifica)
    * - ``confirmPassword``
      - No
-     - Contrasena de confirmacion
+     - Contraseña de confirmación
    * - ``attributes``
      - No
-     - Mapa de atributos (vease "Crear Usuario")
+     - Mapa de atributos (véase "Crear Usuario")
    * - ``roles``
      - No
      - Array de IDs de roles
@@ -324,9 +324,9 @@ Descripcion de Campos
 
 .. note::
 
-   En la actualizacion, ``id``, ``name`` y ``versionNo`` son obligatorios.
-   ``versionNo`` es el valor devuelto al obtener el usuario objetivo (GET), y corresponde a la version del documento de OpenSearch.
-   Si no coincide con la version actual, la solicitud se trata como un conflicto y la actualizacion es rechazada.
+   En la actualización, ``id``, ``name`` y ``versionNo`` son obligatorios.
+   ``versionNo`` es el valor devuelto al obtener el usuario objetivo (GET), y corresponde a la versión del documento de OpenSearch.
+   Si no coincide con la versión actual, la solicitud se trata como un conflicto y la actualización es rechazada.
 
 Respuesta
 ---------
@@ -342,7 +342,7 @@ Respuesta
       }
     }
 
-- ``created`` : ``false`` para una actualizacion.
+- ``created`` : ``false`` para una actualización.
 
 Eliminar Usuario
 ================
@@ -358,7 +358,7 @@ Especifique el ID de documento del usuario a eliminar en ``{id}``.
 
 .. note::
 
-   No es posible eliminar el usuario que tiene la sesion actualmente iniciada.
+   No es posible eliminar el usuario que tiene la sesión actualmente iniciada.
 
 Respuesta
 ---------
@@ -418,7 +418,7 @@ Cambiar Roles de Usuario
 Referencia
 ==========
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-role` - API de gestion de roles
-- :doc:`api-admin-group` - API de gestion de grupos
-- :doc:`../../admin/user-guide` - Guia de gestion de usuarios
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-role` - API de gestión de roles
+- :doc:`api-admin-group` - API de gestión de grupos
+- :doc:`../../admin/user-guide` - Guía de gestión de usuarios

--- a/es/15.8/api/admin/api-admin-webconfig.rst
+++ b/es/15.8/api/admin/api-admin-webconfig.rst
@@ -2,11 +2,11 @@
 API de WebConfig
 ==========================
 
-Vision General
+Visión General
 ==============
 
-La API de WebConfig es para gestionar la configuracion de rastreo web de |Fess|.
-Puede operar configuraciones como URLs de rastreo, profundidad de rastreo y patrones de exclusion.
+La API de WebConfig es para gestionar la configuración de rastreo web de |Fess|.
+Puede operar configuraciones como URLs de rastreo, profundidad de rastreo y patrones de exclusión.
 
 URL Base
 ========
@@ -17,8 +17,8 @@ URL Base
 
 .. note::
 
-   Todos los endpoints requieren privilegios de administrador y un token de acceso valido.
-   Consulte :doc:`api-admin-overview` para obtener informacion sobre la autenticacion.
+   Todos los endpoints requieren privilegios de administrador y un token de acceso válido.
+   Consulte :doc:`api-admin-overview` para obtener información sobre la autenticación.
 
 Lista de Endpoints
 ==================
@@ -27,24 +27,24 @@ Lista de Endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Metodo
+   * - Método
      - Ruta
-     - Descripcion
+     - Descripción
    * - GET
      - /settings
      - Obtener lista de configuraciones de rastreo web
    * - GET
      - /setting/{id}
-     - Obtener configuracion de rastreo web
+     - Obtener configuración de rastreo web
    * - POST
      - /setting
-     - Crear configuracion de rastreo web
+     - Crear configuración de rastreo web
    * - PUT
      - /setting
-     - Actualizar configuracion de rastreo web
+     - Actualizar configuración de rastreo web
    * - DELETE
      - /setting/{id}
-     - Eliminar configuracion de rastreo web
+     - Eliminar configuración de rastreo web
 
 Obtener Lista de Configuraciones de Rastreo Web
 ===============================================
@@ -58,31 +58,31 @@ Solicitud
 
 .. note::
 
-   El endpoint de lista tambien acepta ``PUT`` ademas de ``GET``.
+   El endpoint de lista también acepta ``PUT`` además de ``GET``.
 
-Parametros
+Parámetros
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 10 55
 
-   * - Parametro
+   * - Parámetro
      - Tipo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``page``
      - Integer
      - No
-     - Numero de pagina (comienza en 1, predeterminado: 1)
+     - Número de página (comienza en 1, predeterminado: 1)
    * - ``size``
      - Integer
      - No
-     - Numero de elementos por pagina (predeterminado: 25, segun la configuracion ``paging.page.size``)
+     - Número de elementos por página (predeterminado: 25, según la configuración ``paging.page.size``)
    * - ``name``
      - String
      - No
-     - Filtrar por nombre de configuracion
+     - Filtrar por nombre de configuración
    * - ``urls``
      - String
      - No
@@ -90,7 +90,7 @@ Parametros
    * - ``description``
      - String
      - No
-     - Filtrar por descripcion
+     - Filtrar por descripción
 
 Respuesta
 ---------
@@ -127,9 +127,9 @@ Respuesta
       }
     }
 
-``total`` indica el numero total de configuraciones que coinciden con los criterios de busqueda.
+``total`` indica el número total de configuraciones que coinciden con los criterios de búsqueda.
 
-Obtener Configuracion de Rastreo Web
+Obtener Configuración de Rastreo Web
 =====================================
 
 Solicitud
@@ -178,12 +178,12 @@ Respuesta
 
 .. note::
 
-   La respuesta incluye los campos de auditoria ``createdBy``, ``createdTime``,
-   ``updatedBy``, ``updatedTime`` y ``versionNo``, que son asignados automaticamente
-   en el momento del registro o la actualizacion.
-   ``versionNo`` es obligatorio al actualizar (consulte la seccion "Actualizar configuracion de rastreo web" a continuacion).
+   La respuesta incluye los campos de auditoría ``createdBy``, ``createdTime``,
+   ``updatedBy``, ``updatedTime`` y ``versionNo``, que son asignados automáticamente
+   en el momento del registro o la actualización.
+   ``versionNo`` es obligatorio al actualizar (consulte la sección "Actualizar configuración de rastreo web" a continuación).
 
-Crear Configuracion de Rastreo Web
+Crear Configuración de Rastreo Web
 ===================================
 
 Solicitud
@@ -213,7 +213,7 @@ Cuerpo de la Solicitud
       "permissions": "{role}admin\n{role}user"
     }
 
-Descripcion de Campos
+Descripción de Campos
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -222,66 +222,66 @@ Descripcion de Campos
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``name``
-     - Si
-     - Nombre de la configuracion (maximo 200 caracteres)
+     - Sí
+     - Nombre de la configuración (máximo 200 caracteres)
    * - ``description``
      - No
-     - Descripcion de la configuracion (maximo 1000 caracteres)
+     - Descripción de la configuración (máximo 1000 caracteres)
    * - ``urls``
-     - Si
-     - URL de inicio de rastreo (separadas por salto de linea si son multiples). Se especifica con ``http:`` o ``https:``
+     - Sí
+     - URL de inicio de rastreo (separadas por salto de línea si son múltiples). Se especifica con ``http:`` o ``https:``
    * - ``includedUrls``
      - No
-     - Patron de expresion regular para URLs a rastrear
+     - Patrón de expresión regular para URLs a rastrear
    * - ``excludedUrls``
      - No
-     - Patron de expresion regular para URLs a excluir del rastreo
+     - Patrón de expresión regular para URLs a excluir del rastreo
    * - ``includedDocUrls``
      - No
-     - Patron de expresion regular para URLs a indexar
+     - Patrón de expresión regular para URLs a indexar
    * - ``excludedDocUrls``
      - No
-     - Patron de expresion regular para URLs a excluir del indice
+     - Patrón de expresión regular para URLs a excluir del índice
    * - ``configParameter``
      - No
-     - Parametros de configuracion adicionales (formato ``key=value``, un elemento por linea)
+     - Parámetros de configuración adicionales (formato ``key=value``, un elemento por línea)
    * - ``depth``
      - No
-     - Profundidad de rastreo (0 o mas)
+     - Profundidad de rastreo (0 o más)
    * - ``maxAccessCount``
      - No
-     - Numero maximo de accesos (0 o mas)
+     - Número máximo de accesos (0 o más)
    * - ``userAgent``
-     - Si
-     - Cadena User-Agent (maximo 200 caracteres)
+     - Sí
+     - Cadena User-Agent (máximo 200 caracteres)
    * - ``numOfThread``
-     - Si
-     - Numero de hilos paralelos (1 o mas)
+     - Sí
+     - Número de hilos paralelos (1 o más)
    * - ``intervalTime``
-     - Si
-     - Intervalo de acceso (milisegundos, 0 o mas)
+     - Sí
+     - Intervalo de acceso (milisegundos, 0 o más)
    * - ``boost``
-     - Si
-     - Valor de impulso en resultados de busqueda
+     - Sí
+     - Valor de impulso en resultados de búsqueda
    * - ``available``
-     - Si
+     - Sí
      - Habilitado/Deshabilitado (cadena ``"true"`` / ``"false"``)
    * - ``sortOrder``
-     - Si
-     - Orden de visualizacion (0 o mas)
+     - Sí
+     - Orden de visualización (0 o más)
    * - ``permissions``
      - No
-     - Roles con permiso de acceso (separados por saltos de linea si son varios)
+     - Roles con permiso de acceso (separados por saltos de línea si son varios)
    * - ``virtualHosts``
      - No
-     - Hosts virtuales (separados por saltos de linea si son varios)
+     - Hosts virtuales (separados por saltos de línea si son varios)
 
 .. note::
 
-   Los campos de auditoria como ``createdBy``, ``createdTime``, ``updatedBy`` y ``updatedTime``
-   son asignados automaticamente por el servidor, por lo que no es necesario incluirlos en el cuerpo de la solicitud.
+   Los campos de auditoría como ``createdBy``, ``createdTime``, ``updatedBy`` y ``updatedTime``
+   son asignados automáticamente por el servidor, por lo que no es necesario incluirlos en el cuerpo de la solicitud.
 
 Respuesta
 ---------
@@ -296,7 +296,7 @@ Respuesta
       }
     }
 
-Actualizar Configuracion de Rastreo Web
+Actualizar Configuración de Rastreo Web
 =========================================
 
 Solicitud
@@ -310,8 +310,8 @@ Solicitud
 Cuerpo de la Solicitud
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Al actualizar, ademas de los campos de creacion, son obligatorios ``id`` para identificar
-el registro a actualizar y ``versionNo`` como numero de version.
+Al actualizar, además de los campos de creación, son obligatorios ``id`` para identificar
+el registro a actualizar y ``versionNo`` como número de versión.
 En ``versionNo`` se debe especificar el valor actual incluido en la respuesta de la API de consulta (GET).
 
 .. code-block:: json
@@ -333,7 +333,7 @@ En ``versionNo`` se debe especificar el valor actual incluido en la respuesta de
       "versionNo": 1
     }
 
-Campos Adicionales para la Actualizacion
+Campos Adicionales para la Actualización
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -342,13 +342,13 @@ Campos Adicionales para la Actualizacion
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``id``
-     - Si
-     - ID de la configuracion a actualizar (maximo 1000 caracteres)
+     - Sí
+     - ID de la configuración a actualizar (máximo 1000 caracteres)
    * - ``versionNo``
-     - Si
-     - Numero de version actual del registro a actualizar. Se especifica el valor de ``versionNo`` incluido en la respuesta de la API de consulta (GET)
+     - Sí
+     - Número de versión actual del registro a actualizar. Se especifica el valor de ``versionNo`` incluido en la respuesta de la API de consulta (GET)
 
 Respuesta
 ---------
@@ -363,7 +363,7 @@ Respuesta
       }
     }
 
-Eliminar Configuracion de Rastreo Web
+Eliminar Configuración de Rastreo Web
 =======================================
 
 Solicitud
@@ -393,8 +393,8 @@ En ``includedUrls`` / ``excludedUrls`` / ``includedDocUrls`` / ``excludedDocUrls
    :header-rows: 1
    :widths: 50 50
 
-   * - Patron
-     - Descripcion
+   * - Patrón
+     - Descripción
    * - ``.*example\\.com.*``
      - Todas las URLs que contienen example.com
    * - ``https://example\\.com/docs/.*``
@@ -402,14 +402,14 @@ En ``includedUrls`` / ``excludedUrls`` / ``includedDocUrls`` / ``excludedDocUrls
    * - ``.*\\.(pdf|doc|docx)$``
      - Archivos PDF, DOC, DOCX
    * - ``.*\\?.*``
-     - URLs con parametros de consulta
+     - URLs con parámetros de consulta
    * - ``.*/(login|logout|admin)/.*``
-     - URLs que contienen rutas especificas
+     - URLs que contienen rutas específicas
 
 Ejemplos de Uso
 ===============
 
-Configuracion de Rastreo de Sitio Corporativo
+Configuración de Rastreo de Sitio Corporativo
 ---------------------------------------------
 
 .. code-block:: bash
@@ -433,7 +433,7 @@ Configuracion de Rastreo de Sitio Corporativo
            "permissions": "{role}guest"
          }'
 
-Configuracion de Rastreo de Sitio de Documentacion
+Configuración de Rastreo de Sitio de Documentación
 ----------------------------------------------------
 
 .. code-block:: bash
@@ -455,10 +455,10 @@ Configuracion de Rastreo de Sitio de Documentacion
            "sortOrder": 0
          }'
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`api-admin-overview` - Vision general de Admin API
-- :doc:`api-admin-fileconfig` - API de configuracion de rastreo de archivos
-- :doc:`api-admin-dataconfig` - API de configuracion de almacen de datos
-- :doc:`../../admin/webconfig-guide` - Guia de configuracion de rastreo web
+- :doc:`api-admin-overview` - Visión general de Admin API
+- :doc:`api-admin-fileconfig` - API de configuración de rastreo de archivos
+- :doc:`api-admin-dataconfig` - API de configuración de almacén de datos
+- :doc:`../../admin/webconfig-guide` - Guía de configuración de rastreo web

--- a/es/15.8/api/admin/index.rst
+++ b/es/15.8/api/admin/index.rst
@@ -2,17 +2,17 @@
 Referencia de Admin API
 ==========================
 
-|Fess| Admin API es una API RESTful para acceder programaticamente a las funciones de administracion.
+|Fess| Admin API es una API RESTful para acceder programáticamente a las funciones de administración.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Vision General
+   :caption: Visión General
 
    api-admin-overview
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion de Rastreo
+   :caption: Configuración de Rastreo
 
    api-admin-webconfig
    api-admin-fileconfig
@@ -20,7 +20,7 @@ Referencia de Admin API
 
 .. toctree::
    :maxdepth: 2
-   :caption: Gestion de Indices
+   :caption: Gestión de Índices
 
    api-admin-documents
    api-admin-crawlinginfo
@@ -36,7 +36,7 @@ Referencia de Admin API
 
 .. toctree::
    :maxdepth: 2
-   :caption: Gestion de Usuarios y Permisos
+   :caption: Gestión de Usuarios y Permisos
 
    api-admin-user
    api-admin-role
@@ -45,7 +45,7 @@ Referencia de Admin API
 
 .. toctree::
    :maxdepth: 2
-   :caption: Ajuste de Busqueda
+   :caption: Ajuste de Búsqueda
 
    api-admin-labeltype
    api-admin-keymatch
@@ -75,6 +75,6 @@ Referencia de Admin API
 
 .. toctree::
    :maxdepth: 2
-   :caption: Registro de Busqueda
+   :caption: Registro de Búsqueda
 
    api-admin-searchlist

--- a/es/15.8/config/admin-log-notification.rst
+++ b/es/15.8/config/admin-log-notification.rst
@@ -1,163 +1,163 @@
 ==========================
-Notificacion de Registros
+Notificación de Registros
 ==========================
 
-Descripcion General
+Descripción General
 ===================
 
-|Fess| dispone de una funcionalidad que captura automaticamente los eventos de registro de nivel ERROR o WARN y notifica a los administradores.
-Esta funcionalidad permite detectar rapidamente anomalias en el sistema e iniciar la respuesta ante incidencias de forma temprana.
+|Fess| dispone de una funcionalidad que captura automáticamente los eventos de registro de nivel ERROR o WARN y notifica a los administradores.
+Esta funcionalidad permite detectar rápidamente anomalías en el sistema e iniciar la respuesta ante incidencias de forma temprana.
 
-Caracteristicas principales:
+Características principales:
 
-- **Canales de notificacion compatibles**: Correo electronico, Slack, Google Chat
-- **Procesos objetivo**: Aplicacion principal, rastreador, generacion de sugerencias, generacion de miniaturas
-- **Deshabilitado por defecto**: Al ser un sistema de activacion voluntaria (opt-in), es necesario habilitarlo explicitamente
+- **Canales de notificación compatibles**: Correo electrónico, Slack, Google Chat
+- **Procesos objetivo**: Aplicación principal, rastreador, generación de sugerencias, generación de miniaturas
+- **Deshabilitado por defecto**: Al ser un sistema de activación voluntaria (opt-in), es necesario habilitarlo explícitamente
 
 Funcionamiento
 ==============
 
-La notificacion de registros funciona segun el siguiente flujo.
+La notificación de registros funciona según el siguiente flujo.
 
 1. El ``LogNotificationAppender`` de Log4j2 captura los eventos de registro que igualan o superan el nivel configurado.
-2. Los eventos capturados se acumulan en un bufer en memoria (maximo 1,000 eventos por defecto). Si el bufer supera su limite, los eventos se descartan empezando por el mas antiguo.
-3. Un temporizador escribe los eventos del bufer en un indice de OpenSearch (``fess_log.notification_queue``) cada 30 segundos.
-4. El trabajo programado "Log Notification" lee los eventos de OpenSearch cada 5 minutos, los agrupa por nivel de registro y envia una notificacion por cada nivel.
-5. Despues del envio de la notificacion, los eventos procesados se eliminan del indice.
+2. Los eventos capturados se acumulan en un búfer en memoria (máximo 1,000 eventos por defecto). Si el búfer supera su límite, los eventos se descartan empezando por el más antiguo.
+3. Un temporizador escribe los eventos del búfer en un índice de OpenSearch (``fess_log.notification_queue``) cada 30 segundos.
+4. El trabajo programado "Log Notification" lee los eventos de OpenSearch cada 5 minutos, los agrupa por nivel de registro y envía una notificación por cada nivel.
+5. Después del envío de la notificación, los eventos procesados se eliminan del índice.
 
 .. note::
-   Cada nodo notifica unicamente los registros que el mismo ha generado (los eventos se filtran por ``hostname``).
-   En una configuracion en cluster, se envia una notificacion individual por cada nodo.
+   Cada nodo notifica únicamente los registros que el mismo ha generado (los eventos se filtran por ``hostname``).
+   En una configuración en cluster, se envía una notificación individual por cada nodo.
 
 .. note::
-   Para evitar bucles infinitos, se excluyen de la notificacion los registros de los loggers
-   relacionados con la propia funcionalidad de notificacion
+   Para evitar bucles infinitos, se excluyen de la notificación los registros de los loggers
+   relacionados con la propia funcionalidad de notificación
    (``LogNotificationAppender``, ``LogNotificationHelper``, ``LogNotificationTarget``,
    ``LogNotificationJob``, ``NotificationHelper`` y ``org.codelibs.curl``, utilizado para
-   la comunicacion HTTP).
+   la comunicación HTTP).
 
-Configuracion
+Configuración
 =============
 
-Habilitacion
+Habilitación
 ------------
 
-Habilitacion desde la Pantalla de Administracion
+Habilitación desde la Pantalla de Administración
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Inicie sesion en la pantalla de administracion.
-2. Seleccione "General" del menu "Sistema".
-3. Active la casilla de verificacion "Log Notification".
-4. Seleccione el nivel objetivo de notificacion en "Log Notification Level" (``ERROR``, ``WARN``, ``INFO``, ``DEBUG``, ``TRACE``).
-5. Haga clic en el boton "Actualizar".
+1. Inicie sesión en la pantalla de administración.
+2. Seleccione "General" del menú "Sistema".
+3. Active la casilla de verificación "Log Notification".
+4. Seleccione el nivel objetivo de notificación en "Log Notification Level" (``ERROR``, ``WARN``, ``INFO``, ``DEBUG``, ``TRACE``).
+5. Haga clic en el botón "Actualizar".
 
 .. note::
    Por defecto, solo se notifica el nivel ``ERROR``.
-   Si selecciona ``WARN``, se notificaran tanto ``WARN`` como ``ERROR``.
+   Si selecciona ``WARN``, se notificarán tanto ``WARN`` como ``ERROR``.
 
-Habilitacion mediante Propiedades del Sistema
+Habilitación mediante Propiedades del Sistema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tambien puede configurar directamente las propiedades del sistema (``system.properties``) que se guardan en la configuracion "General" de la pantalla de administracion.
+También puede configurar directamente las propiedades del sistema (``system.properties``) que se guardan en la configuración "General" de la pantalla de administración.
 
 ::
 
     log.notification.enabled=true
     fess.log.notification.level=ERROR
 
-Configuracion del Destino de Notificacion
+Configuración del Destino de Notificación
 -----------------------------------------
 
-Los destinos de notificacion (la direccion de correo, las URL de Webhook de Slack / Google Chat) se configuran todos
-en la configuracion "Sistema" -> "General" de la pantalla de administracion. Configure al menos un destino de notificacion.
-Si no se ha configurado ningun destino de notificacion, el trabajo de notificacion de registros finaliza sin enviar nada.
+Los destinos de notificación (la dirección de correo, las URL de Webhook de Slack / Google Chat) se configuran todos
+en la configuración "Sistema" -> "General" de la pantalla de administración. Configure al menos un destino de notificación.
+Si no se ha configurado ningún destino de notificación, el trabajo de notificación de registros finaliza sin enviar nada.
 
-Notificacion por Correo Electronico
+Notificación por Correo Electrónico
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Para utilizar la notificacion por correo electronico, es necesaria la siguiente configuracion.
+Para utilizar la notificación por correo electrónico, es necesaria la siguiente configuración.
 
-1. Configuracion del servidor de correo (``fess_env.properties``):
+1. Configuración del servidor de correo (``fess_env.properties``):
 
    ::
 
        mail.smtp.server.main.host.and.port=smtp.example.com:587
 
-2. Introduzca la direccion de correo electronico en "Correo de notificacion" en la configuracion "General" de la pantalla de administracion.
+2. Introduzca la dirección de correo electrónico en "Correo de notificación" en la configuración "General" de la pantalla de administración.
    Puede especificar varias direcciones separadas por comas.
 
-Notificacion por Slack
+Notificación por Slack
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Introduzca la URL del Incoming Webhook de Slack en "Slack Webhook URLs" en la configuracion "General" de la pantalla de administracion.
+Introduzca la URL del Incoming Webhook de Slack en "Slack Webhook URLs" en la configuración "General" de la pantalla de administración.
 Puede especificar varias URL separadas por comas o espacios.
 Este valor se guarda como la propiedad del sistema ``slack.webhook.urls``.
 
-Notificacion por Google Chat
+Notificación por Google Chat
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Introduzca la URL del Webhook de Google Chat en "Google Chat Webhook URLs" en la configuracion "General" de la pantalla de administracion.
+Introduzca la URL del Webhook de Google Chat en "Google Chat Webhook URLs" en la configuración "General" de la pantalla de administración.
 Puede especificar varias URL separadas por comas o espacios.
 Este valor se guarda como la propiedad del sistema ``google.chat.webhook.urls``.
 
 .. note::
-   Si configura unicamente la URL de Webhook de Slack o Google Chat sin configurar "Correo de notificacion",
-   no se enviara correo electronico y solo se realizaran las notificaciones a Slack / Google Chat.
-   A Slack / Google Chat se les envia como mensaje el mismo asunto y cuerpo que la notificacion por correo.
+   Si configura únicamente la URL de Webhook de Slack o Google Chat sin configurar "Correo de notificación",
+   no se enviará correo electrónico y solo se realizarán las notificaciones a Slack / Google Chat.
+   A Slack / Google Chat se les envía como mensaje el mismo asunto y cuerpo que la notificación por correo.
 
-Propiedades de Configuracion
+Propiedades de Configuración
 ============================
 
 Las siguientes propiedades se pueden configurar en ``fess_config.properties``.
 
-.. list-table:: Propiedades de Configuracion de Notificacion de Registros
+.. list-table:: Propiedades de Configuración de Notificación de Registros
    :header-rows: 1
    :widths: 40 15 45
 
    * - Propiedad
      - Valor Predeterminado
-     - Descripcion
+     - Descripción
    * - ``log.notification.flush.interval``
      - ``30``
-     - Intervalo de vaciado del bufer a OpenSearch (segundos)
+     - Intervalo de vaciado del búfer a OpenSearch (segundos)
    * - ``log.notification.buffer.size``
      - ``1000``
-     - Numero maximo de eventos almacenados en el bufer en memoria
+     - Número máximo de eventos almacenados en el búfer en memoria
    * - ``log.notification.interval``
      - ``300``
-     - Periodo de agregacion (segundos) mostrado en el mensaje de notificacion. Es un valor unicamente de visualizacion y no representa el intervalo real de ejecucion del trabajo (vease la nota mas abajo).
+     - Período de agregación (segundos) mostrado en el mensaje de notificación. Es un valor únicamente de visualización y no representa el intervalo real de ejecución del trabajo (véase la nota más abajo).
    * - ``log.notification.search.size``
      - ``1000``
-     - Numero maximo de eventos obtenidos de OpenSearch por ejecucion del trabajo
+     - Número máximo de eventos obtenidos de OpenSearch por ejecución del trabajo
    * - ``log.notification.max.display.events``
      - ``50``
-     - Numero maximo de eventos incluidos en un solo mensaje de notificacion
+     - Número máximo de eventos incluidos en un solo mensaje de notificación
    * - ``log.notification.max.message.length``
      - ``200``
-     - Numero maximo de caracteres por mensaje de registro (el exceso se trunca)
+     - Número máximo de caracteres por mensaje de registro (el exceso se trunca)
    * - ``log.notification.max.details.length``
      - ``3000``
-     - Numero maximo de caracteres en la seccion de detalles del mensaje de notificacion
+     - Número máximo de caracteres en la sección de detalles del mensaje de notificación
 
 .. note::
-   Los cambios en ``log.notification.flush.interval`` se aplican despues de reiniciar |Fess|.
-   El resto de propiedades se aplican a partir del siguiente ciclo de notificacion.
+   Los cambios en ``log.notification.flush.interval`` se aplican después de reiniciar |Fess|.
+   El resto de propiedades se aplican a partir del siguiente ciclo de notificación.
 
 .. note::
-   ``log.notification.interval`` es el valor utilizado para el texto "en los ultimos N segundos" que se
-   muestra dentro del mensaje de notificacion, y no modifica la frecuencia de ejecucion del trabajo.
-   El intervalo real de ejecucion lo determina la configuracion cron del trabajo programado "Log Notification"
-   (por defecto, cada 5 minutos). Si desea cambiar el intervalo de ejecucion del trabajo, modifique la expresion
-   cron de este trabajo en "Sistema" -> "Programador" y ajuste tambien ``log.notification.interval`` para que la
-   visualizacion coincida con la realidad.
+   ``log.notification.interval`` es el valor utilizado para el texto "en los últimos N segundos" que se
+   muestra dentro del mensaje de notificación, y no modifica la frecuencia de ejecución del trabajo.
+   El intervalo real de ejecución lo determina la configuración cron del trabajo programado "Log Notification"
+   (por defecto, cada 5 minutos). Si desea cambiar el intervalo de ejecución del trabajo, modifique la expresión
+   cron de este trabajo en "Sistema" -> "Programador" y ajuste también ``log.notification.interval`` para que la
+   visualización coincida con la realidad.
 
-Formato del Mensaje de Notificacion
+Formato del Mensaje de Notificación
 ===================================
 
-Notificacion por Correo Electronico
+Notificación por Correo Electrónico
 -----------------------------------
 
-La notificacion por correo electronico se envia con el siguiente formato.
+La notificación por correo electrónico se envía con el siguiente formato.
 
 **Asunto:**
 
@@ -185,23 +185,23 @@ La notificacion por correo electronico se envia con el siguiente formato.
     Note: See the log files for full details.
 
 .. note::
-   Los eventos ERROR y WARN se envian como notificaciones separadas por cada nivel.
+   Los eventos ERROR y WARN se envían como notificaciones separadas por cada nivel.
 
 .. note::
-   Si el numero de eventos a mostrar supera ``log.notification.max.display.events``, el inicio de la
-   seccion de detalles sera ``Total: N event(s) (showing M)`` y al final se anadira ``... and X more``.
+   Si el número de eventos a mostrar supera ``log.notification.max.display.events``, el inicio de la
+   sección de detalles será ``Total: N event(s) (showing M)`` y al final se añadirá ``... and X more``.
    Cada mensaje de registro que supere ``log.notification.max.message.length`` se trunca al final con ``...``,
-   y cuando la seccion de detalles completa supera ``log.notification.max.details.length`` el resto se descarta.
+   y cuando la sección de detalles completa supera ``log.notification.max.details.length`` el resto se descarta.
 
-Notificacion por Slack / Google Chat
+Notificación por Slack / Google Chat
 ------------------------------------
 
-Las notificaciones de Slack y Google Chat tambien se envian como mensajes con el mismo contenido.
+Las notificaciones de Slack y Google Chat también se envían como mensajes con el mismo contenido.
 
-Guia de Operacion
+Guía de Operación
 =================
 
-Configuracion Recomendada
+Configuración Recomendada
 -------------------------
 
 .. list-table::
@@ -210,8 +210,8 @@ Configuracion Recomendada
 
    * - Entorno
      - Nivel Recomendado
-     - Razon
-   * - Entorno de Produccion
+     - Razón
+   * - Entorno de Producción
      - ``ERROR``
      - Notificar solo errores importantes y reducir el ruido
    * - Entorno de Staging
@@ -221,49 +221,49 @@ Configuracion Recomendada
      - Deshabilitado
      - Verificar directamente los archivos de registro
 
-Indice de OpenSearch
+Índice de OpenSearch
 --------------------
 
-La funcionalidad de notificacion de registros utiliza el indice ``fess_log.notification_queue`` para el almacenamiento
-temporal de eventos (el nombre del indice se forma anadiendo ``.notification_queue`` al valor de ``index.log``,
-``fess_log`` por defecto). Este indice se crea automaticamente la primera vez que se utiliza la funcionalidad.
-Dado que los eventos se eliminan despues del envio de la notificacion, normalmente el tamano del indice no crece significativamente.
+La funcionalidad de notificación de registros utiliza el índice ``fess_log.notification_queue`` para el almacenamiento
+temporal de eventos (el nombre del índice se forma añadiendo ``.notification_queue`` al valor de ``index.log``,
+``fess_log`` por defecto). Este índice se crea automáticamente la primera vez que se utiliza la funcionalidad.
+Dado que los eventos se eliminan después del envío de la notificación, normalmente el tamaño del índice no crece significativamente.
 
 .. note::
-   El numero de eventos procesados en una sola ejecucion del trabajo tiene como limite ``log.notification.search.size``
-   (1,000 eventos por defecto). Los eventos acumulados que superen este limite se descartan en conjunto despues del envio
-   de la notificacion y no se trasladan a las ejecuciones posteriores. En entornos donde se genera una gran cantidad de
-   registros en poco tiempo, aumente ``log.notification.search.size`` segun sea necesario.
+   El número de eventos procesados en una sola ejecución del trabajo tiene como límite ``log.notification.search.size``
+   (1,000 eventos por defecto). Los eventos acumulados que superen este límite se descartan en conjunto después del envío
+   de la notificación y no se trasladan a las ejecuciones posteriores. En entornos donde se genera una gran cantidad de
+   registros en poco tiempo, aumente ``log.notification.search.size`` según sea necesario.
 
-Resolucion de Problemas
+Resolución de Problemas
 =======================
 
-Las Notificaciones no se Envian
+Las Notificaciones no se Envían
 -------------------------------
 
-1. **Verificar la habilitacion**
+1. **Verificar la habilitación**
 
-   Verifique que "Log Notification" este habilitada en la configuracion "General" de la pantalla de administracion.
+   Verifique que "Log Notification" esté habilitada en la configuración "General" de la pantalla de administración.
 
-2. **Verificar el destino de notificacion**
+2. **Verificar el destino de notificación**
 
-   Verifique que se haya configurado al menos un destino de notificacion ("Correo de notificacion",
-   "Slack Webhook URLs" o "Google Chat Webhook URLs"). Si ninguno esta configurado, el trabajo
-   genera ``No notification targets configured.`` y no envia nada.
+   Verifique que se haya configurado al menos un destino de notificación ("Correo de notificación",
+   "Slack Webhook URLs" o "Google Chat Webhook URLs"). Si ninguno está configurado, el trabajo
+   genera ``No notification targets configured.`` y no envía nada.
 
-3. **Verificar la configuracion del servidor de correo**
+3. **Verificar la configuración del servidor de correo**
 
-   Si utiliza la notificacion por correo electronico, verifique que el servidor de correo este
+   Si utiliza la notificación por correo electrónico, verifique que el servidor de correo esté
    configurado correctamente en ``fess_env.properties``.
 
 4. **Verificar el trabajo programado**
 
-   Verifique que el trabajo "Log Notification" este habilitado en "Sistema" -> "Programador".
-   Si este trabajo esta deshabilitado, no se enviaran notificaciones.
+   Verifique que el trabajo "Log Notification" esté habilitado en "Sistema" -> "Programador".
+   Si este trabajo está deshabilitado, no se enviarán notificaciones.
 
 5. **Verificar los registros**
 
-   Verifique los mensajes de error relacionados con la notificacion en ``fess.log``.
+   Verifique los mensajes de error relacionados con la notificación en ``fess.log``.
 
    ::
 
@@ -274,23 +274,23 @@ Se Reciben Demasiadas Notificaciones
 
 1. **Elevar el nivel de registro**
 
-   Cambie el nivel de notificacion de ``WARN`` a ``ERROR``.
+   Cambie el nivel de notificación de ``WARN`` a ``ERROR``.
 
-2. **Resolver la causa raiz**
+2. **Resolver la causa raíz**
 
-   Si se producen errores con frecuencia, investigue la causa raiz de los errores.
+   Si se producen errores con frecuencia, investigue la causa raíz de los errores.
 
-El Contenido de la Notificacion se Trunca
+El Contenido de la Notificación se Trunca
 -----------------------------------------
 
 Ajuste las siguientes propiedades.
 
-- ``log.notification.max.details.length``: Numero maximo de caracteres en la seccion de detalles
-- ``log.notification.max.display.events``: Numero maximo de eventos a mostrar
-- ``log.notification.max.message.length``: Numero maximo de caracteres por mensaje
+- ``log.notification.max.details.length``: Número máximo de caracteres en la sección de detalles
+- ``log.notification.max.display.events``: Número máximo de eventos a mostrar
+- ``log.notification.max.message.length``: Número máximo de caracteres por mensaje
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`admin-logging` - Configuracion de registros
-- :doc:`setup-memory` - Configuracion de memoria
+- :doc:`admin-logging` - Configuración de registros
+- :doc:`setup-memory` - Configuración de memoria

--- a/es/15.8/config/datastore/ds-atlassian.rst
+++ b/es/15.8/config/datastore/ds-atlassian.rst
@@ -2,11 +2,11 @@
 Conector de Atlassian
 ==================================
 
-Descripcion General
+Descripción General
 ===================
 
 El conector de Atlassian proporciona funcionalidad para obtener datos de productos Atlassian
-(Jira, Confluence) y registrarlos en el indice de |Fess|.
+(Jira, Confluence) y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-atlassian``.
 
@@ -19,25 +19,25 @@ Productos Compatibles
 Requisitos Previos
 ==================
 
-1. Se requiere instalacion del plugin
-2. Se requieren credenciales de autenticacion apropiadas para productos Atlassian
-3. Para la version Cloud, se puede usar OAuth 2.0; para Server, OAuth 1.0a o autenticacion basica
+1. Se requiere instalación del plugin
+2. Se requieren credenciales de autenticación apropiadas para productos Atlassian
+3. Para la versión Cloud, se puede usar OAuth 2.0; para Server, OAuth 1.0a o autenticación básica
 
-Instalacion del Plugin
+Instalación del Plugin
 ----------------------
 
-Instale desde la consola de administracion en "Sistema" -> "Plugins":
+Instale desde la consola de administración en "Sistema" -> "Plugins":
 
 1. Descargue ``fess-ds-atlassian-X.X.X.jar`` de Maven Central
-2. Cargue e instale desde la pantalla de administracion de plugins
+2. Cargue e instale desde la pantalla de administración de plugins
 3. Reinicie |Fess|
 
-Metodo de Configuracion
+Método de Configuración
 =======================
 
-Configure desde la consola de administracion en "Rastreador" -> "Almacen de Datos" -> "Crear Nuevo".
+Configure desde la consola de administración en "Rastreador" -> "Almacén de Datos" -> "Crear Nuevo".
 
-Configuracion Basica
+Configuración Básica
 --------------------
 
 .. list-table::
@@ -45,7 +45,7 @@ Configuracion Basica
    :widths: 25 75
 
    * - Elemento
-     - Ejemplo de Configuracion
+     - Ejemplo de Configuración
    * - Nombre
      - Company Jira/Confluence
    * - Nombre del Manejador
@@ -53,10 +53,10 @@ Configuracion Basica
    * - Habilitado
      - Activado
 
-Configuracion de Parametros
+Configuración de Parámetros
 ---------------------------
 
-Ejemplo version Cloud (OAuth 2.0):
+Ejemplo versión Cloud (OAuth 2.0):
 
 ::
 
@@ -68,7 +68,7 @@ Ejemplo version Cloud (OAuth 2.0):
     oauth2.access_token=your_access_token
     oauth2.refresh_token=your_refresh_token
 
-Ejemplo version Server (Autenticacion Basica):
+Ejemplo versión Server (Autenticación Básica):
 
 ::
 
@@ -78,7 +78,7 @@ Ejemplo version Server (Autenticacion Basica):
     basic.username=admin
     basic.password=your_password
 
-Ejemplo version Server (OAuth 1.0a):
+Ejemplo versión Server (OAuth 1.0a):
 
 ::
 
@@ -90,25 +90,25 @@ Ejemplo version Server (OAuth 1.0a):
     oauth.secret=verification_code
     oauth.access_token=your_access_token
 
-Lista de Parametros
+Lista de Parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``home``
-     - Si
+     - Sí
      - URL de la instancia de Atlassian
    * - ``is_cloud``
      - No
-     - ``true`` para Cloud, ``false`` para Server (predeterminado: ``true``). Solo se utiliza para la seleccion del endpoint durante la autenticacion OAuth 2.0; se ignora en la autenticacion Basica y OAuth 1.0a.
+     - ``true`` para Cloud, ``false`` para Server (predeterminado: ``true``). Solo se utiliza para la selección del endpoint durante la autenticación OAuth 2.0; se ignora en la autenticación Básica y OAuth 1.0a.
    * - ``auth_type``
-     - Si
-     - Tipo de autenticacion: ``oauth``, ``oauth2``, ``basic``
+     - Sí
+     - Tipo de autenticación: ``oauth``, ``oauth2``, ``basic``
    * - ``oauth.consumer_key``
      - Para OAuth 1.0a
      - Clave del consumidor (normalmente ``OauthKey``)
@@ -117,7 +117,7 @@ Lista de Parametros
      - Clave privada RSA (formato PEM)
    * - ``oauth.secret``
      - Para OAuth 1.0a
-     - Codigo de verificacion
+     - Código de verificación
    * - ``oauth.access_token``
      - Para OAuth 1.0a
      - Token de acceso
@@ -132,46 +132,46 @@ Lista de Parametros
      - Token de acceso
    * - ``oauth2.refresh_token``
      - No
-     - Token de actualizacion (OAuth 2.0)
+     - Token de actualización (OAuth 2.0)
    * - ``oauth2.token_url``
      - No
      - URL del token (OAuth 2.0, predeterminado: ``https://auth.atlassian.com/oauth/token``)
    * - ``basic.username``
-     - Para autenticacion basica
+     - Para autenticación básica
      - Nombre de usuario
    * - ``basic.password``
-     - Para autenticacion basica
-     - Contrasena
+     - Para autenticación básica
+     - Contraseña
    * - ``issue.jql``
      - No
-     - JQL (solo Jira, condiciones de busqueda avanzadas). Si no se especifica, se procesan todas las incidencias (``created is not empty``).
+     - JQL (solo Jira, condiciones de búsqueda avanzadas). Si no se especifica, se procesan todas las incidencias (``created is not empty``).
    * - ``issue_max_results``
      - No
-     - Resultados maximos por solicitud de API de Jira (predeterminado: ``50``, solo Jira)
+     - Resultados máximos por solicitud de API de Jira (predeterminado: ``50``, solo Jira)
    * - ``content_limit``
      - No
-     - Elementos maximos por solicitud de API de Confluence (predeterminado: ``25``, solo Confluence)
+     - Elementos máximos por solicitud de API de Confluence (predeterminado: ``25``, solo Confluence)
    * - ``ignore_error``
      - No
      - Continuar procesamiento en caso de error (predeterminado: ``true``)
    * - ``include_pattern``
      - No
-     - Patron de inclusion de URL (regex)
+     - Patrón de inclusión de URL (regex)
    * - ``exclude_pattern``
      - No
-     - Patron de exclusion de URL (regex)
+     - Patrón de exclusión de URL (regex)
    * - ``number_of_threads``
      - No
-     - Numero de hilos para procesamiento paralelo (predeterminado: ``1``)
+     - Número de hilos para procesamiento paralelo (predeterminado: ``1``)
    * - ``proxy_host``
      - No
      - Nombre de host del proxy HTTP
    * - ``proxy_port``
      - No
-     - Numero de puerto del proxy HTTP
+     - Número de puerto del proxy HTTP
    * - ``connection_timeout``
      - No
-     - Tiempo de espera de conexion HTTP (milisegundos)
+     - Tiempo de espera de conexión HTTP (milisegundos)
    * - ``read_timeout``
      - No
      - Tiempo de espera de lectura HTTP (milisegundos)
@@ -179,7 +179,7 @@ Lista de Parametros
      - No
      - Intervalo entre el procesamiento de cada documento (en milisegundos, predeterminado: ``0``)
 
-Configuracion de Script
+Configuración de Script
 -----------------------
 
 Para Jira
@@ -196,9 +196,9 @@ Campos disponibles:
 
 - ``issue.view_url`` - URL de la incidencia
 - ``issue.summary`` - Resumen de la incidencia
-- ``issue.description`` - Descripcion de la incidencia
+- ``issue.description`` - Descripción de la incidencia
 - ``issue.comments`` - Comentarios de la incidencia
-- ``issue.last_modified`` - Fecha de ultima modificacion
+- ``issue.last_modified`` - Fecha de última modificación
 
 Para Confluence
 ~~~~~~~~~~~~~~~
@@ -212,34 +212,34 @@ Para Confluence
 
 Campos disponibles:
 
-- ``content.view_url`` - URL de la pagina
-- ``content.title`` - Titulo de la pagina
-- ``content.body`` - Cuerpo de la pagina
-- ``content.comments`` - Comentarios de la pagina
-- ``content.last_modified`` - Fecha de ultima modificacion
+- ``content.view_url`` - URL de la página
+- ``content.title`` - Título de la página
+- ``content.body`` - Cuerpo de la página
+- ``content.comments`` - Comentarios de la página
+- ``content.last_modified`` - Fecha de última modificación
 
 .. note::
-   El conector de Confluence recupera tanto paginas regulares (page) como entradas de blog (blogpost).
+   El conector de Confluence recupera tanto páginas regulares (page) como entradas de blog (blogpost).
 
-Configuracion de Autenticacion OAuth 2.0
+Configuración de Autenticación OAuth 2.0
 ========================================
 
-Para la Version Cloud (Recomendado)
+Para la Versión Cloud (Recomendado)
 -----------------------------------
 
-1. Cree una aplicacion en Atlassian Developer Console
+1. Cree una aplicación en Atlassian Developer Console
 2. Obtenga credenciales de OAuth 2.0
 3. Configure los alcances requeridos:
 
    - Jira: ``read:jira-work``, ``read:jira-user``
    - Confluence: ``read:confluence-content.all``, ``read:confluence-user``
 
-4. Obtenga tokens de acceso y actualizacion
+4. Obtenga tokens de acceso y actualización
 
-Configuracion de Autenticacion OAuth 1.0a
+Configuración de Autenticación OAuth 1.0a
 =========================================
 
-Para la Version Server
+Para la Versión Server
 ----------------------
 
 1. Cree un Application Link en Jira o Confluence
@@ -250,31 +250,31 @@ Para la Version Server
        openssl genrsa -out private_key.pem 2048
        openssl rsa -in private_key.pem -pubout -out public_key.pem
 
-3. Registre la clave publica en el Application Link
-4. Configure la clave privada en los parametros
+3. Registre la clave pública en el Application Link
+4. Configure la clave privada en los parámetros
 
-Configuracion de Autenticacion Basica
+Configuración de Autenticación Básica
 =====================================
 
-Configuracion Simple para Version Server
+Configuración Simple para Versión Server
 ----------------------------------------
 
 .. warning::
-   La autenticacion basica no se recomienda por razones de seguridad. Use autenticacion OAuth siempre que sea posible.
+   La autenticación básica no se recomienda por razones de seguridad. Use autenticación OAuth siempre que sea posible.
 
-Al usar autenticacion basica:
+Al usar autenticación básica:
 
 1. Prepare una cuenta de usuario con permisos de administrador
-2. Configure el nombre de usuario y contrasena en los parametros
-3. Asegure una conexion segura usando HTTPS
+2. Configure el nombre de usuario y contraseña en los parámetros
+3. Asegure una conexión segura usando HTTPS
 
-Busqueda Avanzada con JQL
+Búsqueda Avanzada con JQL
 =========================
 
 Filtrar Incidencias de Jira con JQL
 -----------------------------------
 
-Rastree solo incidencias que coincidan con condiciones especificas:
+Rastree solo incidencias que coincidan con condiciones específicas:
 
 ::
 
@@ -290,7 +290,7 @@ Rastree solo incidencias que coincidan con condiciones especificas:
     # Combinacion de multiples condiciones
     issue.jql=project IN ("PROJ1", "PROJ2") AND updated >= -90d AND status != "Done"
 
-Para mas detalles sobre JQL, consulte la `Documentacion JQL de Atlassian <https://confluence.atlassian.com/jirasoftwarecloud/advanced-searching-764478330.html>`_.
+Para más detalles sobre JQL, consulte la `Documentación JQL de Atlassian <https://confluence.atlassian.com/jirasoftwarecloud/advanced-searching-764478330.html>`_.
 
 Ejemplos de Uso
 ===============
@@ -298,7 +298,7 @@ Ejemplos de Uso
 Rastreo de Jira Cloud
 ---------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -323,7 +323,7 @@ Script:
 Rastreo de Confluence Server
 ----------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -343,64 +343,64 @@ Script:
     last_modified=content.last_modified
     digest=content.title
 
-Solucion de Problemas
+Solución de Problemas
 =====================
 
-Errores de Autenticacion
+Errores de Autenticación
 ------------------------
 
-**Sintoma**: ``401 Unauthorized`` o ``403 Forbidden``
+**Síntoma**: ``401 Unauthorized`` o ``403 Forbidden``
 
 **Verifique**:
 
-1. Verifique que las credenciales de autenticacion sean correctas
-2. Para la version Cloud, verifique que los alcances apropiados esten configurados
-3. Para la version Server, verifique que el usuario tenga los permisos apropiados
-4. Para OAuth 2.0, verifique la expiracion del token
+1. Verifique que las credenciales de autenticación sean correctas
+2. Para la versión Cloud, verifique que los alcances apropiados estén configurados
+3. Para la versión Server, verifique que el usuario tenga los permisos apropiados
+4. Para OAuth 2.0, verifique la expiración del token
 
-Errores de Conexion
+Errores de Conexión
 -------------------
 
-**Sintoma**: ``Connection refused`` o tiempo de espera de conexion
+**Síntoma**: ``Connection refused`` o tiempo de espera de conexión
 
 **Verifique**:
 
 1. Verifique que la URL ``home`` sea correcta
-2. Verifique la configuracion del firewall
-3. Verifique que la instancia de Atlassian este en ejecucion
-4. Verifique que el parametro ``is_cloud`` este configurado correctamente
+2. Verifique la configuración del firewall
+3. Verifique que la instancia de Atlassian esté en ejecución
+4. Verifique que el parámetro ``is_cloud`` esté configurado correctamente
 
 No Se Pueden Obtener Datos
 --------------------------
 
-**Sintoma**: El rastreo tiene exito pero hay 0 documentos
+**Síntoma**: El rastreo tiene éxito pero hay 0 documentos
 
 **Verifique**:
 
-1. Verifique que JQL no este filtrando demasiado
+1. Verifique que JQL no esté filtrando demasiado
 2. Verifique que el usuario tenga permisos de lectura en los proyectos/espacios
-3. Verifique la configuracion del script
+3. Verifique la configuración del script
 4. Revise los logs en busca de errores
 
-Actualizacion de Token OAuth 2.0
+Actualización de Token OAuth 2.0
 --------------------------------
 
-**Sintoma**: Ocurren errores de autenticacion despues de un tiempo
+**Síntoma**: Ocurren errores de autenticación después de un tiempo
 
-**Solucion**:
+**Solución**:
 
-Los tokens de acceso OAuth 2.0 tienen fechas de expiracion. Configure el token de actualizacion para permitir la renovacion automatica:
+Los tokens de acceso OAuth 2.0 tienen fechas de expiración. Configure el token de actualización para permitir la renovación automática:
 
 ::
 
     oauth2.refresh_token=your_refresh_token
 
-Cuando los tokens se renuevan, el nuevo token de acceso y el token de actualizacion se guardan automaticamente en la configuracion del almacen de datos, por lo que los rastreos posteriores utilizan los tokens actualizados sin necesidad de actualizarlos manualmente.
+Cuando los tokens se renuevan, el nuevo token de acceso y el token de actualización se guardan automáticamente en la configuración del almacén de datos, por lo que los rastreos posteriores utilizan los tokens actualizados sin necesidad de actualizarlos manualmente.
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`ds-overview` - Descripcion General de Conectores de Almacen de Datos
+- :doc:`ds-overview` - Descripción General de Conectores de Almacén de Datos
 - :doc:`ds-database` - Conector de Base de Datos
-- :doc:`../../admin/dataconfig-guide` - Guia de Configuracion de Almacen de Datos
+- :doc:`../../admin/dataconfig-guide` - Guía de Configuración de Almacén de Datos
 - `Atlassian Developer <https://developer.atlassian.com/>`_

--- a/es/15.8/config/datastore/ds-box.rst
+++ b/es/15.8/config/datastore/ds-box.rst
@@ -2,30 +2,30 @@
 Conector de Box
 ===========================
 
-Descripcion general
+Descripción general
 ===================
 
 El conector de Box proporciona la funcionalidad de obtener archivos del almacenamiento
-en la nube Box.com y registrarlos en el indice de |Fess|.
+en la nube Box.com y registrarlos en el índice de |Fess|.
 
 Este conector se conecta a la empresa mediante JWT (Server Authentication) y rastreo
 recursivo de los archivos accesibles para cada usuario de la empresa suplantando su
 identidad (impersonation). Los usuarios a rastrear pueden acotarse mediante el
-parametro ``filter_term``.
+parámetro ``filter_term``.
 
 Esta funcionalidad requiere el plugin ``fess-ds-box``.
 
 Requisitos previos
 ==================
 
-1. Se requiere la instalacion del plugin
-2. Se requiere una cuenta de desarrollador de Box y la creacion de una aplicacion
-3. Se requiere la configuracion de autenticacion JWT (JSON Web Token)
+1. Se requiere la instalación del plugin
+2. Se requiere una cuenta de desarrollador de Box y la creación de una aplicación
+3. Se requiere la configuración de autenticación JWT (JSON Web Token)
 
-Instalacion del plugin
+Instalación del plugin
 ----------------------
 
-Metodo 1: Colocar el archivo JAR directamente
+Método 1: Colocar el archivo JAR directamente
 
 ::
 
@@ -37,18 +37,18 @@ Metodo 1: Colocar el archivo JAR directamente
     # o
     cp fess-ds-box-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Metodo 2: Instalar desde la consola de administracion
+Método 2: Instalar desde la consola de administración
 
 1. Abra "Sistema" -> "Plugins"
 2. Cargue el archivo JAR
 3. Reinicie |Fess|
 
-Metodo de configuracion
+Método de configuración
 =======================
 
-Configure desde la consola de administracion en "Rastreador" -> "Almacen de datos" -> "Crear nuevo".
+Configure desde la consola de administración en "Rastreador" -> "Almacén de datos" -> "Crear nuevo".
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -56,7 +56,7 @@ Configuracion basica
    :widths: 25 75
 
    * - Elemento
-     - Ejemplo de configuracion
+     - Ejemplo de configuración
    * - Nombre
      - Company Box Storage
    * - Nombre del manejador
@@ -64,10 +64,10 @@ Configuracion basica
    * - Habilitado
      - Activado
 
-Configuracion de parametros
+Configuración de parámetros
 ----------------------------
 
-Ejemplo de autenticacion JWT:
+Ejemplo de autenticación JWT:
 
 ::
 
@@ -78,103 +78,103 @@ Ejemplo de autenticacion JWT:
     passphrase=7ba8sd9f7a9sd8f7a9sd8f7a9sd8f
     enterprise_id=1923456
 
-Lista de parametros
+Lista de parámetros
 ~~~~~~~~~~~~~~~~~~~
 
-Parametros de autenticacion (obligatorios)
+Parámetros de autenticación (obligatorios)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``client_id``
-     - Si
-     - ID de cliente de la aplicacion Box
+     - Sí
+     - ID de cliente de la aplicación Box
    * - ``client_secret``
-     - Si
-     - Secreto de cliente de la aplicacion Box
+     - Sí
+     - Secreto de cliente de la aplicación Box
    * - ``public_key_id``
-     - Si
-     - ID de la clave publica
+     - Sí
+     - ID de la clave pública
    * - ``private_key``
-     - Si
-     - Clave privada (formato PEM, los saltos de linea se representan con ``\n``)
+     - Sí
+     - Clave privada (formato PEM, los saltos de línea se representan con ``\n``)
    * - ``passphrase``
-     - Si
-     - Frase de contrasena de la clave privada
+     - Sí
+     - Frase de contraseña de la clave privada
    * - ``enterprise_id``
-     - Si
+     - Sí
      - ID de empresa de Box
 
-Parametros de rastreo (opcionales)
+Parámetros de rastreo (opcionales)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
    :widths: 25 20 55
 
-   * - Parametro
+   * - Parámetro
      - Valor predeterminado
-     - Descripcion
+     - Descripción
    * - ``max_size``
      - ``10000000``
-     - Tamano maximo de archivo a rastrear (bytes). El valor predeterminado es 10 MB.
+     - Tamaño máximo de archivo a rastrear (bytes). El valor predeterminado es 10 MB.
    * - ``supported_mimetypes``
      - ``.*``
-     - Tipos MIME a rastrear (expresion regular). Se pueden especificar varios separados por comas.
+     - Tipos MIME a rastrear (expresión regular). Se pueden especificar varios separados por comas.
    * - ``include_pattern``
      - (ninguno)
-     - Patron de URL a incluir en el rastreo
+     - Patrón de URL a incluir en el rastreo
    * - ``exclude_pattern``
      - (ninguno)
-     - Patron de URL a excluir del rastreo
+     - Patrón de URL a excluir del rastreo
    * - ``number_of_threads``
      - ``1``
-     - Numero de hilos del proceso de rastreo
+     - Número de hilos del proceso de rastreo
    * - ``ignore_folder``
      - ``true``
-     - Indica si las carpetas deben quedar fuera del indice. En la implementacion actual, las carpetas en si mismas no se indexan (solo los archivos son el objetivo), por lo que este parametro no tiene efecto.
+     - Indica si las carpetas deben quedar fuera del índice. En la implementación actual, las carpetas en sí mismas no se indexan (solo los archivos son el objetivo), por lo que este parámetro no tiene efecto.
    * - ``ignore_error``
      - ``true``
      - Indica si se debe continuar el procesamiento cuando ocurre un error
    * - ``filter_term``
      - (ninguno)
-     - Condicion de filtro para acotar los usuarios de la empresa a rastrear. Si no se especifica, se incluyen todos los usuarios de la empresa.
+     - Condición de filtro para acotar los usuarios de la empresa a rastrear. Si no se específica, se incluyen todos los usuarios de la empresa.
    * - ``fields``
      - (todos los campos)
-     - Especificacion de los campos a obtener desde la API de Box
+     - Especificación de los campos a obtener desde la API de Box
 
-Parametros de conexion (opcionales)
+Parámetros de conexión (opcionales)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
    :widths: 25 20 55
 
-   * - Parametro
+   * - Parámetro
      - Valor predeterminado
-     - Descripcion
+     - Descripción
    * - ``base_url``
      - ``https://app.box.com``
      - URL base para construir la URL de apertura del archivo en el navegador (``file.url``). No afecta a los endpoints de la API utilizados por el SDK de Box.
    * - ``max_retry_count``
      - ``10``
-     - Numero maximo de reintentos de la llamada a la API
+     - Número máximo de reintentos de la llamada a la API
    * - ``proxy_host``
      - (ninguno)
      - Nombre de host del proxy HTTP
    * - ``proxy_port``
      - (ninguno)
-     - Numero de puerto del proxy HTTP
+     - Número de puerto del proxy HTTP
    * - ``refresh_token_interval``
      - ``3540``
      - Intervalo de actualizacion del token (segundos). El valor predeterminado es 59 minutos.
 
-Configuracion de script
+Configuración de script
 -----------------------
 
 ::
@@ -200,7 +200,7 @@ Campos principales
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``file.url``
      - Enlace para abrir el archivo en el navegador
    * - ``file.contents``
@@ -212,19 +212,19 @@ Campos principales
    * - ``file.name``
      - Nombre del archivo
    * - ``file.size``
-     - Tamano del archivo (bytes)
+     - Tamaño del archivo (bytes)
    * - ``file.created_at``
-     - Fecha y hora de creacion
+     - Fecha y hora de creación
    * - ``file.modified_at``
-     - Fecha y hora de ultima modificacion
+     - Fecha y hora de última modificación
    * - ``file.download_url``
      - URL de descarga directa de Box
    * - ``file.id``
      - ID de elemento de Box
    * - ``file.description``
-     - Descripcion del archivo
+     - Descripción del archivo
    * - ``file.extension``
-     - Extension del archivo
+     - Extensión del archivo
    * - ``file.sha1``
      - Hash SHA1 del archivo
    * - ``file.path_collection``
@@ -238,11 +238,11 @@ Campos de metadatos
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``file.type``
      - Tipo de elemento ("file" o "folder")
    * - ``file.file_version``
-     - Informacion de version del archivo
+     - Información de versión del archivo
    * - ``file.sequence_id``
      - ID de secuencia
    * - ``file.etag``
@@ -250,66 +250,66 @@ Campos de metadatos
    * - ``file.trashed_at``
      - Fecha y hora de traslado a la papelera
    * - ``file.purged_at``
-     - Fecha y hora de eliminacion definitiva
+     - Fecha y hora de eliminación definitiva
    * - ``file.content_created_at``
-     - Fecha y hora de creacion del contenido
+     - Fecha y hora de creación del contenido
    * - ``file.content_modified_at``
-     - Fecha y hora de modificacion del contenido
+     - Fecha y hora de modificación del contenido
    * - ``file.created_by``
-     - Informacion del creador
+     - Información del creador
    * - ``file.modified_by``
-     - Informacion del modificador
+     - Información del modificador
    * - ``file.owned_by``
-     - Informacion del propietario
+     - Información del propietario
    * - ``file.shared_link``
-     - Informacion del enlace compartido
+     - Información del enlace compartido
    * - ``file.parent``
-     - Informacion de la carpeta padre
+     - Información de la carpeta padre
    * - ``file.item_status``
      - Estado del elemento
    * - ``file.version_number``
-     - Numero de version
+     - Número de versión
    * - ``file.comment_count``
-     - Numero de comentarios
+     - Número de comentarios
    * - ``file.permissions``
-     - Informacion de permisos
+     - Información de permisos
    * - ``file.tags``
-     - Informacion de etiquetas
+     - Información de etiquetas
    * - ``file.lock``
-     - Informacion de bloqueo
+     - Información de bloqueo
    * - ``file.is_package``
      - Indicador de paquete
    * - ``file.is_watermark``
      - Indicador de marca de agua
    * - ``file.collections``
-     - Informacion de colecciones
+     - Información de colecciones
    * - ``file.representations``
-     - Informacion de representaciones
+     - Información de representaciones
    * - ``file.api``
-     - Objeto BoxFileAPI (para obtener informacion de colaboracion y permisos)
+     - Objeto BoxFileAPI (para obtener información de colaboración y permisos)
 
-Para mas detalles, consulte el `Objeto File de Box <https://developer.box.com/reference#file-object>`_.
+Para más detalles, consulte el `Objeto File de Box <https://developer.box.com/reference#file-object>`_.
 
-Configuracion de autenticacion de Box
+Configuración de autenticación de Box
 ======================================
 
-Pasos de configuracion de autenticacion JWT
+Pasos de configuración de autenticación JWT
 --------------------------------------------
 
-1. Crear una aplicacion en Box Developer Console
+1. Crear una aplicación en Box Developer Console
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Acceda a https://app.box.com/developers/console:
 
 1. Haga clic en "Create New App"
 2. Seleccione "Custom App"
-3. Seleccione "Server Authentication (with JWT)" como metodo de autenticacion
-4. Ingrese el nombre de la aplicacion y cree
+3. Seleccione "Server Authentication (with JWT)" como método de autenticación
+4. Ingrese el nombre de la aplicación y cree
 
-2. Configuracion de la aplicacion
+2. Configuración de la aplicación
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Configure en la pestana "Configuration":
+Configure en la pestaña "Configuration":
 
 **Application Scopes**:
 
@@ -327,15 +327,15 @@ Configure en la pestana "Configuration":
 3. Aprobar en la empresa
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-En la consola de administracion de Box:
+En la consola de administración de Box:
 
 1. Abra "Apps" -> "Custom Apps"
-2. Apruebe la aplicacion creada
+2. Apruebe la aplicación creada
 
-4. Obtener las credenciales de autenticacion
+4. Obtener las credenciales de autenticación
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Obtenga la siguiente informacion del archivo JSON descargado:
+Obtenga la siguiente información del archivo JSON descargado:
 
 ::
 
@@ -355,7 +355,7 @@ Obtenga la siguiente informacion del archivo JSON descargado:
 Formato de la clave privada
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Reemplace los saltos de linea de ``private_key`` con ``\n`` para convertirla en una sola linea:
+Reemplace los saltos de línea de ``private_key`` con ``\n`` para convertirla en una sola línea:
 
 ::
 
@@ -367,7 +367,7 @@ Ejemplos de uso
 Rastrear todo el almacenamiento Box de la empresa
 --------------------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -392,12 +392,12 @@ Script:
     created=file.created_at
     last_modified=file.modified_at
 
-Rastrear solo una carpeta especifica
+Rastrear solo una carpeta específica
 -------------------------------------
 
-Es posible filtrar por ruta de carpeta mediante el parametro ``include_pattern``.
+Es posible filtrar por ruta de carpeta mediante el parámetro ``include_pattern``.
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -426,9 +426,9 @@ Script:
 Rastrear solo archivos PDF
 --------------------------
 
-Es posible filtrar por tipo MIME mediante el parametro ``supported_mimetypes``.
+Es posible filtrar por tipo MIME mediante el parámetro ``supported_mimetypes``.
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -454,30 +454,30 @@ Script:
     created=file.created_at
     last_modified=file.modified_at
 
-Solucion de problemas
+Solución de problemas
 =====================
 
-Errores de autenticacion
+Errores de autenticación
 ------------------------
 
-**Sintoma**: ``Authentication failed`` o ``Invalid grant``
+**Síntoma**: ``Authentication failed`` o ``Invalid grant``
 
 **Verifique**:
 
 1. Verifique que ``client_id`` y ``client_secret`` sean correctos
-2. Verifique que la clave privada se haya copiado correctamente (los saltos de linea esten como ``\n``)
-3. Verifique que la frase de contrasena sea correcta
-4. Verifique que la aplicacion este aprobada en la consola de administracion de Box
+2. Verifique que la clave privada se haya copiado correctamente (los saltos de línea estén como ``\n``)
+3. Verifique que la frase de contraseña sea correcta
+4. Verifique que la aplicación esté aprobada en la consola de administración de Box
 5. Verifique que ``enterprise_id`` sea correcto
 
 Error de formato de clave privada
 ----------------------------------
 
-**Sintoma**: ``Invalid private key format``
+**Síntoma**: ``Invalid private key format``
 
-**Solucion**:
+**Solución**:
 
-Verifique que los saltos de linea de la clave privada esten correctamente convertidos a ``\n``:
+Verifique que los saltos de línea de la clave privada estén correctamente convertidos a ``\n``:
 
 ::
 
@@ -492,38 +492,38 @@ Verifique que los saltos de linea de la clave privada esten correctamente conver
 No se pueden obtener archivos
 ------------------------------
 
-**Sintoma**: El rastreo finaliza con exito pero hay 0 archivos
+**Síntoma**: El rastreo finaliza con éxito pero hay 0 archivos
 
 **Verifique**:
 
-1. Verifique que "Read all files and folders" este habilitado en Application Scopes
+1. Verifique que "Read all files and folders" esté habilitado en Application Scopes
 2. Verifique que App Access Level sea "App + Enterprise Access"
 3. Verifique que realmente existan archivos en el almacenamiento de Box
 4. Verifique que la cuenta de servicio tenga los permisos apropiados
 
-Cuando hay un gran numero de archivos
+Cuando hay un gran número de archivos
 --------------------------------------
 
-**Sintoma**: El rastreo tarda mucho tiempo o se agota el tiempo de espera
+**Síntoma**: El rastreo tarda mucho tiempo o se agota el tiempo de espera
 
-**Solucion**:
+**Solución**:
 
-Divida el procesamiento en la configuracion del almacen de datos:
+Divida el procesamiento en la configuración del almacén de datos:
 
 1. Ajuste el intervalo de rastreo
-2. Configure multiples almacenes de datos (por unidad de carpeta, etc.)
-3. Aumente el numero de hilos con el parametro ``number_of_threads``
-4. Distribuya la carga con la configuracion de programacion
+2. Configure múltiples almacenes de datos (por unidad de carpeta, etc.)
+3. Aumente el número de hilos con el parámetro ``number_of_threads``
+4. Distribuya la carga con la configuración de programación
 
 Permisos y control de acceso
 =============================
 
-Reflejar los permisos de colaboracion de Box
+Reflejar los permisos de colaboración de Box
 ---------------------------------------------
 
 Mediante el objeto ``BoxFileAPI`` proporcionado por el campo ``file.api``, es posible
-asignar la informacion de colaboracion de Box a los roles de busqueda de |Fess|.
-``file.api.collaborationRoles`` devuelve una lista de roles de busqueda correspondientes
+asignar la información de colaboración de Box a los roles de búsqueda de |Fess|.
+``file.api.collaborationRoles`` devuelve una lista de roles de búsqueda correspondientes
 a los usuarios y grupos que tienen acceso al archivo.
 
 Establecer los permisos en el script:
@@ -540,22 +540,22 @@ Establecer los permisos en el script:
     last_modified=file.modified_at
 
 .. note::
-   ``file.api.collaborationRoles`` obtiene la informacion de colaboracion de cada archivo,
-   lo que incrementa el numero de llamadas a la API de Box y puede hacer que el rastreo
-   tarde mas tiempo.
+   ``file.api.collaborationRoles`` obtiene la información de colaboración de cada archivo,
+   lo que incrementa el número de llamadas a la API de Box y puede hacer que el rastreo
+   tarde más tiempo.
 
-Para asignar un rol fijo a todos los archivos, especifiquelo de la siguiente manera:
+Para asignar un rol fijo a todos los archivos, especifíquelo de la siguiente manera:
 
 ::
 
     role="{role}box-users"
 
-Informacion de referencia
+Información de referencia
 ==========================
 
-- :doc:`ds-overview` - Descripcion general de conectores de almacen de datos
+- :doc:`ds-overview` - Descripción general de conectores de almacén de datos
 - :doc:`ds-dropbox` - Conector de Dropbox
 - :doc:`ds-gsuite` - Conector de Google Workspace
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de almacen de datos
-- `Documentacion para desarrolladores de Box <https://developer.box.com/>`_
-- `Autenticacion de Box Platform <https://developer.box.com/guides/authentication/>`_
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de almacén de datos
+- `Documentación para desarrolladores de Box <https://developer.box.com/>`_
+- `Autenticación de Box Platform <https://developer.box.com/guides/authentication/>`_

--- a/es/15.8/config/datastore/ds-csv.rst
+++ b/es/15.8/config/datastore/ds-csv.rst
@@ -2,11 +2,11 @@
 Conector CSV
 ==================================
 
-Descripcion general
+Descripción general
 ===================
 
 El conector CSV proporciona la funcionalidad para obtener datos de archivos CSV
-y registrarlos en el indice de |Fess|.
+y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-csv``.
 
@@ -15,12 +15,12 @@ Requisitos previos
 
 1. Es necesario instalar el plugin
 2. Se requiere acceso a los archivos CSV
-3. Es necesario conocer la codificacion de caracteres del archivo CSV
+3. Es necesario conocer la codificación de caracteres del archivo CSV
 
-Instalacion del plugin
+Instalación del plugin
 ----------------------
 
-Metodo 1: Colocar el archivo JAR directamente
+Método 1: Colocar el archivo JAR directamente
 
 ::
 
@@ -32,18 +32,18 @@ Metodo 1: Colocar el archivo JAR directamente
     # o
     cp fess-ds-csv-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Metodo 2: Instalar desde la pantalla de administracion
+Método 2: Instalar desde la pantalla de administración
 
 1. Abrir "Sistema" -> "Plugins"
 2. Subir el archivo JAR
 3. Reiniciar |Fess|
 
-Configuracion
+Configuración
 =============
 
-Configure desde la pantalla de administracion en "Crawler" -> "Data Store" -> "Crear nuevo".
+Configure desde la pantalla de administración en "Crawler" -> "Data Store" -> "Crear nuevo".
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -59,7 +59,7 @@ Configuracion basica
    * - Habilitado
      - Activado
 
-Configuracion de parametros
+Configuración de parámetros
 ---------------------------
 
 Archivo local:
@@ -73,7 +73,7 @@ Archivo local:
     quote_character="
     quote_disabled=false
 
-Multiples archivos:
+Múltiples archivos:
 
 ::
 
@@ -86,70 +86,70 @@ Multiples archivos:
 
 .. note::
 
-   El procesamiento de comillas (quote) y el procesamiento de escape estan **deshabilitados** por defecto.
-   Si desea manejar CSV con caracteres separadores o saltos de linea dentro de campos entrecomillados
-   (compatible con RFC 4180), especifique explicitamente ``quote_disabled=false`` para habilitar
+   El procesamiento de comillas (quote) y el procesamiento de escape están **deshabilitados** por defecto.
+   Si desea manejar CSV con caracteres separadores o saltos de línea dentro de campos entrecomillados
+   (compatible con RFC 4180), especifique explícitamente ``quote_disabled=false`` para habilitar
    el procesamiento de comillas.
-   Consulte la seccion "Habilitacion del procesamiento de comillas y escape" mas adelante para mas detalles.
+   Consulte la sección "Habilitación del procesamiento de comillas y escape" más adelante para más detalles.
 
-Lista de parametros
+Lista de parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``files``
      - No
-     - Ruta del archivo CSV (ruta local, multiples rutas separadas por comas). Se requiere especificar ``files`` o ``directories``. Si se especifican ambos, ``files`` tiene prioridad. Los archivos deben tener extension ``.csv`` o ``.tsv``; los archivos con otras extensiones son omitidos.
+     - Ruta del archivo CSV (ruta local, múltiples rutas separadas por comas). Se requiere especificar ``files`` o ``directories``. Si se especifican ambos, ``files`` tiene prioridad. Los archivos deben tener extensión ``.csv`` o ``.tsv``; los archivos con otras extensiones son omitidos.
    * - ``directories``
      - No
-     - Ruta del directorio que contiene archivos CSV (multiples rutas separadas por comas). Solo se procesan los archivos ``.csv`` y ``.tsv`` dentro del directorio. Se utiliza cuando no se especifica ``files``.
+     - Ruta del directorio que contiene archivos CSV (múltiples rutas separadas por comas). Solo se procesan los archivos ``.csv`` y ``.tsv`` dentro del directorio. Se utiliza cuando no se especifica ``files``.
    * - ``file_encoding``
      - No
-     - Codificacion de caracteres (predeterminado: UTF-8)
+     - Codificación de caracteres (predeterminado: UTF-8)
    * - ``has_header_line``
      - No
      - Si tiene fila de encabezado (predeterminado: false)
    * - ``separator_character``
      - No
-     - Caracter separador (predeterminado: coma ``,``). Se pueden especificar secuencias de escape como ``\t`` (separador de tabulador).
+     - Carácter separador (predeterminado: coma ``,``). Se pueden especificar secuencias de escape como ``\t`` (separador de tabulador).
    * - ``quote_character``
      - No
-     - Caracter de comillas (predeterminado: comillas dobles ``"``). Sin embargo, el procesamiento de comillas esta deshabilitado por defecto (consulte ``quote_disabled``).
+     - Carácter de comillas (predeterminado: comillas dobles ``"``). Sin embargo, el procesamiento de comillas está deshabilitado por defecto (consulte ``quote_disabled``).
    * - ``escape_character``
      - No
-     - Caracter de escape (predeterminado: barra invertida ``\``). Sin embargo, el procesamiento de escape esta deshabilitado por defecto (consulte ``escape_disabled``).
+     - Carácter de escape (predeterminado: barra invertida ``\``). Sin embargo, el procesamiento de escape está deshabilitado por defecto (consulte ``escape_disabled``).
 
 .. note::
 
-   Si tanto ``files`` como ``directories`` estan vacios, se producira un error (``DataStoreException``).
+   Si tanto ``files`` como ``directories`` están vacíos, se producirá un error (``DataStoreException``).
    Debe especificar al menos uno de los dos.
 
-Parametros avanzados
+Parámetros avanzados
 ~~~~~~~~~~~~~~~~~~~~
 
-Los siguientes parametros controlan de forma detallada el comportamiento del analisis del CSV:
+Los siguientes parámetros controlan de forma detallada el comportamiento del análisis del CSV:
 
 .. list-table::
    :header-rows: 1
    :widths: 30 70
 
-   * - Parametro
-     - Descripcion
+   * - Parámetro
+     - Descripción
    * - ``quote_disabled``
      - Si deshabilitar el procesamiento de comillas (predeterminado: true). Especifique ``false`` para manejar campos entrecomillados compatibles con RFC 4180.
    * - ``escape_disabled``
      - Si deshabilitar el procesamiento de escape (predeterminado: true). Especifique ``false`` para habilitar el escape mediante ``escape_character``.
    * - ``skip_lines``
-     - Numero de lineas iniciales a omitir (predeterminado: 0)
+     - Número de líneas iniciales a omitir (predeterminado: 0)
    * - ``ignore_line_patterns``
-     - Patron de expresion regular para ignorar lineas (por ejemplo: ``^#.*`` para ignorar lineas de comentario)
+     - Patrón de expresión regular para ignorar líneas (por ejemplo: ``^#.*`` para ignorar líneas de comentario)
    * - ``ignore_empty_lines``
-     - Si ignorar las lineas vacias (predeterminado: false)
+     - Si ignorar las líneas vacías (predeterminado: false)
    * - ``ignore_trailing_whitespaces``
      - Si ignorar los espacios en blanco al final (predeterminado: false)
    * - ``ignore_leading_whitespaces``
@@ -157,16 +157,16 @@ Los siguientes parametros controlan de forma detallada el comportamiento del ana
    * - ``null_string``
      - Cadena que se trata como valor nulo
    * - ``break_string``
-     - Cadena que reemplaza los saltos de linea dentro de los valores de campo
+     - Cadena que reemplaza los saltos de línea dentro de los valores de campo
    * - ``readInterval``
      - Tiempo de espera por cada registro procesado (milisegundos) (predeterminado: 0)
 
-Configuracion de scripts
+Configuración de scripts
 ------------------------
 
 Los valores de cada campo se construyen referenciando los valores de cada columna del CSV. Las columnas
 del CSV pueden referenciarse directamente en el script como **variables sin prefijo**
-(no se usa ningun prefijo como ``data.``).
+(no se usa ningún prefijo como ``data.``).
 
 Con encabezado (referenciando por nombre de columna):
 
@@ -178,7 +178,7 @@ Con encabezado (referenciando por nombre de columna):
     digest=category
     price=price
 
-Sin encabezado (referenciando por indice de columna):
+Sin encabezado (referenciando por índice de columna):
 
 ::
 
@@ -190,20 +190,20 @@ Sin encabezado (referenciando por indice de columna):
 Campos disponibles
 ~~~~~~~~~~~~~~~~~~
 
-- ``<nombre_columna>`` - Referencia directa por nombre de columna del encabezado (solo cuando ``has_header_line=true`` y el nombre de columna no esta en blanco)
-- ``cell<N>`` - Referencia por indice de columna (empezando desde 1: ``cell1``, ``cell2``...; disponible independientemente de si hay encabezado)
-- ``csvfile`` - Ruta completa del archivo CSV que se esta procesando
-- ``csvfilename`` - Nombre del archivo CSV que se esta procesando
+- ``<nombre_columna>`` - Referencia directa por nombre de columna del encabezado (solo cuando ``has_header_line=true`` y el nombre de columna no está en blanco)
+- ``cell<N>`` - Referencia por índice de columna (empezando desde 1: ``cell1``, ``cell2``...; disponible independientemente de si hay encabezado)
+- ``csvfile`` - Ruta completa del archivo CSV que se está procesando
+- ``csvfilename`` - Nombre del archivo CSV que se está procesando
 
 .. note::
 
-   Si el nombre de columna contiene caracteres invalidos como identificadores de Groovy (espacios,
+   Si el nombre de columna contiene caracteres inválidos como identificadores de Groovy (espacios,
    guiones, etc.), no se puede referenciar por nombre de columna. En ese caso, use ``cell<N>``.
 
 Detalles del formato CSV
 =========================
 
-CSV estandar (compatible con RFC 4180)
+CSV estándar (compatible con RFC 4180)
 ---------------------------------------
 
 ::
@@ -215,16 +215,16 @@ CSV estandar (compatible con RFC 4180)
 
 .. note::
 
-   Para incluir el caracter separador dentro de un campo entrecomillado como ``"Book, Programming"``
+   Para incluir el carácter separador dentro de un campo entrecomillado como ``"Book, Programming"``
    arriba, es necesario especificar ``quote_disabled=false`` para habilitar el procesamiento de comillas.
-   Cuando el procesamiento de comillas esta deshabilitado (valor predeterminado), las comillas se tratan
-   como caracteres normales y los campos se dividen por el caracter separador.
+   Cuando el procesamiento de comillas está deshabilitado (valor predeterminado), las comillas se tratan
+   como caracteres normales y los campos se dividen por el carácter separador.
 
-Habilitacion del procesamiento de comillas y escape
+Habilitación del procesamiento de comillas y escape
 ----------------------------------------------------
 
-El procesamiento de comillas y el procesamiento de escape estan deshabilitados por defecto.
-Habilitelos explicitamente de la siguiente manera.
+El procesamiento de comillas y el procesamiento de escape están deshabilitados por defecto.
+Habilítelos explícitamente de la siguiente manera.
 
 Habilitar el procesamiento de comillas:
 
@@ -270,16 +270,16 @@ Comillas simples (requiere habilitar el procesamiento de comillas):
     quote_disabled=false
     quote_character='
 
-Codificacion
+Codificación
 ------------
 
-Archivo en espanol con codificacion Shift_JIS:
+Archivo en español con codificación Shift_JIS:
 
 ::
 
     file_encoding=Shift_JIS
 
-Archivo con codificacion EUC-JP:
+Archivo con codificación EUC-JP:
 
 ::
 
@@ -288,7 +288,7 @@ Archivo con codificacion EUC-JP:
 Ejemplos de uso
 ===============
 
-CSV de catalogo de productos
+CSV de catálogo de productos
 ----------------------------
 
 Archivo CSV (products.csv):
@@ -300,7 +300,7 @@ Archivo CSV (products.csv):
     1002,Mouse,Mouse inalambrico,2500,Perifericos,true
     1003,Teclado,Teclado mecanico,8500,Perifericos,false
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -319,7 +319,7 @@ Script:
     digest=category
     price=price
 
-Filtrado por informacion de stock:
+Filtrado por información de stock:
 
 ::
 
@@ -340,7 +340,7 @@ Archivo CSV (employees.csv):
     E002,Maria Lopez,Desarrollo,maria@example.com,03-2345-6789,Gerente
     E003,Pedro Rodriguez,Administracion,pedro@example.com,03-3456-7890,Encargado
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -369,7 +369,7 @@ Archivo CSV (data.csv):
     2,Producto B,Este es el producto B,2000
     3,Producto C,Este es el producto C,3000
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -387,10 +387,10 @@ Script:
     content=cell3
     price=cell4
 
-Integracion de multiples archivos CSV
+Integración de múltiples archivos CSV
 -------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -419,7 +419,7 @@ Archivo TSV (data.tsv):
     1	Articulo1	Este es el contenido del articulo 1	Noticias
     2	Articulo2	Este es el contenido del articulo 2	Blog
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -437,30 +437,30 @@ Script:
     content=content
     digest=category
 
-Solucion de problemas
+Solución de problemas
 =====================
 
 Archivo no encontrado
 ---------------------
 
-**Sintoma**: El crawl se ejecuta pero el archivo no se procesa; el log muestra ``is not found``
+**Síntoma**: El crawl se ejecuta pero el archivo no se procesa; el log muestra ``is not found``
 
 **Verificaciones**:
 
 1. Verificar que la ruta del archivo sea correcta (se recomienda ruta absoluta)
 2. Confirmar que el archivo existe
-3. Verificar que la extension del archivo sea ``.csv`` o ``.tsv`` (los archivos con otras extensiones son omitidos)
+3. Verificar que la extensión del archivo sea ``.csv`` o ``.tsv`` (los archivos con otras extensiones son omitidos)
 4. Verificar que tiene permisos de lectura
 5. Confirmar que es accesible desde el usuario que ejecuta |Fess|
 
 Caracteres ilegibles
 --------------------
 
-**Sintoma**: Los caracteres no se muestran correctamente
+**Síntoma**: Los caracteres no se muestran correctamente
 
-**Solucion**:
+**Solución**:
 
-Especificar la codificacion correcta:
+Especificar la codificación correcta:
 
 ::
 
@@ -476,7 +476,7 @@ Especificar la codificacion correcta:
     # Windows estandar (CP932)
     file_encoding=Windows-31J
 
-Verificar la codificacion del archivo:
+Verificar la codificación del archivo:
 
 ::
 
@@ -487,11 +487,11 @@ Verificar la codificacion del archivo:
 Las columnas no se reconocen correctamente
 ------------------------------------------
 
-**Sintoma**: El delimitador de columnas no se reconoce correctamente, o los campos entrecomillados se dividen incorrectamente
+**Síntoma**: El delimitador de columnas no se reconoce correctamente, o los campos entrecomillados se dividen incorrectamente
 
 **Verificaciones**:
 
-1. Verificar que el caracter separador sea correcto:
+1. Verificar que el carácter separador sea correcto:
 
    ::
 
@@ -504,7 +504,7 @@ Las columnas no se reconocen correctamente
        # Punto y coma
        separator_character=;
 
-2. Para manejar campos entrecomillados (campos que contienen el caracter separador), habilitar el procesamiento de comillas:
+2. Para manejar campos entrecomillados (campos que contienen el carácter separador), habilitar el procesamiento de comillas:
 
    ::
 
@@ -515,9 +515,9 @@ Las columnas no se reconocen correctamente
 Manejo de la fila de encabezado
 --------------------------------
 
-**Sintoma**: La primera fila se reconoce como datos
+**Síntoma**: La primera fila se reconoce como datos
 
-**Solucion**:
+**Solución**:
 
 Cuando hay fila de encabezado:
 
@@ -534,32 +534,32 @@ Cuando no hay fila de encabezado:
 No se obtienen datos
 --------------------
 
-**Sintoma**: El crawl tiene exito pero el conteo es 0
+**Síntoma**: El crawl tiene éxito pero el conteo es 0
 
 **Verificaciones**:
 
-1. Verificar que el archivo CSV no este vacio
-2. Verificar que la configuracion del script sea correcta (comprobar que las referencias a nombres de columna o ``cell<N>`` no llevan el prefijo ``data.``)
+1. Verificar que el archivo CSV no esté vacío
+2. Verificar que la configuración del script sea correcta (comprobar que las referencias a nombres de columna o ``cell<N>`` no llevan el prefijo ``data.``)
 3. Verificar que los nombres de columna sean correctos (cuando has_header_line=true)
 4. Revisar los mensajes de error en el log
 
 Archivo CSV grande
 ------------------
 
-**Sintoma**: Memoria insuficiente o timeout
+**Síntoma**: Memoria insuficiente o timeout
 
-**Solucion**:
+**Solución**:
 
 1. Dividir el archivo CSV en varios
 2. Usar solo las columnas necesarias en el script
-3. Aumentar el tamano del heap de |Fess|
+3. Aumentar el tamaño del heap de |Fess|
 4. Filtrar filas innecesarias
 
-Campo con saltos de linea
+Campo con saltos de línea
 --------------------------
 
-En formato RFC 4180, los campos con saltos de linea pueden manejarse entrecomillandolos.
-Como el procesamiento de comillas esta deshabilitado por defecto, es necesario especificar ``quote_disabled=false``:
+En formato RFC 4180, los campos con saltos de línea pueden manejarse entrecomillándolos.
+Como el procesamiento de comillas está deshabilitado por defecto, es necesario especificar ``quote_disabled=false``:
 
 ::
 
@@ -569,7 +569,7 @@ Como el procesamiento de comillas esta deshabilitado por defecto, es necesario e
     description"
     2,"Product B","Single line"
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -583,17 +583,17 @@ Parametros:
 CsvListDataStore
 =================
 
-El plugin ``fess-ds-csv`` incluye, ademas de ``CsvDataStore``, el handler ``CsvListDataStore``.
+El plugin ``fess-ds-csv`` incluye, además de ``CsvDataStore``, el handler ``CsvListDataStore``.
 
 ``CsvListDataStore`` extiende ``CsvDataStore`` y proporciona las siguientes funciones adicionales:
 
-- Procesamiento multihilo (controlado mediante el parametro ``numOfThreads``)
-- Eliminacion automatica de archivos CSV procesados
-- Filtrado de archivos basado en marca de tiempo (omite archivos que aun se estan escribiendo)
+- Procesamiento multihilo (controlado mediante el parámetro ``numOfThreads``)
+- Eliminación automática de archivos CSV procesados
+- Filtrado de archivos basado en marca de tiempo (omite archivos que aún se están escribiendo)
 
-Todos los parametros y configuraciones de script de ``CsvDataStore`` pueden utilizarse sin cambios.
+Todos los parámetros y configuraciones de script de ``CsvDataStore`` pueden utilizarse sin cambios.
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -605,26 +605,26 @@ Configuracion basica
    * - Nombre del handler
      - CsvListDataStore
 
-Parametros adicionales
+Parámetros adicionales
 ----------------------
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``timestamp_margin``
      - No
-     - Tiempo transcurrido desde la ultima modificacion del archivo (milisegundos). Los archivos que no hayan superado este tiempo se consideran en proceso de escritura y son omitidos (predeterminado: 10000)
+     - Tiempo transcurrido desde la última modificación del archivo (milisegundos). Los archivos que no hayan superado este tiempo se consideran en proceso de escritura y son omitidos (predeterminado: 10000)
    * - ``numOfThreads``
      - No
-     - Numero de hilos de procesamiento (predeterminado: 1)
+     - Número de hilos de procesamiento (predeterminado: 1)
 
 .. note::
 
-   ``CsvListDataStore`` elimina automaticamente los archivos CSV tras procesarlos. Si se produce un error durante el procesamiento, el archivo se renombra con extension ``.txt`` (si el renombrado falla, el archivo se elimina).
+   ``CsvListDataStore`` elimina automáticamente los archivos CSV tras procesarlos. Si se produce un error durante el procesamiento, el archivo se renombra con extensión ``.txt`` (si el renombrado falla, el archivo se elimina).
 
 Ejemplos avanzados de scripts
 ==============================
@@ -651,7 +651,7 @@ Indexado condicional
     content=Integer.parseInt(price) >= 10000 ? description : null
     price=Integer.parseInt(price) >= 10000 ? price : null
 
-Concatenacion de multiples columnas
+Concatenación de múltiples columnas
 ------------------------------------
 
 ::
@@ -672,11 +672,11 @@ Formato de fecha
     created=created_date
     // Si se necesita conversion de formato de fecha, agregar procesamiento adicional
 
-Informacion de referencia
+Información de referencia
 =========================
 
-- :doc:`ds-overview` - Descripcion general de conectores de Data Store
+- :doc:`ds-overview` - Descripción general de conectores de Data Store
 - :doc:`ds-json` - Conector JSON
 - :doc:`ds-database` - Conector de base de datos
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de Data Store
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de Data Store
 - `RFC 4180 - Formato CSV <https://datatracker.ietf.org/doc/html/rfc4180>`_

--- a/es/15.8/config/datastore/ds-dropbox.rst
+++ b/es/15.8/config/datastore/ds-dropbox.rst
@@ -2,11 +2,11 @@
 Conector de Dropbox
 ==================================
 
-Descripcion General
+Descripción General
 ===================
 
 El conector de Dropbox proporciona funcionalidad para obtener archivos del almacenamiento
-en la nube Dropbox y registrarlos en el indice de |Fess|.
+en la nube Dropbox y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-dropbox``.
 
@@ -19,27 +19,27 @@ Servicios Compatibles
 Requisitos Previos
 ==================
 
-1. Se requiere instalacion del plugin
-2. Se requiere una cuenta de desarrollador de Dropbox y la creacion de una aplicacion
+1. Se requiere instalación del plugin
+2. Se requiere una cuenta de desarrollador de Dropbox y la creación de una aplicación
 3. Se requiere obtener un token de acceso
 
-Instalacion del Plugin
+Instalación del Plugin
 ----------------------
 
-Instale desde la consola de administracion en "Sistema" -> "Plugins":
+Instale desde la consola de administración en "Sistema" -> "Plugins":
 
 1. Descargue ``fess-ds-dropbox-X.X.X.jar`` de Maven Central
-2. Cargue e instale desde la pantalla de administracion de plugins
+2. Cargue e instale desde la pantalla de administración de plugins
 3. Reinicie |Fess|
 
-O consulte :doc:`../../admin/plugin-guide` para mas detalles.
+O consulte :doc:`../../admin/plugin-guide` para más detalles.
 
-Metodo de Configuracion
+Método de Configuración
 =======================
 
-Configure desde la consola de administracion en "Rastreador" -> "Almacen de Datos" -> "Crear Nuevo".
+Configure desde la consola de administración en "Rastreador" -> "Almacén de Datos" -> "Crear Nuevo".
 
-Configuracion Basica
+Configuración Básica
 --------------------
 
 .. list-table::
@@ -47,7 +47,7 @@ Configuracion Basica
    :widths: 25 75
 
    * - Elemento
-     - Ejemplo de Configuracion
+     - Ejemplo de Configuración
    * - Nombre
      - Company Dropbox
    * - Nombre del Manejador
@@ -55,7 +55,7 @@ Configuracion Basica
    * - Habilitado
      - Activado
 
-Configuracion de Parametros
+Configuración de Parámetros
 ----------------------------
 
 ::
@@ -63,54 +63,54 @@ Configuracion de Parametros
     access_token=sl.your-dropbox-token-here
     basic_plan=false
 
-Lista de Parametros
+Lista de Parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``access_token``
-     - Si
+     - Sí
      - Token de acceso de Dropbox (generado en App Console)
    * - ``basic_plan``
      - No
      - ``true`` para cuenta individual, ``false`` para cuenta de equipo (predeterminado: ``false``)
    * - ``max_size``
      - No
-     - Tamano maximo de archivo para indexacion en bytes (predeterminado: ``10000000``)
+     - Tamaño máximo de archivo para indexación en bytes (predeterminado: ``10000000``)
    * - ``number_of_threads``
      - No
-     - Numero de hilos para rastreo (predeterminado: ``1``)
+     - Número de hilos para rastreo (predeterminado: ``1``)
    * - ``ignore_folder``
      - No
      - Indica si se omiten los metadatos de carpetas (predeterminado: ``true``)
    * - ``ignore_error``
      - No
-     - Indica si se ignoran los errores durante la extraccion de contenido (predeterminado: ``true``)
+     - Indica si se ignoran los errores durante la extracción de contenido (predeterminado: ``true``)
    * - ``supported_mimetypes``
      - No
      - Patrones regex para tipos MIME permitidos, separados por comas (predeterminado: ``.*``)
    * - ``include_pattern``
      - No
-     - Patron de URL a incluir en el rastreo
+     - Patrón de URL a incluir en el rastreo
    * - ``exclude_pattern``
      - No
-     - Patron de URL a excluir del rastreo
+     - Patrón de URL a excluir del rastreo
    * - ``default_permissions``
      - No
      - Permisos predeterminados para documentos indexados, separados por comas
    * - ``max_cached_content_size``
      - No
-     - Tamano maximo de contenido almacenado en cache en memoria en bytes. El contenido que supere este limite se escribe en un archivo temporal (predeterminado: ``1048576``)
+     - Tamaño máximo de contenido almacenado en caché en memoria en bytes. El contenido que supere este límite se escribe en un archivo temporal (predeterminado: ``1048576``)
    * - ``readInterval``
      - No
      - Tiempo de espera en milisegundos entre el procesamiento de cada registro (predeterminado: ``0``)
 
-Configuracion de Script
+Configuración de Script
 -----------------------
 
 Para Archivos de Dropbox
@@ -135,7 +135,7 @@ Campos disponibles:
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``file.url``
      - Enlace de vista previa del archivo
    * - ``file.contents``
@@ -149,7 +149,7 @@ Campos disponibles:
    * - ``file.path_display``
      - Ruta del archivo
    * - ``file.size``
-     - Tamano del archivo (bytes)
+     - Tamaño del archivo (bytes)
    * - ``file.client_modified``
      - Fecha de ultima modificacion del lado del cliente
    * - ``file.server_modified``
@@ -159,13 +159,13 @@ Campos disponibles:
    * - ``file.id``
      - ID del archivo de Dropbox
    * - ``file.path_lower``
-     - Ruta del archivo en minusculas
+     - Ruta del archivo en minúsculas
    * - ``file.parent_shared_folder_id``
      - ID de la carpeta compartida principal
    * - ``file.content_hash``
      - Hash del contenido
    * - ``file.rev``
-     - Revision del archivo
+     - Revisión del archivo
 
 Para Dropbox Paper
 ~~~~~~~~~~~~~~~~~~
@@ -186,7 +186,7 @@ Campos disponibles:
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``paper.url``
      - Enlace de vista previa del documento Paper
    * - ``paper.contents``
@@ -196,22 +196,22 @@ Campos disponibles:
    * - ``paper.filetype``
      - Tipo de archivo
    * - ``paper.title``
-     - Titulo del documento Paper
+     - Título del documento Paper
    * - ``paper.owner``
      - Propietario del documento Paper
    * - ``paper.roles``
      - Permisos de acceso del documento
    * - ``paper.revision``
-     - Revision del documento Paper
+     - Revisión del documento Paper
 
-Configuracion de Autenticacion de Dropbox
+Configuración de Autenticación de Dropbox
 ==========================================
 
 Tipo de Cuenta y Token de Acceso
 ---------------------------------
 
-Este conector alterna entre dos modos de operacion segun el parametro ``basic_plan``.
-Dado que el tipo de aplicacion y de token de acceso que se debe crear difiere, verifiquelo primero.
+Este conector alterna entre dos modos de operación según el parámetro ``basic_plan``.
+Dado que el tipo de aplicación y de token de acceso que se debe crear difiere, verifíquelo primero.
 
 .. list-table::
    :header-rows: 1
@@ -219,24 +219,24 @@ Dado que el tipo de aplicacion y de token de acceso que se debe crear difiere, v
 
    * - Modo
      - ``basic_plan``
-     - Descripcion
+     - Descripción
    * - Cuenta de equipo (predeterminado)
      - ``false``
      - Destinado a cuentas Dropbox Business (equipo). Requiere un token de acceso con permisos de administrador del equipo, y rastrea archivos de los miembros del equipo y carpetas de equipo de forma transversal.
    * - Cuenta individual
      - ``true``
-     - Destinado a cuentas individuales (no de equipo). Utiliza un token de acceso con alcance estandar y rastrea directamente los archivos dentro de esa cuenta.
+     - Destinado a cuentas individuales (no de equipo). Utiliza un token de acceso con alcance estándar y rastrea directamente los archivos dentro de esa cuenta.
 
 .. note::
-   Con la configuracion predeterminada (``basic_plan=false``), se utilizan las API de administracion de equipos
+   Con la configuración predeterminada (``basic_plan=false``), se utilizan las API de administración de equipos
    (lista de miembros, acceso a archivos por miembro, carpetas de equipo), por lo que es obligatorio
    disponer de una cuenta Dropbox Business y un token con permisos de administrador del equipo.
-   Si utiliza una cuenta individual, asegurese de configurar ``basic_plan=true``.
+   Si utiliza una cuenta individual, asegúrese de configurar ``basic_plan=true``.
 
 Pasos para Obtener el Token de Acceso
 --------------------------------------
 
-1. Crear una aplicacion en Dropbox App Console
+1. Crear una aplicación en Dropbox App Console
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Acceda a https://www.dropbox.com/developers/apps:
@@ -244,18 +244,18 @@ Acceda a https://www.dropbox.com/developers/apps:
 1. Haga clic en "Create app"
 2. Seleccione "Scoped access" para el tipo de API
 3. Seleccione el tipo de acceso (se recomienda "Full Dropbox" para rastrear cuentas de equipo de forma transversal)
-4. Ingrese el nombre de la aplicacion y cree
+4. Ingrese el nombre de la aplicación y cree
 
-2. Configuracion de Permisos
+2. Configuración de Permisos
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-En la pestana "Permissions", seleccione los permisos requeridos:
+En la pestaña "Permissions", seleccione los permisos requeridos:
 
 **Permisos necesarios para el rastreo de archivos y Paper**:
 
 - ``files.metadata.read`` - Lectura de metadatos de archivos
 - ``files.content.read`` - Lectura de contenido de archivos y documentos Paper
-- ``sharing.read`` - Lectura de informacion de uso compartido
+- ``sharing.read`` - Lectura de información de uso compartido
 
 **Permisos adicionales requeridos para cuentas de equipo (``basic_plan=false``)**:
 
@@ -264,15 +264,15 @@ En la pestana "Permissions", seleccione los permisos requeridos:
 
 .. note::
    En el modo de cuenta de equipo, se accede a cada miembro y carpeta de equipo como administrador del equipo.
-   Habilite los permisos de equipo mencionados en la pestana Permissions y genere un token de administrador del equipo.
+   Habilite los permisos de equipo mencionados en la pestaña Permissions y genere un token de administrador del equipo.
 
 3. Generar Token de Acceso
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-En la pestana "Settings":
+En la pestaña "Settings":
 
-1. Desplacese hasta la seccion "Generated access token"
-2. Haga clic en el boton "Generate"
+1. Desplácese hasta la sección "Generated access token"
+2. Haga clic en el botón "Generate"
 3. Copie el token generado (este token se muestra solo una vez)
 
 .. warning::
@@ -282,20 +282,20 @@ En la pestana "Settings":
 4. Configurar el Token
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Configure el token obtenido en los parametros:
+Configure el token obtenido en los parámetros:
 
 ::
 
     access_token=sl.your-dropbox-token-here
 
-Configuracion para Cuenta Individual
+Configuración para Cuenta Individual
 =====================================
 
 Uso con Cuentas Individuales
 -----------------------------
 
 Para cuentas individuales (no cuentas de equipo),
-configure el parametro ``basic_plan`` como ``true``:
+configure el parámetro ``basic_plan`` como ``true``:
 
 ::
 
@@ -311,7 +311,7 @@ Ejemplos de Uso
 Rastrear Todos los Archivos de Dropbox
 ---------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -334,7 +334,7 @@ Script:
 Rastrear Documentos de Dropbox Paper
 --------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -354,7 +354,7 @@ Script:
 Rastrear con Permisos
 ----------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -386,18 +386,18 @@ Script (Dropbox Paper):
     filetype=paper.filetype
     role=paper.roles
 
-Rastrear Solo Tipos de Archivo Especificos
+Rastrear Solo Tipos de Archivo Específicos
 -------------------------------------------
 
-Para indexar unicamente tipos MIME especificos, especifique en el parametro ``supported_mimetypes``
+Para indexar únicamente tipos MIME específicos, especifique en el parámetro ``supported_mimetypes``
 las expresiones regulares de los tipos MIME permitidos, separadas por comas.
 
 .. note::
-   Los scripts del almacen de datos evaluan cada linea como una expresion independiente con el formato ``campo=expresion``.
-   Por ello, no es posible asignar multiples campos en un bloque ``if`` de varias lineas.
-   El filtrado por tipo MIME debe realizarse mediante el parametro ``supported_mimetypes``, no con scripts.
+   Los scripts del almacén de datos evalúan cada línea como una expresión independiente con el formato ``campo=expresion``.
+   Por ello, no es posible asignar múltiples campos en un bloque ``if`` de varias lineas.
+   El filtrado por tipo MIME debe realizarse mediante el parámetro ``supported_mimetypes``, no con scripts.
 
-Parametros (solo PDF y archivos Word):
+Parámetros (solo PDF y archivos Word):
 
 ::
 
@@ -416,34 +416,34 @@ Script:
     filename=file.name
     last_modified=file.client_modified
 
-Solucion de Problemas
+Solución de Problemas
 ======================
 
-Errores de Autenticacion
+Errores de Autenticación
 -------------------------
 
-**Sintoma**: ``Invalid access token`` o ``401 Unauthorized``
+**Síntoma**: ``Invalid access token`` o ``401 Unauthorized``
 
 **Verifique**:
 
 1. Verifique que el token de acceso se haya copiado correctamente
-2. Verifique que el token no haya expirado (use token de larga duracion)
-3. Verifique que los permisos requeridos esten otorgados en Dropbox App Console
-4. Verifique que la aplicacion no este desactivada
+2. Verifique que el token no haya expirado (use token de larga duración)
+3. Verifique que los permisos requeridos estén otorgados en Dropbox App Console
+4. Verifique que la aplicación no esté desactivada
 
 No Se Pueden Obtener Archivos
 ------------------------------
 
-**Sintoma**: El rastreo tiene exito pero hay 0 archivos
+**Síntoma**: El rastreo tiene éxito pero hay 0 archivos
 
 **Verifique**:
 
-1. Verifique que el "Access type" de la aplicacion sea apropiado:
+1. Verifique que el "Access type" de la aplicación sea apropiado:
 
    - "Full Dropbox": Puede acceder a todo Dropbox
-   - "App folder": Solo puede acceder a una carpeta especifica
+   - "App folder": Solo puede acceder a una carpeta específica
 
-2. Verifique que los permisos requeridos esten otorgados:
+2. Verifique que los permisos requeridos estén otorgados:
 
    - ``files.metadata.read``
    - ``files.content.read``
@@ -451,25 +451,25 @@ No Se Pueden Obtener Archivos
 
 3. Verifique que existan archivos en la cuenta de Dropbox
 
-Errores de Limite de Tasa de API
+Errores de Límite de Tasa de API
 ----------------------------------
 
-**Sintoma**: Error ``429 Too Many Requests``
+**Síntoma**: Error ``429 Too Many Requests``
 
-**Solucion**:
+**Solución**:
 
 1. Configure ``readInterval`` para aumentar el intervalo de procesamiento entre archivos
-2. Reduzca ``number_of_threads`` para disminuir el numero de solicitudes simultaneas
-3. Divida el almacen de datos en varios (por carpeta u otro criterio) y escalone los horarios de ejecucion
+2. Reduzca ``number_of_threads`` para disminuir el número de solicitudes simultáneas
+3. Divida el almacén de datos en varios (por carpeta u otro criterio) y escalone los horarios de ejecución
 
 .. note::
-   ``basic_plan`` es un parametro que alterna el tipo de cuenta (equipo/individual)
-   y no afecta al ajuste de los limites de tasa. Configurelo correctamente segun su cuenta.
+   ``basic_plan`` es un parámetro que alterna el tipo de cuenta (equipo/individual)
+   y no afecta al ajuste de los límites de tasa. Configúrelo correctamente según su cuenta.
 
 No Se Pueden Obtener Documentos Paper
 ---------------------------------------
 
-**Sintoma**: Los documentos Paper no se rastrean
+**Síntoma**: Los documentos Paper no se rastrean
 
 **Verifique**:
 
@@ -477,16 +477,16 @@ No Se Pueden Obtener Documentos Paper
 2. Verifique que se incluya el permiso ``files.content.read``
 3. Verifique que realmente existan documentos Paper
 
-Cuando Hay un Gran Numero de Archivos
+Cuando Hay un Gran Número de Archivos
 ---------------------------------------
 
-**Sintoma**: El rastreo toma mucho tiempo o se agota el tiempo
+**Síntoma**: El rastreo toma mucho tiempo o se agota el tiempo
 
-**Solucion**:
+**Solución**:
 
-1. Divida los almacenes de datos en multiples (por unidad de carpeta, etc.)
-2. Distribuya la carga con configuracion de programacion
-3. En el plan Basic, tenga en cuenta los limites de tasa de API
+1. Divida los almacenes de datos en múltiples (por unidad de carpeta, etc.)
+2. Distribuya la carga con configuración de programacion
+3. En el plan Basic, tenga en cuenta los límites de tasa de API
 
 Permisos y Control de Acceso
 ==============================
@@ -494,9 +494,9 @@ Permisos y Control de Acceso
 Reflejar Permisos de Uso Compartido de Dropbox
 ------------------------------------------------
 
-Puede reflejar la configuracion de uso compartido de Dropbox en los permisos de Fess:
+Puede reflejar la configuración de uso compartido de Dropbox en los permisos de Fess:
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -515,14 +515,14 @@ Script:
     filename=file.name
     last_modified=file.client_modified
 
-``file.roles`` o ``paper.roles`` contienen informacion de uso compartido de Dropbox.
+``file.roles`` o ``paper.roles`` contienen información de uso compartido de Dropbox.
 
-Informacion de Referencia
+Información de Referencia
 ==========================
 
-- :doc:`ds-overview` - Descripcion General de Conectores de Almacen de Datos
+- :doc:`ds-overview` - Descripción General de Conectores de Almacén de Datos
 - :doc:`ds-box` - Conector de Box
 - :doc:`ds-gsuite` - Conector de Google Workspace
-- :doc:`../../admin/dataconfig-guide` - Guia de Configuracion de Almacen de Datos
+- :doc:`../../admin/dataconfig-guide` - Guía de Configuración de Almacén de Datos
 - `Desarrolladores de Dropbox <https://www.dropbox.com/developers>`_
-- `Documentacion de API de Dropbox <https://www.dropbox.com/developers/documentation>`_
+- `Documentación de API de Dropbox <https://www.dropbox.com/developers/documentation>`_

--- a/es/15.8/config/datastore/ds-elasticsearch.rst
+++ b/es/15.8/config/datastore/ds-elasticsearch.rst
@@ -2,11 +2,11 @@
 Conector Elasticsearch/OpenSearch
 ==================================
 
-Descripcion general
+Descripción general
 ===================
 
 El conector Elasticsearch/OpenSearch proporciona la funcionalidad para obtener datos
-de un cluster de Elasticsearch u OpenSearch y registrarlos en el indice de |Fess|.
+de un cluster de Elasticsearch u OpenSearch y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-elasticsearch``.
 
@@ -23,10 +23,10 @@ Requisitos previos
 2. Se requiere acceso de lectura al cluster de Elasticsearch/OpenSearch
 3. Se necesitan permisos para ejecutar consultas
 
-Instalacion del plugin
+Instalación del plugin
 ----------------------
 
-Metodo 1: Colocar el archivo JAR directamente
+Método 1: Colocar el archivo JAR directamente
 
 ::
 
@@ -38,18 +38,18 @@ Metodo 1: Colocar el archivo JAR directamente
     # o
     cp fess-ds-elasticsearch-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Metodo 2: Instalar desde la pantalla de administracion
+Método 2: Instalar desde la pantalla de administración
 
 1. Abrir "Sistema" -> "Plugins"
 2. Subir el archivo JAR
 3. Reiniciar |Fess|
 
-Configuracion
+Configuración
 =============
 
-Configure desde la pantalla de administracion en "Crawler" -> "Data Store" -> "Crear nuevo".
+Configure desde la pantalla de administración en "Crawler" -> "Data Store" -> "Crear nuevo".
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -66,13 +66,13 @@ Configuracion basica
      - Activado
 
 .. note::
-   ``ElasticsearchListDataStore`` es una extension de ``ElasticsearchDataStore`` que procesa los datos obtenidos como una lista de archivos y soporta el registro en el indice con multiples hilos.
-   El numero de hilos se puede especificar con el parametro ``numOfThreads`` (predeterminado: 1).
+   ``ElasticsearchListDataStore`` es una extensión de ``ElasticsearchDataStore`` que procesa los datos obtenidos como una lista de archivos y soporta el registro en el índice con múltiples hilos.
+   El número de hilos se puede especificar con el parámetro ``numOfThreads`` (predeterminado: 1).
 
-Configuracion de parametros
+Configuración de parámetros
 ---------------------------
 
-Conexion basica:
+Conexión básica:
 
 ::
 
@@ -81,7 +81,7 @@ Conexion basica:
     size=100
     scroll=1m
 
-Conexion con autenticacion:
+Conexión con autenticación:
 
 ::
 
@@ -92,28 +92,28 @@ Conexion con autenticacion:
     size=100
     scroll=1m
 
-Lista de parametros
+Lista de parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``settings.http.hosts``
      - No
-     - URL del host de Elasticsearch/OpenSearch. Se pueden especificar multiples hosts separados por comas (ej: ``http://host1:9200,http://host2:9200``). Si no se especifica, se produce un error de conexion
+     - URL del host de Elasticsearch/OpenSearch. Se pueden especificar múltiples hosts separados por comas (ej: ``http://host1:9200,http://host2:9200``). Si no se especifica, se produce un error de conexión
    * - ``settings.fesen.username``
      - No
-     - Nombre de usuario para autenticacion
+     - Nombre de usuario para autenticación
    * - ``settings.fesen.password``
      - No
-     - Contrasena para autenticacion
+     - Contraseña para autenticación
    * - ``index``
      - No
-     - Nombre del indice objetivo (predeterminado: ``_all``). Se pueden especificar multiples indices separados por comas
+     - Nombre del índice objetivo (predeterminado: ``_all``). Se pueden especificar múltiples indices separados por comas
    * - ``size``
      - No
      - Cantidad de registros obtenidos por scroll (si no se especifica, se usa el valor predeterminado del servidor Elasticsearch/OpenSearch)
@@ -131,46 +131,46 @@ Lista de parametros
      - Campos a obtener (separados por comas)
    * - ``preference``
      - No
-     - Preferencia de replica de shard para la ejecucion de busqueda (predeterminado: ``_local``)
+     - Preferencia de réplica de shard para la ejecución de búsqueda (predeterminado: ``_local``)
    * - ``delete.processed.doc``
      - No
-     - Si se eliminan los documentos procesados del indice fuente (predeterminado: false)
+     - Si se eliminan los documentos procesados del índice fuente (predeterminado: false)
    * - ``readInterval``
      - No
      - Tiempo de espera entre el procesamiento de cada documento en milisegundos (predeterminado: 0)
    * - ``numOfThreads``
      - No
-     - Numero de hilos para el registro en el indice (valido solo para ``ElasticsearchListDataStore``, predeterminado: 1)
+     - Número de hilos para el registro en el índice (válido solo para ``ElasticsearchListDataStore``, predeterminado: 1)
 
-Parametros adicionales de conexion
+Parámetros adicionales de conexión
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Los parametros con el prefijo ``settings.`` se pasan como configuracion del cliente interno de Elasticsearch/OpenSearch (cliente HTTP de fesen).
+Los parámetros con el prefijo ``settings.`` se pasan como configuración del cliente interno de Elasticsearch/OpenSearch (cliente HTTP de fesen).
 Las principales configuraciones adicionales son las siguientes.
 
 .. list-table::
    :header-rows: 1
    :widths: 40 60
 
-   * - Parametro
-     - Descripcion
+   * - Parámetro
+     - Descripción
    * - ``settings.http.ssl.certificate_authorities``
      - Ruta al archivo de certificado CA de confianza (formato X.509) para conexiones HTTPS
    * - ``settings.http.compression``
-     - Si se habilita la compresion HTTP (predeterminado: true)
+     - Si se habilita la compresión HTTP (predeterminado: true)
    * - ``settings.http.proxy_host``
-     - Nombre de host del servidor proxy (tambien se puede especificar ``settings.https.proxy_host``)
+     - Nombre de host del servidor proxy (también se puede especificar ``settings.https.proxy_host``)
    * - ``settings.http.proxy_port``
-     - Numero de puerto del servidor proxy (tambien se puede especificar ``settings.https.proxy_port``)
+     - Número de puerto del servidor proxy (también se puede especificar ``settings.https.proxy_port``)
    * - ``settings.http.proxy_username``
-     - Nombre de usuario para autenticacion del proxy (tambien se puede especificar ``settings.https.proxy_username``)
+     - Nombre de usuario para autenticación del proxy (también se puede especificar ``settings.https.proxy_username``)
    * - ``settings.http.proxy_password``
-     - Contrasena para autenticacion del proxy (tambien se puede especificar ``settings.https.proxy_password``)
+     - Contraseña para autenticación del proxy (también se puede especificar ``settings.https.proxy_password``)
 
-Configuracion de scripts
+Configuración de scripts
 ------------------------
 
-Mapeo basico:
+Mapeo básico:
 
 ::
 
@@ -195,50 +195,50 @@ Campos disponibles
 
 - ``source.<field_name>`` - Campo ``_source`` del documento de Elasticsearch
 - ``id`` - ID del documento
-- ``index`` - Nombre del indice
-- ``score`` - Puntuacion de busqueda
-- ``version`` - Version del documento
-- ``seqNo`` - Numero de secuencia
-- ``primaryTerm`` - Termino primario
-- ``clusterAlias`` - Alias del cluster (para busqueda entre clusters)
+- ``index`` - Nombre del índice
+- ``score`` - Puntuación de búsqueda
+- ``versión`` - Versión del documento
+- ``seqNo`` - Número de secuencia
+- ``primaryTerm`` - Término primario
+- ``clusterAlias`` - Alias del cluster (para búsqueda entre clusters)
 - ``hit`` - Objeto SearchHit (uso avanzado)
 
-Configuracion de consultas
+Configuración de consultas
 ==========================
 
 Obtener todos los documentos
 ----------------------------
 
 Por defecto se obtienen todos los documentos.
-Si no se especifica el parametro ``query``, se usa ``match_all``.
+Si no se especifica el parámetro ``query``, se usa ``match_all``.
 
-Filtrado con condiciones especificas
+Filtrado con condiciones específicas
 ------------------------------------
 
 ::
 
     query={"term":{"status":"published"}}
 
-Especificacion de rango:
+Especificación de rango:
 
 ::
 
     query={"range":{"timestamp":{"gte":"2024-01-01","lte":"2024-12-31"}}}
 
-Multiples condiciones:
+Múltiples condiciones:
 
 ::
 
     query={"bool":{"must":[{"term":{"category":"news"}},{"range":{"views":{"gte":100}}}]}}
 
 .. note::
-   El parametro ``query`` solo acepta el cuerpo de la query. El wrapper externo ``{"query":...}`` no es necesario.
-   Las opciones a nivel de busqueda como ordenamiento no pueden especificarse en este parametro.
+   El parámetro ``query`` solo acepta el cuerpo de la query. El wrapper externo ``{"query":...}`` no es necesario.
+   Las opciones a nivel de búsqueda como ordenamiento no pueden especificarse en este parámetro.
 
-Obtener solo campos especificos
+Obtener solo campos específicos
 ===============================
 
-Limitar campos a obtener con el parametro fields
+Limitar campos a obtener con el parámetro fields
 -------------------------------------------------
 
 ::
@@ -248,15 +248,15 @@ Limitar campos a obtener con el parametro fields
     fields=title,content,url,timestamp
     size=100
 
-Para obtener todos los campos, no especifique ``fields`` o dejelo vacio.
+Para obtener todos los campos, no especifique ``fields`` o déjelo vacio.
 
 Ejemplos de uso
 ===============
 
-Crawl basico de indice
+Crawl básico de índice
 ----------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -275,10 +275,10 @@ Script:
     created=source.created_at
     last_modified=source.updated_at
 
-Crawl desde cluster con autenticacion
+Crawl desde cluster con autenticación
 --------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -299,10 +299,10 @@ Script:
     digest=source.category
     last_modified=source.updated_at
 
-Crawl desde multiples indices
+Crawl desde múltiples indices
 ------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -324,7 +324,7 @@ Script:
 Crawl de cluster OpenSearch
 ----------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -347,7 +347,7 @@ Script:
 Crawl con campos limitados
 ---------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -365,12 +365,12 @@ Script:
     content=source.content
     last_modified=source.timestamp
 
-Balanceo de carga con multiples hosts
+Balanceo de carga con múltiples hosts
 --------------------------------------
 
-Al especificar multiples hosts separados por comas en ``settings.http.hosts``, las solicitudes se distribuyen entre cada host.
+Al especificar múltiples hosts separados por comas en ``settings.http.hosts``, las solicitudes se distribuyen entre cada host.
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -388,61 +388,61 @@ Script:
     content=source.content
     last_modified=source.timestamp
 
-Solucion de problemas
+Solución de problemas
 =====================
 
-Error de conexion
+Error de conexión
 -----------------
 
-**Sintoma**: ``Connection refused`` o ``No route to host``
+**Síntoma**: ``Connection refused`` o ``No route to host``
 
 **Verificaciones**:
 
 1. Verificar que la URL del host sea correcta (protocolo, nombre de host, puerto)
-2. Confirmar que Elasticsearch/OpenSearch este ejecutandose
-3. Verificar la configuracion del firewall
-4. En caso de HTTPS, verificar que el certificado sea valido
+2. Confirmar que Elasticsearch/OpenSearch esté ejecutándose
+3. Verificar la configuración del firewall
+4. En caso de HTTPS, verificar que el certificado sea válido
 
-Error de autenticacion
+Error de autenticación
 ----------------------
 
-**Sintoma**: ``401 Unauthorized`` o ``403 Forbidden``
+**Síntoma**: ``401 Unauthorized`` o ``403 Forbidden``
 
 **Verificaciones**:
 
-1. Verificar que el nombre de usuario y contrasena sean correctos
+1. Verificar que el nombre de usuario y contraseña sean correctos
 2. Confirmar que el usuario tenga los permisos apropiados:
 
-   - Permisos de lectura en el indice
+   - Permisos de lectura en el índice
    - Permisos para usar la API de scroll
 
-3. Si Elasticsearch Security (X-Pack) esta habilitado, verificar la configuracion correcta
+3. Si Elasticsearch Security (X-Pack) está habilitado, verificar la configuración correcta
 
-Indice no encontrado
+Índice no encontrado
 --------------------
 
-**Sintoma**: ``index_not_found_exception``
+**Síntoma**: ``index_not_found_exception``
 
 **Verificaciones**:
 
-1. Verificar que el nombre del indice sea correcto (incluyendo mayusculas/minusculas)
-2. Confirmar que el indice existe:
+1. Verificar que el nombre del índice sea correcto (incluyendo mayúsculas/minúsculas)
+2. Confirmar que el índice existe:
 
    ::
 
        GET /_cat/indices
 
-3. Verificar que el patron de comodin sea correcto (ej: ``logs-*``)
+3. Verificar que el patrón de comodín sea correcto (ej: ``logs-*``)
 
 Error de consulta
 -----------------
 
-**Sintoma**: ``parsing_exception`` o ``search_phase_execution_exception``
+**Síntoma**: ``parsing_exception`` o ``search_phase_execution_exception``
 
 **Verificaciones**:
 
 1. Verificar que el JSON de la consulta sea correcto
-2. Confirmar que la consulta sea compatible con la version de Elasticsearch/OpenSearch
+2. Confirmar que la consulta sea compatible con la versión de Elasticsearch/OpenSearch
 3. Verificar que los nombres de campo sean correctos
 4. Probar ejecutando la consulta directamente en Elasticsearch/OpenSearch:
 
@@ -456,9 +456,9 @@ Error de consulta
 Timeout de scroll
 -----------------
 
-**Sintoma**: ``No search context found`` o ``Scroll timeout``
+**Síntoma**: ``No search context found`` o ``Scroll timeout``
 
-**Solucion**:
+**Solución**:
 
 1. Aumentar el ``scroll``:
 
@@ -474,12 +474,12 @@ Timeout de scroll
 
 3. Verificar los recursos del cluster
 
-Crawl de grandes volumenes de datos
+Crawl de grandes volúmenes de datos
 ------------------------------------
 
-**Sintoma**: El crawl es lento o tiene timeout
+**Síntoma**: El crawl es lento o tiene timeout
 
-**Solucion**:
+**Solución**:
 
 1. Ajustar ``size`` (demasiado grande puede hacerlo lento):
 
@@ -490,32 +490,32 @@ Crawl de grandes volumenes de datos
 
 2. Limitar los campos a obtener con ``fields``
 3. Filtrar solo los documentos necesarios con ``query``
-4. Dividir en multiples data stores (por indice, por rango de tiempo, etc.)
+4. Dividir en múltiples data stores (por índice, por rango de tiempo, etc.)
 
 Memoria insuficiente
 --------------------
 
-**Sintoma**: OutOfMemoryError
+**Síntoma**: OutOfMemoryError
 
-**Solucion**:
+**Solución**:
 
 1. Reducir ``size``
 2. Limitar los campos a obtener con ``fields``
-3. Aumentar el tamano del heap de |Fess|
+3. Aumentar el tamaño del heap de |Fess|
 4. Excluir campos grandes (datos binarios, etc.)
 
-Conexion SSL/TLS
+Conexión SSL/TLS
 ================
 
 En caso de certificado autofirmado
 ------------------------------------
 
 .. warning::
-   Use certificados firmados adecuadamente en entornos de produccion.
+   Use certificados firmados adecuadamente en entornos de producción.
 
-Metodo 1: Especificar el certificado CA con el parametro ``settings.http.ssl.certificate_authorities`` (recomendado)
+Método 1: Especificar el certificado CA con el parámetro ``settings.http.ssl.certificate_authorities`` (recomendado)
 
-Especifique la ruta al archivo de certificado CA de confianza (formato X.509). Este metodo no afecta al keystore global de |Fess|.
+Especifique la ruta al archivo de certificado CA de confianza (formato X.509). Este método no afecta al keystore global de |Fess|.
 
 ::
 
@@ -523,18 +523,18 @@ Especifique la ruta al archivo de certificado CA de confianza (formato X.509). E
     settings.http.ssl.certificate_authorities=/path/to/es-cert.crt
     index=myindex
 
-Metodo 2: Agregar el certificado al keystore de Java
+Método 2: Agregar el certificado al keystore de Java
 
-Agregue el certificado al almacen de confianza de la JVM que inicia |Fess|.
+Agregue el certificado al almacén de confianza de la JVM que inicia |Fess|.
 
 ::
 
     keytool -import -alias es-cert -file es-cert.crt -keystore $JAVA_HOME/lib/security/cacerts
 
-Conexion a traves de proxy
+Conexión a través de proxy
 ---------------------------
 
-Para conectarse a traves de un servidor proxy, especifique ``settings.http.proxy_host`` y ``settings.http.proxy_port``.
+Para conectarse a través de un servidor proxy, especifique ``settings.http.proxy_host`` y ``settings.http.proxy_port``.
 
 ::
 
@@ -546,27 +546,27 @@ Para conectarse a traves de un servidor proxy, especifique ``settings.http.proxy
 Ejemplos de consultas avanzadas
 ================================
 
-Consulta con agregacion
+Consulta con agregación
 ------------------------
 
 .. note::
-   El parametro ``query`` solo acepta el cuerpo de la query. Agregaciones (aggs), ordenamiento y otras
-   opciones a nivel de busqueda no pueden especificarse. Solo se obtienen los documentos.
+   El parámetro ``query`` solo acepta el cuerpo de la query. Agregaciones (aggs), ordenamiento y otras
+   opciones a nivel de búsqueda no pueden especificarse. Solo se obtienen los documentos.
 
 Campos de script
 -----------------
 
 .. note::
-   Los campos de script de Elasticsearch/OpenSearch no estan incluidos en ``_source``, por lo que no se
+   Los campos de script de Elasticsearch/OpenSearch no están incluidos en ``_source``, por lo que no se
    puede acceder a ellos mediante el prefijo ``source.*``. Para usar campos de script, acceda a ellos
    mediante el objeto ``hit`` usando ``hit.getFields()``.
 
-Informacion de referencia
+Información de referencia
 ==========================
 
-- :doc:`ds-overview` - Descripcion general de conectores de Data Store
+- :doc:`ds-overview` - Descripción general de conectores de Data Store
 - :doc:`ds-database` - Conector de base de datos
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de Data Store
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de Data Store
 - `Elasticsearch Documentation <https://www.elastic.co/guide/>`_
 - `OpenSearch Documentation <https://opensearch.org/docs/>`_
 - `Elasticsearch Query DSL <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html>`_

--- a/es/15.8/config/datastore/ds-gsuite.rst
+++ b/es/15.8/config/datastore/ds-gsuite.rst
@@ -2,11 +2,11 @@
 Conector de Google Workspace
 ==================================
 
-Vision General
+Visión General
 ==============
 
 El conector de Google Workspace proporciona funcionalidad para obtener archivos de Google Drive
-(anteriormente G Suite) y registrarlos en el indice de |Fess|.
+(anteriormente G Suite) y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-gsuite``.
 
@@ -14,20 +14,20 @@ Servicios Soportados
 ====================
 
 - Google Drive (Mi unidad, Unidades compartidas)
-- Documentos de Google, Hojas de calculo, Presentaciones, Formularios, etc.
+- Documentos de Google, Hojas de cálculo, Presentaciones, Formularios, etc.
 
 Requisitos Previos
 ==================
 
-1. Se requiere la instalacion del plugin
-2. Se requiere la creacion de un proyecto en Google Cloud Platform
-3. Se requiere la creacion de una cuenta de servicio y la obtencion de credenciales
-4. Se requiere la configuracion de delegacion de dominio de Google Workspace
+1. Se requiere la instalación del plugin
+2. Se requiere la creación de un proyecto en Google Cloud Platform
+3. Se requiere la creación de una cuenta de servicio y la obtención de credenciales
+4. Se requiere la configuración de delegación de dominio de Google Workspace
 
-Instalacion del Plugin
+Instalación del Plugin
 ----------------------
 
-Metodo 1: Colocar el archivo JAR directamente
+Método 1: Colocar el archivo JAR directamente
 
 ::
 
@@ -39,18 +39,18 @@ Metodo 1: Colocar el archivo JAR directamente
     # o
     cp fess-ds-gsuite-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Metodo 2: Instalar desde la pantalla de administracion
+Método 2: Instalar desde la pantalla de administración
 
 1. Abra "Sistema" -> "Plugins"
 2. Cargue el archivo JAR
 3. Reinicie |Fess|
 
-Metodo de Configuracion
+Método de Configuración
 =======================
 
-Configure desde la pantalla de administracion en "Rastreador" -> "Almacen de datos" -> "Nuevo".
+Configure desde la pantalla de administración en "Rastreador" -> "Almacén de datos" -> "Nuevo".
 
-Configuracion Basica
+Configuración Básica
 --------------------
 
 .. list-table::
@@ -66,7 +66,7 @@ Configuracion Basica
    * - Habilitado
      - Activado
 
-Configuracion de Parametros
+Configuración de Parámetros
 ---------------------------
 
 ::
@@ -75,28 +75,28 @@ Configuracion de Parametros
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project.iam.gserviceaccount.com
 
-Lista de Parametros
+Lista de Parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``private_key``
-     - Si
-     - Clave privada de la cuenta de servicio (formato PEM, saltos de linea como ``\n``)
+     - Sí
+     - Clave privada de la cuenta de servicio (formato PEM, saltos de línea como ``\n``)
    * - ``private_key_id``
-     - Si
+     - Sí
      - ID de la clave privada
    * - ``client_email``
-     - Si
-     - Direccion de correo de la cuenta de servicio
+     - Sí
+     - Dirección de correo de la cuenta de servicio
    * - ``max_size``
      - No
-     - Tamano maximo de archivo a indexar (en bytes). Predeterminado: ``10000000`` (aprox. 10MB)
+     - Tamaño máximo de archivo a indexar (en bytes). Predeterminado: ``10000000`` (aprox. 10MB)
    * - ``ignore_folder``
      - No
      - Si se deben omitir las carpetas. Predeterminado: ``true``
@@ -105,28 +105,28 @@ Lista de Parametros
      - Si se debe continuar el procesamiento cuando ocurre un error. Predeterminado: ``true``
    * - ``supported_mimetypes``
      - No
-     - Tipos MIME a indexar (expresion regular, separados por comas). Predeterminado: ``.*`` (todos los tipos)
+     - Tipos MIME a indexar (expresión regular, separados por comas). Predeterminado: ``.*`` (todos los tipos)
    * - ``include_pattern``
      - No
-     - Patron de expresion regular para las URL que se incluyen en el indice
+     - Patrón de expresión regular para las URL que se incluyen en el índice
    * - ``exclude_pattern``
      - No
-     - Patron de expresion regular para las URL que se excluyen
+     - Patrón de expresión regular para las URL que se excluyen
    * - ``default_permissions``
      - No
      - Permisos predeterminados (separados por comas, p. ej. ``{role}drive-users``)
    * - ``number_of_threads``
      - No
-     - Numero de hilos de procesamiento en paralelo. Predeterminado: ``1``
+     - Número de hilos de procesamiento en paralelo. Predeterminado: ``1``
    * - ``query``
      - No
-     - Cadena de consulta de busqueda de la API de Google Drive
+     - Cadena de consulta de búsqueda de la API de Google Drive
    * - ``corpora``
      - No
      - Corpora a buscar. Predeterminado: ``allDrives``
    * - ``spaces``
      - No
-     - Espacios a buscar (parametro ``spaces`` de la API de Google Drive, p. ej. ``drive``, ``appDataFolder``). Predeterminado: sin especificar (valor predeterminado de la API).
+     - Espacios a buscar (parámetro ``spaces`` de la API de Google Drive, p. ej. ``drive``, ``appDataFolder``). Predeterminado: sin especificar (valor predeterminado de la API).
    * - ``fields``
      - No
      - Campos de archivo que se solicitan a la API de Google Drive. Predeterminado: ``*`` (todos los campos).
@@ -135,21 +135,21 @@ Lista de Parametros
      - Tiempo de espera de lectura HTTP (en milisegundos). Predeterminado: ``20000``
    * - ``connect_timeout``
      - No
-     - Tiempo de espera de conexion HTTP (en milisegundos). Predeterminado: ``20000``
+     - Tiempo de espera de conexión HTTP (en milisegundos). Predeterminado: ``20000``
    * - ``refresh_token_interval``
      - No
      - Intervalo (en segundos) para renovar el token de acceso OAuth. Predeterminado: ``3540`` (59 minutos).
    * - ``max_cached_content_size``
      - No
-     - Tamano maximo (en bytes) del contenido mantenido en memoria; el contenido mayor se vuelca a un archivo temporal. Predeterminado: ``1048576`` (1MB).
+     - Tamaño máximo (en bytes) del contenido mantenido en memoria; el contenido mayor se vuelca a un archivo temporal. Predeterminado: ``1048576`` (1MB).
    * - ``proxy_host``
      - No
      - Nombre de host del servidor proxy
    * - ``proxy_port``
      - No
-     - Numero de puerto del servidor proxy
+     - Número de puerto del servidor proxy
 
-Configuracion de Script
+Configuración de Script
 -----------------------
 
 ::
@@ -174,11 +174,11 @@ Campos Disponibles
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``file.name``
      - Nombre del archivo
    * - ``file.description``
-     - Descripcion del archivo
+     - Descripción del archivo
    * - ``file.contents``
      - Contenido de texto del archivo
    * - ``file.mimetype``
@@ -186,23 +186,23 @@ Campos Disponibles
    * - ``file.filetype``
      - Tipo de archivo
    * - ``file.created_time``
-     - Fecha de creacion
+     - Fecha de creación
    * - ``file.modified_time``
-     - Ultima fecha de modificacion
+     - Última fecha de modificación
    * - ``file.web_view_link``
      - Enlace para abrir en el navegador
    * - ``file.url``
      - URL del archivo
    * - ``file.thumbnail_link``
-     - Enlace de miniatura (valido por tiempo limitado)
+     - Enlace de miniatura (válido por tiempo limitado)
    * - ``file.size``
-     - Tamano del archivo (bytes)
+     - Tamaño del archivo (bytes)
    * - ``file.roles``
      - Permisos de acceso
 
-Para mas detalles, consulte `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_.
+Para más detalles, consulte `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_.
 
-Configuracion de Google Cloud Platform
+Configuración de Google Cloud Platform
 ======================================
 
 1. Crear Proyecto
@@ -212,7 +212,7 @@ Acceda a https://console.cloud.google.com/:
 
 1. Cree un nuevo proyecto
 2. Ingrese el nombre del proyecto
-3. Seleccione la organizacion y la ubicacion
+3. Seleccione la organización y la ubicación
 
 2. Habilitar Google Drive API
 -----------------------------
@@ -239,30 +239,30 @@ En "APIs y servicios" -> "Credenciales":
 En la cuenta de servicio creada:
 
 1. Haga clic en la cuenta de servicio
-2. Abra la pestana "Claves"
+2. Abra la pestaña "Claves"
 3. "Agregar clave" -> "Crear nueva clave"
 4. Seleccione el formato JSON
 5. Guarde el archivo JSON descargado
 
-5. Habilitar Delegacion de Dominio
+5. Habilitar Delegación de Dominio
 ----------------------------------
 
-En la configuracion de la cuenta de servicio:
+En la configuración de la cuenta de servicio:
 
-1. Marque "Habilitar delegacion de dominio"
+1. Marque "Habilitar delegación de dominio"
 2. Haga clic en "Guardar"
 3. Copie el "ID de cliente OAuth 2"
 
-6. Autorizar en la Consola de Administracion de Google Workspace
+6. Autorizar en la Consola de Administración de Google Workspace
 ----------------------------------------------------------------
 
 Acceda a https://admin.google.com/:
 
 1. Abra "Seguridad" -> "Acceso y control de datos" -> "Controles de API"
-2. Seleccione "Delegacion de dominio"
+2. Seleccione "Delegación de dominio"
 3. Haga clic en "Agregar nuevo"
 4. Ingrese el ID de cliente
-5. Ingrese los ambitos OAuth:
+5. Ingrese los ámbitos OAuth:
 
    ::
 
@@ -270,10 +270,10 @@ Acceda a https://admin.google.com/:
 
 6. Haga clic en "Autorizar"
 
-Configuracion de Credenciales
+Configuración de Credenciales
 =============================
 
-Obtener Informacion del Archivo JSON
+Obtener Información del Archivo JSON
 ------------------------------------
 
 Archivo JSON descargado:
@@ -293,75 +293,75 @@ Archivo JSON descargado:
       "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/..."
     }
 
-Configure la siguiente informacion en los parametros:
+Configure la siguiente información en los parámetros:
 
 - ``private_key_id`` -> ``private_key_id``
-- ``private_key`` -> ``private_key`` (los saltos de linea permanecen como ``\n``)
+- ``private_key`` -> ``private_key`` (los saltos de línea permanecen como ``\n``)
 - ``client_email`` -> ``client_email``
 
 Formato de Clave Privada
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-``private_key`` mantiene los saltos de linea como ``\n``:
+``private_key`` mantiene los saltos de línea como ``\n``:
 
 ::
 
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG...\n-----END PRIVATE KEY-----\n
 
-Solucion de Problemas
+Solución de Problemas
 =====================
 
-Error de Autenticacion
+Error de Autenticación
 ----------------------
 
-**Sintoma**: ``401 Unauthorized`` o ``403 Forbidden``
+**Síntoma**: ``401 Unauthorized`` o ``403 Forbidden``
 
 **Verificar**:
 
 1. Verificar que las credenciales de la cuenta de servicio sean correctas:
 
-   - Los saltos de linea de ``private_key`` estan como ``\n``
+   - Los saltos de línea de ``private_key`` están como ``\n``
    - ``private_key_id`` es correcto
    - ``client_email`` es correcto
 
-2. Verificar que Google Drive API este habilitada
-3. Verificar que la delegacion de dominio este configurada
-4. Verificar que este autorizado en la consola de administracion de Google Workspace
-5. Verificar que el ambito OAuth sea correcto (``https://www.googleapis.com/auth/drive``)
+2. Verificar que Google Drive API esté habilitada
+3. Verificar que la delegación de dominio esté configurada
+4. Verificar que esté autorizado en la consola de administración de Google Workspace
+5. Verificar que el ámbito OAuth sea correcto (``https://www.googleapis.com/auth/drive``)
 
-Error de Delegacion de Dominio
+Error de Delegación de Dominio
 ------------------------------
 
-**Sintoma**: ``Not Authorized to access this resource/api``
+**Síntoma**: ``Not Authorized to access this resource/api``
 
-**Solucion**:
+**Solución**:
 
-1. Verificar la autorizacion en la consola de administracion de Google Workspace:
+1. Verificar la autorización en la consola de administración de Google Workspace:
 
-   - El ID de cliente esta registrado correctamente
-   - El ambito OAuth es correcto (``https://www.googleapis.com/auth/drive``)
+   - El ID de cliente está registrado correctamente
+   - El ámbito OAuth es correcto (``https://www.googleapis.com/auth/drive``)
 
-2. Verificar que la delegacion de dominio este habilitada en la cuenta de servicio
+2. Verificar que la delegación de dominio esté habilitada en la cuenta de servicio
 
 No se Pueden Obtener Archivos
 -----------------------------
 
-**Sintoma**: El rastreo tiene exito pero hay 0 archivos
+**Síntoma**: El rastreo tiene éxito pero hay 0 archivos
 
 **Verificar**:
 
 1. Verificar que existan archivos en Google Drive
 2. Verificar que la cuenta de servicio tenga permisos de lectura
-3. Verificar que la delegacion de dominio este configurada correctamente
+3. Verificar que la delegación de dominio esté configurada correctamente
 4. Verificar que se pueda acceder al Drive del usuario objetivo
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`ds-overview` - Vision general de conectores de almacen de datos
+- :doc:`ds-overview` - Visión general de conectores de almacén de datos
 - :doc:`ds-microsoft365` - Conector de Microsoft 365
 - :doc:`ds-box` - Conector de Box
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de almacen de datos
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de almacén de datos
 - `Google Drive API <https://developers.google.com/drive/api>`_
 - `Google Cloud Platform <https://console.cloud.google.com/>`_
 - `Google Workspace Admin <https://admin.google.com/>`_

--- a/es/15.8/config/datastore/ds-json.rst
+++ b/es/15.8/config/datastore/ds-json.rst
@@ -2,11 +2,11 @@
 Conector JSON
 ==============================
 
-Descripcion general
+Descripción general
 ===================
 
 El conector JSON proporciona la funcionalidad para obtener datos de archivos JSONL
-locales (formato JSON Lines) y registrarlos en el indice de |Fess|.
+locales (formato JSON Lines) y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-json``.
 
@@ -17,10 +17,10 @@ Requisitos previos
 2. Se requiere permiso de acceso a los archivos JSON
 3. Es necesario comprender la estructura del JSON
 
-Instalacion del plugin
+Instalación del plugin
 ----------------------
 
-Metodo 1: Colocar el archivo JAR directamente
+Método 1: Colocar el archivo JAR directamente
 
 ::
 
@@ -32,18 +32,18 @@ Metodo 1: Colocar el archivo JAR directamente
     # o
     cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Metodo 2: Instalar desde la pantalla de administracion
+Método 2: Instalar desde la pantalla de administración
 
 1. Abrir "Sistema" -> "Plugins"
 2. Subir el archivo JAR
 3. Reiniciar |Fess|
 
-Metodo de configuracion
+Método de configuración
 =======================
 
-Configure desde la pantalla de administracion en "Crawler" -> "Data Store" -> "Crear nuevo".
+Configure desde la pantalla de administración en "Crawler" -> "Data Store" -> "Crear nuevo".
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -51,7 +51,7 @@ Configuracion basica
    :widths: 25 75
 
    * - Campo
-     - Ejemplo de configuracion
+     - Ejemplo de configuración
    * - Nombre
      - Products JSON
    * - Nombre del handler
@@ -59,7 +59,7 @@ Configuracion basica
    * - Habilitado
      - Activado
 
-Configuracion de parametros
+Configuración de parámetros
 ----------------------------
 
 Archivo local:
@@ -69,66 +69,66 @@ Archivo local:
     files=/path/to/data.json
     fileEncoding=UTF-8
 
-Multiples archivos:
+Múltiples archivos:
 
 ::
 
     files=/path/to/data1.json,/path/to/data2.json
     fileEncoding=UTF-8
 
-Especificacion de directorio:
+Especificación de directorio:
 
 ::
 
     directories=/path/to/json_dir/
     fileEncoding=UTF-8
 
-Lista de parametros
+Lista de parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 10 70
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``files``
      - No
-     - Ruta de los archivos JSON a procesar (se pueden especificar varios separados por comas). Solo se procesan archivos con extension ``.json`` o ``.jsonl``.
+     - Ruta de los archivos JSON a procesar (se pueden especificar varios separados por comas). Solo se procesan archivos con extensión ``.json`` o ``.jsonl``.
    * - ``directories``
      - No
      - Ruta de los directorios que contienen archivos JSON (se pueden especificar varios separados por comas)
    * - ``fileEncoding``
      - No
-     - Codificacion de caracteres (predeterminado: UTF-8)
+     - Codificación de caracteres (predeterminado: UTF-8)
 
 .. warning::
    Es necesario especificar ``files`` o ``directories``.
-   Si no se especifica ninguno (ambos vacios), se producira una ``DataStoreException``.
+   Si no se especifica ninguno (ambos vacíos), se producirá una ``DataStoreException``.
    Si se especifican ambos, ``files`` tiene prioridad y ``directories`` se ignora.
 
 .. note::
-   El nombre del parametro usa camelCase: ``fileEncoding`` (no snake_case ``file_encoding``).
+   El nombre del parámetro usa camelCase: ``fileEncoding`` (no snake_case ``file_encoding``).
 
 Comportamiento al especificar directorios
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Cuando se especifica ``directories``, los archivos ubicados directamente en cada directorio se procesan segun las siguientes reglas.
+Cuando se especifica ``directories``, los archivos ubicados directamente en cada directorio se procesan según las siguientes reglas.
 
-- **Los subdirectorios no se recorren** (no se realiza busqueda recursiva).
-- Solo se procesan archivos con extension ``.json`` o ``.jsonl`` (sin distinguir mayusculas de minusculas).
-- Los archivos se procesan en orden ascendente por fecha de modificacion (hora de ultima modificacion).
+- **Los subdirectorios no se recorren** (no se realiza búsqueda recursiva).
+- Solo se procesan archivos con extensión ``.json`` o ``.jsonl`` (sin distinguir mayúsculas de minúsculas).
+- Los archivos se procesan en orden ascendente por fecha de modificación (hora de última modificación).
 
 .. note::
-   Este conector solo admite archivos JSON en el sistema de archivos local. No es compatible con acceso HTTP ni funciones de autenticacion de API.
+   Este conector solo admite archivos JSON en el sistema de archivos local. No es compatible con acceso HTTP ni funciones de autenticación de API.
 
-Configuracion de scripts
+Configuración de scripts
 -------------------------
 
 Los valores de cada campo se construyen referenciando los valores de los campos del objeto JSON.
 Los campos del nivel superior del objeto JSON se pueden referenciar directamente dentro del script
-como **variables sin prefijo** (no se usa ningun prefijo como ``data.``).
+como **variables sin prefijo** (no se usa ningún prefijo como ``data.``).
 
 Objeto JSON simple:
 
@@ -165,12 +165,12 @@ Campos disponibles
 
 - ``<nombre_campo>`` - Referencia directa a un campo del nivel superior del objeto JSON por nombre
 - ``<padre>.<hijo>`` - Campo de un objeto anidado
-- ``<array>[<indice>]`` - Elemento de array
-- ``<array>.<metodo>`` - Metodos de array (``join``, ``collect``, ``size``, etc.)
+- ``<array>[<índice>]`` - Elemento de array
+- ``<array>.<método>`` - Métodos de array (``join``, ``collect``, ``size``, etc.)
 
 .. note::
 
-   Si el nombre de un campo contiene caracteres invalidos como identificador de Groovy (espacios,
+   Si el nombre de un campo contiene caracteres inválidos como identificador de Groovy (espacios,
    guiones, etc.), ese campo no puede referenciarse directamente como nombre de variable.
 
 Detalles del formato JSON
@@ -180,14 +180,14 @@ Formato de archivo JSON
 ------------------------
 
 El conector JSON lee archivos en formato JSONL (JSON Lines).
-Es un formato en el que se escribe un objeto JSON por linea. El archivo se lee linea a linea
-y cada linea se analiza como un objeto JSON independiente.
+Es un formato en el que se escribe un objeto JSON por línea. El archivo se lee línea a línea
+y cada línea se analiza como un objeto JSON independiente.
 
 .. note::
-   Los archivos con extension ``.json`` tambien son procesados, pero su contenido debe estar
-   en formato JSONL (un objeto por linea).
-   Los archivos JSON en formato de array ( ``[{...}, {...}]`` ) o con formato de varias lineas
-   (pretty-printed) no se pueden leer directamente. Conviertelos al formato JSONL.
+   Los archivos con extensión ``.json`` también son procesados, pero su contenido debe estar
+   en formato JSONL (un objeto por línea).
+   Los archivos JSON en formato de array ( ``[{...}, {...}]`` ) o con formato de varias líneas
+   (pretty-printed) no se pueden leer directamente. Conviértelos al formato JSONL.
 
 Archivo en formato JSONL:
 
@@ -199,10 +199,10 @@ Archivo en formato JSONL:
 Ejemplos de uso
 ===============
 
-Catalogo de productos
+Catálogo de productos
 ----------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -219,10 +219,10 @@ Scripts:
     digest=category
     price=price
 
-Integracion de multiples archivos JSON
+Integración de múltiples archivos JSON
 ---------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -237,67 +237,67 @@ Scripts:
     title=title
     content=content
 
-Solucion de problemas
+Solución de problemas
 ======================
 
 Archivo no encontrado
 ----------------------
 
-**Sintoma**: El registro muestra ``... is not found.`` o ``Source file ... does not exist.``
+**Síntoma**: El registro muestra ``... is not found.`` o ``Source file ... does not exist.``
 
 **Puntos a verificar**:
 
 1. Verificar que la ruta del archivo sea correcta
 2. Verificar que el archivo exista
-3. Verificar que la extension del archivo sea ``.json`` o ``.jsonl``
+3. Verificar que la extensión del archivo sea ``.json`` o ``.jsonl``
 4. Verificar que el archivo tenga permisos de lectura
 
-Error de analisis JSON
+Error de análisis JSON
 -----------------------
 
-**Sintoma**: El registro muestra ``Crawling Access Exception`` y ``JsonParseException``, entre otros
+**Síntoma**: El registro muestra ``Crawling Access Exception`` y ``JsonParseException``, entre otros
 
-Si una linea contiene datos invalidos, solo esa linea se omite y se registra como URL fallida,
-y el crawling continua desde la siguiente linea.
+Si una línea contiene datos inválidos, solo esa línea se omite y se registra como URL fallida,
+y el crawling continúa desde la siguiente línea.
 
 **Puntos a verificar**:
 
-1. Verificar que el archivo JSON tenga el formato correcto (JSONL: un objeto por linea):
+1. Verificar que el archivo JSON tenga el formato correcto (JSONL: un objeto por línea):
 
    ::
 
        # Validar que cada linea sea un objeto JSON valido
        cat data.json | jq -c .
 
-2. Verificar la codificacion de caracteres
-3. Verificar que un mismo objeto no este dividido en varias lineas
-4. Verificar que no contenga comentarios (no permitidos en el estandar JSON)
+2. Verificar la codificación de caracteres
+3. Verificar que un mismo objeto no esté dividido en varias líneas
+4. Verificar que no contenga comentarios (no permitidos en el estándar JSON)
 
 No se obtienen datos
 ---------------------
 
-**Sintoma**: El crawling se completa con exito pero el recuento es 0
+**Síntoma**: El crawling se completa con éxito pero el recuento es 0
 
 **Puntos a verificar**:
 
 1. Verificar la estructura JSON
-2. Verificar que la configuracion de scripts sea correcta (que las referencias a campos no tengan el prefijo ``data.``)
-3. Verificar los nombres de campo (incluyendo mayusculas y minusculas)
+2. Verificar que la configuración de scripts sea correcta (que las referencias a campos no tengan el prefijo ``data.``)
+3. Verificar los nombres de campo (incluyendo mayúsculas y minúsculas)
 4. Verificar los mensajes de error en los registros
 
 Archivos JSON grandes
 ----------------------
 
-**Sintoma**: Falta de memoria o tiempo de espera agotado
+**Síntoma**: Falta de memoria o tiempo de espera agotado
 
-El archivo se lee linea a linea, por lo que el tamano total del archivo no afecta directamente
-al uso de memoria. Sin embargo, pueden surgir problemas si una sola linea (un objeto) es
-extremadamente grande o si la carga de indexacion es elevada.
+El archivo se lee línea a línea, por lo que el tamaño total del archivo no afecta directamente
+al uso de memoria. Sin embargo, pueden surgir problemas si una sola línea (un objeto) es
+extremadamente grande o si la carga de indexación es elevada.
 
-**Solucion**:
+**Solución**:
 
 1. Dividir el archivo JSON en varios archivos
-2. Aumentar el tamano del heap de |Fess|
+2. Aumentar el tamaño del heap de |Fess|
 
 Uso avanzado de scripts
 ========================
@@ -305,7 +305,7 @@ Uso avanzado de scripts
 Procesamiento condicional
 --------------------------
 
-Cada campo se evalua como una expresion independiente. Para valores condicionales, utilice el operador ternario:
+Cada campo se evalúa como una expresión independiente. Para valores condicionales, utilice el operador ternario:
 
 ::
 
@@ -314,7 +314,7 @@ Cada campo se evalua como una expresion independiente. Para valores condicionale
     content=status == "published" ? description : null
     price=status == "published" ? price : null
 
-Union de arrays
+Unión de arrays
 ----------------
 
 ::
@@ -325,7 +325,7 @@ Union de arrays
     tags=tags ? tags.join(", ") : ""
     categories=categories.collect { it.name }.join(", ")
 
-Configuracion de valores predeterminados
+Configuración de valores predeterminados
 -----------------------------------------
 
 ::
@@ -346,7 +346,7 @@ Formato de fechas
     created=created_at
     last_modified=updated_at
 
-Procesamiento de numeros
+Procesamiento de números
 -------------------------
 
 ::
@@ -357,13 +357,13 @@ Procesamiento de numeros
     price=price as Float
     stock=stock_quantity as Integer
 
-Informacion de referencia
+Información de referencia
 ==========================
 
-- :doc:`ds-overview` - Descripcion general de conectores de Data Store
+- :doc:`ds-overview` - Descripción general de conectores de Data Store
 - :doc:`ds-csv` - Conector CSV
 - :doc:`ds-database` - Conector de base de datos
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de Data Store
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de Data Store
 - `JSON (JavaScript Object Notation) <https://www.json.org/>`_
 - `JSON Lines <https://jsonlines.org/>`_
 - `jq - JSON processor <https://stedolan.github.io/jq/>`_

--- a/es/15.8/config/datastore/ds-overview.rst
+++ b/es/15.8/config/datastore/ds-overview.rst
@@ -1,17 +1,17 @@
 ==================================
-Descripcion General de los Conectores de Almacen de Datos
+Descripción General de los Conectores de Almacén de Datos
 ==================================
 
-Descripcion General
+Descripción General
 ===================
 
-Los conectores de almacen de datos de |Fess| proporcionan funcionalidad para obtener contenido
+Los conectores de almacén de datos de |Fess| proporcionan funcionalidad para obtener contenido
 de fuentes de datos distintas a sitios web o sistemas de archivos y indexarlo.
 
-Al utilizar conectores de almacen de datos, puede hacer que los datos de las siguientes fuentes sean buscables:
+Al utilizar conectores de almacén de datos, puede hacer que los datos de las siguientes fuentes sean buscables:
 
 - Almacenamiento en la nube (Box, Dropbox, Google Drive, OneDrive)
-- Herramientas de colaboracion (Confluence, Jira, Slack)
+- Herramientas de colaboración (Confluence, Jira, Slack)
 - Bases de datos (MySQL, PostgreSQL, Oracle, etc.)
 - Otros sistemas (Git, Salesforce, Elasticsearch, etc.)
 
@@ -19,7 +19,7 @@ Conectores Disponibles
 ======================
 
 |Fess| proporciona conectores para diversas fuentes de datos.
-Muchos conectores se proporcionan como plugins y pueden instalarse segun sea necesario.
+Muchos conectores se proporcionan como plugins y pueden instalarse según sea necesario.
 
 Almacenamiento en la Nube
 -------------------------
@@ -30,7 +30,7 @@ Almacenamiento en la Nube
 
    * - Conector
      - Plugin
-     - Descripcion
+     - Descripción
    * - :doc:`ds-box`
      - fess-ds-box
      - Rastrea archivos y carpetas de Box.com
@@ -44,7 +44,7 @@ Almacenamiento en la Nube
      - fess-ds-microsoft365
      - Rastrea OneDrive, SharePoint, etc.
 
-Herramientas de Colaboracion
+Herramientas de Colaboración
 ----------------------------
 
 .. list-table::
@@ -53,7 +53,7 @@ Herramientas de Colaboracion
 
    * - Conector
      - Plugin
-     - Descripcion
+     - Descripción
    * - :doc:`ds-atlassian`
      - fess-ds-atlassian
      - Rastrea Confluence y Jira
@@ -70,10 +70,10 @@ Herramientas de Desarrollo y Operaciones
 
    * - Conector
      - Plugin
-     - Descripcion
+     - Descripción
    * - :doc:`ds-git`
      - fess-ds-git
-     - Rastrea codigo fuente de repositorios Git
+     - Rastrea código fuente de repositorios Git
    * - :doc:`ds-elasticsearch`
      - fess-ds-elasticsearch
      - Obtiene datos de Elasticsearch/OpenSearch
@@ -90,7 +90,7 @@ Bases de Datos y Archivos
 
    * - Conector
      - Plugin
-     - Descripcion
+     - Descripción
    * - :doc:`ds-database`
      - fess-ds-db
      - Obtiene datos de bases de datos compatibles con JDBC
@@ -101,65 +101,65 @@ Bases de Datos y Archivos
      - fess-ds-json
      - Obtiene datos de archivos JSON
 
-Instalacion de Conectores
+Instalación de Conectores
 =========================
 
-Instalacion de Plugins
+Instalación de Plugins
 ----------------------
 
-Los plugins de conectores de almacen de datos pueden instalarse desde la consola de administracion.
+Los plugins de conectores de almacén de datos pueden instalarse desde la consola de administración.
 
-Desde la Consola de Administracion
+Desde la Consola de Administración
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Inicie sesion en la consola de administracion
+1. Inicie sesión en la consola de administración
 2. Vaya a "Sistema" -> "Plugin"
-3. Haga clic en el boton "Instalar"
-4. Seleccione el plugin en la pestana "Remoto" (o suba un archivo JAR desde la pestana "Local")
+3. Haga clic en el botón "Instalar"
+4. Seleccione el plugin en la pestaña "Remoto" (o suba un archivo JAR desde la pestaña "Local")
 5. Haga clic en "Instalar"
 6. Reinicie |Fess|
 
-Conceptos Basicos de Configuracion del Almacen de Datos
+Conceptos Básicos de Configuración del Almacén de Datos
 =======================================================
 
-La configuracion de los conectores de almacen de datos se realiza en la consola de administracion bajo "Rastreador" -> "Almacen de Datos".
+La configuración de los conectores de almacén de datos se realiza en la consola de administración bajo "Rastreador" -> "Almacén de Datos".
 
-Elementos de Configuracion Comunes
+Elementos de Configuración Comunes
 ----------------------------------
 
-Elementos de configuracion comunes a todos los conectores de almacen de datos:
+Elementos de configuración comunes a todos los conectores de almacén de datos:
 
 .. list-table::
    :header-rows: 1
    :widths: 25 75
 
    * - Elemento
-     - Descripcion
+     - Descripción
    * - Nombre
-     - Nombre identificador de la configuracion
-   * - Descripcion
-     - Texto descriptivo de la configuracion
+     - Nombre identificador de la configuración
+   * - Descripción
+     - Texto descriptivo de la configuración
    * - Nombre del Manejador
      - Nombre del manejador del conector a utilizar (ej., ``CsvDataStore``)
-   * - Parametros
-     - Parametros de configuracion especificos del conector (formato key=value)
+   * - Parámetros
+     - Parámetros de configuración específicos del conector (formato key=value)
    * - Script
-     - Script de mapeo de campos del indice
+     - Script de mapeo de campos del índice
    * - Boost
-     - Prioridad en los resultados de busqueda
+     - Prioridad en los resultados de búsqueda
    * - Permisos
-     - Permisos de acceso para los documentos obtenidos de este almacen de datos
+     - Permisos de acceso para los documentos obtenidos de este almacén de datos
    * - Hosts virtuales
-     - Host virtual al que se aplica esta configuracion
-   * - Orden de visualizacion
-     - Orden de visualizacion en la lista de configuraciones
+     - Host virtual al que se aplica esta configuración
+   * - Orden de visualización
+     - Orden de visualización en la lista de configuraciones
    * - Habilitado
-     - Si esta configuracion esta activa o no
+     - Si esta configuración está activa o no
 
-Configuracion de Parametros
+Configuración de Parámetros
 ---------------------------
 
-Los parametros se especifican en formato ``key=value`` separados por saltos de linea:
+Los parámetros se especifican en formato ``key=value`` separados por saltos de linea:
 
 ::
 
@@ -167,11 +167,11 @@ Los parametros se especifican en formato ``key=value`` separados por saltos de l
     folder.id=0
     max.depth=3
 
-Configuracion de Script
+Configuración de Script
 -----------------------
 
-Los scripts mapean los datos obtenidos a los campos del indice de |Fess|.
-El lado izquierdo de cada linea es el campo del indice de |Fess|; el lado derecho es el campo obtenido del conector.
+Los scripts mapean los datos obtenidos a los campos del índice de |Fess|.
+El lado izquierdo de cada línea es el campo del índice de |Fess|; el lado derecho es el campo obtenido del conector.
 
 El siguiente es un ejemplo para el conector CSV con columnas de encabezado ``link``, ``subject`` y ``body``:
 
@@ -183,73 +183,73 @@ El siguiente es un ejemplo para el conector CSV con columnas de encabezado ``lin
 
 .. note::
 
-   Los nombres de campo utilizables en los scripts difieren segun el conector.
+   Los nombres de campo utilizables en los scripts difieren según el conector.
    Box/Dropbox/Google Drive/OneDrive referencian el objeto obtenido con el prefijo ``file.*``; Slack utiliza ``message.*``; Jira utiliza ``issue.*``.
    Los conectores CSV, JSON y de base de datos NO utilizan prefijo; los campos se referencian directamente:
 
-   - CSV: nombres de columna del encabezado (si ``has_header_line=true``), o ``cell1``, ``cell2``, ... (indice basado en 1); ademas de ``csvfile`` y ``csvfilename``.
+   - CSV: nombres de columna del encabezado (si ``has_header_line=true``), o ``cell1``, ``cell2``, ... (índice basado en 1); además de ``csvfile`` y ``csvfilename``.
    - JSON: nombres de campo del objeto JSON.
    - Base de datos: nombres de columna (alias) del resultado del SELECT.
 
-   Consulte la documentacion individual de cada conector para mas detalles.
+   Consulte la documentación individual de cada conector para más detalles.
 
-Configuracion de Autenticacion
+Configuración de Autenticación
 ==============================
 
-Muchos conectores de almacen de datos requieren autenticacion mediante OAuth 2.0, claves API, cuentas de servicio, etc.
+Muchos conectores de almacén de datos requieren autenticación mediante OAuth 2.0, claves API, cuentas de servicio, etc.
 
-Los parametros de autenticacion varian segun el conector.
-Consulte la documentacion individual de cada conector para los detalles de configuracion de autenticacion.
+Los parámetros de autenticación varían según el conector.
+Consulte la documentación individual de cada conector para los detalles de configuración de autenticación.
 
-Parametros Comunes
+Parámetros Comunes
 ==================
 
-Parametros comunes disponibles para todos los conectores de almacen de datos:
+Parámetros comunes disponibles para todos los conectores de almacén de datos:
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 65
 
-   * - Parametro
+   * - Parámetro
      - Valor por defecto
-     - Descripcion
+     - Descripción
    * - ``readInterval``
      - ``0``
      - Tiempo de espera entre el procesamiento de cada registro (milisegundos). Se utiliza para reducir la carga del servidor al procesar grandes cantidades de datos.
    * - ``script_type``
      - ``groovy``
-     - Tipo de motor de scripts usado para el mapeo de campos del indice. De forma predeterminada solo esta disponible ``groovy``.
+     - Tipo de motor de scripts usado para el mapeo de campos del índice. De forma predeterminada solo está disponible ``groovy``.
 
-Solucion de Problemas
+Solución de Problemas
 =====================
 
 El Conector No Aparece
 ----------------------
 
-1. Verifique que el plugin este instalado correctamente
+1. Verifique que el plugin esté instalado correctamente
 2. Reinicie |Fess|
 3. Revise los logs en busca de errores
 
-Errores de Autenticacion
+Errores de Autenticación
 ------------------------
 
-1. Verifique que las credenciales de autenticacion sean correctas
-2. Verifique la fecha de expiracion del token
+1. Verifique que las credenciales de autenticación sean correctas
+2. Verifique la fecha de expiración del token
 3. Confirme que se hayan otorgado los permisos necesarios
-4. Verifique que el acceso a la API este permitido en el servicio
+4. Verifique que el acceso a la API esté permitido en el servicio
 
 No Se Pueden Obtener Datos
 --------------------------
 
-1. Verifique que el formato de los parametros sea correcto
+1. Verifique que el formato de los parámetros sea correcto
 2. Verifique los permisos de acceso a las carpetas/archivos de destino
-3. Revise la configuracion de filtros
+3. Revise la configuración de filtros
 4. Revise los logs para mensajes de error detallados
 
-Configuracion de Depuracion
+Configuración de Depuración
 ---------------------------
 
-Al investigar problemas, ajuste el nivel de log. El rastreo de almacenes de datos se ejecuta en el proceso del rastreador, por lo que debe editar el archivo de configuracion de log del rastreador:
+Al investigar problemas, ajuste el nivel de log. El rastreo de almacenes de datos se ejecuta en el proceso del rastreador, por lo que debe editar el archivo de configuración de log del rastreador:
 
 ``app/WEB-INF/env/crawler/resources/log4j2.xml``:
 
@@ -257,9 +257,9 @@ Al investigar problemas, ajuste el nivel de log. El rastreo de almacenes de dato
 
     <Logger name="org.codelibs.fess.ds" level="DEBUG"/>
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`../../admin/dataconfig-guide` - Guia de Configuracion de Almacen de Datos
-- :doc:`../../admin/plugin-guide` - Guia de Administracion de Plugins
-- :doc:`../../api/admin/api-admin-dataconfig` - API de Configuracion de Almacen de Datos
+- :doc:`../../admin/dataconfig-guide` - Guía de Configuración de Almacén de Datos
+- :doc:`../../admin/plugin-guide` - Guía de Administración de Plugins
+- :doc:`../../api/admin/api-admin-dataconfig` - API de Configuración de Almacén de Datos

--- a/es/15.8/config/datastore/ds-salesforce.rst
+++ b/es/15.8/config/datastore/ds-salesforce.rst
@@ -2,28 +2,28 @@
 Conector Salesforce
 ==================================
 
-Descripcion general
+Descripción general
 ===================
 
 El conector Salesforce proporciona la funcionalidad para obtener datos de objetos de Salesforce
-(objetos estandar, objetos personalizados) y registrarlos en el indice de |Fess|.
+(objetos estándar, objetos personalizados) y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-salesforce``.
 
 Objetos compatibles
 ===================
 
-- **Objetos estandar**: objetos estandar predefinidos (Account, Contact, Lead, Opportunity, Case, Solution, etc.). El conjunto de objetos estandar es fijo y todos ellos se recuperan en cada crawl.
-- **Objetos personalizados**: objetos definidos por el usuario y especificados mediante el parametro ``custom`` (objetos cuyos nombres de API terminan en ``__c``).
+- **Objetos estándar**: objetos estándar predefinidos (Account, Contact, Lead, Opportunity, Case, Solution, etc.). El conjunto de objetos estándar es fijo y todos ellos se recuperan en cada crawl.
+- **Objetos personalizados**: objetos definidos por el usuario y especificados mediante el parámetro ``custom`` (objetos cuyos nombres de API terminan en ``__c``).
 
 .. note::
 
-   Los objetos estandar se crawlean siempre en su totalidad (no es posible seleccionar individualmente cuales se crawlean). Para excluir objetos no deseados, utilice el filtrado por URL mediante ``include_pattern`` / ``exclude_pattern``.
+   Los objetos estándar se crawlean siempre en su totalidad (no es posible seleccionar individualmente cuáles se crawlean). Para excluir objetos no deseados, utilice el filtrado por URL mediante ``include_pattern`` / ``exclude_pattern``.
 
-Lista de objetos estandar
+Lista de objetos estándar
 -------------------------
 
-Los siguientes objetos estandar son crawleados. El "Nombre de objeto" es el identificador que se usa en el mapeo de campos (p. ej. ``<NombreObjeto>.title``); ``object.type`` es el valor del tipo de objeto al que puede hacer referencia en los scripts.
+Los siguientes objetos estándar son crawleados. El "Nombre de objeto" es el identificador que se usa en el mapeo de campos (p. ej. ``<NombreObjeto>.title``); ``object.type`` es el valor del tipo de objeto al que puede hacer referencia en los scripts.
 
 .. list-table::
    :header-rows: 1
@@ -31,7 +31,7 @@ Los siguientes objetos estandar son crawleados. El "Nombre de objeto" es el iden
 
    * - Nombre de objeto
      - ``object.type``
-     - Descripcion
+     - Descripción
    * - ``ACCOUNT``
      - ``Account``
      - Account
@@ -106,23 +106,23 @@ Requisitos previos
 ==================
 
 1. Es necesario instalar el plugin
-2. Es necesario crear una aplicacion conectada (Connected App) en Salesforce
-3. Es necesario configurar la autenticacion OAuth
+2. Es necesario crear una aplicación conectada (Connected App) en Salesforce
+3. Es necesario configurar la autenticación OAuth
 4. Se requiere acceso de lectura a los objetos
 
-Instalacion del plugin
+Instalación del plugin
 ----------------------
 
-Instale desde la pantalla de administracion en "Sistema" -> "Plugins".
+Instale desde la pantalla de administración en "Sistema" -> "Plugins".
 
-O consulte :doc:`../../admin/plugin-guide` para mas detalles.
+O consulte :doc:`../../admin/plugin-guide` para más detalles.
 
-Configuracion
+Configuración
 =============
 
-Configure desde la pantalla de administracion en "Crawler" -> "Data Store" -> "Crear nuevo".
+Configure desde la pantalla de administración en "Crawler" -> "Data Store" -> "Crear nuevo".
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -138,10 +138,10 @@ Configuracion basica
    * - Habilitado
      - Activado
 
-Configuracion de parametros
+Configuración de parámetros
 ---------------------------
 
-Autenticacion OAuth Token (recomendada):
+Autenticación OAuth Token (recomendada):
 
 ::
 
@@ -158,7 +158,7 @@ Autenticacion OAuth Token (recomendada):
     CustomProduct.title=Product_Name__c
     CustomProduct.contents=Product_Name__c,Product_Description__c
 
-Autenticacion OAuth Password:
+Autenticación OAuth Password:
 
 ::
 
@@ -172,43 +172,43 @@ Autenticacion OAuth Password:
     number_of_threads=1
     ignore_error=true
 
-Lista de parametros
+Lista de parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``base_url``
      - No
      - URL de Salesforce (predeterminado: ``https://login.salesforce.com``; Sandbox: ``https://test.salesforce.com``)
    * - ``auth_type``
-     - Si
-     - Tipo de autenticacion (``oauth_token`` o ``oauth_password``)
+     - Sí
+     - Tipo de autenticación (``oauth_token`` o ``oauth_password``)
    * - ``username``
-     - Si
+     - Sí
      - Nombre de usuario de Salesforce
    * - ``client_id``
-     - Si
-     - Consumer Key de la aplicacion conectada
+     - Sí
+     - Consumer Key de la aplicación conectada
    * - ``password``
      - Para oauth_password
-     - Contrasena de Salesforce
+     - Contraseña de Salesforce
    * - ``private_key``
      - Para oauth_token
-     - Clave privada (formato PEM, saltos de linea como ``\n``)
+     - Clave privada (formato PEM, saltos de línea como ``\n``)
    * - ``client_secret``
      - Para oauth_password
-     - Consumer Secret de la aplicacion conectada
+     - Consumer Secret de la aplicación conectada
    * - ``security_token``
      - Para oauth_password
      - Token de seguridad del usuario
    * - ``number_of_threads``
      - No
-     - Numero de hilos de procesamiento paralelo (predeterminado: 1)
+     - Número de hilos de procesamiento paralelo (predeterminado: 1)
    * - ``ignore_error``
      - No
      - Continuar procesando en caso de error (predeterminado: true)
@@ -217,33 +217,33 @@ Lista de parametros
      - Nombres de objetos personalizados (separados por comas)
    * - ``<objeto>.title``
      - No
-     - Nombre del campo a usar para el titulo
+     - Nombre del campo a usar para el título
    * - ``<objeto>.contents``
      - No
      - Nombres de campos a usar para el contenido (separados por comas)
    * - ``<objeto>.descriptions``
      - No
-     - Nombres de campos para descripcion (separados por comas)
+     - Nombres de campos para descripción (separados por comas)
    * - ``<objeto>.thumbnail``
      - No
      - Nombre del campo para miniatura
    * - ``include_pattern``
      - No
-     - Patron de inclusion del filtro URL (regex)
+     - Patrón de inclusión del filtro URL (regex)
    * - ``exclude_pattern``
      - No
-     - Patron de exclusion del filtro URL (regex)
+     - Patrón de exclusión del filtro URL (regex)
    * - ``refresh_token_interval``
      - No
-     - Intervalo de actualizacion del token en segundos (predeterminado: 3540)
+     - Intervalo de actualización del token en segundos (predeterminado: 3540)
    * - ``proxy_host``
      - No
      - Nombre del host del proxy HTTP
    * - ``proxy_port``
-     - Si proxy_host esta configurado
-     - Numero de puerto del proxy HTTP
+     - Si proxy_host está configurado
+     - Número de puerto del proxy HTTP
 
-Configuracion de scripts
+Configuración de scripts
 ------------------------
 
 ::
@@ -263,13 +263,13 @@ Campos disponibles
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``object.type``
      - Tipo del objeto (ej: Case, User, Solution)
    * - ``object.title``
      - Nombre del objeto
    * - ``object.description``
-     - Descripcion del objeto
+     - Descripción del objeto
    * - ``object.content``
      - Contenido de texto del objeto
    * - ``object.id``
@@ -277,39 +277,39 @@ Campos disponibles
    * - ``object.content_length``
      - Longitud del contenido
    * - ``object.created``
-     - Fecha y hora de creacion
+     - Fecha y hora de creación
    * - ``object.last_modified``
-     - Fecha y hora de ultima modificacion
+     - Fecha y hora de última modificación
    * - ``object.url``
      - URL del objeto
    * - ``object.thumbnail``
      - URL del thumbnail
 
-Configuracion de aplicacion conectada de Salesforce
+Configuración de aplicación conectada de Salesforce
 ===================================================
 
-1. Crear aplicacion conectada
+1. Crear aplicación conectada
 -----------------------------
 
 En Salesforce Setup:
 
 1. Abrir "Application Manager"
 2. Hacer clic en "New Connected App"
-3. Ingresar informacion basica:
+3. Ingresar información básica:
 
-   - Nombre de aplicacion conectada: Fess Crawler
+   - Nombre de aplicación conectada: Fess Crawler
    - Nombre de API: Fess_Crawler
    - Email de contacto: your-email@example.com
 
 4. Marcar "Enable OAuth Settings"
 
-2. Configuracion de autenticacion OAuth Token (recomendada)
+2. Configuración de autenticación OAuth Token (recomendada)
 -----------------------------------------------------------
 
-En configuracion OAuth:
+En configuración OAuth:
 
 1. Marcar "Use digital signatures"
-2. Subir el certificado (crear segun los pasos a continuacion)
+2. Subir el certificado (crear según los pasos a continuación)
 3. OAuth Scopes seleccionados:
 
    - Full access (full)
@@ -318,7 +318,7 @@ En configuracion OAuth:
 4. Hacer clic en "Save"
 5. Copiar el Consumer Key
 
-Creacion del certificado:
+Creación del certificado:
 
 ::
 
@@ -332,12 +332,12 @@ Creacion del certificado:
     cat private_key.pem
 
 Suba el certificado (certificate.crt) a Salesforce y
-configure el contenido de la clave privada (private_key.pem) en los parametros.
+configure el contenido de la clave privada (private_key.pem) en los parámetros.
 
-3. Configuracion de autenticacion OAuth Password
+3. Configuración de autenticación OAuth Password
 ------------------------------------------------
 
-En configuracion OAuth:
+En configuración OAuth:
 
 1. URL de callback: ``https://localhost`` (no se usa pero es requerido)
 2. OAuth Scopes seleccionados:
@@ -350,27 +350,27 @@ En configuracion OAuth:
 
 Obtener el token de seguridad:
 
-1. Abrir configuracion personal en Salesforce
+1. Abrir configuración personal en Salesforce
 2. Hacer clic en "Reset My Security Token"
 3. Copiar el token enviado por email
 
-4. Aprobacion de aplicacion conectada
+4. Aprobación de aplicación conectada
 -------------------------------------
 
 En "Manage" -> "Manage Connected Apps":
 
-1. Seleccionar la aplicacion conectada creada
+1. Seleccionar la aplicación conectada creada
 2. Hacer clic en "Edit"
 3. Cambiar "Permitted Users" a "Admin approved users are pre-authorized"
 4. Asignar perfiles o conjuntos de permisos
 
-Configuracion de objetos personalizados
+Configuración de objetos personalizados
 =======================================
 
 Crawl de objetos personalizados
 -------------------------------
 
-Especifique los nombres de objetos personalizados en el parametro ``custom``:
+Especifique los nombres de objetos personalizados en el parámetro ``custom``:
 
 ::
 
@@ -392,25 +392,25 @@ Mapeo de campos para cada objeto:
 Reglas de mapeo de campos
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``<nombre_objeto>.title`` - Campo a usar para el titulo (campo unico)
-- ``<nombre_objeto>.contents`` - Campos a usar para el contenido (multiples separados por comas)
-- ``<nombre_objeto>.descriptions`` - Campos a usar para la descripcion (multiples separados por comas)
-- ``<nombre_objeto>.thumbnail`` - Campo a usar para la miniatura (campo unico)
+- ``<nombre_objeto>.title`` - Campo a usar para el título (campo único)
+- ``<nombre_objeto>.contents`` - Campos a usar para el contenido (múltiples separados por comas)
+- ``<nombre_objeto>.descriptions`` - Campos a usar para la descripción (múltiples separados por comas)
+- ``<nombre_objeto>.thumbnail`` - Campo a usar para la miniatura (campo único)
 
 .. note::
 
-   En el mapeo de campos de objetos estandar, el nombre de objeto usa UPPER_SNAKE_CASE
-   (el valor de la columna "Nombre de objeto" de la seccion `Lista de objetos estandar`_)
+   En el mapeo de campos de objetos estándar, el nombre de objeto usa UPPER_SNAKE_CASE
+   (el valor de la columna "Nombre de objeto" de la sección `Lista de objetos estándar`_)
    (p. ej. ``ACCOUNT.title=Name``, ``DAND_B_COMPANY.title=Name``).
    Para objetos personalizados, se usa el nombre de referencia de la API tal cual (p. ej. ``Product__c.title=Name``).
 
 Ejemplos de uso
 ===============
 
-Crawl de objetos estandar
+Crawl de objetos estándar
 -------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -436,7 +436,7 @@ Script:
 Crawl de objetos personalizados
 -------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -466,7 +466,7 @@ Script:
 Crawl de entorno Sandbox
 ------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -489,38 +489,38 @@ Script:
     timestamp=object.last_modified
     url=object.url
 
-Solucion de problemas
+Solución de problemas
 =====================
 
-Error de autenticacion
+Error de autenticación
 ----------------------
 
-**Sintoma**: ``Authentication failed`` o ``invalid_grant``
+**Síntoma**: ``Authentication failed`` o ``invalid_grant``
 
 **Verificaciones**:
 
-1. Para autenticacion OAuth Token:
+1. Para autenticación OAuth Token:
 
    - Verificar que el Consumer Key sea correcto
-   - Verificar que la clave privada este copiada correctamente (saltos de linea como ``\n``)
-   - Confirmar que el certificado este subido a Salesforce
+   - Verificar que la clave privada esté copiada correctamente (saltos de línea como ``\n``)
+   - Confirmar que el certificado esté subido a Salesforce
    - Verificar que el nombre de usuario sea correcto
 
-2. Para autenticacion OAuth Password:
+2. Para autenticación OAuth Password:
 
    - Verificar que Consumer Key y Consumer Secret sean correctos
    - Verificar que el token de seguridad sea correcto
-   - Confirmar que la contrasena y el token de seguridad no esten concatenados (configurar por separado)
+   - Confirmar que la contraseña y el token de seguridad no estén concatenados (configurar por separado)
 
-3. Comun:
+3. Común:
 
-   - Verificar que base_url sea correcta (entorno de produccion o Sandbox)
-   - Confirmar que la aplicacion conectada este aprobada
+   - Verificar que base_url sea correcta (entorno de producción o Sandbox)
+   - Confirmar que la aplicación conectada esté aprobada
 
 No se obtienen objetos
 ----------------------
 
-**Sintoma**: El crawl tiene exito pero hay 0 objetos
+**Síntoma**: El crawl tiene éxito pero hay 0 objetos
 
 **Verificaciones**:
 
@@ -543,7 +543,7 @@ Ejemplo:
 - Label: Product
 - API Name: Product__c (usar este)
 
-Verificacion de nombres de campo
+Verificación de nombres de campo
 --------------------------------
 
 Verificar el API Name del campo personalizado:
@@ -557,26 +557,26 @@ Ejemplo:
 - Field Label: Product Description
 - Field Name: Product_Description__c (usar este)
 
-Limite de tasa de API
+Límite de tasa de API
 ---------------------
 
-**Sintoma**: ``REQUEST_LIMIT_EXCEEDED``
+**Síntoma**: ``REQUEST_LIMIT_EXCEEDED``
 
-**Solucion**:
+**Solución**:
 
 1. Reducir ``number_of_threads`` (configurar a 1)
 2. Aumentar el intervalo de crawl
 3. Verificar el uso de la API de Salesforce
-4. Comprar limite de API adicional si es necesario
+4. Comprar límite de API adicional si es necesario
 
 Gran volumen de datos
 ---------------------
 
-**Sintoma**: El crawl toma mucho tiempo o tiene timeout
+**Síntoma**: El crawl toma mucho tiempo o tiene timeout
 
-**Solucion**:
+**Solución**:
 
-1. Dividir objetos en multiples data stores
+1. Dividir objetos en múltiples data stores
 2. Ajustar ``number_of_threads`` (aproximadamente 2-4)
 3. Distribuir el horario de crawl
 4. Mapear solo los campos necesarios
@@ -584,11 +584,11 @@ Gran volumen de datos
 Error de formato de clave privada
 ---------------------------------
 
-**Sintoma**: ``Invalid private key format``
+**Síntoma**: ``Invalid private key format``
 
-**Solucion**:
+**Solución**:
 
-Verificar que los saltos de linea en la clave privada sean correctamente ``\n``:
+Verificar que los saltos de línea en la clave privada sean correctamente ``\n``:
 
 ::
 
@@ -600,12 +600,12 @@ Verificar que los saltos de linea en la clave privada sean correctamente ``\n``:
     MIIEvgIBADANBgkqhkiG9w0BAQE...
     -----END PRIVATE KEY-----
 
-Informacion de referencia
+Información de referencia
 =========================
 
-- :doc:`ds-overview` - Descripcion general de conectores de Data Store
+- :doc:`ds-overview` - Descripción general de conectores de Data Store
 - :doc:`ds-database` - Conector de base de datos
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de Data Store
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de Data Store
 - `Salesforce REST API <https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/>`_
 - `Salesforce OAuth 2.0 JWT Bearer Flow <https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm>`_
 - `Salesforce Connected Apps <https://help.salesforce.com/s/articleView?id=sf.connected_app_overview.htm>`_

--- a/es/15.8/config/datastore/index.rst
+++ b/es/15.8/config/datastore/index.rst
@@ -1,12 +1,12 @@
 ===================================
-Guia de Conectores de Almacen de Datos
+Guía de Conectores de Almacén de Datos
 ===================================
 
-Los conectores de almacen de datos de |Fess| permiten obtener contenido de diversas fuentes de datos y hacerlo buscable.
+Los conectores de almacén de datos de |Fess| permiten obtener contenido de diversas fuentes de datos y hacerlo buscable.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Descripcion General
+   :caption: Descripción General
 
    ds-overview
 
@@ -21,7 +21,7 @@ Los conectores de almacen de datos de |Fess| permiten obtener contenido de diver
 
 .. toctree::
    :maxdepth: 2
-   :caption: Herramientas de Colaboracion
+   :caption: Herramientas de Colaboración
 
    ds-atlassian
    ds-slack

--- a/es/15.8/config/index.rst
+++ b/es/15.8/config/index.rst
@@ -1,17 +1,17 @@
-Guia de Configuracion de |Fess|
+Guía de Configuración de |Fess|
 ================================
 
-Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por proposito.
+Guía integral sobre la configuración de |Fess|. Cada sección está organizada por propósito.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Introduccion
+   :caption: Introducción
 
    intro
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion Basica
+   :caption: Configuración Básica
 
    setup-port-network
    setup-memory
@@ -19,7 +19,7 @@ Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion del Rastreador
+   :caption: Configuración del Rastreador
 
    crawler-basic
    crawler-advanced
@@ -33,7 +33,7 @@ Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion de Funciones de Busqueda
+   :caption: Configuración de Funciones de Búsqueda
 
    search-basic
    search-advanced
@@ -44,7 +44,7 @@ Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion de Seguridad
+   :caption: Configuración de Seguridad
 
    security-role
    security-virtual-host
@@ -53,7 +53,7 @@ Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion SSO
+   :caption: Configuración SSO
 
    sso-saml
    sso-oidc
@@ -62,7 +62,7 @@ Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por
 
 .. toctree::
    :maxdepth: 2
-   :caption: Configuracion LLM/Modo de busqueda IA
+   :caption: Configuración LLM/Modo de búsqueda IA
 
    llm-overview
    llm-ollama
@@ -79,14 +79,14 @@ Guia integral sobre la configuracion de |Fess|. Cada seccion esta organizada por
 
 .. toctree::
    :maxdepth: 2
-   :caption: Rendimiento y Operacion
+   :caption: Rendimiento y Operación
 
    rate-limiting
    load-control
 
 .. toctree::
    :maxdepth: 2
-   :caption: Administracion del Sistema
+   :caption: Administración del Sistema
 
    admin-logging
    admin-log-notification

--- a/es/15.8/config/load-control.rst
+++ b/es/15.8/config/load-control.rst
@@ -1,28 +1,28 @@
 ====================================
-Configuracion de control de carga
+Configuración de control de carga
 ====================================
 
-Descripcion general
+Descripción general
 ===================
 
-|Fess| incluye dos tipos de funciones de control de carga que protegen la estabilidad del sistema en funcion del uso de CPU.
+|Fess| incluye dos tipos de funciones de control de carga que protegen la estabilidad del sistema en función del uso de CPU.
 
 **Control de carga de solicitudes HTTP** (``web.load.control`` / ``api.load.control``):
 
 - Monitoreo en tiempo real del uso de CPU del cluster de OpenSearch
 - Umbrales independientes para solicitudes web y solicitudes API
 - Devuelve HTTP 429 (Too Many Requests) cuando se superan los umbrales
-- El panel de administracion, el inicio de sesion y los recursos estaticos estan excluidos del control
+- El panel de administración, el inicio de sesión y los recursos estáticos están excluidos del control
 - Deshabilitado por defecto (umbral=100)
 
 **Control de carga adaptativo** (``adaptive.load.control``):
 
 - Monitorea el uso de CPU del sistema del propio servidor Fess
-- Regula automaticamente las tareas en segundo plano como rastreo, indexacion, actualizaciones de sugerencias y generacion de miniaturas
+- Regula automáticamente las tareas en segundo plano como rastreo, indexación, actualizaciones de sugerencias y generación de miniaturas
 - Cuando el uso de CPU alcanza o supera el umbral, los hilos de procesamiento se pausan y se reanudan cuando desciende por debajo del umbral
 - Habilitado por defecto (umbral=50)
 
-Configuracion del control de carga de solicitudes HTTP
+Configuración del control de carga de solicitudes HTTP
 ======================================================
 
 Configure las siguientes propiedades en ``fess_config.properties``:
@@ -45,33 +45,33 @@ Configure las siguientes propiedades en ``fess_config.properties``:
     load.control.monitor.interval=1
 
 .. note::
-   Cuando tanto ``web.load.control`` como ``api.load.control`` estan establecidos en 100 (predeterminado),
+   Cuando tanto ``web.load.control`` como ``api.load.control`` están establecidos en 100 (predeterminado),
    el monitoreo de CPU de OpenSearch no se inicia.
 
-Como funciona
+Cómo funciona
 =============
 
 Mecanismo de monitoreo
 ----------------------
 
-Cuando el control de carga esta habilitado (algun umbral es inferior a 100), LoadControlMonitorTarget monitorea periodicamente el uso de CPU del cluster de OpenSearch.
+Cuando el control de carga está habilitado (algún umbral es inferior a 100), LoadControlMonitorTarget monitorea periódicamente el uso de CPU del cluster de OpenSearch.
 
-- Obtiene estadisticas del SO de todos los nodos del cluster de OpenSearch
-- Registra el uso de CPU mas alto entre todos los nodos
+- Obtiene estadísticas del SO de todos los nodos del cluster de OpenSearch
+- Registra el uso de CPU más alto entre todos los nodos
 - Monitorea en el intervalo especificado por ``load.control.monitor.interval`` (predeterminado: 1 segundo)
 - El monitoreo se inicia de forma diferida en la primera solicitud
 
 .. note::
-   Si falla la obtencion de informacion de monitoreo, el uso de CPU se restablece a 0.
+   Si falla la obtención de información de monitoreo, el uso de CPU se restablece a 0.
    Hasta el tercer fallo consecutivo, el nivel de log es WARNING; a partir del cuarto fallo, cambia a DEBUG
-   (para evitar que los fallos continuos hinchen los logs). El contador de fallos se reinicia cuando el monitoreo tiene exito al menos una vez.
+   (para evitar que los fallos continuos hinchen los logs). El contador de fallos se reinicia cuando el monitoreo tiene éxito al menos una vez.
 
 Control de solicitudes
 ----------------------
 
 Cuando llega una solicitud, LoadControlFilter la procesa en el siguiente orden:
 
-1. Verificar si la ruta esta excluida (si esta excluida, dejar pasar)
+1. Verificar si la ruta está excluida (si está excluida, dejar pasar)
 2. Determinar el tipo de solicitud (Web / API)
 3. Obtener el umbral correspondiente
 4. Si el umbral es 100 o superior, no controlar (dejar pasar)
@@ -80,19 +80,19 @@ Cuando llega una solicitud, LoadControlFilter la procesa en el siguiente orden:
 
 **Solicitudes excluidas:**
 
-- Rutas que comienzan con ``/admin`` (panel de administracion)
-- Rutas que comienzan con ``/error`` (paginas de error)
-- Rutas que comienzan con ``/login`` (paginas de inicio de sesion)
-- Recursos estaticos (``.css``, ``.js``, ``.png``, ``.jpg``, ``.gif``, ``.ico``, ``.svg``, ``.woff``, ``.woff2``, ``.ttf``, ``.eot``)
+- Rutas que comienzan con ``/admin`` (panel de administración)
+- Rutas que comienzan con ``/error`` (páginas de error)
+- Rutas que comienzan con ``/login`` (páginas de inicio de sesión)
+- Recursos estáticos (``.css``, ``.js``, ``.png``, ``.jpg``, ``.gif``, ``.ico``, ``.svg``, ``.woff``, ``.woff2``, ``.ttf``, ``.eot``)
 
 **Para solicitudes web:**
 
-- Devuelve el codigo de estado HTTP 429
-- Muestra la pagina de error (``busy.jsp``)
+- Devuelve el código de estado HTTP 429
+- Muestra la página de error (``busy.jsp``)
 
 **Para solicitudes API:**
 
-- Devuelve el codigo de estado HTTP 429
+- Devuelve el código de estado HTTP 429
 - Adjunta el encabezado de respuesta HTTP ``Retry-After: 60``
 - Devuelve una respuesta JSON:
 
@@ -109,15 +109,15 @@ Cuando llega una solicitud, LoadControlFilter la procesa en el siguiente orden:
 .. note::
    Cuando una solicitud es rechazada, el servidor registra a nivel INFO el mensaje
    ``Rejecting request due to high CPU load: path=..., cpu=...%, threshold=...%``.
-   Esto permite verificar que rutas fueron rechazadas y con que umbral.
+   Esto permite verificar qué rutas fueron rechazadas y con qué umbral.
 
-Ejemplos de configuracion
+Ejemplos de configuración
 =========================
 
 Limitar solo solicitudes web
 -----------------------------
 
-Configuracion que limita solo las solicitudes de busqueda web sin restringir la API:
+Configuración que limita solo las solicitudes de búsqueda web sin restringir la API:
 
 ::
 
@@ -147,14 +147,14 @@ Ejemplo con diferentes umbrales para web y API:
     load.control.monitor.interval=2
 
 .. note::
-   Al establecer el umbral de API mas alto que el de web, puede lograr un control escalonado
+   Al establecer el umbral de API más alto que el de web, puede lograr un control escalonado
    donde las solicitudes web se restringen primero durante alta carga, y las solicitudes API tambien
-   se restringen cuando la carga aumenta aun mas.
+   se restringen cuando la carga aumenta aún más.
 
-Diferencia con el limite de tasa
+Diferencia con el límite de tasa
 =================================
 
-|Fess| tiene una funcion de :doc:`rate-limiting` separada del control de carga.
+|Fess| tiene una función de :doc:`rate-limiting` separada del control de carga.
 Estas protegen el sistema usando enfoques diferentes.
 
 .. list-table::
@@ -162,33 +162,33 @@ Estas protegen el sistema usando enfoques diferentes.
    :widths: 20 40 40
 
    * - Aspecto
-     - Limite de tasa
+     - Límite de tasa
      - Control de carga
    * - Base de control
-     - Numero de solicitudes (por unidad de tiempo)
+     - Número de solicitudes (por unidad de tiempo)
      - Uso de CPU de OpenSearch
-   * - Proposito
-     - Prevencion de solicitudes excesivas
-     - Proteccion del motor de busqueda contra alta carga
-   * - Unidad de limite
-     - Por direccion IP
+   * - Propósito
+     - Prevención de solicitudes excesivas
+     - Protección del motor de búsqueda contra alta carga
+   * - Unidad de límite
+     - Por dirección IP
      - Todo el sistema
    * - Respuesta
      - HTTP 429
      - HTTP 429
    * - Alcance
      - Todas las solicitudes HTTP
-     - Solicitudes web / Solicitudes API (panel de administracion etc. excluido)
+     - Solicitudes web / Solicitudes API (panel de administración etc. excluido)
 
-Combinar ambas funciones permite una proteccion del sistema mas robusta.
+Combinar ambas funciones permite una protección del sistema más robusta.
 
 Control de carga adaptativo
 ===========================
 
-El control de carga adaptativo ajusta automaticamente la velocidad de procesamiento de las tareas
-en segundo plano en funcion del uso de CPU del sistema del servidor Fess.
+El control de carga adaptativo ajusta automáticamente la velocidad de procesamiento de las tareas
+en segundo plano en función del uso de CPU del sistema del servidor Fess.
 
-Configuracion
+Configuración
 -------------
 
 ``fess_config.properties``:
@@ -205,19 +205,19 @@ Comportamiento
 
 - Monitorea el uso de CPU del sistema del servidor donde se ejecuta Fess
 - Cuando el uso de CPU alcanza o supera el umbral, los hilos de procesamiento afectados esperan hasta que el uso de CPU descienda por debajo del umbral
-- Cuando el uso de CPU desciende por debajo del umbral, el procesamiento se reanuda automaticamente
+- Cuando el uso de CPU desciende por debajo del umbral, el procesamiento se reanuda automáticamente
 
 **Tareas en segundo plano afectadas:**
 
 - Rastreo (Web / Sistema de archivos)
-- Indexacion (registro de documentos)
-- Procesamiento de almacen de datos
+- Indexación (registro de documentos)
+- Procesamiento de almacén de datos
 - Actualizaciones de sugerencias
-- Generacion de miniaturas
-- Respaldo y restauracion
+- Generación de miniaturas
+- Respaldo y restauración
 
 .. note::
-   El control de carga adaptativo esta habilitado por defecto (umbral=50).
+   El control de carga adaptativo está habilitado por defecto (umbral=50).
    Opera de forma independiente del control de carga de solicitudes HTTP (``web.load.control`` / ``api.load.control``).
 
 .. list-table::
@@ -233,33 +233,33 @@ Comportamiento
    * - Objetivo de control
      - Solicitudes HTTP (Web / API)
      - Tareas en segundo plano
-   * - Metodo de control
+   * - Método de control
      - Rechaza solicitudes devolviendo HTTP 429
      - Pausa temporalmente los hilos de procesamiento
    * - Predeterminado
      - Deshabilitado (umbral=100)
      - Habilitado (umbral=50)
 
-Solucion de problemas
+Solución de problemas
 =====================
 
 El control de carga no se activa
 ---------------------------------
 
-**Causa**: La configuracion no se refleja correctamente
+**Causa**: La configuración no se refleja correctamente
 
 **Verificaciones**:
 
-1. Si ``web.load.control`` o ``api.load.control`` esta establecido por debajo de 100
-2. Si el archivo de configuracion se esta leyendo correctamente
+1. Si ``web.load.control`` o ``api.load.control`` está establecido por debajo de 100
+2. Si el archivo de configuración se está leyendo correctamente
 3. Si |Fess| fue reiniciado
 
-Solicitudes legitimas son rechazadas
+Solicitudes legítimas son rechazadas
 --------------------------------------
 
 **Causa**: Los umbrales son demasiado bajos
 
-**Solucion**:
+**Solución**:
 
 1. Aumentar los valores de ``web.load.control`` o ``api.load.control``
 2. Ajustar ``load.control.monitor.interval`` para cambiar la frecuencia de monitoreo
@@ -272,20 +272,20 @@ Solicitudes legitimas son rechazadas
 El rastreo es lento
 -------------------
 
-**Causa**: Los hilos estan en estado de espera debido al control de carga adaptativo
+**Causa**: Los hilos están en estado de espera debido al control de carga adaptativo
 
 **Verificaciones**:
 
 1. Si ``Cpu Load XX% is greater than YY%`` aparece en los logs
 2. Si el umbral de ``adaptive.load.control`` es demasiado bajo
 
-**Solucion**:
+**Solución**:
 
 1. Aumentar el valor de ``adaptive.load.control`` (ej: 70)
 2. Aumentar los recursos de CPU del servidor Fess
 3. Establecer en 0 para deshabilitar el control de carga adaptativo (no recomendado)
 
-Informacion de referencia
+Información de referencia
 =========================
 
-- :doc:`rate-limiting` - Configuracion de limite de tasa
+- :doc:`rate-limiting` - Configuración de límite de tasa

--- a/es/15.8/config/multitenancy.rst
+++ b/es/15.8/config/multitenancy.rst
@@ -1,52 +1,52 @@
 =====================================
-Configuracion de multitenencia
+Configuración de multitenencia
 =====================================
 
-Descripcion general
+Descripción general
 ===================
 
 La funcionalidad de multitenencia de |Fess| permite operar
-multiples inquilinos (organizaciones, departamentos, clientes, etc.) de forma separada con una sola instancia de |Fess|.
+múltiples inquilinos (organizaciones, departamentos, clientes, etc.) de forma separada con una sola instancia de |Fess|.
 
 Al usar la funcionalidad de host virtual, puede proporcionar para cada inquilino:
 
-- Interfaz de busqueda independiente
+- Interfaz de búsqueda independiente
 - Contenido separado
-- Diseno personalizado
+- Diseño personalizado
 
-El host virtual actual se refleja en las funciones de filtrado de resultados de busqueda, etiquetas, contenido relacionado,
-consultas relacionadas y diseno (tema), entre otras funciones de |Fess|.
+El host virtual actual se refleja en las funciones de filtrado de resultados de búsqueda, etiquetas, contenido relacionado,
+consultas relacionadas y diseño (tema), entre otras funciones de |Fess|.
 
 Funcionalidad de host virtual
 ==============================
 
-El host virtual es una funcionalidad que proporciona diferentes entornos de busqueda basados en el nombre de host de la solicitud HTTP.
+El host virtual es una funcionalidad que proporciona diferentes entornos de búsqueda basados en el nombre de host de la solicitud HTTP.
 
 Mecanismo
 ---------
 
 1. El usuario accede a ``tenant1.example.com``
 2. |Fess| identifica el nombre de host
-3. Se aplica la configuracion de host virtual correspondiente
-4. Se muestra el contenido y la UI especificos del inquilino
+3. Se aplica la configuración de host virtual correspondiente
+4. Se muestra el contenido y la UI específicos del inquilino
 
-Configuracion de encabezados de host virtual
+Configuración de encabezados de host virtual
 =============================================
 
 Para habilitar la funcionalidad de host virtual, configure la correspondencia entre los encabezados de la solicitud HTTP
-y las claves de host virtual. Existen dos metodos de configuracion:
+y las claves de host virtual. Existen dos métodos de configuración:
 
-- **Pantalla de administracion (recomendado)**: Configure el campo "Host Virtual" en "Sistema" -> "General".
-  Este valor se guarda como configuracion del sistema y se conserva tras el reinicio. Tiene prioridad sobre
+- **Pantalla de administración (recomendado)**: Configure el campo "Host Virtual" en "Sistema" -> "General".
+  Este valor se guarda como configuración del sistema y se conserva tras el reinicio. Tiene prioridad sobre
   ``virtual.host.headers`` en ``fess_config.properties``.
-- **Archivo de configuracion**: Configure la propiedad ``virtual.host.headers`` en ``fess_config.properties``.
+- **Archivo de configuración**: Configure la propiedad ``virtual.host.headers`` en ``fess_config.properties``.
 
-Ambos metodos utilizan el mismo formato de valor de configuracion.
+Ambos métodos utilizan el mismo formato de valor de configuración.
 
-Formato de configuracion
+Formato de configuración
 ------------------------
 
-Especifique cada entrada en el formato ``NombreEncabezado:ValorEncabezado=ClaveHostVirtual``, una por linea:
+Especifique cada entrada en el formato ``NombreEncabezado:ValorEncabezado=ClaveHostVirtual``, una por línea:
 
 ::
 
@@ -54,101 +54,101 @@ Especifique cada entrada en el formato ``NombreEncabezado:ValorEncabezado=ClaveH
     virtual.host.headers=Host:tenant1.example.com=tenant1\n\
     Host:tenant2.example.com=tenant2
 
-Para multiples hosts virtuales, separe las entradas con saltos de linea.
+Para múltiples hosts virtuales, separe las entradas con saltos de línea.
 
 Comportamiento de coincidencia
 ------------------------------
 
 Cada vez que |Fess| recibe una solicitud, compara el valor del encabezado de solicitud correspondiente al
-"NombreEncabezado" de cada linea configurada con el "ValorEncabezado" configurado.
+"NombreEncabezado" de cada línea configurada con el "ValorEncabezado" configurado.
 
-- La comparacion de valores de encabezado no distingue entre mayusculas y minusculas.
-- Las lineas configuradas se evaluan en orden de arriba a abajo; se aplica la clave de host virtual de la primera linea que coincida.
-- Si no hay coincidencia, la solicitud se trata sin host virtual (entorno comun).
-- El resultado de la evaluacion se almacena en cache por solicitud.
+- La comparación de valores de encabezado no distingue entre mayúsculas y minúsculas.
+- Las líneas configuradas se evalúan en orden de arriba a abajo; se aplica la clave de host virtual de la primera línea que coincida.
+- Si no hay coincidencia, la solicitud se trata sin host virtual (entorno común).
+- El resultado de la evaluación se almacena en caché por solicitud.
 
 Restricciones de claves de host virtual
 ----------------------------------------
 
 Las claves de host virtual tienen las siguientes restricciones:
 
-- Solo se permiten caracteres alfanumericos y guiones bajos (``a-zA-Z0-9_``). Otros caracteres se eliminan automaticamente.
-- Los siguientes nombres de clave estan reservados y no se pueden usar: ``admin``, ``common``, ``error``, ``login``, ``profile``
+- Solo se permiten caracteres alfanuméricos y guiones bajos (``a-zA-Z0-9_``). Otros caracteres se eliminan automáticamente.
+- Los siguientes nombres de clave están reservados y no se pueden usar: ``admin``, ``common``, ``error``, ``login``, ``profile``
 
-Configuracion desde la pantalla de administracion
+Configuración desde la pantalla de administración
 ==================================================
 
-Configuracion de crawl
+Configuración de crawl
 ----------------------
 
-Puede separar el contenido especificando el host virtual en la configuracion de crawl web:
+Puede separar el contenido especificando el host virtual en la configuración de crawl web:
 
-1. Iniciar sesion en la pantalla de administracion
-2. Crear configuracion de crawl en "Crawler" -> "Web"
-3. Seleccionar la clave de host virtual configurada en el campo "Host Virtual" (se admite seleccion multiple)
-4. El contenido crawleado con esta configuracion solo sera buscable en el host virtual especificado
+1. Iniciar sesión en la pantalla de administración
+2. Crear configuración de crawl en "Crawler" -> "Web"
+3. Seleccionar la clave de host virtual configurada en el campo "Host Virtual" (se admite selección múltiple)
+4. El contenido crawleado con esta configuración solo será buscable en el host virtual especificado
 
 .. note::
-   El campo "Host Virtual" esta disponible en las configuraciones de crawl de web, sistema de archivos y almacen de datos.
-   La clave de host virtual seleccionada aqui se asigna a cada documento crawleado y se usa para filtrar
-   por el host virtual actual en el momento de la busqueda.
+   El campo "Host Virtual" está disponible en las configuraciones de crawl de web, sistema de archivos y almacén de datos.
+   La clave de host virtual seleccionada aquí se asigna a cada documento crawleado y se usa para filtrar
+   por el host virtual actual en el momento de la búsqueda.
 
 Control de acceso
 =================
 
-Combinacion de host virtual y roles
+Combinación de host virtual y roles
 -------------------------------------
 
 Al combinar hosts virtuales con control de acceso basado en roles,
-es posible un control de acceso mas detallado.
+es posible un control de acceso más detallado.
 
-Configure el host virtual y los permisos juntos en la configuracion de crawl:
+Configure el host virtual y los permisos juntos en la configuración de crawl:
 
 ::
 
-    # Host virtual en la configuracion de crawl
+    # Host virtual en la configuración de crawl
     tenant1
 
-    # Permisos en la configuracion de crawl
+    # Permisos en la configuración de crawl
     {role}tenant1_user
 
-Busqueda basada en roles
+Búsqueda basada en roles
 ------------------------
 
-Para mas detalles, consulte :doc:`security-role`.
+Para más detalles, consulte :doc:`security-role`.
 
-Personalizacion de UI
+Personalización de UI
 =====================
 
 Puede personalizar la UI para cada host virtual.
 
-Aplicacion de tema
+Aplicación de tema
 ------------------
 
 Aplicar un tema diferente para cada host virtual:
 
-1. Configurar tema en "Sistema" -> "Diseno"
-2. Especificar tema en la configuracion del host virtual
+1. Configurar tema en "Sistema" -> "Diseño"
+2. Especificar tema en la configuración del host virtual
 
 CSS personalizado
 -----------------
 
-Para aplicar CSS personalizado por host virtual, edite los archivos CSS en la pantalla de administracion en "Sistema" -> "Diseno". Tambien puede colocar plantillas personalizadas en el directorio de vista correspondiente a la clave del host virtual.
+Para aplicar CSS personalizado por host virtual, edite los archivos CSS en la pantalla de administración en "Sistema" -> "Diseño". También puede colocar plantillas personalizadas en el directorio de vista correspondiente a la clave del host virtual.
 
-Configuracion de etiquetas
+Configuración de etiquetas
 --------------------------
 
 Limitar etiquetas mostradas para cada host virtual:
 
-1. Especificar host virtual en la configuracion del tipo de etiqueta
+1. Especificar host virtual en la configuración del tipo de etiqueta
 2. La etiqueta solo se muestra en el host virtual especificado
 
 Acceso mediante API
 ===================
 
-Las solicitudes a la API de busqueda tambien determinan el host virtual por el nombre de host de la solicitud
+Las solicitudes a la API de búsqueda también determinan el host virtual por el nombre de host de la solicitud
 (el encabezado configurado, normalmente el encabezado ``Host``), igual que la UI. Por ejemplo,
-una solicitud dirigida a ``tenant1.example.com`` se limita automaticamente al host virtual ``tenant1``
+una solicitud dirigida a ``tenant1.example.com`` se limita automáticamente al host virtual ``tenant1``
 y solo se busca en el contenido de ese host virtual.
 
 Solicitud de API
@@ -158,7 +158,7 @@ Solicitud de API
 
     curl "https://tenant1.example.com/api/v2/search?q=keyword"
 
-Para autenticarse con un token de acceso, especifiquelo en el encabezado ``Authorization``
+Para autenticarse con un token de acceso, especifíquelo en el encabezado ``Authorization``
 en formato ``Bearer``:
 
 ::
@@ -167,33 +167,33 @@ en formato ``Bearer``:
          "https://tenant1.example.com/api/v2/search?q=keyword"
 
 .. note::
-   Los tokens de acceso no estan vinculados a un host virtual especifico. Un token es valido para
+   Los tokens de acceso no están vinculados a un host virtual específico. Un token es válido para
    cualquier host virtual; el host virtual de destino se determina por el nombre de host al que se
-   envia la solicitud. Si se envia el mismo token a un nombre de host diferente, se aplica al
+   envía la solicitud. Si se envía el mismo token a un nombre de host diferente, se aplica al
    host virtual correspondiente. Si desea controlar el alcance del acceso independientemente del
    host virtual, combinen con el control de acceso basado en roles (:doc:`security-role`).
 
-Configuracion de DNS
+Configuración de DNS
 ====================
 
-Ejemplo de configuracion de DNS para implementar multitenencia:
+Ejemplo de configuración de DNS para implementar multitenencia:
 
 Subdominios al mismo servidor
 ------------------------------
 
 ::
 
-    # Configuracion de DNS
+    # Configuración de DNS
     tenant1.example.com    A    192.168.1.100
     tenant2.example.com    A    192.168.1.100
 
     # O comodin
     *.example.com          A    192.168.1.100
 
-Configuracion de proxy inverso
+Configuración de proxy inverso
 --------------------------------
 
-Ejemplo de configuracion de proxy inverso con Nginx:
+Ejemplo de configuración de proxy inverso con Nginx:
 
 ::
 
@@ -217,15 +217,15 @@ Ejemplo de configuracion de proxy inverso con Nginx:
         }
     }
 
-Separacion de datos
+Separación de datos
 ===================
 
-Si se requiere separacion completa de datos, considere los siguientes enfoques:
+Si se requiere separación completa de datos, considere los siguientes enfoques:
 
-Separacion a nivel de indice
+Separación a nivel de índice
 ------------------------------
 
-Usar instancias e indices separados de |Fess| para cada inquilino:
+Usar instancias e índices separados de |Fess| para cada inquilino:
 
 ::
 
@@ -237,27 +237,27 @@ Usar instancias e indices separados de |Fess| para cada inquilino:
 
 .. note::
    ``index.document.search.index`` solo puede establecerse en un valor por instancia.
-   Para una separacion completa a nivel de indice, necesita ejecutar instancias separadas de |Fess| por inquilino
-   o implementar codigo personalizado. Para multitenencia tipica, la separacion logica mediante la funcionalidad de host virtual es suficiente.
+   Para una separación completa a nivel de índice, necesita ejecutar instancias separadas de |Fess| por inquilino
+   o implementar código personalizado. Para multitenencia típica, la separación lógica mediante la funcionalidad de host virtual es suficiente.
 
-Mejores practicas
+Mejores prácticas
 =================
 
-1. **Convencion de nombres clara**: Usar una convencion de nombres consistente para hosts virtuales y roles
+1. **Convención de nombres clara**: Usar una convención de nombres consistente para hosts virtuales y roles
 2. **Pruebas**: Probar exhaustivamente el funcionamiento en cada inquilino
 3. **Monitoreo**: Monitorear el uso de recursos por inquilino
-4. **Documentacion**: Documentar la configuracion de inquilinos
+4. **Documentación**: Documentar la configuración de inquilinos
 
 Limitaciones
 ============
 
-- La pantalla de administracion es compartida por todos los inquilinos
-- La configuracion del sistema afecta a todos los inquilinos
+- La pantalla de administración es compartida por todos los inquilinos
+- La configuración del sistema afecta a todos los inquilinos
 - Algunas funcionalidades pueden no ser compatibles con hosts virtuales
 
-Informacion de referencia
+Información de referencia
 =========================
 
 - :doc:`security-role` - Control de acceso basado en roles
-- :doc:`security-virtual-host` - Detalles de configuracion de host virtual
-- :doc:`../admin/design-guide` - Personalizacion de diseno
+- :doc:`security-virtual-host` - Detalles de configuración de host virtual
+- :doc:`../admin/design-guide` - Personalización de diseño

--- a/es/15.8/config/scripting-groovy.rst
+++ b/es/15.8/config/scripting-groovy.rst
@@ -1,18 +1,18 @@
 ==================================
-Guia de scripting Groovy
+Guía de scripting Groovy
 ==================================
 
-Descripcion general
+Descripción general
 ===================
 
 Groovy es el lenguaje de scripting predeterminado de |Fess|.
-Se ejecuta en la maquina virtual Java (JVM) y permite escribir scripts con una sintaxis mas concisa
+Se ejecuta en la máquina virtual Java (JVM) y permite escribir scripts con una sintaxis más concisa
 mientras mantiene alta compatibilidad con Java.
 
-Sintaxis basica
+Sintaxis básica
 ===============
 
-Declaracion de variables
+Declaración de variables
 ------------------------
 
 ::
@@ -110,15 +110,15 @@ Bucles
 Scripts de Data Store
 =====================
 
-Ejemplos de scripts en configuracion de data store.
+Ejemplos de scripts en configuración de data store.
 
 .. note::
-   En los scripts de data store, cada linea ``campo=expresion`` se evalua de forma independiente como una unica expresion.
-   Por lo tanto, no se pueden usar sentencias ``import``, declaraciones ``def`` multilinea ni estructuras de control multilinea que establezcan varios campos a la vez (como bloques ``if``).
-   Al usar clases Java, escribalas como una unica expresion con el nombre de clase completamente calificado (FQCN), y use el operador ternario por campo para los valores condicionales (por ejemplo, ``url=data.published ? data.url : null`` ).
-   Ademas, el nombre de variable ``data`` usado aqui es solo un ejemplo; el nombre de variable real depende del conector de data store utilizado. Consulte :doc:`../admin/dataconfig-guide` para mas detalles.
+   En los scripts de data store, cada línea ``campo=expresion`` se evalúa de forma independiente como una única expresión.
+   Por lo tanto, no se pueden usar sentencias ``import``, declaraciones ``def`` multilínea ni estructuras de control multilínea que establezcan varios campos a la vez (como bloques ``if``).
+   Al usar clases Java, escríbalas como una única expresión con el nombre de clase completamente calificado (FQCN), y use el operador ternario por campo para los valores condicionales (por ejemplo, ``url=data.published ? data.url : null`` ).
+   Además, el nombre de variable ``data`` usado aquí es solo un ejemplo; el nombre de variable real depende del conector de data store utilizado. Consulte :doc:`../admin/dataconfig-guide` para más detalles.
 
-Mapeo basico
+Mapeo básico
 ------------
 
 ::
@@ -128,7 +128,7 @@ Mapeo basico
     content=data.content
     lastModified=data.updated_at
 
-Generacion de URL
+Generación de URL
 -----------------
 
 ::
@@ -170,7 +170,7 @@ Procesamiento de fechas
 Objetos disponibles
 ===================
 
-Los objetos disponibles en los scripts varian segun el contexto de ejecucion.
+Los objetos disponibles en los scripts varían según el contexto de ejecución.
 
 .. list-table::
    :header-rows: 1
@@ -178,36 +178,36 @@ Los objetos disponibles en los scripts varian segun el contexto de ejecucion.
 
    * - Contexto
      - Objeto
-     - Descripcion
+     - Descripción
    * - Todos los contextos
      - ``container``
      - Contenedor DI. Se usa para acceder a los componentes mediante ``container.getComponent("...")``
    * - Trabajos programados
      - ``executor``
-     - Control de ejecucion de trabajos ( ``JobExecutor`` ). Necesario para el soporte de detencion de trabajos
+     - Control de ejecución de trabajos ( ``JobExecutor`` ). Necesario para el soporte de detención de trabajos
    * - Data Store
-     - (especifico del conector)
+     - (específico del conector)
      - Variables de registro de datos proporcionadas por cada data store. El nombre de la variable depende del conector
    * - Mapeo de rutas
      - ``url`` , ``matcher``
-     - La cadena de URL a convertir y el resultado de coincidencia de expresion regular ( ``Matcher`` ). Disponible en configuraciones de reemplazo con el prefijo ``groovy:``
+     - La cadena de URL a convertir y el resultado de coincidencia de expresión regular ( ``Matcher`` ). Disponible en configuraciones de reemplazo con el prefijo ``groovy:``
    * - Boost de documento
      - (campos del documento)
-     - Cada campo del documento objetivo esta disponible como variable (se usa en expresiones de condicion y de valor de boost)
+     - Cada campo del documento objetivo está disponible como variable (se usa en expresiones de condición y de valor de boost)
 
 Scripts de trabajos programados
 ===============================
 
 Ejemplos de scripts Groovy para trabajos programados.
-En los trabajos programados, ``container`` y ``executor`` estan disponibles.
-Pasar ``executor`` al metodo ``execute()`` del trabajo habilita el control de detencion del trabajo.
+En los trabajos programados, ``container`` y ``executor`` están disponibles.
+Pasar ``executor`` al método ``execute()`` del trabajo habilita el control de detención del trabajo.
 
 .. note::
-   Un script de trabajo programado se evalua como un unico script Groovy completo.
-   Por lo tanto, a diferencia de los scripts de data store, puede usar sentencias ``import``, declaraciones ``def`` multilinea y estructuras de control multilinea.
-   Los ejemplos de "Uso de clases Java", "Acceso a componentes de Fess", "Manejo de errores" y "Depuracion y salida de logs" que aparecen a continuacion tambien asumen este contexto de script completo.
+   Un script de trabajo programado se evalúa como un único script Groovy completo.
+   Por lo tanto, a diferencia de los scripts de data store, puede usar sentencias ``import``, declaraciones ``def`` multilínea y estructuras de control multilínea.
+   Los ejemplos de "Uso de clases Java", "Acceso a componentes de Fess", "Manejo de errores" y "Depuración y salida de logs" que aparecen a continuación también asumen este contexto de script completo.
 
-Ejecucion de trabajo de crawl
+Ejecución de trabajo de crawl
 -----------------------------
 
 ::
@@ -230,7 +230,7 @@ Crawl condicional
     }
     return "Skipped during business hours"
 
-Ejecucion secuencial de multiples trabajos
+Ejecución secuencial de múltiples trabajos
 ------------------------------------------
 
 ::
@@ -248,7 +248,7 @@ Ejecucion secuencial de multiples trabajos
 Uso de clases Java
 ==================
 
-Dentro de los scripts Groovy, puede usar la biblioteca estandar de Java y las clases de Fess.
+Dentro de los scripts Groovy, puede usar la biblioteca estándar de Java y las clases de Fess.
 
 Fecha y hora
 ------------
@@ -271,7 +271,7 @@ Operaciones de archivo
 
     def content = new String(Files.readAllBytes(Paths.get("/path/to/file.txt")))
 
-Comunicacion HTTP
+Comunicación HTTP
 -----------------
 
 ::
@@ -283,7 +283,7 @@ Comunicacion HTTP
 
 .. warning::
    El acceso a recursos externos afecta el rendimiento,
-   mantengalo al minimo necesario.
+   manténgalo al mínimo necesario.
 
 Acceso a componentes de Fess
 ============================
@@ -298,7 +298,7 @@ System Helper
     def systemHelper = container.getComponent("systemHelper")
     def currentTime = systemHelper.getCurrentTimeAsLong()
 
-Obtencion de valores de configuracion
+Obtención de valores de configuración
 -------------------------------------
 
 ::
@@ -306,7 +306,7 @@ Obtencion de valores de configuracion
     def fessConfig = container.getComponent("fessConfig")
     def indexName = fessConfig.getIndexDocumentUpdateIndex()
 
-Ejecucion de busqueda
+Ejecución de búsqueda
 ---------------------
 
 ::
@@ -333,7 +333,7 @@ Puede capturar excepciones con ``try-catch`` para controlar los errores del trab
         return "Error: " + e.message
     }
 
-Depuracion y salida de logs
+Depuración y salida de logs
 ===========================
 
 Salida de logs
@@ -350,7 +350,7 @@ Salida de logs
     logger.warn("Warning: {}", message)
     logger.error("Error: {}", e.message, e)
 
-Salida de depuracion
+Salida de depuración
 --------------------
 
 ::
@@ -359,19 +359,19 @@ Salida de depuracion
     println "data.id = ${data.id}"
     println "data.title = ${data.title}"
 
-Mejores practicas
+Mejores prácticas
 =================
 
-1. **Mantenerlo simple**: Evitar logica compleja, escribir codigo legible
-2. **Verificacion de null**: Usar operadores ``?.`` y ``?:``
+1. **Mantenerlo simple**: Evitar lógica compleja, escribir código legible
+2. **Verificación de null**: Usar operadores ``?.`` y ``?:``
 3. **Manejo de excepciones**: Manejar errores inesperados con try-catch apropiado
-4. **Salida de logs**: Registrar logs para facilitar la depuracion
+4. **Salida de logs**: Registrar logs para facilitar la depuración
 5. **Rendimiento**: Minimizar acceso a recursos externos
 
-Informacion de referencia
+Información de referencia
 =========================
 
-- `Documentacion oficial de Groovy <https://groovy-lang.org/documentation.html>`__
-- :doc:`scripting-overview` - Descripcion general de scripting
-- :doc:`../admin/dataconfig-guide` - Guia de configuracion de Data Store
-- :doc:`../admin/scheduler-guide` - Guia de configuracion del programador
+- `Documentación oficial de Groovy <https://groovy-lang.org/documentation.html>`__
+- :doc:`scripting-overview` - Descripción general de scripting
+- :doc:`../admin/dataconfig-guide` - Guía de configuración de Data Store
+- :doc:`../admin/scheduler-guide` - Guía de configuración del programador

--- a/es/15.8/config/scripting-overview.rst
+++ b/es/15.8/config/scripting-overview.rst
@@ -1,13 +1,13 @@
 =======================================
-Descripcion general del scripting
+Descripción general del scripting
 =======================================
 
-Descripcion general
+Descripción general
 ===================
 
-En |Fess|, puede implementar logica personalizada usando scripts en diversos escenarios.
+En |Fess|, puede implementar lógica personalizada usando scripts en diversos escenarios.
 Al aprovechar los scripts, puede controlar de manera flexible el procesamiento de datos
-durante el crawl, la transformacion de URLs y la ejecucion de trabajos programados.
+durante el crawl, la transformación de URLs y la ejecución de trabajos programados.
 
 Lenguajes de scripting compatibles
 ===================================
@@ -20,25 +20,25 @@ Lenguajes de scripting compatibles
 
    * - Lenguaje
      - Identificador
-     - Descripcion
+     - Descripción
    * - Groovy
      - ``groovy``
      - Lenguaje de scripting registrado de forma predeterminada. Compatible con Java y proporciona funcionalidades potentes
 
 .. note::
-   El unico motor de scripting registrado de forma predeterminada en |Fess| es Groovy.
+   El único motor de scripting registrado de forma predeterminada en |Fess| es Groovy.
    El lenguaje de scripting por defecto es ``groovy`` ( ``Constants.DEFAULT_SCRIPT`` ).
-   Todos los ejemplos de scripts de este documento estan escritos en sintaxis Groovy.
+   Todos los ejemplos de scripts de este documento están escritos en sintaxis Groovy.
 
 Casos de uso del scripting
 ===========================
 
-Configuracion de data store
+Configuración de data store
 ----------------------------
 
 En los conectores de data store, se usan scripts para mapear los datos obtenidos
-a los campos del indice. La configuracion se escribe en formato ``nombre_de_campo=expresion``
-una linea por entrada, y cada linea se evalua como una expresion Groovy independiente.
+a los campos del índice. La configuración se escribe en formato ``nombre_de_campo=expresion``
+una línea por entrada, y cada línea se evalúa como una expresión Groovy independiente.
 
 ::
 
@@ -47,31 +47,31 @@ una linea por entrada, y cada linea se evalua como una expresion Groovy independ
     content=description
     last_modified=updated_at
 
-Los nombres de variables disponibles en los scripts de data store varian segun el tipo de conector.
+Los nombres de variables disponibles en los scripts de data store varían según el tipo de conector.
 Por ejemplo, en el data store CSV y en el data store JSON, cada nombre de columna o campo
-puede usarse directamente como variable (sin prefijo comun como ``data``).
+puede usarse directamente como variable (sin prefijo común como ``data``).
 En los conectores de tipo archivo (Box, Google Drive, OneDrive, etc.) se usa el prefijo ``file.*``,
 en Slack se usa ``message.*``, y cada conector tiene su propio prefijo.
-Consulte la documentacion de cada conector de data store para conocer las variables disponibles.
+Consulte la documentación de cada conector de data store para conocer las variables disponibles.
 
 .. note::
-   Cada linea de un data store se evalua como una expresion unica, por lo que no es posible
-   usar bloques ``if`` de varias lineas, sentencias ``import`` ni declaraciones de variables
-   con ``def``. Para cambiar un valor segun una condicion, use el operador ternario por campo
+   Cada línea de un data store se evalúa como una expresión única, por lo que no es posible
+   usar bloques ``if`` de varias líneas, sentencias ``import`` ni declaraciones de variables
+   con ``def``. Para cambiar un valor según una condición, use el operador ternario por campo
    (por ejemplo: ``title=enabled == "true" ? name : null`` ). Para referenciar clases,
-   escriba el nombre completamente cualificado (FQCN) en linea.
+   escriba el nombre completamente cualificado (FQCN) en línea.
 
 Mapeo de rutas
 --------------
 
-El mapeo de rutas es una funcion para normalizar y transformar las URLs a crawlear.
-De forma predeterminada, se configura mediante un par de "expresion regular" y "cadena de
+El mapeo de rutas es una función para normalizar y transformar las URLs a crawlear.
+De forma predeterminada, se configura mediante un par de "expresión regular" y "cadena de
 reemplazo", y no es un script Groovy. Por ejemplo, si se especifica ``http://`` como
-expresion regular y ``https://`` como cadena de reemplazo, se sustituye el esquema de la URL.
+expresión regular y ``https://`` como cadena de reemplazo, se sustituye el esquema de la URL.
 
 Solo cuando la cadena de reemplazo comienza con el prefijo ``groovy:``, la cadena restante
-se evalua como un script Groovy. Dentro de este script, se puede usar ``url`` para la cadena
-de URL a transformar y ``matcher`` para el ``java.util.regex.Matcher`` de la expresion regular.
+se evalúa como un script Groovy. Dentro de este script, se puede usar ``url`` para la cadena
+de URL a transformar y ``matcher`` para el ``java.util.regex.Matcher`` de la expresión regular.
 
 ::
 
@@ -80,24 +80,24 @@ de URL a transformar y ``matcher`` para el ``java.util.regex.Matcher`` de la exp
 Trabajos programados
 --------------------
 
-En los trabajos programados, puede escribir logica de procesamiento personalizada en scripts
-Groovy. El script completo se evalua como un unico script Groovy, por lo que es posible
-usar multiples lineas, sentencias ``import`` y declaraciones de variables con ``def``.
+En los trabajos programados, puede escribir lógica de procesamiento personalizada en scripts
+Groovy. El script completo se evalúa como un único script Groovy, por lo que es posible
+usar múltiples líneas, sentencias ``import`` y declaraciones de variables con ``def``.
 
 ::
 
     return container.getComponent("crawlJob").logLevel("info").gcLogging().execute(executor);
 
-Los metodos como ``logLevel("info")`` son metodos de la clase del trabajo ( ``ExecJob`` y sus
-subclases) y pueden encadenarse. Consulte "Contexto de ejecucion y objetos disponibles" para
-obtener informacion sobre la variable ``executor``.
+Los métodos como ``logLevel("info")`` son métodos de la clase del trabajo ( ``ExecJob`` y sus
+subclases) y pueden encadenarse. Consulte "Contexto de ejecución y objetos disponibles" para
+obtener información sobre la variable ``executor``.
 
-Sintaxis basica
+Sintaxis básica
 ===============
 
-A continuacion se muestran ejemplos de sintaxis basica de Groovy. Los comentarios se escriben
-con ``//`` (comentario de linea) o ``/* */`` (comentario de bloque). Tenga en cuenta que los
-comentarios que comienzan con ``#`` no son validos en Groovy.
+A continuación se muestran ejemplos de sintaxis básica de Groovy. Los comentarios se escriben
+con ``//`` (comentario de línea) o ``/* */`` (comentario de bloque). Tenga en cuenta que los
+comentarios que comienzan con ``#`` no son válidos en Groovy.
 
 Acceso a variables
 ------------------
@@ -146,52 +146,52 @@ Operaciones de fecha
     // Formato
     new java.text.SimpleDateFormat("yyyy-MM-dd").format(updated_at)
 
-Contexto de ejecucion y objetos disponibles
+Contexto de ejecución y objetos disponibles
 ============================================
 
-Los objetos disponibles dentro de un script varian segun el contexto en que se ejecuta.
-Solo ``container`` esta disponible en todos los contextos.
+Los objetos disponibles dentro de un script varían según el contexto en que se ejecuta.
+Solo ``container`` está disponible en todos los contextos.
 
 .. list-table::
    :header-rows: 1
    :widths: 30 25 45
 
-   * - Contexto de ejecucion
+   * - Contexto de ejecución
      - Objetos disponibles
-     - Descripcion
+     - Descripción
    * - Todos los contextos
      - ``container``
      - Contenedor DI. Acceso a componentes mediante
        ``container.getComponent("systemHelper")`` o
        ``container.getComponent("fessConfig")``
    * - Script de data store
-     - Variables de campo especificas del conector
-     - Cada campo obtenido del data store esta disponible como variable
-       (los nombres de variable y prefijos varian segun el conector; en CSV/JSON el nombre del campo se usa directamente como variable)
+     - Variables de campo específicas del conector
+     - Cada campo obtenido del data store está disponible como variable
+       (los nombres de variable y prefijos varían según el conector; en CSV/JSON el nombre del campo se usa directamente como variable)
    * - Mapeo de rutas
      - ``url`` ``matcher``
-     - La cadena de URL a transformar y el ``Matcher`` de la expresion regular (solo cuando se usa el prefijo ``groovy:``)
+     - La cadena de URL a transformar y el ``Matcher`` de la expresión regular (solo cuando se usa el prefijo ``groovy:``)
    * - Trabajos programados
      - ``executor``
-     - Instancia de ejecucion del trabajo ( ``JobExecutor`` ). Se usa para controlar el apagado del trabajo
+     - Instancia de ejecución del trabajo ( ``JobExecutor`` ). Se usa para controlar el apagado del trabajo
 
 .. note::
-   Los objetos distintos de ``container`` solo se inyectan en contextos especificos.
-   Por ejemplo, ``executor`` solo esta disponible en trabajos programados y no puede
+   Los objetos distintos de ``container`` solo se inyectan en contextos específicos.
+   Por ejemplo, ``executor`` solo está disponible en trabajos programados y no puede
    usarse en scripts de data store ni en mapeo de rutas.
 
 Seguridad
 =========
 
 .. warning::
-   Los scripts tienen funcionalidades muy potentes; uselos unicamente desde fuentes de confianza.
+   Los scripts tienen funcionalidades muy potentes; úselos únicamente desde fuentes de confianza.
 
 - Los scripts se ejecutan en el servidor
 - Es posible acceder al sistema de archivos y a la red
-- Asegurese de que solo los usuarios con privilegios de administrador puedan editar scripts
-- La ejecucion de scripts se registra en el log de auditoria ( ``audit.log`` ).
-  El registro puede controlarse con ``script.audit.log.enabled`` y esta activado por defecto ( ``true`` ).
-  La longitud maxima de la cadena de script registrada se controla con ``script.audit.log.max.length``
+- Asegúrese de que solo los usuarios con privilegios de administrador puedan editar scripts
+- La ejecución de scripts se registra en el log de auditoría ( ``audit.log`` ).
+  El registro puede controlarse con ``script.audit.log.enabled`` y está activado por defecto ( ``true`` ).
+  La longitud máxima de la cadena de script registrada se controla con ``script.audit.log.max.length``
   y el valor por defecto es ``100`` caracteres.
 
 Rendimiento
@@ -201,15 +201,15 @@ Consejos para optimizar el rendimiento de los scripts:
 
 1. **Evitar procesamiento complejo**: Los scripts de data store se ejecutan por cada documento
 2. **Minimizar el acceso a recursos externos**: Las llamadas de red son una fuente de latencia
-3. **Aprovechar la cache**: Considere usar cache para valores que se usan repetidamente
+3. **Aprovechar la caché**: Considere usar caché para valores que se usan repetidamente
 
-Depuracion
+Depuración
 ==========
 
-En los scripts de trabajos programados, el script completo se evalua como un unico script
+En los scripts de trabajos programados, el script completo se evalúa como un único script
 Groovy, por lo que puede usar la salida de logs para depurar.
-(En los scripts de data store, cada linea se evalua como una expresion individual, por lo que
-no es posible usar sentencias ``import`` ni procesamiento en varias lineas.)
+(En los scripts de data store, cada línea se evalúa como una expresión individual, por lo que
+no es posible usar sentencias ``import`` ni procesamiento en varias líneas.)
 
 ::
 
@@ -218,23 +218,23 @@ no es posible usar sentencias ``import`` ni procesamiento en varias lineas.)
     logger.info("executor = {}", executor)
 
 El ejemplo anterior usa un logger denominado ``fess.script``.
-Para que este log se emita, agregue la configuracion del logger correspondiente
+Para que este log se emita, agregue la configuración del logger correspondiente
 en ``app/WEB-INF/classes/log4j2.xml``.
 
 ::
 
     <Logger name="fess.script" level="DEBUG"/>
 
-Ademas, para activar los logs de depuracion del propio motor de scripting, establezca
+Además, para activar los logs de depuración del propio motor de scripting, establezca
 el nivel de log del paquete ``org.codelibs.fess.script`` en ``DEBUG``.
 
 ::
 
     <Logger name="org.codelibs.fess.script" level="DEBUG"/>
 
-Informacion de referencia
+Información de referencia
 ==========================
 
-- :doc:`scripting-groovy` - Guia de scripting Groovy
-- :doc:`../admin/dataconfig-guide` - Guia de configuracion de data store
-- :doc:`../admin/scheduler-guide` - Guia de configuracion del planificador
+- :doc:`scripting-groovy` - Guía de scripting Groovy
+- :doc:`../admin/dataconfig-guide` - Guía de configuración de data store
+- :doc:`../admin/scheduler-guide` - Guía de configuración del planificador

--- a/es/15.8/dev/script-engine-plugin.rst
+++ b/es/15.8/dev/script-engine-plugin.rst
@@ -2,13 +2,13 @@
 Plugin de Motor de Scripts
 ==================================
 
-Vision General
+Visión General
 ==============
 
 Al desarrollar un plugin de motor de scripts, puede agregar soporte para
 nuevos lenguajes de script a |Fess|.
 
-Implementacion Basica
+Implementación Básica
 =====================
 
 Implemente la interfaz ``ScriptEngine``:
@@ -47,15 +47,15 @@ Registro
 Ejemplo de Uso
 ==============
 
-Seleccione como tipo de script en la pantalla de administracion:
+Seleccione como tipo de script en la pantalla de administración:
 
 ::
 
     scriptType=example
     scriptData=your script here
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
 - :doc:`plugin-architecture` - Arquitectura de plugins
-- :doc:`../config/scripting-overview` - Vision general de scripting
+- :doc:`../config/scripting-overview` - Visión general de scripting

--- a/fr/15.7/api/admin/api-admin-accesstoken.rst
+++ b/fr/15.7/api/admin/api-admin-accesstoken.rst
@@ -5,18 +5,18 @@ AccessToken API
 Vue d'ensemble
 ==============
 
-L'API AccessToken est une API permettant de gerer les jetons d'acces API de |Fess|.
-Il est possible de creer, recuperer, mettre a jour et supprimer des jetons.
+L'API AccessToken est une API permettant de gérer les jetons d'accès API de |Fess|.
+Il est possible de créer, récupérer, mettre à jour et supprimer des jetons.
 
-Les jetons d'acces sont utilises pour l'authentification lors d'appels programmatiques a l'API de recherche ou a l'API Admin de |Fess|.
-Pour les specifications communes de l'API Admin incluant cette API (methode d'authentification, format des reponses, valeurs de ``status``, reponses d'erreur,
+Les jetons d'accès sont utilisés pour l'authentification lors d'appels programmatiques à l'API de recherche ou à l'API Admin de |Fess|.
+Pour les spécifications communes de l'API Admin incluant cette API (méthode d'authentification, format des réponses, valeurs de ``status``, réponses d'erreur,
 codes de statut HTTP), consultez :doc:`api-admin-overview`.
 
 .. note::
 
-   Pour acceder a cette API, le jeton d'acces utilise dans la requete doit disposer d'une permission
-   correspondant a ``api.admin.access.permissions``
-   (valeur par defaut : ``{role}admin-api``).
+   Pour accéder à cette API, le jeton d'accès utilisé dans la requête doit disposer d'une permission
+   correspondant à ``api.admin.access.permissions``
+   (valeur par défaut : ``{role}admin-api``).
 
 URL de base
 ===========
@@ -32,60 +32,60 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /settings
-     - Obtention de la liste des jetons d'acces
+     - Obtention de la liste des jetons d'accès
    * - GET
      - /setting/{id}
-     - Obtention d'un jeton d'acces
+     - Obtention d'un jeton d'accès
    * - POST
      - /setting
-     - Creation d'un jeton d'acces
+     - Création d'un jeton d'accès
    * - PUT
      - /setting
-     - Mise a jour d'un jeton d'acces
+     - Mise à jour d'un jeton d'accès
    * - DELETE
      - /setting/{id}
-     - Suppression d'un jeton d'acces
+     - Suppression d'un jeton d'accès
 
-Obtention de la liste des jetons d'acces
+Obtention de la liste des jetons d'accès
 ========================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/accesstoken/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 25 ; modifiable via ``paging.page.size``)
+     - Nombre d'éléments par page (par défaut : 25 ; modifiable via ``paging.page.size``)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1 ; par defaut : 1)
+     - Numéro de page (commence à 1 ; par défaut : 1)
    * - ``id``
      - String
      - Non
-     - Filtre permettant de recuperer uniquement le jeton ayant l'ID specifie
+     - Filtre permettant de récupérer uniquement le jeton ayant l'ID spécifié
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -115,24 +115,24 @@ Reponse
 
 .. note::
 
-   Chaque objet jeton contient egalement des informations d'audit et de version telles que
+   Chaque objet jeton contient également des informations d'audit et de version telles que
    ``createdBy``, ``createdTime``, ``updatedBy``,
    ``updatedTime`` et ``versionNo``.
-   ``createdTime`` et ``updatedTime`` sont exprimes en millisecondes depuis l'epoch (valeur numerique).
-   Les champs dont la valeur est ``null`` sont exclus de la reponse.
-   ``permissions`` est retourne sous forme de chaine separee par des sauts de ligne (``\n``).
+   ``createdTime`` et ``updatedTime`` sont exprimés en millisecondes depuis l'epoch (valeur numérique).
+   Les champs dont la valeur est ``null`` sont exclus de la réponse.
+   ``permissions`` est retourné sous forme de chaîne séparée par des sauts de ligne (``\n``).
 
-Obtention d'un jeton d'acces
+Obtention d'un jeton d'accès
 ============================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/accesstoken/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -156,10 +156,10 @@ Reponse
       }
     }
 
-Creation d'un jeton d'acces
+Création d'un jeton d'accès
 ============================
 
-Requete
+Requête
 -------
 
 ::
@@ -167,7 +167,7 @@ Requete
     POST /api/admin/accesstoken/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -190,24 +190,24 @@ Description des champs
      - Description
    * - ``name``
      - Oui
-     - Nom du jeton (1000 caracteres maximum)
+     - Nom du jeton (1000 caractères maximum)
    * - ``permissions``
      - Non
-     - Permissions accordees a ce jeton. Plusieurs permissions peuvent etre specifiees en les separant par des sauts de ligne (``\n``) (exemple : ``{role}admin-api``). Pour les jetons appelant l'API Admin, une permission correspondant a ``api.admin.access.permissions`` (valeur par defaut : ``{role}admin-api``) est requise.
+     - Permissions accordées à ce jeton. Plusieurs permissions peuvent être spécifiées en les séparant par des sauts de ligne (``\n``) (exemple : ``{role}admin-api``). Pour les jetons appelant l'API Admin, une permission correspondant à ``api.admin.access.permissions`` (valeur par défaut : ``{role}admin-api``) est requise.
    * - ``parameterName``
      - Non
-     - Nom du parametre de requete permettant de transmettre des permissions supplementaires. Si une requete authentifiee par ce jeton contient un parametre portant ce nom, sa valeur est ajoutee aux ``permissions``. Si omis, aucun parametre n'est configure.
+     - Nom du paramètre de requête permettant de transmettre des permissions supplémentaires. Si une requête authentifiée par ce jeton contient un paramètre portant ce nom, sa valeur est ajoutée aux ``permissions``. Si omis, aucun paramètre n'est configuré.
    * - ``expires``
      - Non
-     - Date d'expiration, specifiee sous forme de chaine au format ``YYYY-MM-DDTHH:MM:SS`` (exemple : ``2026-01-01T00:00:00``). Si omis, le jeton n'expire pas.
+     - Date d'expiration, spécifiée sous forme de chaîne au format ``YYYY-MM-DDTHH:MM:SS`` (exemple : ``2026-01-01T00:00:00``). Si omis, le jeton n'expire pas.
 
 .. note::
 
-   La chaine du jeton (``token``) est generee automatiquement cote serveur. Si ``token``
-   est specifie dans le corps de la requete, il est ignore. La reponse de creation ne contient pas la chaine du jeton ;
-   pour recuperer la chaine de jeton generee, utilisez "Obtention d'un jeton d'acces" (``GET /setting/{id}``).
+   La chaîne du jeton (``token``) est générée automatiquement côté serveur. Si ``token``
+   est spécifié dans le corps de la requête, il est ignoré. La réponse de création ne contient pas la chaîne du jeton ;
+   pour récupérer la chaîne de jeton générée, utilisez "Obtention d'un jeton d'accès" (``GET /setting/{id}``).
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -220,10 +220,10 @@ Reponse
       }
     }
 
-Mise a jour d'un jeton d'acces
+Mise à jour d'un jeton d'accès
 ==============================
 
-Requete
+Requête
 -------
 
 ::
@@ -231,7 +231,7 @@ Requete
     PUT /api/admin/accesstoken/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -247,7 +247,7 @@ Corps de la requete
 Description des champs
 ~~~~~~~~~~~~~~~~~~~~~~
 
-En plus des champs utilises lors de la creation, les champs suivants sont employes lors de la mise a jour.
+En plus des champs utilisés lors de la création, les champs suivants sont employés lors de la mise à jour.
 
 .. list-table::
    :header-rows: 1
@@ -258,17 +258,17 @@ En plus des champs utilises lors de la creation, les champs suivants sont employ
      - Description
    * - ``id``
      - Oui
-     - ID du jeton a mettre a jour
+     - ID du jeton à mettre à jour
    * - ``versionNo``
      - Oui
-     - Numero de version pour le verrouillage optimiste. Specifiez le ``versionNo`` du jeton obtenu au prealable.
+     - Numéro de version pour le verrouillage optimiste. Spécifiez le ``versionNo`` du jeton obtenu au préalable.
 
 .. note::
 
-   La chaine du jeton (``token``) ne peut pas etre mise a jour. Si ``token`` est specifie dans le corps de la requete,
-   il est ignore et la valeur existante est conservee.
+   La chaîne du jeton (``token``) ne peut pas être mise à jour. Si ``token`` est spécifié dans le corps de la requête,
+   il est ignoré et la valeur existante est conservée.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -281,17 +281,17 @@ Reponse
       }
     }
 
-Suppression d'un jeton d'acces
+Suppression d'un jeton d'accès
 ==============================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/accesstoken/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -305,7 +305,7 @@ Reponse
 Exemples d'utilisation
 ======================
 
-Creation d'un jeton API
+Création d'un jeton API
 -----------------------
 
 .. code-block:: bash
@@ -321,7 +321,7 @@ Creation d'un jeton API
 Appel API utilisant un jeton
 ----------------------------
 
-Le jeton cree est utilise pour l'authentification lors d'appels a l'API de recherche ou a d'autres APIs.
+Le jeton créé est utilisé pour l'authentification lors d'appels à l'API de recherche ou à d'autres APIs.
 
 .. code-block:: bash
 
@@ -332,9 +332,9 @@ Le jeton cree est utilise pour l'authentification lors d'appels a l'API de reche
     # Utiliser le jeton comme parametre de requete (necessite la configuration de api.access.token.request.parameter)
     curl "http://localhost:8080/api/v2/search?q=test&token=your_token_here"
 
-Informations complementaires
+Informations complémentaires
 ============================
 
-- :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin (authentification, format des reponses, erreurs)
+- :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin (authentification, format des réponses, erreurs)
 - :doc:`../api-search` - API de recherche
-- :doc:`../../admin/accesstoken-guide` - Guide de gestion des jetons d'acces
+- :doc:`../../admin/accesstoken-guide` - Guide de gestion des jetons d'accès

--- a/fr/15.7/api/admin/api-admin-backup.rst
+++ b/fr/15.7/api/admin/api-admin-backup.rst
@@ -5,10 +5,10 @@ API Backup
 Vue d'ensemble
 ==============
 
-L'API Backup permet de consulter et de telecharger les donnees cibles de sauvegarde de |Fess|.
-Vous pouvez obtenir la liste des cibles de sauvegarde et telecharger individuellement chaque fichier de sauvegarde (proprietes systeme, donnees en masse de chaque index, donnees NDJSON des journaux).
+L'API Backup permet de consulter et de télécharger les données cibles de sauvegarde de |Fess|.
+Vous pouvez obtenir la liste des cibles de sauvegarde et télécharger individuellement chaque fichier de sauvegarde (propriétés système, données en masse de chaque index, données NDJSON des journaux).
 
-Cette API est reservee a la consultation et au telechargement (lecture seule). La fonctionnalite de restauration permettant de televerser des fichiers de sauvegarde pour les restaurer n'est pas fournie par l'API. Si vous avez besoin d'effectuer une restauration, utilisez Informations systeme → Sauvegarde dans la console d'administration.
+Cette API est réservée à la consultation et au téléchargement (lecture seule). La fonctionnalité de restauration permettant de téléverser des fichiers de sauvegarde pour les restaurer n'est pas fournie par l'API. Si vous avez besoin d'effectuer une restauration, utilisez Informations système → Sauvegarde dans la console d'administration.
 
 URL de base
 ===========
@@ -20,14 +20,14 @@ URL de base
 Authentification
 ================
 
-Comme pour les autres API Admin, une authentification par jeton d'acces est requise. Le jeton d'acces doit disposer de la permission ``Radmin-api`` (configuree via ``api.admin.access.permissions``, valeur par defaut : ``Radmin-api``).
-Indiquez le jeton d'acces dans l'en-tete de la requete.
+Comme pour les autres API Admin, une authentification par jeton d'accès est requise. Le jeton d'accès doit disposer de la permission ``Radmin-api`` (configurée via ``api.admin.access.permissions``, valeur par défaut : ``Radmin-api``).
+Indiquez le jeton d'accès dans l'en-tête de la requête.
 
 ::
 
     Authorization: Bearer <jeton d'acces>
 
-Pour plus de details sur l'authentification et l'obtention d'un jeton d'acces, consultez :doc:`api-admin-overview`.
+Pour plus de détails sur l'authentification et l'obtention d'un jeton d'accès, consultez :doc:`api-admin-overview`.
 
 Liste des endpoints
 ===================
@@ -36,7 +36,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
@@ -44,27 +44,27 @@ Liste des endpoints
      - Obtention de la liste des cibles de sauvegarde
    * - GET
      - /file/{id}
-     - Telechargement d'un fichier de sauvegarde
+     - Téléchargement d'un fichier de sauvegarde
 
 Obtention de la liste des cibles de sauvegarde
 ===============================================
 
-Renvoie la liste des cibles de sauvegarde. Les cibles reposent sur les parametres ``index.backup.targets`` et ``index.backup.log.targets`` ; la liste retournee est la concatenation des deux.
+Renvoie la liste des cibles de sauvegarde. Les cibles reposent sur les paramètres ``index.backup.targets`` et ``index.backup.log.targets`` ; la liste retournée est la concaténation des deux.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/backup/files
 
-Reponse
+Réponse
 -------
 
-``files`` contient un tableau d'objets representant les cibles de sauvegarde, et ``total`` contient le nombre d'elements.
-Chaque objet possede ``id`` et ``name``, tous deux renseignes avec le nom de la cible (``fess_config.bulk``, ``system.properties``, ``search_log.ndjson``, etc.).
+``files`` contient un tableau d'objets représentant les cibles de sauvegarde, et ``total`` contient le nombre d'éléments.
+Chaque objet possède ``id`` et ``name``, tous deux renseignés avec le nom de la cible (``fess_config.bulk``, ``system.properties``, ``search_log.ndjson``, etc.).
 
-Voici un exemple avec la configuration par defaut (valeurs par defaut de ``index.backup.targets`` et ``index.backup.log.targets``).
+Voici un exemple avec la configuration par défaut (valeurs par défaut de ``index.backup.targets`` et ``index.backup.log.targets``).
 
 .. code-block:: json
 
@@ -90,15 +90,15 @@ Voici un exemple avec la configuration par defaut (valeurs par defaut de ``index
 
 .. note::
 
-   ``version`` contient la version du produit |Fess| en cours d'execution. Le contenu de ``files``
-   varie selon les parametres ``index.backup.targets`` / ``index.backup.log.targets`` ;
-   l'exemple ci-dessus correspond aux valeurs par defaut.
+   ``version`` contient la version du produit |Fess| en cours d'exécution. Le contenu de ``files``
+   varie selon les paramètres ``index.backup.targets`` / ``index.backup.log.targets`` ;
+   l'exemple ci-dessus correspond aux valeurs par défaut.
 
-Telechargement d'un fichier de sauvegarde
+Téléchargement d'un fichier de sauvegarde
 ==========================================
 
-Telecharge le contenu du fichier de sauvegarde specifie. Pour ``{id}``, indiquez l'``id`` (nom de la cible) obtenu lors de l'obtention de la liste.
-Selon le type de ``{id}``, le contenu de la reponse change comme suit.
+Télécharge le contenu du fichier de sauvegarde spécifié. Pour ``{id}``, indiquez l'``id`` (nom de la cible) obtenu lors de l'obtention de la liste.
+Selon le type de ``{id}``, le contenu de la réponse change comme suit.
 
 .. list-table::
    :header-rows: 1
@@ -107,39 +107,39 @@ Selon le type de ``{id}``, le contenu de la reponse change comme suit.
    * - ID
      - Contenu
    * - ``system.properties``
-     - Contenu des proprietes systeme (``application/octet-stream``)
+     - Contenu des propriétés système (``application/octet-stream``)
    * - ``*.bulk`` ou nom d'index sans extension
-     - Donnees en masse generees en parcourant (scroll) l'index du meme nom que la cible (``application/octet-stream``). Le nom sans ``.bulk`` est traite comme le nom de l'index.
+     - Données en masse générées en parcourant (scroll) l'index du même nom que la cible (``application/octet-stream``). Le nom sans ``.bulk`` est traité comme le nom de l'index.
    * - ``*.ndjson`` (``search_log`` / ``user_info`` / ``click_log`` / ``favorite_log``)
-     - Donnees NDJSON du journal correspondant (``application/x-ndjson``)
+     - Données NDJSON du journal correspondant (``application/x-ndjson``)
 
 .. note::
 
-   ``fess.json`` et ``doc.json`` sont des fichiers de definition de mapping (schema) d'index.
-   Ils figurent dans la liste des cibles (``/files``), mais lors du telechargement via cette API,
-   ils sont traites comme un parcours (scroll) d'index, de la meme maniere que ``.bulk``.
-   Pour la sauvegarde et la restauration incluant les definitions de mapping, utilisez
-   Informations systeme → Sauvegarde dans la console d'administration.
+   ``fess.json`` et ``doc.json`` sont des fichiers de définition de mapping (schéma) d'index.
+   Ils figurent dans la liste des cibles (``/files``), mais lors du téléchargement via cette API,
+   ils sont traités comme un parcours (scroll) d'index, de la même manière que ``.bulk``.
+   Pour la sauvegarde et la restauration incluant les définitions de mapping, utilisez
+   Informations système → Sauvegarde dans la console d'administration.
 
-Si vous specifiez un ``{id}`` inexistant parmi les cibles de sauvegarde, une reponse d'erreur est renvoyee avec une valeur differente de 0 dans ``status`` et le message d'erreur (``Could not find any backup index.``).
+Si vous spécifiez un ``{id}`` inexistant parmi les cibles de sauvegarde, une réponse d'erreur est renvoyée avec une valeur différente de 0 dans ``status`` et le message d'erreur (``Could not find any backup index.``).
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/backup/file/{id}
 
-Reponse
+Réponse
 -------
 
-Flux du fichier de sauvegarde. Au format NDJSON, il est renvoye avec ``Content-Type: application/x-ndjson``, sinon avec ``application/octet-stream``.
+Flux du fichier de sauvegarde. Au format NDJSON, il est renvoyé avec ``Content-Type: application/x-ndjson``, sinon avec ``application/octet-stream``.
 
 .. note::
 
-   L'export des journaux (``*.ndjson``) est soumis a la contrainte ``index.backup.log.load.timeout``
-   (valeur par defaut : ``60000`` millisecondes). Si la generation prend trop de temps, les donnees
-   de journal peuvent etre tronquees en cours de route.
+   L'export des journaux (``*.ndjson``) est soumis à la contrainte ``index.backup.log.load.timeout``
+   (valeur par défaut : ``60000`` millisecondes). Si la génération prend trop de temps, les données
+   de journal peuvent être tronquées en cours de route.
 
 Exemples d'utilisation
 ======================
@@ -152,7 +152,7 @@ Obtention de la liste des cibles de sauvegarde
     curl -X GET "http://localhost:8080/api/admin/backup/files" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Telechargement de l'index de configuration
+Téléchargement de l'index de configuration
 ------------------------------------------
 
 .. code-block:: bash
@@ -161,7 +161,7 @@ Telechargement de l'index de configuration
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o fess_config.bulk
 
-Telechargement des journaux de recherche
+Téléchargement des journaux de recherche
 ----------------------------------------
 
 .. code-block:: bash
@@ -170,7 +170,7 @@ Telechargement des journaux de recherche
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o search_log.ndjson
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.7/api/admin/api-admin-badword.rst
+++ b/fr/15.7/api/admin/api-admin-badword.rst
@@ -5,8 +5,8 @@ API BadWord
 Vue d'ensemble
 ==============
 
-L'API BadWord permet de gerer les mots interdits (exclusion de mots inappropries des suggestions) dans |Fess|.
-Vous pouvez configurer les mots-cles que vous ne souhaitez pas afficher dans la fonction de suggestion.
+L'API BadWord permet de gérer les mots interdits (exclusion de mots inappropriés des suggestions) dans |Fess|.
+Vous pouvez configurer les mots-clés que vous ne souhaitez pas afficher dans la fonction de suggestion.
 
 URL de base
 ===========
@@ -22,7 +22,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
@@ -33,55 +33,55 @@ Liste des endpoints
      - Obtention d'un mot interdit
    * - POST
      - /setting
-     - Creation d'un mot interdit
+     - Création d'un mot interdit
    * - PUT
      - /setting
-     - Mise a jour d'un mot interdit
+     - Mise à jour d'un mot interdit
    * - DELETE
      - /setting/{id}
      - Suppression d'un mot interdit
    * - PUT
      - /upload
-     - Televersement CSV des mots interdits
+     - Téléversement CSV des mots interdits
    * - GET
      - /download
-     - Telechargement CSV des mots interdits
+     - Téléchargement CSV des mots interdits
 
 Obtention de la liste des mots interdits
 ========================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/badword/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 20)
+     - Nombre d'éléments par page (par défaut : 20)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1, par defaut : 1)
+     - Numéro de page (commence à 1, par défaut : 1)
    * - ``id``
      - String
      - Non
-     - Filtrer uniquement sur le mot interdit ayant l'ID specifie
+     - Filtrer uniquement sur le mot interdit ayant l'ID spécifié
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -102,14 +102,14 @@ Reponse
 Obtention d'un mot interdit
 ===========================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/badword/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -124,10 +124,10 @@ Reponse
       }
     }
 
-Creation d'un mot interdit
+Création d'un mot interdit
 ==========================
 
-Requete
+Requête
 -------
 
 ::
@@ -135,7 +135,7 @@ Requete
     POST /api/admin/badword/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -156,9 +156,9 @@ Description des champs
      - Description
    * - ``suggestWord``
      - Oui
-     - Mot-cle a exclure (ne peut pas contenir d'espaces)
+     - Mot-clé à exclure (ne peut pas contenir d'espaces)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -171,10 +171,10 @@ Reponse
       }
     }
 
-Mise a jour d'un mot interdit
+Mise à jour d'un mot interdit
 =============================
 
-Requete
+Requête
 -------
 
 ::
@@ -182,7 +182,7 @@ Requete
     PUT /api/admin/badword/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -193,7 +193,7 @@ Corps de la requete
       "versionNo": 1
     }
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -209,14 +209,14 @@ Reponse
 Suppression d'un mot interdit
 =============================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/badword/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -229,12 +229,12 @@ Reponse
       }
     }
 
-Televersement CSV des mots interdits
+Téléversement CSV des mots interdits
 ====================================
 
-Enregistre en masse des mots interdits depuis un fichier CSV. Le fichier est envoye en ``multipart/form-data``. L'import est execute de maniere asynchrone cote serveur.
+Enregistre en masse des mots interdits depuis un fichier CSV. Le fichier est envoyé en ``multipart/form-data``. L'import est exécuté de manière asynchrone côté serveur.
 
-Requete
+Requête
 -------
 
 ::
@@ -242,35 +242,35 @@ Requete
     PUT /api/admin/badword/upload
     Content-Type: multipart/form-data
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``badWordFile``
      - Oui
-     - Fichier CSV des mots interdits a televerser
+     - Fichier CSV des mots interdits à téléverser
 
 Format CSV
 ~~~~~~~~~~
 
-- La premiere ligne est ignoree en tant que ligne d'en-tete (le nom de colonne est arbitraire ; ``BadWord`` est ecrit lors du telechargement).
-- A partir de la deuxieme ligne, ecrivez un mot interdit par ligne en tant que ``suggestWord``.
-- Les lignes dont la valeur est vide sont ignorees.
-- Prefixez un mot par ``--`` pour le supprimer (par exemple, ``--spam`` supprime ``spam``).
-- Specifier un mot deja enregistre est traite comme une mise a jour (l'auteur et la date de mise a jour sont reinitialises).
+- La première ligne est ignorée en tant que ligne d'en-tête (le nom de colonne est arbitraire ; ``BadWord`` est écrit lors du téléchargement).
+- À partir de la deuxième ligne, écrivez un mot interdit par ligne en tant que ``suggestWord``.
+- Les lignes dont la valeur est vide sont ignorées.
+- Préfixez un mot par ``--`` pour le supprimer (par exemple, ``--spam`` supprime ``spam``).
+- Spécifier un mot déjà enregistré est traité comme une mise à jour (l'auteur et la date de mise à jour sont réinitialisés).
 
 .. note::
 
-   Comme l'import s'execute de maniere asynchrone cote serveur, une reponse ``status: 0``
-   indique que la requete a ete acceptee, et non que l'import est termine.
+   Comme l'import s'exécute de manière asynchrone côté serveur, une réponse ``status: 0``
+   indique que la requête a été acceptée, et non que l'import est terminé.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -281,13 +281,13 @@ Reponse
       }
     }
 
-Telechargement CSV des mots interdits
+Téléchargement CSV des mots interdits
 =====================================
 
-Telecharge les mots interdits enregistres sous forme de fichier CSV (``badword.csv``). La reponse est un flux ``application/octet-stream``.
-Le CSV comporte une ligne d'en-tete ``BadWord`` sur la premiere ligne, suivie d'un mot interdit enregistre par ligne.
+Télécharge les mots interdits enregistrés sous forme de fichier CSV (``badword.csv``). La réponse est un flux ``application/octet-stream``.
+Le CSV comporte une ligne d'en-tête ``BadWord`` sur la première ligne, suivie d'un mot interdit enregistré par ligne.
 
-Requete
+Requête
 -------
 
 ::
@@ -297,7 +297,7 @@ Requete
 Exemples d'utilisation
 ======================
 
-Exclusion d'un mot-cle spam
+Exclusion d'un mot-clé spam
 ---------------------------
 
 .. code-block:: bash
@@ -309,7 +309,7 @@ Exclusion d'un mot-cle spam
            "suggestWord": "spam"
          }'
 
-Televersement d'un fichier CSV
+Téléversement d'un fichier CSV
 ------------------------------
 
 .. code-block:: bash
@@ -318,7 +318,7 @@ Televersement d'un fichier CSV
          -H "Authorization: Bearer YOUR_TOKEN" \
          -F "badWordFile=@badword.csv"
 
-Telechargement d'un fichier CSV
+Téléchargement d'un fichier CSV
 -------------------------------
 
 .. code-block:: bash
@@ -327,7 +327,7 @@ Telechargement d'un fichier CSV
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o badword.csv
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.7/api/admin/api-admin-boostdoc.rst
+++ b/fr/15.7/api/admin/api-admin-boostdoc.rst
@@ -5,19 +5,19 @@ BoostDoc API
 Vue d'ensemble
 ==============
 
-L'API BoostDoc est une API permettant de gerer les configurations de boost de documents dans |Fess|.
-En configurant le boost de documents, vous pouvez augmenter le score des documents correspondant a certaines conditions
-et les faire apparaitre plus haut dans les resultats de recherche.
+L'API BoostDoc est une API permettant de gérer les configurations de boost de documents dans |Fess|.
+En configurant le boost de documents, vous pouvez augmenter le score des documents correspondant à certaines conditions
+et les faire apparaître plus haut dans les résultats de recherche.
 
-Le boost est applique a chaque document lors de la creation de l'index (au moment du crawl).
-La condition (``urlExpr``) et la valeur de boost (``boostExpr``) sont toutes deux evaluees comme des expressions Groovy.
-Les regles multiples sont evaluees dans l'ordre croissant de ``sortOrder``, et seule la valeur de boost de la premiere regle
-dont la condition correspond est appliquee (une fois qu'une regle correspondante est trouvee, les regles suivantes ne sont pas evaluees).
+Le boost est appliqué à chaque document lors de la création de l'index (au moment du crawl).
+La condition (``urlExpr``) et la valeur de boost (``boostExpr``) sont toutes deux évaluées comme des expressions Groovy.
+Les règles multiples sont évaluées dans l'ordre croissant de ``sortOrder``, et seule la valeur de boost de la première règle
+dont la condition correspond est appliquée (une fois qu'une règle correspondante est trouvée, les règles suivantes ne sont pas évaluées).
 
 .. note::
 
-   Dans l'interface d'administration, ``urlExpr`` est affiche sous le nom « Condition » et ``boostExpr`` sous le nom « Expression de valeur de boost ».
-   Pour plus de details sur les elements de configuration, consultez :doc:`../../admin/boostdoc-guide`.
+   Dans l'interface d'administration, ``urlExpr`` est affiché sous le nom « Condition » et ``boostExpr`` sous le nom « Expression de valeur de boost ».
+   Pour plus de détails sur les éléments de configuration, consultez :doc:`../../admin/boostdoc-guide`.
 
 URL de base
 ===========
@@ -29,8 +29,8 @@ URL de base
 Authentification
 ================
 
-Pour utiliser cette API, un jeton d'acces avec la permission ``Radmin-api`` est requis.
-Pour savoir comment obtenir et specifier un jeton d'acces, consultez :doc:`api-admin-overview`.
+Pour utiliser cette API, un jeton d'accès avec la permission ``Radmin-api`` est requis.
+Pour savoir comment obtenir et spécifier un jeton d'accès, consultez :doc:`api-admin-overview`.
 
 Liste des endpoints
 ===================
@@ -39,7 +39,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
@@ -50,10 +50,10 @@ Liste des endpoints
      - Obtention d'un boost de document
    * - POST
      - /setting
-     - Creation d'un boost de document
+     - Création d'un boost de document
    * - PUT
      - /setting
-     - Mise a jour d'un boost de document
+     - Mise à jour d'un boost de document
    * - DELETE
      - /setting/{id}
      - Suppression d'un boost de document
@@ -61,32 +61,32 @@ Liste des endpoints
 Obtention de la liste des boosts de documents
 =============================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/boostdoc/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 25)
+     - Nombre d'éléments par page (par défaut : 25)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1. Par defaut : 1)
+     - Numéro de page (commence à 1. Par défaut : 1)
    * - ``urlExpr``
      - String
      - Non
@@ -96,7 +96,7 @@ Parametres
      - Non
      - Filtrage par expression de valeur de boost (correspondance partielle)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -119,20 +119,20 @@ Reponse
 
 .. note::
 
-   En plus des champs presentes ci-dessus, chaque objet de configuration dans la reponse inclut egalement des metadonnees de creation/mise a jour (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``).
-   ``versionNo`` est obligatoire lors d'une mise a jour (PUT) ; recuperez sa valeur actuelle via l'API d'obtention ou de liste avant de proceder a la mise a jour.
+   En plus des champs présentés ci-dessus, chaque objet de configuration dans la réponse inclut également des métadonnées de création/mise à jour (``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime``).
+   ``versionNo`` est obligatoire lors d'une mise à jour (PUT) ; récupérez sa valeur actuelle via l'API d'obtention ou de liste avant de procéder à la mise à jour.
 
 Obtention d'un boost de document
 ==================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/boostdoc/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -150,10 +150,10 @@ Reponse
       }
     }
 
-Creation d'un boost de document
+Création d'un boost de document
 =================================
 
-Requete
+Requête
 -------
 
 ::
@@ -161,7 +161,7 @@ Requete
     POST /api/admin/boostdoc/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -184,15 +184,15 @@ Description des champs
      - Description
    * - ``urlExpr``
      - Oui
-     - Expression de condition. Expression Groovy retournant un ``Boolean`` permettant de determiner les documents a booster. Correspond au champ « Condition » de l'interface d'administration (maximum 10000 caracteres).
+     - Expression de condition. Expression Groovy retournant un ``Boolean`` permettant de déterminer les documents à booster. Correspond au champ « Condition » de l'interface d'administration (maximum 10000 caractères).
    * - ``boostExpr``
      - Oui
-     - Expression de valeur de boost. Expression Groovy retournant la valeur de boost (numerique). Une valeur fixe telle que ``3.0`` peut egalement etre specifiee. Correspond au champ « Expression de valeur de boost » de l'interface d'administration (maximum 10000 caracteres).
+     - Expression de valeur de boost. Expression Groovy retournant la valeur de boost (numérique). Une valeur fixe telle que ``3.0`` peut également être spécifiée. Correspond au champ « Expression de valeur de boost » de l'interface d'administration (maximum 10000 caractères).
    * - ``sortOrder``
      - Oui
-     - Ordre d'application. Les regles sont evaluees dans l'ordre croissant et la valeur de boost de la premiere regle correspondante est appliquee (valeur initiale du formulaire : 0, entier superieur ou egal a 0).
+     - Ordre d'application. Les règles sont évaluées dans l'ordre croissant et la valeur de boost de la première règle correspondante est appliquée (valeur initiale du formulaire : 0, entier supérieur ou égal à 0).
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -205,10 +205,10 @@ Reponse
       }
     }
 
-Mise a jour d'un boost de document
+Mise à jour d'un boost de document
 ====================================
 
-Requete
+Requête
 -------
 
 ::
@@ -216,7 +216,7 @@ Requete
     PUT /api/admin/boostdoc/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -229,9 +229,9 @@ Corps de la requete
       "versionNo": 1
     }
 
-Lors de la mise a jour, en plus des champs utilises lors de la creation, ``id`` (l'identifiant de la regle cible, 1000 caracteres maximum) et ``versionNo`` (le numero de version pour le verrouillage optimiste) sont obligatoires. Specifiez pour ``versionNo`` la valeur actuelle obtenue depuis la reponse de l'API d'obtention ou de liste. La mise a jour echoue si le numero de version ne correspond pas.
+Lors de la mise à jour, en plus des champs utilisés lors de la création, ``id`` (l'identifiant de la règle cible, 1000 caractères maximum) et ``versionNo`` (le numéro de version pour le verrouillage optimiste) sont obligatoires. Spécifiez pour ``versionNo`` la valeur actuelle obtenue depuis la réponse de l'API d'obtention ou de liste. La mise à jour échoue si le numéro de version ne correspond pas.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -247,14 +247,14 @@ Reponse
 Suppression d'un boost de document
 ====================================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/boostdoc/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -268,18 +268,18 @@ Reponse
 Expressions de condition et de valeur de boost
 ===============================================
 
-``urlExpr`` (condition) et ``boostExpr`` (expression de valeur de boost) sont toutes deux evaluees comme des expressions Groovy.
-Dans les expressions, les valeurs des champs du document cible de l'indexation peuvent etre referenciees comme des variables portant le nom du champ.
+``urlExpr`` (condition) et ``boostExpr`` (expression de valeur de boost) sont toutes deux évaluées comme des expressions Groovy.
+Dans les expressions, les valeurs des champs du document cible de l'indexation peuvent être référenciées comme des variables portant le nom du champ.
 
-- ``urlExpr`` doit retourner un ``Boolean`` (exemple : ``url.startsWith("https://docs.example.com/")``). Une simple chaine d'expression reguliere (exemple : ``.*docs\.example\.com.*``) ne retourne pas un ``Boolean`` en tant qu'expression Groovy et ne fonctionne donc pas comme condition. Pour utiliser des expressions regulieres, utilisez ``String#matches`` de Groovy.
-- ``boostExpr`` doit retourner une valeur numerique. Le resultat est converti en ``float`` et le boost n'est applique que si la valeur est superieure a 0.
+- ``urlExpr`` doit retourner un ``Boolean`` (exemple : ``url.startsWith("https://docs.example.com/")``). Une simple chaîne d'expression régulière (exemple : ``.*docs\.example\.com.*``) ne retourne pas un ``Boolean`` en tant qu'expression Groovy et ne fonctionne donc pas comme condition. Pour utiliser des expressions régulières, utilisez ``String#matches`` de Groovy.
+- ``boostExpr`` doit retourner une valeur numérique. Le résultat est converti en ``float`` et le boost n'est appliqué que si la valeur est supérieure à 0.
 
 .. note::
 
-   Principales variables de champs referenciables dans les expressions : ``url``, ``title``, ``content``, ``content_length``, ``last_modified``, etc.
+   Principales variables de champs référenciables dans les expressions : ``url``, ``title``, ``content``, ``content_length``, ``last_modified``, etc.
    ``click_count`` et ``favorite_count`` sont disponibles respectivement lorsque ``indexer.click.count.enabled`` /
-   ``indexer.favorite.count.enabled`` sont actives (toutes deux activees par defaut).
-   La syntaxe de calcul de date OpenSearch telle que ``now - 7d`` ne peut pas etre utilisee en Groovy.
+   ``indexer.favorite.count.enabled`` sont actives (toutes deux activées par défaut).
+   La syntaxe de calcul de date OpenSearch telle que ``now - 7d`` ne peut pas être utilisée en Groovy.
 
 Exemples d'expressions de condition (``urlExpr``)
 --------------------------------------------------
@@ -291,11 +291,11 @@ Exemples d'expressions de condition (``urlExpr``)
    * - Expression de condition
      - Description
    * - ``url.startsWith("https://docs.example.com/")``
-     - Cible les documents dont l'URL commence par la valeur specifiee
+     - Cible les documents dont l'URL commence par la valeur spécifiée
    * - ``url.matches("https://www\\.example\\.com/.*")``
-     - Evalue l'URL avec une expression reguliere (``String#matches`` de Groovy)
+     - Évalue l'URL avec une expression régulière (``String#matches`` de Groovy)
    * - ``title.contains("Notes de version")``
-     - Cible les documents dont le titre contient un mot specifique
+     - Cible les documents dont le titre contient un mot spécifique
 
 Exemples d'expressions de valeur de boost (``boostExpr``)
 ----------------------------------------------------------
@@ -311,7 +311,7 @@ Exemples d'expressions de valeur de boost (``boostExpr``)
    * - ``click_count * 0.1 + 1``
      - Boost proportionnel au nombre de clics
    * - ``Math.log(click_count + 1)``
-     - Boost sur une echelle logarithmique basee sur le nombre de clics
+     - Boost sur une échelle logarithmique basée sur le nombre de clics
 
 Exemples d'utilisation
 ======================
@@ -344,7 +344,7 @@ Boost de contenu populaire
            "sortOrder": 10
          }'
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.7/api/admin/api-admin-crawlinginfo.rst
+++ b/fr/15.7/api/admin/api-admin-crawlinginfo.rst
@@ -5,7 +5,7 @@ API CrawlingInfo
 Vue d'ensemble
 ==============
 
-L'API CrawlingInfo permet de consulter et de gerer les informations de crawl (sessions de crawl) de |Fess|.
+L'API CrawlingInfo permet de consulter et de gérer les informations de crawl (sessions de crawl) de |Fess|.
 Vous pouvez obtenir la liste des sessions de crawl, les consulter individuellement, les supprimer, etc.
 
 URL de base
@@ -22,7 +22,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
@@ -36,43 +36,43 @@ Liste des endpoints
      - Suppression d'une information de crawl
    * - DELETE
      - /all
-     - Suppression groupee des sessions de crawl (hors sessions en cours)
+     - Suppression groupée des sessions de crawl (hors sessions en cours)
 
 Obtention de la liste des informations de crawl
 ===============================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/crawlinginfo/logs
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (defaut : 20)
+     - Nombre d'éléments par page (défaut : 20)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (base 1, defaut : 1)
+     - Numéro de page (base 1, défaut : 1)
    * - ``sessionId``
      - String
      - Non
      - Filtre par ID de session (correspondance partielle)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -100,7 +100,7 @@ Reponse
       }
     }
 
-Champs de la reponse
+Champs de la réponse
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -116,27 +116,27 @@ Champs de la reponse
    * - ``name``
      - Nom de la session
    * - ``expiredTime``
-     - Date d'expiration (millisecondes epoch ; retournee sous forme de chaine)
+     - Date d'expiration (millisecondes epoch ; retournée sous forme de chaîne)
    * - ``createdTime``
-     - Heure de creation (millisecondes epoch ; retournee sous forme de nombre)
+     - Heure de création (millisecondes epoch ; retournée sous forme de nombre)
 
 .. note::
 
-   Chaque objet de journal dans la reponse inclut egalement un champ interne ``crudMode``
-   (un entier indiquant le mode d'operation CRUD, toujours ``0`` pour les operations de lecture).
-   Les clients peuvent l'ignorer en toute securite.
+   Chaque objet de journal dans la réponse inclut également un champ interne ``crudMode``
+   (un entier indiquant le mode d'opération CRUD, toujours ``0`` pour les opérations de lecture).
+   Les clients peuvent l'ignorer en toute sécurité.
 
 Obtention d'une information de crawl
 ====================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/crawlinginfo/log/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -157,14 +157,14 @@ Reponse
 Suppression d'une information de crawl
 ======================================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/crawlinginfo/log/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -175,19 +175,19 @@ Reponse
       }
     }
 
-Suppression groupee des sessions de crawl
+Suppression groupée des sessions de crawl
 ==========================================
 
-Supprime toutes les sessions de crawl (ainsi que leurs donnees de parametres), a l'exception de celles qui sont actuellement en cours d'execution. Il n'y a pas de seuil d'age ou de duree ; toute session qui n'est pas en cours d'execution est supprimee.
+Supprime toutes les sessions de crawl (ainsi que leurs données de paramètres), à l'exception de celles qui sont actuellement en cours d'exécution. Il n'y a pas de seuil d'âge ou de durée ; toute session qui n'est pas en cours d'exécution est supprimée.
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/crawlinginfo/all
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -209,7 +209,7 @@ Obtention de la liste des informations de crawl
     curl -X GET "http://localhost:8080/api/admin/crawlinginfo/logs?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Filtrage par session specifique
+Filtrage par session spécifique
 -------------------------------
 
 .. code-block:: bash
@@ -233,7 +233,7 @@ Suppression d'une information de crawl
     curl -X DELETE "http://localhost:8080/api/admin/crawlinginfo/log/crawling_info_id_1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Suppression groupee des sessions
+Suppression groupée des sessions
 --------------------------------
 
 .. code-block:: bash
@@ -241,10 +241,10 @@ Suppression groupee des sessions
     curl -X DELETE "http://localhost:8080/api/admin/crawlinginfo/all" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
-- :doc:`api-admin-failureurl` - API des URLs en echec
-- :doc:`api-admin-joblog` - API des journaux de taches
+- :doc:`api-admin-failureurl` - API des URLs en échec
+- :doc:`api-admin-joblog` - API des journaux de tâches
 - :doc:`../../admin/crawlinginfo-guide` - Guide des informations de crawl

--- a/fr/15.7/api/admin/api-admin-dataconfig.rst
+++ b/fr/15.7/api/admin/api-admin-dataconfig.rst
@@ -5,8 +5,8 @@ API DataConfig
 Vue d'ensemble
 ==============
 
-L'API DataConfig permet de gerer les configurations de datastore de |Fess|.
-Vous pouvez manipuler les configurations de crawl pour les bases de donnees, les fichiers CSV, JSON et autres sources de donnees.
+L'API DataConfig permet de gérer les configurations de datastore de |Fess|.
+Vous pouvez manipuler les configurations de crawl pour les bases de données, les fichiers CSV, JSON et autres sources de données.
 
 URL de base
 ===========
@@ -22,7 +22,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
@@ -33,10 +33,10 @@ Liste des endpoints
      - Obtention d'une configuration datastore
    * - POST
      - /setting
-     - Creation d'une configuration datastore
+     - Création d'une configuration datastore
    * - PUT
      - /setting
-     - Mise a jour d'une configuration datastore
+     - Mise à jour d'une configuration datastore
    * - DELETE
      - /setting/{id}
      - Suppression d'une configuration datastore
@@ -44,32 +44,32 @@ Liste des endpoints
 Obtention de la liste des configurations datastore
 ==================================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/dataconfig/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 25)
+     - Nombre d'éléments par page (par défaut : 25)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1, par defaut : 1)
+     - Numéro de page (commence à 1, par défaut : 1)
    * - ``name``
      - String
      - Non
@@ -83,7 +83,7 @@ Parametres
      - Non
      - Filtrer par description
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -113,14 +113,14 @@ Reponse
 Obtention d'une configuration datastore
 =======================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/dataconfig/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -144,10 +144,10 @@ Reponse
       }
     }
 
-Creation d'une configuration datastore
+Création d'une configuration datastore
 ======================================
 
-Requete
+Requête
 -------
 
 ::
@@ -155,7 +155,7 @@ Requete
     POST /api/admin/dataconfig/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -192,27 +192,27 @@ Description des champs
      - Nom du gestionnaire de datastore
    * - ``handlerParameter``
      - Non
-     - Parametres du gestionnaire (informations de connexion, etc.)
+     - Paramètres du gestionnaire (informations de connexion, etc.)
    * - ``handlerScript``
      - Non
-     - Script de transformation des donnees
+     - Script de transformation des données
    * - ``boost``
      - Oui
-     - Valeur de boost des resultats de recherche
+     - Valeur de boost des résultats de recherche
    * - ``available``
      - Oui
-     - Active/Desactive (chaine ``"true"`` / ``"false"``)
+     - Active/Désactivé (chaîne ``"true"`` / ``"false"``)
    * - ``sortOrder``
      - Oui
      - Ordre d'affichage
    * - ``permissions``
      - Non
-     - Roles autorises (separes par des sauts de ligne si plusieurs)
+     - Rôles autorisés (séparés par des sauts de ligne si plusieurs)
    * - ``virtualHosts``
      - Non
-     - Hotes virtuels (separes par des sauts de ligne si plusieurs)
+     - Hôtes virtuels (séparés par des sauts de ligne si plusieurs)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -225,10 +225,10 @@ Reponse
       }
     }
 
-Mise a jour d'une configuration datastore
+Mise à jour d'une configuration datastore
 =========================================
 
-Requete
+Requête
 -------
 
 ::
@@ -236,7 +236,7 @@ Requete
     PUT /api/admin/dataconfig/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -253,7 +253,7 @@ Corps de la requete
       "versionNo": 1
     }
 
-Les requetes de mise a jour necessitent les memes champs obligatoires que la creation (``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``), ainsi que les champs suivants :
+Les requêtes de mise à jour nécessitent les mêmes champs obligatoires que la création (``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``), ainsi que les champs suivants :
 
 .. list-table::
    :header-rows: 1
@@ -264,12 +264,12 @@ Les requetes de mise a jour necessitent les memes champs obligatoires que la cre
      - Description
    * - ``id``
      - Oui
-     - ID de la configuration a mettre a jour
+     - ID de la configuration à mettre à jour
    * - ``versionNo``
      - Oui
-     - Numero de version pour le verrouillage optimiste (indiquer la valeur obtenue lors de la recuperation du parametre)
+     - Numéro de version pour le verrouillage optimiste (indiquer la valeur obtenue lors de la récupération du paramètre)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -285,14 +285,14 @@ Reponse
 Suppression d'une configuration datastore
 =========================================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/dataconfig/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -313,24 +313,24 @@ Types de gestionnaires
    * - Nom du gestionnaire
      - Description
    * - ``DatabaseDataStore``
-     - Connexion a une base de donnees via JDBC
+     - Connexion à une base de données via JDBC
    * - ``CsvDataStore``
-     - Lecture des donnees depuis un fichier CSV (traitement de chaque ligne comme un document)
+     - Lecture des données depuis un fichier CSV (traitement de chaque ligne comme un document)
    * - ``CsvListDataStore``
-     - Lecture des fichiers CSV avec suppression automatique des fichiers traites (extension de ``CsvDataStore`` avec filtrage par horodatage)
+     - Lecture des fichiers CSV avec suppression automatique des fichiers traités (extension de ``CsvDataStore`` avec filtrage par horodatage)
    * - ``JsonDataStore``
-     - Lecture des donnees depuis un fichier JSON ou une API JSON
+     - Lecture des données depuis un fichier JSON ou une API JSON
 
 .. note::
 
-   Les types de gestionnaires disponibles dependent des plugins de datastore installes.
-   Les gestionnaires ci-dessus sont inclus par defaut. L'installation de plugins de datastore
+   Les types de gestionnaires disponibles dépendent des plugins de datastore installés.
+   Les gestionnaires ci-dessus sont inclus par défaut. L'installation de plugins de datastore
    tels que SharePoint, Slack ou Salesforce rend disponibles leurs noms de gestionnaire respectifs.
 
 Exemples d'utilisation
 ======================
 
-Configuration de crawl de base de donnees
+Configuration de crawl de base de données
 -----------------------------------------
 
 .. code-block:: bash
@@ -348,7 +348,7 @@ Configuration de crawl de base de donnees
            "sortOrder": 0
          }'
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.7/api/admin/api-admin-dict.rst
+++ b/fr/15.7/api/admin/api-admin-dict.rst
@@ -5,9 +5,9 @@ API Dict
 Vue d'ensemble
 ==============
 
-L'API Dict est une API permettant de gerer les dictionnaires de |Fess|.
+L'API Dict est une API permettant de gérer les dictionnaires de |Fess|.
 L'endpoint racine permet d'obtenir la liste des dictionnaires disponibles.
-La consultation, la creation, la mise a jour et la suppression des entrees de dictionnaire individuelles, ainsi que le televersement et le telechargement des fichiers de dictionnaire, s'effectuent via les sous-endpoints propres a chaque type de dictionnaire (synonym, kuromoji, mapping, protwords, stopwords, stemmeroverride).
+La consultation, la création, la mise à jour et la suppression des entrées de dictionnaire individuelles, ainsi que le téléversement et le téléchargement des fichiers de dictionnaire, s'effectuent via les sous-endpoints propres à chaque type de dictionnaire (synonym, kuromoji, mapping, protwords, stopwords, stemmeroverride).
 
 URL de base
 ===========
@@ -26,62 +26,62 @@ Racine des dictionnaires
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /
      - Obtention de la liste des dictionnaires
 
-Endpoints propres a chaque type de dictionnaire
+Endpoints propres à chaque type de dictionnaire
 -----------------------------------------------
 
-``{type}`` doit etre l'une des valeurs suivantes : ``synonym`` , ``kuromoji`` , ``mapping`` , ``protwords`` , ``stopwords`` , ``stemmeroverride`` .
-Ces valeurs correspondent a la valeur du champ ``type`` inclus dans la reponse de la liste des dictionnaires.
+``{type}`` doit être l'une des valeurs suivantes : ``synonym`` , ``kuromoji`` , ``mapping`` , ``protwords`` , ``stopwords`` , ``stemmeroverride`` .
+Ces valeurs correspondent à la valeur du champ ``type`` inclus dans la réponse de la liste des dictionnaires.
 ``{dictId}`` est l'ID du dictionnaire obtenu via l'obtention de la liste des dictionnaires.
 
 .. list-table::
    :header-rows: 1
    :widths: 15 50 35
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /{type}/settings/{dictId}
-     - Obtention de la liste des entrees de dictionnaire
+     - Obtention de la liste des entrées de dictionnaire
    * - GET
      - /{type}/setting/{dictId}/{id}
-     - Obtention d'une entree de dictionnaire
+     - Obtention d'une entrée de dictionnaire
    * - POST
      - /{type}/setting/{dictId}
-     - Creation d'une entree de dictionnaire
+     - Création d'une entrée de dictionnaire
    * - PUT
      - /{type}/setting/{dictId}
-     - Mise a jour d'une entree de dictionnaire
+     - Mise à jour d'une entrée de dictionnaire
    * - DELETE
      - /{type}/setting/{dictId}/{id}
-     - Suppression d'une entree de dictionnaire
+     - Suppression d'une entrée de dictionnaire
    * - PUT
      - /{type}/upload/{dictId}
-     - Televersement d'un fichier de dictionnaire
+     - Téléversement d'un fichier de dictionnaire
    * - GET
      - /{type}/download/{dictId}
-     - Telechargement d'un fichier de dictionnaire
+     - Téléchargement d'un fichier de dictionnaire
 
 Obtention de la liste des dictionnaires
 =======================================
 
 Obtient la liste des fichiers de dictionnaire disponibles.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/dict
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -108,7 +108,7 @@ Reponse
       }
     }
 
-Champs de la reponse
+Champs de la réponse
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -118,56 +118,56 @@ Champs de la reponse
    * - Champ
      - Description
    * - ``settings[].id``
-     - ID du dictionnaire (utilise comme ``{dictId}`` dans les operations sur les dictionnaires individuels)
+     - ID du dictionnaire (utilisé comme ``{dictId}`` dans les opérations sur les dictionnaires individuels)
    * - ``settings[].type``
      - Type de dictionnaire
    * - ``settings[].path``
      - Chemin du fichier de dictionnaire
    * - ``settings[].timestamp``
-     - Date et heure de mise a jour du fichier de dictionnaire
+     - Date et heure de mise à jour du fichier de dictionnaire
    * - ``total``
      - Nombre total de fichiers de dictionnaire
 
-Obtention de la liste des entrees de dictionnaire
+Obtention de la liste des entrées de dictionnaire
 =================================================
 
-Obtient la liste des entrees du dictionnaire specifie.
+Obtient la liste des entrées du dictionnaire spécifié.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/dict/{type}/settings/{dictId}
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``dictId``
      - String
      - Oui
-     - ID du dictionnaire (parametre de chemin)
+     - ID du dictionnaire (paramètre de chemin)
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (defaut : 25)
+     - Nombre d'éléments par page (défaut : 25)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1, defaut : 1)
+     - Numéro de page (commence à 1, défaut : 1)
 
-Reponse
+Réponse
 -------
 
-Les champs de chaque element du tableau ``settings`` de la reponse varient selon le type de dictionnaire (voir « Champs des entrees par type de dictionnaire » ci-dessous).
+Les champs de chaque élément du tableau ``settings`` de la réponse varient selon le type de dictionnaire (voir « Champs des entrées par type de dictionnaire » ci-dessous).
 
 .. code-block:: json
 
@@ -189,39 +189,39 @@ Les champs de chaque element du tableau ``settings`` de la reponse varient selon
 
 L'exemple ci-dessus correspond au dictionnaire ``synonym``.
 
-Obtention d'une entree de dictionnaire
+Obtention d'une entrée de dictionnaire
 ======================================
 
-Obtient une entree specifique du dictionnaire.
+Obtient une entrée spécifique du dictionnaire.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/dict/{type}/setting/{dictId}/{id}
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``dictId``
      - String
      - Oui
-     - ID du dictionnaire (parametre de chemin)
+     - ID du dictionnaire (paramètre de chemin)
    * - ``id``
      - Long
      - Oui
-     - ID de l'entree (parametre de chemin)
+     - ID de l'entrée (paramètre de chemin)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -239,12 +239,12 @@ Reponse
       }
     }
 
-Creation d'une entree de dictionnaire
+Création d'une entrée de dictionnaire
 =====================================
 
-Cree une nouvelle entree dans le dictionnaire.
+Crée une nouvelle entrée dans le dictionnaire.
 
-Requete
+Requête
 -------
 
 ::
@@ -252,7 +252,7 @@ Requete
     POST /api/admin/dict/{type}/setting/{dictId}
     Content-Type: application/json
 
-Corps de la requete (exemple synonym)
+Corps de la requête (exemple synonym)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -262,7 +262,7 @@ Corps de la requete (exemple synonym)
       "outputs": "検索,サーチ,リサーチ"
     }
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -276,12 +276,12 @@ Reponse
       }
     }
 
-Mise a jour d'une entree de dictionnaire
+Mise à jour d'une entrée de dictionnaire
 ========================================
 
-Met a jour une entree existante du dictionnaire.
+Met à jour une entrée existante du dictionnaire.
 
-Requete
+Requête
 -------
 
 ::
@@ -289,7 +289,7 @@ Requete
     PUT /api/admin/dict/{type}/setting/{dictId}
     Content-Type: application/json
 
-Corps de la requete (exemple synonym)
+Corps de la requête (exemple synonym)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -300,7 +300,7 @@ Corps de la requete (exemple synonym)
       "outputs": "検索,サーチ,リサーチ,search"
     }
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -314,39 +314,39 @@ Reponse
       }
     }
 
-Suppression d'une entree de dictionnaire
+Suppression d'une entrée de dictionnaire
 ========================================
 
-Supprime une entree du dictionnaire.
+Supprime une entrée du dictionnaire.
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/dict/{type}/setting/{dictId}/{id}
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``dictId``
      - String
      - Oui
-     - ID du dictionnaire (parametre de chemin)
+     - ID du dictionnaire (paramètre de chemin)
    * - ``id``
      - Long
      - Oui
-     - ID de l'entree (parametre de chemin)
+     - ID de l'entrée (paramètre de chemin)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -360,12 +360,12 @@ Reponse
       }
     }
 
-Televersement d'un fichier de dictionnaire
+Téléversement d'un fichier de dictionnaire
 ==========================================
 
-Televerse et remplace l'integralite du fichier de dictionnaire.
+Téléverse et remplace l'intégralité du fichier de dictionnaire.
 
-Requete
+Requête
 -------
 
 ::
@@ -373,9 +373,9 @@ Requete
     PUT /api/admin/dict/{type}/upload/{dictId}
     Content-Type: multipart/form-data
 
-Le nom du champ de fichier varie selon le type de dictionnaire (voir « Champs des entrees par type de dictionnaire » ci-dessous).
+Le nom du champ de fichier varie selon le type de dictionnaire (voir « Champs des entrées par type de dictionnaire » ci-dessous).
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -387,33 +387,33 @@ Reponse
       }
     }
 
-Telechargement d'un fichier de dictionnaire
+Téléchargement d'un fichier de dictionnaire
 ===========================================
 
-Telecharge le fichier de dictionnaire.
+Télécharge le fichier de dictionnaire.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/dict/{type}/download/{dictId}
 
-La reponse est le binaire du fichier de dictionnaire ( ``application/octet-stream`` ).
+La réponse est le binaire du fichier de dictionnaire ( ``application/octet-stream`` ).
 
-Champs des entrees par type de dictionnaire
+Champs des entrées par type de dictionnaire
 ===========================================
 
-Les champs du corps de requete de creation/mise a jour d'une entree de dictionnaire ainsi que ceux de la reponse varient selon le type de dictionnaire.
-``id`` (ID de l'entree) et ``dictId`` (ID du dictionnaire) sont inclus de maniere commune dans la reponse.
+Les champs du corps de requête de création/mise à jour d'une entrée de dictionnaire ainsi que ceux de la réponse varient selon le type de dictionnaire.
+``id`` (ID de l'entrée) et ``dictId`` (ID du dictionnaire) sont inclus de manière commune dans la réponse.
 
 .. list-table::
    :header-rows: 1
    :widths: 18 42 40
 
    * - Type
-     - Champs de l'entree
-     - Champ du fichier televerse
+     - Champs de l'entrée
+     - Champ du fichier téléversé
    * - ``synonym``
      - ``inputs`` (requis), ``outputs`` (requis)
      - ``synonymFile``
@@ -444,7 +444,7 @@ Obtention de la liste des dictionnaires
     curl -X GET "http://localhost:8080/api/admin/dict" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Obtention de la liste des entrees du dictionnaire de synonymes
+Obtention de la liste des entrées du dictionnaire de synonymes
 --------------------------------------------------------------
 
 .. code-block:: bash
@@ -452,7 +452,7 @@ Obtention de la liste des entrees du dictionnaire de synonymes
     curl -X GET "http://localhost:8080/api/admin/dict/synonym/settings/{dictId}" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Ajout d'une entree au dictionnaire de synonymes
+Ajout d'une entrée au dictionnaire de synonymes
 -----------------------------------------------
 
 .. code-block:: bash
@@ -465,7 +465,7 @@ Ajout d'une entree au dictionnaire de synonymes
            "outputs": "検索,サーチ,リサーチ"
          }'
 
-Televersement du fichier de dictionnaire de synonymes
+Téléversement du fichier de dictionnaire de synonymes
 -----------------------------------------------------
 
 .. code-block:: bash
@@ -474,7 +474,7 @@ Televersement du fichier de dictionnaire de synonymes
          -H "Authorization: Bearer YOUR_TOKEN" \
          -F "synonymFile=@synonym.txt"
 
-Telechargement du fichier de dictionnaire de synonymes
+Téléchargement du fichier de dictionnaire de synonymes
 ------------------------------------------------------
 
 .. code-block:: bash
@@ -483,7 +483,7 @@ Telechargement du fichier de dictionnaire de synonymes
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o synonym.txt
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.7/api/admin/api-admin-documents.rst
+++ b/fr/15.7/api/admin/api-admin-documents.rst
@@ -6,8 +6,8 @@ Vue d'ensemble
 ==============
 
 L'API Documents est une API d'administration de |Fess| permettant d'enregistrer en masse des documents dans l'index.
-Elle permet aux systemes externes d'ajouter directement des documents a l'index sans passer par le moteur de crawl.
-Plusieurs documents peuvent etre enregistres en une seule requete.
+Elle permet aux systèmes externes d'ajouter directement des documents à l'index sans passer par le moteur de crawl.
+Plusieurs documents peuvent être enregistrés en une seule requête.
 
 URL de base
 ===========
@@ -19,9 +19,9 @@ URL de base
 Authentification
 ================
 
-Pour appeler cette API, une authentification par jeton d'acces est requise, comme explique dans :doc:`api-admin-overview`.
-Le jeton doit disposer des permissions d'acces a l'API d'administration (par defaut ``Radmin-api``).
-Cette permission peut etre modifiee via la cle de configuration ``api.admin.access.permissions``.
+Pour appeler cette API, une authentification par jeton d'accès est requise, comme expliqué dans :doc:`api-admin-overview`.
+Le jeton doit disposer des permissions d'accès à l'API d'administration (par défaut ``Radmin-api``).
+Cette permission peut être modifiée via la clé de configuration ``api.admin.access.permissions``.
 
 Liste des endpoints
 ===================
@@ -30,7 +30,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - PUT
@@ -39,14 +39,14 @@ Liste des endpoints
 
 .. note::
 
-   Cet endpoint accepte uniquement la methode ``PUT``.
+   Cet endpoint accepte uniquement la méthode ``PUT``.
 
 Enregistrement en masse de documents
 =====================================
 
 Enregistre plusieurs documents dans l'index en une seule fois.
 
-Requete
+Requête
 -------
 
 ::
@@ -54,7 +54,7 @@ Requete
     PUT /api/admin/documents/bulk
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -86,26 +86,26 @@ Description des champs
      - Description
    * - ``documents``
      - Oui
-     - Tableau des documents a enregistrer. Chaque document est specifie sous forme de correspondance entre nom de champ et valeur. Si la valeur est ``null`` ou un tableau vide, une erreur est retournee (``status`` = ``1``).
+     - Tableau des documents à enregistrer. Chaque document est spécifié sous forme de correspondance entre nom de champ et valeur. Si la valeur est ``null`` ou un tableau vide, une erreur est retournée (``status`` = ``1``).
 
 Champs du document
 ~~~~~~~~~~~~~~~~~~
 
-Chaque document peut specifier librement les champs de l'index sous forme de correspondance entre nom et valeur.
-Au minimum, ``url`` et ``title`` doivent etre specifies (conformement au parametre
-``index.admin.required.fields``. La valeur par defaut est ``url,title,role,boost`` ;
-``role`` et ``boost`` etant completes automatiquement comme indique ci-apres, seuls ``url`` et ``title`` sont en pratique obligatoires).
+Chaque document peut spécifier librement les champs de l'index sous forme de correspondance entre nom et valeur.
+Au minimum, ``url`` et ``title`` doivent être spécifiés (conformément au paramètre
+``index.admin.required.fields``. La valeur par défaut est ``url,title,role,boost`` ;
+``role`` et ``boost`` étant complétés automatiquement comme indiqué ci-après, seuls ``url`` et ``title`` sont en pratique obligatoires).
 
-Les champs suivants sont completes automatiquement lorsqu'ils sont omis :
+Les champs suivants sont complétés automatiquement lorsqu'ils sont omis :
 
 .. list-table::
    :header-rows: 1
    :widths: 30 70
 
    * - Champ
-     - Valeur par defaut en cas d'omission
+     - Valeur par défaut en cas d'omission
    * - ``content_length``
-     - Somme du nombre de caracteres de ``title`` et de ``content``
+     - Somme du nombre de caractères de ``title`` et de ``content``
    * - ``favorite_count``
      - ``0``
    * - ``click_count``
@@ -113,39 +113,39 @@ Les champs suivants sont completes automatiquement lorsqu'ils sont omis :
    * - ``boost``
      - ``1.0``
    * - ``role``
-     - Role de recherche invite (role de recherche configure pour les utilisateurs invites)
+     - Rôle de recherche invité (rôle de recherche configuré pour les utilisateurs invités)
    * - ``last_modified``
      - Heure actuelle
    * - ``timestamp``
      - Heure actuelle
 
-De plus, les champs suivants sont generes automatiquement lors de l'enregistrement :
+De plus, les champs suivants sont générés automatiquement lors de l'enregistrement :
 
-- ``id`` - Genere de facon deterministe a partir de l'``url`` du document (ainsi que de ``role`` et ``virtual_host``),
-  et utilise comme identifiant de document OpenSearch (``_id``). Cette valeur est retournee dans ``items[].id`` de la reponse.
-- ``doc_id`` - Un UUID aleatoire est genere a chaque enregistrement et stocke comme champ du document.
+- ``id`` - Généré de façon déterministe à partir de l'``url`` du document (ainsi que de ``role`` et ``virtual_host``),
+  et utilisé comme identifiant de document OpenSearch (``_id``). Cette valeur est retournée dans ``items[].id`` de la réponse.
+- ``doc_id`` - Un UUID aléatoire est généré à chaque enregistrement et stocké comme champ du document.
 
 .. note::
 
-   Comme ``id`` est genere de facon deterministe a partir de l'``url``, l'enregistrement d'un document
-   avec le meme ``url`` mettra a jour le document existant
+   Comme ``id`` est généré de façon déterministe à partir de l'``url``, l'enregistrement d'un document
+   avec le même ``url`` mettra à jour le document existant
    (``items[].result`` aura la valeur ``OK``).
 
 Remarques
 ~~~~~~~~~
 
-- Si le champ ``lang`` contient ``"auto"``, la langue est detectee automatiquement a partir du contenu.
-- Si ``config_id`` est specifie, le pipeline d'ingestion (ingest pipeline) de la configuration de crawl correspondante est applique.
-- Si la generation de miniatures est activee (``thumbnail.crawler.enabled``), une tentative de generation de miniature est effectuee lors de l'enregistrement.
-- La valeur de chaque champ est validee en fonction du type de champ configure (``index.admin.array.fields``,
+- Si le champ ``lang`` contient ``"auto"``, la langue est détectée automatiquement à partir du contenu.
+- Si ``config_id`` est spécifié, le pipeline d'ingestion (ingest pipeline) de la configuration de crawl correspondante est appliqué.
+- Si la génération de miniatures est activée (``thumbnail.crawler.enabled``), une tentative de génération de miniature est effectuée lors de l'enregistrement.
+- La valeur de chaque champ est validée en fonction du type de champ configuré (``index.admin.array.fields``,
   ``index.admin.date.fields``, ``index.admin.long.fields``, etc.).
-  Si le type ne correspond pas, une erreur est retournee (``status`` = ``1``).
+  Si le type ne correspond pas, une erreur est retournée (``status`` = ``1``).
 
-Reponse
+Réponse
 -------
 
-La reponse retourne le resultat du traitement de chaque document enregistre dans un tableau ``items``.
-Les elements traites avec succes contiennent ``result`` et ``id`` ; les elements en echec contiennent ``result`` et ``message``.
+La réponse retourne le résultat du traitement de chaque document enregistré dans un tableau ``items``.
+Les éléments traités avec succès contiennent ``result`` et ``id`` ; les éléments en échec contiennent ``result`` et ``message``.
 
 .. code-block:: json
 
@@ -166,12 +166,12 @@ Les elements traites avec succes contiennent ``result`` et ``id`` ; les elements
       }
     }
 
-Si ``status`` est ``0``, cela indique que tous les documents ont ete enregistres avec succes.
-``items[].result`` est ``CREATED`` lors d'une creation, et ``OK`` lors de la mise a jour d'un document existant.
+Si ``status`` est ``0``, cela indique que tous les documents ont été enregistrés avec succès.
+``items[].result`` est ``CREATED`` lors d'une création, et ``OK`` lors de la mise à jour d'un document existant.
 
-Si l'enregistrement echoue pour l'un des elements, ``status`` devient ``9`` (FAILED) et
-l'element concerne contient un champ ``message`` (``result`` est alors un nom de statut d'erreur tel que ``CONFLICT`` ou
-``BAD_REQUEST``). Les elements traites avec succes retournent leur ``id`` normalement.
+Si l'enregistrement échoue pour l'un des éléments, ``status`` devient ``9`` (FAILED) et
+l'élément concerné contient un champ ``message`` (``result`` est alors un nom de statut d'erreur tel que ``CONFLICT`` ou
+``BAD_REQUEST``). Les éléments traités avec succès retournent leur ``id`` normalement.
 
 .. code-block:: json
 
@@ -194,12 +194,12 @@ l'element concerne contient un champ ``message`` (``result`` est alors un nom de
 
 .. note::
 
-   Si la requete elle-meme est invalide (``documents`` absent ou vide, champ obligatoire manquant,
-   type de champ incorrect, etc.), le traitement d'enregistrement des documents n'est pas execute et
-   une reponse d'erreur contenant ``status`` = ``1`` (BAD_REQUEST) et ``message`` est retournee.
-   Dans ce cas, le tableau ``items`` n'est pas retourne.
+   Si la requête elle-même est invalide (``documents`` absent ou vide, champ obligatoire manquant,
+   type de champ incorrect, etc.), le traitement d'enregistrement des documents n'est pas exécuté et
+   une réponse d'erreur contenant ``status`` = ``1`` (BAD_REQUEST) et ``message`` est retournée.
+   Dans ce cas, le tableau ``items`` n'est pas retourné.
 
-Champs de la reponse
+Champs de la réponse
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -209,13 +209,13 @@ Champs de la reponse
    * - Champ
      - Description
    * - ``items``
-     - Tableau des resultats de traitement de chaque document
+     - Tableau des résultats de traitement de chaque document
    * - ``items[].result``
-     - Nom du statut du resultat de traitement. ``CREATED`` lors d'une creation, ``OK`` lors d'une mise a jour, ou un nom de statut d'erreur tel que ``BAD_REQUEST`` en cas d'echec
+     - Nom du statut du résultat de traitement. ``CREATED`` lors d'une création, ``OK`` lors d'une mise à jour, ou un nom de statut d'erreur tel que ``BAD_REQUEST`` en cas d'échec
    * - ``items[].id``
-     - ID du document enregistre (en cas de succes uniquement)
+     - ID du document enregistré (en cas de succès uniquement)
    * - ``items[].message``
-     - Message indiquant la raison de l'echec (en cas d'echec uniquement)
+     - Message indiquant la raison de l'échec (en cas d'échec uniquement)
 
 Exemples d'utilisation
 ======================
@@ -238,7 +238,7 @@ Enregistrement en masse de documents
            ]
          }'
 
-Informations complementaires
+Informations complémentaires
 =============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.7/api/admin/api-admin-elevateword.rst
+++ b/fr/15.7/api/admin/api-admin-elevateword.rst
@@ -5,8 +5,8 @@ API ElevateWord
 Vue d'ensemble
 ==============
 
-L'API ElevateWord permet de gerer les mots eleves (manipulation du classement de recherche pour des mots-cles specifiques) dans |Fess|.
-Vous pouvez placer des documents specifiques en haut ou en bas des resultats pour certaines requetes de recherche.
+L'API ElevateWord permet de gérer les mots élevés (manipulation du classement de recherche pour des mots-clés spécifiques) dans |Fess|.
+Vous pouvez placer des documents spécifiques en haut ou en bas des résultats pour certaines requêtes de recherche.
 
 URL de base
 ===========
@@ -22,66 +22,66 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /settings
-     - Obtention de la liste des mots eleves
+     - Obtention de la liste des mots élevés
    * - GET
      - /setting/{id}
-     - Obtention d'un mot eleve
+     - Obtention d'un mot élevé
    * - POST
      - /setting
-     - Creation d'un mot eleve
+     - Création d'un mot élevé
    * - PUT
      - /setting
-     - Mise a jour d'un mot eleve
+     - Mise à jour d'un mot élevé
    * - DELETE
      - /setting/{id}
-     - Suppression d'un mot eleve
+     - Suppression d'un mot élevé
    * - PUT
      - /upload
-     - Televersement CSV des mots eleves
+     - Téléversement CSV des mots élevés
    * - GET
      - /download
-     - Telechargement CSV des mots eleves
+     - Téléchargement CSV des mots élevés
 
-Obtention de la liste des mots eleves
+Obtention de la liste des mots élevés
 =====================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/elevateword/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 20)
+     - Nombre d'éléments par page (par défaut : 20)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1, par defaut : 1)
+     - Numéro de page (commence à 1, par défaut : 1)
    * - ``id``
      - String
      - Non
-     - Filtre par correspondance exacte sur l'ID du mot eleve
+     - Filtre par correspondance exacte sur l'ID du mot élevé
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -103,17 +103,17 @@ Reponse
       }
     }
 
-Obtention d'un mot eleve
+Obtention d'un mot élevé
 ========================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/elevateword/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -132,10 +132,10 @@ Reponse
       }
     }
 
-Creation d'un mot eleve
+Création d'un mot élevé
 =======================
 
-Requete
+Requête
 -------
 
 ::
@@ -143,7 +143,7 @@ Requete
     POST /api/admin/elevateword/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -168,21 +168,21 @@ Description des champs
      - Description
    * - ``suggestWord``
      - Oui
-     - Mot-cle a elever
+     - Mot-clé à élever
    * - ``reading``
      - Non
-     - Lecture phonetique
+     - Lecture phonétique
    * - ``permissions``
      - Non
-     - Permissions d'acces (chaine separee par des sauts de ligne, une par ligne. Valeur initiale du formulaire : permissions d'affichage par defaut de la recherche)
+     - Permissions d'accès (chaîne séparée par des sauts de ligne, une par ligne. Valeur initiale du formulaire : permissions d'affichage par défaut de la recherche)
    * - ``boost``
      - Oui
      - Valeur de boost (valeur initiale du formulaire : 100.0)
    * - ``labelTypeIds``
      - Non
-     - ID des labels cibles (tableau de chaines)
+     - ID des labels cibles (tableau de chaînes)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -195,10 +195,10 @@ Reponse
       }
     }
 
-Mise a jour d'un mot eleve
+Mise à jour d'un mot élevé
 ==========================
 
-Requete
+Requête
 -------
 
 ::
@@ -206,7 +206,7 @@ Requete
     PUT /api/admin/elevateword/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -223,12 +223,12 @@ Corps de la requete
 
 .. note::
 
-   Lors de la mise a jour, les champs suivants sont requis en plus des champs utilises pour la creation :
+   Lors de la mise à jour, les champs suivants sont requis en plus des champs utilisés pour la création :
 
-   - ``id`` - ID du mot eleve a mettre a jour
-   - ``versionNo`` - Numero de version pour le verrouillage optimiste. Indiquez la valeur obtenue via ``GET /setting/{id}``.
+   - ``id`` - ID du mot élevé à mettre à jour
+   - ``versionNo`` - Numéro de version pour le verrouillage optimiste. Indiquez la valeur obtenue via ``GET /setting/{id}``.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -241,17 +241,17 @@ Reponse
       }
     }
 
-Suppression d'un mot eleve
+Suppression d'un mot élevé
 ==========================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/elevateword/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -264,12 +264,12 @@ Reponse
       }
     }
 
-Televersement CSV des mots eleves
+Téléversement CSV des mots élevés
 =================================
 
-Enregistre en masse des mots eleves depuis un fichier CSV. Le fichier est envoye en ``multipart/form-data``. L'import est execute de maniere asynchrone cote serveur.
+Enregistre en masse des mots élevés depuis un fichier CSV. Le fichier est envoyé en ``multipart/form-data``. L'import est exécuté de manière asynchrone côté serveur.
 
-Requete
+Requête
 -------
 
 ::
@@ -277,21 +277,21 @@ Requete
     PUT /api/admin/elevateword/upload
     Content-Type: multipart/form-data
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``elevateWordFile``
      - Oui
-     - Fichier CSV des mots eleves a televerser
+     - Fichier CSV des mots élevés à téléverser
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -302,12 +302,12 @@ Reponse
       }
     }
 
-Telechargement CSV des mots eleves
+Téléchargement CSV des mots élevés
 ==================================
 
-Telecharge les mots eleves enregistres sous forme de fichier CSV (``elevate.csv``). La reponse est un flux ``application/octet-stream``.
+Télécharge les mots élevés enregistrés sous forme de fichier CSV (``elevate.csv``). La réponse est un flux ``application/octet-stream``.
 
-Requete
+Requête
 -------
 
 ::
@@ -317,7 +317,7 @@ Requete
 Exemples d'utilisation
 ======================
 
-Elevation d'un nom de produit
+Élévation d'un nom de produit
 -----------------------------
 
 .. code-block:: bash
@@ -331,7 +331,7 @@ Elevation d'un nom de produit
            "permissions": "{role}guest"
          }'
 
-Elevation vers un label specifique
+Élévation vers un label spécifique
 ----------------------------------
 
 .. code-block:: bash
@@ -346,7 +346,7 @@ Elevation vers un label specifique
            "permissions": "{role}guest"
          }'
 
-Televersement d'un fichier CSV
+Téléversement d'un fichier CSV
 ------------------------------
 
 .. code-block:: bash
@@ -355,7 +355,7 @@ Televersement d'un fichier CSV
          -H "Authorization: Bearer YOUR_TOKEN" \
          -F "elevateWordFile=@elevate.csv"
 
-Telechargement d'un fichier CSV
+Téléchargement d'un fichier CSV
 -------------------------------
 
 .. code-block:: bash
@@ -364,10 +364,10 @@ Telechargement d'un fichier CSV
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o elevate.csv
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
 - :doc:`api-admin-keymatch` - API KeyMatch
 - :doc:`api-admin-boostdoc` - API BoostDoc
-- :doc:`../../admin/elevateword-guide` - Guide de gestion des mots eleves
+- :doc:`../../admin/elevateword-guide` - Guide de gestion des mots élevés

--- a/fr/15.7/api/admin/api-admin-general.rst
+++ b/fr/15.7/api/admin/api-admin-general.rst
@@ -5,12 +5,12 @@ API General
 Vue d'ensemble
 ==============
 
-L'API General est une API permettant de gerer les parametres generaux de |Fess|
-(configuration a l'echelle du systeme). Vous pouvez obtenir et mettre a jour les
-parametres relatifs au crawl, aux journaux, a l'affichage des resultats de
-recherche, aux suggestions, aux periodes de conservation des journaux, aux
-notifications, a l'authentification (LDAP / SSO) et a l'integration du stockage
-cloud. Ces parametres correspondent aux reglages « General » de l'interface
+L'API General est une API permettant de gérer les paramètres généraux de |Fess|
+(configuration à l'échelle du système). Vous pouvez obtenir et mettre à jour les
+paramètres relatifs au crawl, aux journaux, à l'affichage des résultats de
+recherche, aux suggestions, aux périodes de conservation des journaux, aux
+notifications, à l'authentification (LDAP / SSO) et à l'intégration du stockage
+cloud. Ces paramètres correspondent aux réglages « General » de l'interface
 d'administration (:doc:`../../admin/general-guide`).
 
 URL de base
@@ -20,8 +20,8 @@ URL de base
 
     /api/admin/general
 
-L'acces a cette API requiert un jeton d'acces disposant de la permission ``Radmin-api``.
-Consultez :doc:`api-admin-overview` pour les details d'authentification.
+L'accès à cette API requiert un jeton d'accès disposant de la permission ``Radmin-api``.
+Consultez :doc:`api-admin-overview` pour les détails d'authentification.
 
 Liste des endpoints
 ===================
@@ -30,36 +30,36 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /
-     - Obtention des parametres generaux
+     - Obtention des paramètres généraux
    * - PUT
      - /
-     - Mise a jour des parametres generaux
+     - Mise à jour des paramètres généraux
 
-Obtention des parametres generaux
+Obtention des paramètres généraux
 ==================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/general
 
-Cet endpoint n'accepte pas de parametres de requete.
+Cet endpoint n'accepte pas de paramètres de requête.
 
-Reponse
+Réponse
 -------
 
-``response.setting`` contient les parametres generaux actuels. La reponse inclut
-tous les champs de parametres modifiables ; l'exemple ci-dessous ne presente que
-les champs representatifs. Les parametres d'activation/desactivation sont exprimes
-sous forme de chaines ``"true"`` / ``"false"``, tandis que les valeurs telles que
-les jours de conservation et les nombres de threads sont exprimes sous forme de
+``response.setting`` contient les paramètres généraux actuels. La réponse inclut
+tous les champs de paramètres modifiables ; l'exemple ci-dessous ne présente que
+les champs représentatifs. Les paramètres d'activation/désactivation sont exprimés
+sous forme de chaînes ``"true"`` / ``"false"``, tandis que les valeurs telles que
+les jours de conservation et les nombres de threads sont exprimés sous forme de
 nombres.
 
 .. code-block:: json
@@ -106,28 +106,28 @@ nombres.
 
 .. note::
 
-   Ce qui precede ne montre que les champs representatifs a titre d'exemple. L'objet
-   ``setting`` reel dans la reponse contient tous les champs des parametres generaux
+   Ce qui précède ne montre que les champs représentatifs à titre d'exemple. L'objet
+   ``setting`` réel dans la réponse contient tous les champs des paramètres généraux
    (crawl, recherche, notification, LDAP, SSO, stockage, etc.). Consultez la page des
-   reglages « General » de l'interface d'administration pour la liste complete des champs.
+   réglages « General » de l'interface d'administration pour la liste complète des champs.
 
 .. note::
 
-   Pour des raisons de securite, les champs contenant des informations
-   d'authentification ne sont pas retournes avec leur valeur reelle.
+   Pour des raisons de sécurité, les champs contenant des informations
+   d'authentification ne sont pas retournés avec leur valeur réelle.
 
    - Le mot de passe de l'administrateur LDAP ``ldapAdminSecurityCredentials`` est
-     toujours retourne sous la forme ``null``.
+     toujours retourné sous la forme ``null``.
    - Les autres secrets (``storageAccessKey`` / ``storageSecretKey`` /
      ``oicClientId`` / ``oicClientSecret`` / ``spnegoPreauthPassword`` /
-     ``entraidClientId`` / ``entraidClientSecret``) sont retournes masques sous la
-     forme ``"**********"`` lorsqu'ils sont definis, ou sous forme de chaine vide
-     (``""``) lorsqu'ils ne sont pas definis.
+     ``entraidClientId`` / ``entraidClientSecret``) sont retournés masqués sous la
+     forme ``"**********"`` lorsqu'ils sont définis, ou sous forme de chaîne vide
+     (``""``) lorsqu'ils ne sont pas définis.
 
-Mise a jour des parametres generaux
+Mise à jour des paramètres généraux
 =====================================
 
-Requete
+Requête
 -------
 
 ::
@@ -135,46 +135,46 @@ Requete
     PUT /api/admin/general
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
-La mise a jour est traitee comme une mise a jour partielle (merge). Le serveur
-charge les parametres actuels, puis ecrase uniquement les champs non ``null``
-inclus dans la requete. Les champs non inclus dans la requete, et les champs
-definis a ``null``, conservent leur valeur existante.
+La mise à jour est traitée comme une mise à jour partielle (merge). Le serveur
+charge les paramètres actuels, puis écrase uniquement les champs non ``null``
+inclus dans la requête. Les champs non inclus dans la requête, et les champs
+définis à ``null``, conservent leur valeur existante.
 
 .. warning::
 
-   Les quatre champs suivants sont obligatoires et **doivent** etre inclus dans
-   **chaque** requete PUT, meme lors d'une mise a jour partielle :
+   Les quatre champs suivants sont obligatoires et **doivent** être inclus dans
+   **chaque** requête PUT, même lors d'une mise à jour partielle :
 
    - ``dayForCleanup``
    - ``crawlingThreadCount``
    - ``failureCountThreshold``
    - ``csvFileEncoding``
 
-   Si l'un d'eux est absent, la requete echoue a la validation et l'API retourne
-   HTTP 400 avec ``status: 1`` et un ``message`` d'erreur. La valeur envoyee ecrase
-   le parametre existant ; si vous ne souhaitez pas modifier une valeur, recuperez
+   Si l'un d'eux est absent, la requête échoue à la validation et l'API retourne
+   HTTP 400 avec ``status: 1`` et un ``message`` d'erreur. La valeur envoyée écrase
+   le paramètre existant ; si vous ne souhaitez pas modifier une valeur, récupérez
    d'abord la valeur actuelle avec ``GET`` et renvoyez-la telle quelle. Tous les
    autres champs sont optionnels ; les champs omis conservent leur valeur existante.
 
 .. note::
 
-   Les champs numeriques font l'objet d'une validation de type et de plage. L'envoi
-   d'une valeur qui ne peut pas etre interpretee comme un entier, ou d'une valeur
-   hors de la plage autorisee, provoque une erreur de validation (HTTP 400 avec
-   ``status: 1``). La plage valide de chaque champ numerique est indiquee dans le
+   Les champs numériques font l'objet d'une validation de type et de plage. L'envoi
+   d'une valeur qui ne peut pas être interprétée comme un entier, ou d'une valeur
+   hors de la plage autorisée, provoque une erreur de validation (HTTP 400 avec
+   ``status: 1``). La plage valide de chaque champ numérique est indiquée dans le
    tableau des champs ci-dessous.
 
 .. note::
 
-   Pour les champs d'activation/desactivation (type ``available``), seuls ``"true"``
+   Pour les champs d'activation/désactivation (type ``available``), seuls ``"true"``
    ou ``"on"`` (les deux sans distinction de casse) signifient l'activation. Toute
-   autre valeur (comme ``"false"`` ou une chaine vide) est traitee comme une
-   desactivation (``false``). La valeur existante n'est conservee que lorsque le
-   champ est omis (non envoye). Dans la reponse GET, ces champs sont retournes sous
-   forme de chaines ``"true"`` / ``"false"``.
+   autre valeur (comme ``"false"`` ou une chaîne vide) est traitée comme une
+   désactivation (``false``). La valeur existante n'est conservée que lorsque le
+   champ est omis (non envoyé). Dans la réponse GET, ces champs sont retournés sous
+   forme de chaînes ``"true"`` / ``"false"``.
 
 .. code-block:: json
 
@@ -190,10 +190,10 @@ definis a ``null``, conservent leur valeur existante.
 Principaux champs
 ~~~~~~~~~~~~~~~~~
 
-Les options de configuration sont nombreuses. Les champs representatifs sont
-indiques ci-dessous (tous les champs correspondent aux reglages « General » de
-l'interface d'administration). Les parametres d'activation/desactivation sont
-specifies sous forme de chaines ``"true"`` / ``"false"``.
+Les options de configuration sont nombreuses. Les champs représentatifs sont
+indiqués ci-dessous (tous les champs correspondent aux réglages « General » de
+l'interface d'administration). Les paramètres d'activation/désactivation sont
+spécifiés sous forme de chaînes ``"true"`` / ``"false"``.
 
 .. list-table::
    :header-rows: 1
@@ -204,106 +204,106 @@ specifies sous forme de chaines ``"true"`` / ``"false"``.
      - Description
    * - ``incrementalCrawling``
      - Non
-     - Activer/desactiver le crawl incremental
+     - Activer/désactiver le crawl incrémental
    * - ``dayForCleanup``
      - Oui
-     - Nombre de jours de conservation des documents crawles (-1 = nettoyage desactive ; plage : -1 a 1000)
+     - Nombre de jours de conservation des documents crawlés (-1 = nettoyage désactivé ; plage : -1 à 1000)
    * - ``crawlingThreadCount``
      - Oui
-     - Nombre de threads utilises pour le crawl (plage : 0 a 100)
+     - Nombre de threads utilisés pour le crawl (plage : 0 à 100)
    * - ``failureCountThreshold``
      - Oui
-     - Seuil du nombre d'echecs pour arreter le crawl d'une URL (-1 = desactive ; plage : -1 a 10000)
+     - Seuil du nombre d'échecs pour arrêter le crawl d'une URL (-1 = désactivé ; plage : -1 à 10000)
    * - ``csvFileEncoding``
      - Oui
      - Encodage de l'export CSV
    * - ``searchLog``
      - Non
-     - Activer/desactiver le journal des requetes de recherche
+     - Activer/désactiver le journal des requêtes de recherche
    * - ``userInfo``
      - Non
-     - Activer/desactiver l'enregistrement des informations utilisateur
+     - Activer/désactiver l'enregistrement des informations utilisateur
    * - ``userFavorite``
      - Non
-     - Activer/desactiver la fonctionnalite de favoris
+     - Activer/désactiver la fonctionnalité de favoris
    * - ``webApiJson``
      - Non
-     - Activer/desactiver l'API Web JSON
+     - Activer/désactiver l'API Web JSON
    * - ``appValue``
      - Non
-     - Valeur de configuration supplementaire specifique a l'application
+     - Valeur de configuration supplémentaire spécifique à l'application
    * - ``virtualHostValue``
      - Non
-     - Configuration d'hote virtuel (pour les configurations multi-locataires)
+     - Configuration d'hôte virtuel (pour les configurations multi-locataires)
    * - ``popularWord``
      - Non
-     - Activer/desactiver l'agregation et l'affichage des mots populaires
+     - Activer/désactiver l'agrégation et l'affichage des mots populaires
    * - ``defaultLabelValue``
      - Non
-     - Valeur de label par defaut
+     - Valeur de label par défaut
    * - ``defaultSortValue``
      - Non
-     - Ordre de tri par defaut
+     - Ordre de tri par défaut
    * - ``appendQueryParameter``
      - Non
-     - Ajout de parametres de requete aux URLs des resultats de recherche
+     - Ajout de paramètres de requête aux URLs des résultats de recherche
    * - ``loginRequired``
      - Non
      - Exiger une connexion pour effectuer une recherche
    * - ``loginLink``
      - Non
-     - Activer/desactiver l'affichage du lien de connexion sur l'ecran de recherche
+     - Activer/désactiver l'affichage du lien de connexion sur l'écran de recherche
    * - ``thumbnail``
      - Non
-     - Activer/desactiver la generation de vignettes
+     - Activer/désactiver la génération de vignettes
    * - ``resultCollapsed``
      - Non
-     - Activer/desactiver le regroupement des documents similaires dans les resultats de recherche
+     - Activer/désactiver le regroupement des documents similaires dans les résultats de recherche
    * - ``ignoreFailureType``
      - Non
-     - Types d'echec de crawl a ignorer
+     - Types d'échec de crawl à ignorer
    * - ``crawlingUserAgent``
      - Non
-     - Chaine User-Agent envoyee lors du crawl
+     - Chaîne User-Agent envoyée lors du crawl
    * - ``purgeSearchLogDay``
      - Non
-     - Nombre de jours de conservation des journaux de recherche (-1 = desactive ; plage : -1 a 100000)
+     - Nombre de jours de conservation des journaux de recherche (-1 = désactivé ; plage : -1 à 100000)
    * - ``purgeJobLogDay``
      - Non
-     - Nombre de jours de conservation des journaux de taches (-1 = desactive ; plage : -1 a 100000)
+     - Nombre de jours de conservation des journaux de tâches (-1 = désactivé ; plage : -1 à 100000)
    * - ``purgeUserInfoDay``
      - Non
-     - Nombre de jours de conservation des informations utilisateur (-1 = desactive ; plage : -1 a 100000)
+     - Nombre de jours de conservation des informations utilisateur (-1 = désactivé ; plage : -1 à 100000)
    * - ``purgeSuggestSearchLogDay``
      - Non
-     - Nombre de jours de conservation des journaux de recherche de suggestion (0 = desactive ; plage : 0 a 100000)
+     - Nombre de jours de conservation des journaux de recherche de suggestion (0 = désactivé ; plage : 0 à 100000)
    * - ``purgeByBots``
      - Non
-     - User-Agents de bots dont les journaux de recherche doivent etre supprimes
+     - User-Agents de bots dont les journaux de recherche doivent être supprimés
    * - ``notificationTo``
      - Non
-     - Adresse e-mail de destination des notifications systeme
+     - Adresse e-mail de destination des notifications système
    * - ``notificationLogin``
      - Non
-     - Message de notification affiche sur la page de connexion
+     - Message de notification affiché sur la page de connexion
    * - ``notificationSearchTop``
      - Non
-     - Message de notification affiche sur la page d'accueil de recherche
+     - Message de notification affiché sur la page d'accueil de recherche
    * - ``notificationAdvanceSearch``
      - Non
-     - Message de notification affiche sur la page de recherche avancee
+     - Message de notification affiché sur la page de recherche avancée
    * - ``suggestSearchLog``
      - Non
-     - Activer/desactiver les suggestions basees sur les journaux de recherche
+     - Activer/désactiver les suggestions basées sur les journaux de recherche
    * - ``suggestDocuments``
      - Non
-     - Activer/desactiver les suggestions basees sur les documents
+     - Activer/désactiver les suggestions basées sur les documents
    * - ``logLevel``
      - Non
-     - Niveau de journalisation du journal systeme
+     - Niveau de journalisation du journal système
    * - ``logNotificationEnabled``
      - Non
-     - Activer/desactiver les notifications de journaux ERROR/WARN
+     - Activer/désactiver les notifications de journaux ERROR/WARN
    * - ``logNotificationLevel``
      - Non
      - Niveau de notification des journaux
@@ -318,17 +318,17 @@ specifies sous forme de chaines ``"true"`` / ``"false"``.
      - Utiliser ou non la locale du navigateur pour la recherche
    * - ``ragLlmName``
      - Non
-     - Nom du fournisseur LLM utilise pour le RAG
+     - Nom du fournisseur LLM utilisé pour le RAG
    * - ``llmLogLevel``
      - Non
-     - Niveau de journalisation des paquets lies au LLM
+     - Niveau de journalisation des paquets liés au LLM
 
-Champs relatifs a l'authentification
+Champs relatifs à l'authentification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Les parametres relatifs a LDAP et au SSO (OpenID Connect, SAML, SPNEGO, Entra ID)
-sont egalement geres par cette API. Les champs representatifs sont indiques
-ci-dessous (tous les champs correspondent aux reglages « General » de l'interface
+Les paramètres relatifs à LDAP et au SSO (OpenID Connect, SAML, SPNEGO, Entra ID)
+sont également gérés par cette API. Les champs représentatifs sont indiqués
+ci-dessous (tous les champs correspondent aux réglages « General » de l'interface
 d'administration).
 
 .. list-table::
@@ -342,15 +342,15 @@ d'administration).
    * - ``ldapBaseDn``
      - DN de base LDAP
    * - ``ldapSecurityPrincipal``
-     - Principal de securite pour le bind LDAP
+     - Principal de sécurité pour le bind LDAP
    * - ``ldapAdminSecurityPrincipal``
-     - Principal de securite pour les operations d'administration LDAP
+     - Principal de sécurité pour les opérations d'administration LDAP
    * - ``ldapAdminSecurityCredentials``
-     - Mot de passe de l'administrateur LDAP (remplace par ``null`` dans la reponse)
+     - Mot de passe de l'administrateur LDAP (remplacé par ``null`` dans la réponse)
    * - ``ldapAccountFilter`` / ``ldapGroupFilter``
      - Filtres de recherche d'utilisateurs/groupes
    * - ``ldapMemberofAttribute``
-     - Nom de l'attribut LDAP indiquant l'appartenance a un groupe
+     - Nom de l'attribut LDAP indiquant l'appartenance à un groupe
    * - ``ssoType``
      - Type de SSO (``none`` / ``oic`` / ``saml`` / ``spnego`` / ``entraid``)
    * - ``oicClientId`` / ``oicClientSecret`` / ``oicAuthServerUrl`` etc.
@@ -365,7 +365,7 @@ d'administration).
 Champs relatifs au stockage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Les parametres d'integration du stockage cloud (S3 / GCS) peuvent egalement etre geres.
+Les paramètres d'intégration du stockage cloud (S3 / GCS) peuvent également être gérés.
 
 .. list-table::
    :header-rows: 1
@@ -378,11 +378,11 @@ Les parametres d'integration du stockage cloud (S3 / GCS) peuvent egalement etre
    * - ``storageEndpoint``
      - URL du point de terminaison du stockage
    * - ``storageAccessKey`` / ``storageSecretKey``
-     - Cle d'acces / cle secrete pour l'authentification
+     - Clé d'accès / clé secrète pour l'authentification
    * - ``storageBucket``
      - Nom du bucket
    * - ``storageRegion``
-     - Region S3
+     - Région S3
    * - ``storageProjectId`` / ``storageCredentialsPath``
      - ID de projet GCS / chemin du fichier d'informations d'authentification
 
@@ -391,19 +391,19 @@ Les parametres d'integration du stockage cloud (S3 / GCS) peuvent egalement etre
    Les champs secrets tels que ``ldapAdminSecurityCredentials``,
    ``storageAccessKey`` / ``storageSecretKey``, ``oicClientId`` /
    ``oicClientSecret``, ``entraidClientId`` / ``entraidClientSecret``, et
-   ``spnegoPreauthPassword`` conservent leur valeur stockee (ne sont pas mis a
-   jour) lorsque la valeur masquee ``"**********"`` est envoyee telle quelle.
-   N'envoyez la valeur reelle que lorsque vous souhaitez la modifier.
+   ``spnegoPreauthPassword`` conservent leur valeur stockée (ne sont pas mis à
+   jour) lorsque la valeur masquée ``"**********"`` est envoyée telle quelle.
+   N'envoyez la valeur réelle que lorsque vous souhaitez la modifier.
 
-   Cette verification etant basee sur le fait que la chaine est vide apres
-   suppression des asterisques, l'envoi d'une chaine vide (``""``) ou d'une valeur
-   composee uniquement d'asterisques laisse egalement la valeur inchangee. Par
-   consequent, ces champs secrets ne peuvent pas etre vides via l'API.
+   Cette vérification étant basée sur le fait que la chaîne est vide après
+   suppression des astérisques, l'envoi d'une chaîne vide (``""``) ou d'une valeur
+   composée uniquement d'astérisques laisse également la valeur inchangée. Par
+   conséquent, ces champs secrets ne peuvent pas être vides via l'API.
 
-Reponse
+Réponse
 -------
 
-En cas de succes de la mise a jour, seuls ``version`` et ``status`` sont retournes
+En cas de succès de la mise à jour, seuls ``version`` et ``status`` sont retournés
 (``id`` et ``created`` ne sont pas inclus).
 
 .. code-block:: json
@@ -415,9 +415,9 @@ En cas de succes de la mise a jour, seuls ``version`` et ``status`` sont retourn
       }
     }
 
-Si la mise a jour echoue (par exemple en raison d'une erreur de validation), l'API
-retourne HTTP 400 et ``status`` est defini a une valeur non nulle (``1`` pour une
-erreur de validation), et ``message`` contient les details de l'erreur. Consultez
+Si la mise à jour échoue (par exemple en raison d'une erreur de validation), l'API
+retourne HTTP 400 et ``status`` est défini à une valeur non nulle (``1`` pour une
+erreur de validation), et ``message`` contient les détails de l'erreur. Consultez
 :doc:`api-admin-overview` pour la liste des valeurs de ``status``.
 
 Exemples d'utilisation
@@ -426,12 +426,12 @@ Exemples d'utilisation
 .. note::
 
    Les exemples ci-dessous incluent les champs obligatoires (``dayForCleanup``,
-   ``crawlingThreadCount``, ``failureCountThreshold``, ``csvFileEncoding``). Etant
-   donne que ceux-ci doivent toujours etre envoyes quelle que soit la modification
-   effectuee, recuperez les valeurs actuelles avec ``GET`` et incluez-les en
-   situation reelle (les exemples ci-dessous utilisent les valeurs par defaut).
+   ``crawlingThreadCount``, ``failureCountThreshold``, ``csvFileEncoding``). Étant
+   donné que ceux-ci doivent toujours être envoyés quelle que soit la modification
+   effectuée, récupérez les valeurs actuelles avec ``GET`` et incluez-les en
+   situation réelle (les exemples ci-dessous utilisent les valeurs par défaut).
 
-Mise a jour des parametres de crawl
+Mise à jour des paramètres de crawl
 -------------------------------------
 
 .. code-block:: bash
@@ -447,7 +447,7 @@ Mise a jour des parametres de crawl
            "csvFileEncoding": "UTF-8"
          }'
 
-Mise a jour des periodes de conservation des journaux
+Mise à jour des périodes de conservation des journaux
 -------------------------------------------------------
 
 .. code-block:: bash
@@ -465,7 +465,7 @@ Mise a jour des periodes de conservation des journaux
            "purgeUserInfoDay": 90
          }'
 
-Mise a jour des parametres de suggestion
+Mise à jour des paramètres de suggestion
 ------------------------------------------
 
 .. code-block:: bash
@@ -482,9 +482,9 @@ Mise a jour des parametres de suggestion
            "suggestDocuments": "true"
          }'
 
-Informations complementaires
+Informations complémentaires
 =============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
-- :doc:`api-admin-systeminfo` - API des informations systeme
-- :doc:`../../admin/general-guide` - Guide des parametres generaux
+- :doc:`api-admin-systeminfo` - API des informations système
+- :doc:`../../admin/general-guide` - Guide des paramètres généraux

--- a/fr/15.7/api/admin/api-admin-group.rst
+++ b/fr/15.7/api/admin/api-admin-group.rst
@@ -5,8 +5,8 @@ API Group
 Vue d'ensemble
 ==============
 
-L'API Group permet de gerer les groupes de |Fess|.
-Vous pouvez creer, mettre a jour et supprimer des groupes.
+L'API Group permet de gérer les groupes de |Fess|.
+Vous pouvez créer, mettre à jour et supprimer des groupes.
 
 URL de base
 ===========
@@ -22,7 +22,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
@@ -33,10 +33,10 @@ Liste des endpoints
      - Obtention d'un groupe
    * - POST
      - /setting
-     - Creation d'un groupe
+     - Création d'un groupe
    * - PUT
      - /setting
-     - Mise a jour d'un groupe
+     - Mise à jour d'un groupe
    * - DELETE
      - /setting/{id}
      - Suppression d'un groupe
@@ -44,38 +44,38 @@ Liste des endpoints
 Obtention de la liste des groupes
 =================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/group/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 25)
+     - Nombre d'éléments par page (par défaut : 25)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1, par defaut : 1)
+     - Numéro de page (commence à 1, par défaut : 1)
    * - ``id``
      - String
      - Non
-     - Filtre par correspondance exacte sur l'ID de groupe specifie
+     - Filtre par correspondance exacte sur l'ID de groupe spécifié
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -108,14 +108,14 @@ Reponse
 Obtention d'un groupe
 =====================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/group/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -134,10 +134,10 @@ Reponse
       }
     }
 
-Creation d'un groupe
+Création d'un groupe
 ====================
 
-Requete
+Requête
 -------
 
 ::
@@ -145,7 +145,7 @@ Requete
     POST /api/admin/group/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -169,12 +169,12 @@ Description des champs
      - Description
    * - ``name``
      - Oui
-     - Nom du groupe (maximum 100 caracteres)
+     - Nom du groupe (maximum 100 caractères)
    * - ``attributes``
      - Non
-     - Map d'attributs (contenant des attributs LDAP comme ``gidNumber``). Les valeurs sont specifiees sous forme de chaines de caracteres
+     - Map d'attributs (contenant des attributs LDAP comme ``gidNumber``). Les valeurs sont spécifiées sous forme de chaînes de caractères
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -187,10 +187,10 @@ Reponse
       }
     }
 
-Mise a jour d'un groupe
+Mise à jour d'un groupe
 =======================
 
-Requete
+Requête
 -------
 
 ::
@@ -198,7 +198,7 @@ Requete
     PUT /api/admin/group/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -224,18 +224,18 @@ Description des champs
      - Description
    * - ``id``
      - Oui
-     - ID du groupe a mettre a jour
+     - ID du groupe à mettre à jour
    * - ``name``
      - Oui
-     - Nom du groupe (maximum 100 caracteres)
+     - Nom du groupe (maximum 100 caractères)
    * - ``attributes``
      - Non
-     - Map d'attributs (contenant des attributs LDAP comme ``gidNumber``). Les valeurs sont specifiees sous forme de chaines de caracteres
+     - Map d'attributs (contenant des attributs LDAP comme ``gidNumber``). Les valeurs sont spécifiées sous forme de chaînes de caractères
    * - ``versionNo``
      - Oui
-     - Numero de version pour le verrouillage optimiste. Specifiez la valeur de ``versionNo`` obtenue lors de l'obtention du groupe
+     - Numéro de version pour le verrouillage optimiste. Spécifiez la valeur de ``versionNo`` obtenue lors de l'obtention du groupe
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -251,14 +251,14 @@ Reponse
 Suppression d'un groupe
 =======================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/group/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -274,7 +274,7 @@ Reponse
 Exemples d'utilisation
 ======================
 
-Creation d'un nouveau groupe
+Création d'un nouveau groupe
 ----------------------------
 
 .. code-block:: bash
@@ -297,10 +297,10 @@ Obtention de la liste des groupes
     curl -X GET "http://localhost:8080/api/admin/group/settings" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
 - :doc:`api-admin-user` - API de gestion des utilisateurs
-- :doc:`api-admin-role` - API de gestion des roles
+- :doc:`api-admin-role` - API de gestion des rôles
 - :doc:`../../admin/group-guide` - Guide de gestion des groupes

--- a/fr/15.7/api/admin/api-admin-joblog.rst
+++ b/fr/15.7/api/admin/api-admin-joblog.rst
@@ -5,8 +5,8 @@ API JobLog
 Vue d'ensemble
 ==============
 
-L'API JobLog permet de consulter et de gerer les journaux d'execution des taches de |Fess|.
-Vous pouvez obtenir l'historique d'execution des taches planifiees et des taches de crawl, les resultats d'execution, les informations d'erreur, et les supprimer.
+L'API JobLog permet de consulter et de gérer les journaux d'exécution des tâches de |Fess|.
+Vous pouvez obtenir l'historique d'exécution des tâches planifiées et des tâches de crawl, les résultats d'exécution, les informations d'erreur, et les supprimer.
 
 URL de base
 ===========
@@ -22,54 +22,54 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /logs
-     - Obtention de la liste des journaux de taches
+     - Obtention de la liste des journaux de tâches
    * - GET
      - /log/{id}
-     - Obtention d'un journal de tache
+     - Obtention d'un journal de tâche
    * - DELETE
      - /log/{id}
-     - Suppression d'un journal de tache
+     - Suppression d'un journal de tâche
 
-Obtention de la liste des journaux de taches
+Obtention de la liste des journaux de tâches
 ============================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/joblog/logs
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (defaut : 20)
+     - Nombre d'éléments par page (défaut : 20)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (base 1, defaut : 1)
+     - Numéro de page (base 1, défaut : 1)
    * - ``id``
      - String
      - Non
-     - Filtre par ID de journal de tache (correspondance exacte)
+     - Filtre par ID de journal de tâche (correspondance exacte)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -105,7 +105,7 @@ Reponse
       }
     }
 
-Champs de la reponse
+Champs de la réponse
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -115,41 +115,41 @@ Champs de la reponse
    * - Champ
      - Description
    * - ``id``
-     - ID du journal de tache
+     - ID du journal de tâche
    * - ``jobName``
-     - Nom de la tache
+     - Nom de la tâche
    * - ``jobStatus``
-     - Statut de la tache (``ok`` : succes, ``fail`` : echec, ``running`` : en cours d'execution)
+     - Statut de la tâche (``ok`` : succès, ``fail`` : échec, ``running`` : en cours d'exécution)
    * - ``target``
-     - Cible d'execution (nom de la cible du planificateur ; valeur par defaut : ``all``)
+     - Cible d'exécution (nom de la cible du planificateur ; valeur par défaut : ``all``)
    * - ``scriptType``
      - Type de script (ex. : ``groovy``)
    * - ``scriptData``
-     - Script execute
+     - Script exécuté
    * - ``scriptResult``
-     - Resultat d'execution
+     - Résultat d'exécution
    * - ``startTime``
-     - Heure de debut (millisecondes epoch ; retournee sous forme de chaine)
+     - Heure de début (millisecondes epoch ; retournée sous forme de chaîne)
    * - ``endTime``
-     - Heure de fin (millisecondes epoch ; retournee sous forme de chaine). Non retournee pour les taches en cours d'execution.
+     - Heure de fin (millisecondes epoch ; retournée sous forme de chaîne). Non retournée pour les tâches en cours d'exécution.
 
 .. note::
 
-   Chaque objet de journal dans la reponse inclut egalement un champ interne ``crudMode``
-   (un entier indiquant le mode d'operation CRUD, toujours ``0`` pour les operations de lecture).
-   Les clients peuvent l'ignorer en toute securite.
+   Chaque objet de journal dans la réponse inclut également un champ interne ``crudMode``
+   (un entier indiquant le mode d'opération CRUD, toujours ``0`` pour les opérations de lecture).
+   Les clients peuvent l'ignorer en toute sécurité.
 
-Obtention d'un journal de tache
+Obtention d'un journal de tâche
 ================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/joblog/log/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -171,20 +171,20 @@ Reponse
       }
     }
 
-Si le journal de tache correspondant a l'ID specifie n'existe pas, une reponse d'erreur
-est retournee avec une valeur differente de 0 dans ``status``.
+Si le journal de tâche correspondant à l'ID spécifié n'existe pas, une réponse d'erreur
+est retournée avec une valeur différente de 0 dans ``status``.
 
-Suppression d'un journal de tache
+Suppression d'un journal de tâche
 ==================================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/joblog/log/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -195,13 +195,13 @@ Reponse
       }
     }
 
-Si le journal de tache correspondant a l'ID specifie n'existe pas, une reponse d'erreur
-est retournee avec une valeur differente de 0 dans ``status``.
+Si le journal de tâche correspondant à l'ID spécifié n'existe pas, une réponse d'erreur
+est retournée avec une valeur différente de 0 dans ``status``.
 
 Exemples d'utilisation
 ======================
 
-Obtention de la liste des journaux de taches
+Obtention de la liste des journaux de tâches
 --------------------------------------------
 
 .. code-block:: bash
@@ -209,7 +209,7 @@ Obtention de la liste des journaux de taches
     curl -X GET "http://localhost:8080/api/admin/joblog/logs?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Extraction des taches en echec uniquement
+Extraction des tâches en échec uniquement
 -----------------------------------------
 
 .. code-block:: bash
@@ -219,7 +219,7 @@ Extraction des taches en echec uniquement
          -H "Authorization: Bearer YOUR_TOKEN" | \
          jq '.response.logs[] | select(.jobStatus=="fail")'
 
-Obtention d'un journal de tache
+Obtention d'un journal de tâche
 --------------------------------
 
 .. code-block:: bash
@@ -227,7 +227,7 @@ Obtention d'un journal de tache
     curl -X GET "http://localhost:8080/api/admin/joblog/log/joblog_id_1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Suppression d'un journal de tache
+Suppression d'un journal de tâche
 ----------------------------------
 
 .. code-block:: bash
@@ -235,7 +235,7 @@ Suppression d'un journal de tache
     curl -X DELETE "http://localhost:8080/api/admin/joblog/log/joblog_id_1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Calcul du taux de reussite des taches
+Calcul du taux de réussite des tâches
 --------------------------------------
 
 .. code-block:: bash
@@ -244,10 +244,10 @@ Calcul du taux de reussite des taches
          -H "Authorization: Bearer YOUR_TOKEN" | \
          jq '.response.logs | {total: length, ok: [.[] | select(.jobStatus=="ok")] | length, fail: [.[] | select(.jobStatus=="fail")] | length}'
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
 - :doc:`api-admin-scheduler` - API du planificateur
 - :doc:`api-admin-crawlinginfo` - API des informations de crawl
-- :doc:`../../admin/joblog-guide` - Guide de gestion des journaux de taches
+- :doc:`../../admin/joblog-guide` - Guide de gestion des journaux de tâches

--- a/fr/15.7/api/admin/api-admin-labeltype.rst
+++ b/fr/15.7/api/admin/api-admin-labeltype.rst
@@ -2,19 +2,19 @@
 LabelType API
 ==========================
 
-Apercu
+Aperçu
 ======
 
-L'API LabelType permet de gerer les types de labels de |Fess|.
-Les types de labels permettent de classer les resultats de recherche en fonction des chemins
-cibles du crawl et des hotes virtuels, et peuvent etre utilises pour le filtrage
+L'API LabelType permet de gérer les types de labels de |Fess|.
+Les types de labels permettent de classer les résultats de recherche en fonction des chemins
+cibles du crawl et des hôtes virtuels, et peuvent être utilisés pour le filtrage
 (restriction) par label dans l'interface de recherche.
 
-Pour les methodes d'authentification et les specifications communes des reponses
+Pour les méthodes d'authentification et les spécifications communes des réponses
 (code ``status``, champ ``version``, format des erreurs, codes de statut HTTP, etc.),
 consultez :doc:`api-admin-overview`.
-Pour acceder a cette API, un jeton d'acces disposant de la permission d'API d'administration
-(``admin-api``) doit etre specifie dans l'en-tete ``Authorization: Bearer <jeton d'acces>``.
+Pour accéder à cette API, un jeton d'accès disposant de la permission d'API d'administration
+(``admin-api``) doit être spécifié dans l'en-tête ``Authorization: Bearer <jeton d'accès>``.
 
 URL de base
 ===========
@@ -30,7 +30,7 @@ Liste des points de terminaison
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
@@ -41,10 +41,10 @@ Liste des points de terminaison
      - Obtention d'un type de label
    * - POST
      - /setting
-     - Creation d'un type de label
+     - Création d'un type de label
    * - PUT
      - /setting
-     - Mise a jour d'un type de label
+     - Mise à jour d'un type de label
    * - DELETE
      - /setting/{id}
      - Suppression d'un type de label
@@ -52,42 +52,42 @@ Liste des points de terminaison
 Obtention de la liste des types de labels
 ==========================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/labeltype/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Obligatoire
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page. La valeur par defaut est celle du parametre ``paging.page.size`` (``25`` par defaut).
+     - Nombre d'éléments par page. La valeur par défaut est celle du paramètre ``paging.page.size`` (``25`` par défaut).
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a ``1``). La valeur par defaut est ``1``.
+     - Numéro de page (commence à ``1``). La valeur par défaut est ``1``.
    * - ``name``
      - String
      - Non
-     - Filtrage par nom d'affichage (recherche avec caracteres generiques).
+     - Filtrage par nom d'affichage (recherche avec caractères génériques).
    * - ``value``
      - String
      - Non
-     - Filtrage par valeur de label (recherche avec caracteres generiques).
+     - Filtrage par valeur de label (recherche avec caractères génériques).
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -119,23 +119,23 @@ Reponse
 
 .. note::
 
-   Chaque objet de configuration inclut egalement ``createdBy`` / ``createdTime`` /
-   ``updatedBy`` / ``updatedTime`` a des fins d'audit, ainsi que ``versionNo`` pour le
+   Chaque objet de configuration inclut également ``createdBy`` / ``createdTime`` /
+   ``updatedBy`` / ``updatedTime`` à des fins d'audit, ainsi que ``versionNo`` pour le
    verrouillage optimiste (les champs dont la valeur est ``null`` sont omis). L'objet
    ``response`` contient toujours ``version``, indiquant la version du produit, mais
-   celui-ci peut etre omis dans les exemples suivants par souci de concision.
+   celui-ci peut être omis dans les exemples suivants par souci de concision.
 
 Obtention d'un type de label
 =============================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/labeltype/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -161,10 +161,10 @@ Reponse
       }
     }
 
-Creation d'un type de label
+Création d'un type de label
 ============================
 
-Requete
+Requête
 -------
 
 ::
@@ -172,7 +172,7 @@ Requete
     POST /api/admin/labeltype/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -200,38 +200,38 @@ Description des champs
    * - ``name``
      - String
      - Oui
-     - Nom d'affichage du label (100 caracteres maximum).
+     - Nom d'affichage du label (100 caractères maximum).
    * - ``value``
      - String
      - Oui
-     - Valeur du label (utilisee avec le parametre ``label`` lors des recherches). Seuls les caracteres alphanumeriques et les tirets bas (``_``) sont autorises ; la valeur doit correspondre a l'expression reguliere ``^[a-zA-Z0-9_]+$`` (100 caracteres maximum).
+     - Valeur du label (utilisée avec le paramètre ``label`` lors des recherches). Seuls les caractères alphanumériques et les tirets bas (``_``) sont autorisés ; la valeur doit correspondre à l'expression régulière ``^[a-zA-Z0-9_]+$`` (100 caractères maximum).
    * - ``includedPaths``
      - String
      - Non
-     - Expression reguliere des chemins cibles du label. Si plusieurs valeurs sont specifees, elles sont separees par un saut de ligne (``\n``).
+     - Expression régulière des chemins cibles du label. Si plusieurs valeurs sont specifees, elles sont séparées par un saut de ligne (``\n``).
    * - ``excludedPaths``
      - String
      - Non
-     - Expression reguliere des chemins a exclure du label. Si plusieurs valeurs sont specifees, elles sont separees par un saut de ligne (``\n``).
+     - Expression régulière des chemins à exclure du label. Si plusieurs valeurs sont specifees, elles sont séparées par un saut de ligne (``\n``).
    * - ``permissions``
      - String
      - Non
-     - Roles, groupes ou utilisateurs autorises a acceder (ex. : ``{role}admin``). Si plusieurs valeurs sont specifees, elles sont separees par un saut de ligne (``\n``).
+     - Rôles, groupes ou utilisateurs autorisés à accéder (ex. : ``{role}admin``). Si plusieurs valeurs sont specifees, elles sont séparées par un saut de ligne (``\n``).
    * - ``sortOrder``
      - Integer
      - Non
-     - Ordre d'affichage (entier superieur ou egal a 0). La valeur par defaut est ``0``.
+     - Ordre d'affichage (entier supérieur ou égal à 0). La valeur par défaut est ``0``.
    * - ``virtualHost``
      - String
      - Non
-     - Hote virtuel (1000 caracteres maximum).
+     - Hôte virtuel (1000 caractères maximum).
 
 .. note::
 
-   Les champs d'audit tels que ``createdBy`` / ``createdTime`` sont definis
-   automatiquement cote serveur et n'ont pas besoin d'etre specifies dans la requete.
+   Les champs d'audit tels que ``createdBy`` / ``createdTime`` sont définis
+   automatiquement côté serveur et n'ont pas besoin d'être spécifiés dans la requête.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -244,12 +244,12 @@ Reponse
       }
     }
 
-En cas de creation reussie, ``created`` prend la valeur ``true``.
+En cas de création réussie, ``created`` prend la valeur ``true``.
 
-Mise a jour d'un type de label
+Mise à jour d'un type de label
 ================================
 
-Requete
+Requête
 -------
 
 ::
@@ -257,7 +257,7 @@ Requete
     PUT /api/admin/labeltype/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -273,7 +273,7 @@ Corps de la requete
       "versionNo": 1
     }
 
-Lors d'une mise a jour, les champs suivants sont obligatoires en plus de ceux utilises lors de la creation.
+Lors d'une mise à jour, les champs suivants sont obligatoires en plus de ceux utilisés lors de la création.
 
 .. list-table::
    :header-rows: 1
@@ -286,13 +286,13 @@ Lors d'une mise a jour, les champs suivants sont obligatoires en plus de ceux ut
    * - ``id``
      - String
      - Oui
-     - ID du type de label a mettre a jour.
+     - ID du type de label à mettre à jour.
    * - ``versionNo``
      - Integer
      - Oui
-     - Numero de version pour le verrouillage optimiste. Specifiez la valeur ``versionNo`` presente dans la reponse obtenue lors de la lecture. Si la version specifiee ne correspond pas a la version actuelle, la mise a jour echoue.
+     - Numéro de version pour le verrouillage optimiste. Spécifiez la valeur ``versionNo`` présente dans la réponse obtenue lors de la lecture. Si la version spécifiée ne correspond pas à la version actuelle, la mise à jour échoue.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -305,19 +305,19 @@ Reponse
       }
     }
 
-Dans le cas d'une mise a jour, ``created`` prend la valeur ``false``.
+Dans le cas d'une mise à jour, ``created`` prend la valeur ``false``.
 
 Suppression d'un type de label
 ================================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/labeltype/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -331,7 +331,7 @@ Reponse
 Exemples d'utilisation
 =======================
 
-Creation d'un label pour la documentation
+Création d'un label pour la documentation
 ------------------------------------------
 
 .. code-block:: bash

--- a/fr/15.7/api/admin/api-admin-log.rst
+++ b/fr/15.7/api/admin/api-admin-log.rst
@@ -5,8 +5,8 @@ API Log
 Vue d'ensemble
 ==============
 
-L'API Log permet de consulter et de telecharger les fichiers journaux de |Fess|.
-Vous pouvez obtenir la liste des fichiers journaux generes sur le serveur et telecharger individuellement chaque fichier journal.
+L'API Log permet de consulter et de télécharger les fichiers journaux de |Fess|.
+Vous pouvez obtenir la liste des fichiers journaux générés sur le serveur et télécharger individuellement chaque fichier journal.
 
 URL de base
 ===========
@@ -18,14 +18,14 @@ URL de base
 Authentification
 ================
 
-Comme pour les autres API Admin, une authentification par jeton d'acces est requise. Le jeton d'acces doit disposer de la permission ``Radmin-api`` (configuree via ``api.admin.access.permissions``, valeur par defaut : ``Radmin-api``).
-Indiquez le jeton d'acces dans l'en-tete de la requete.
+Comme pour les autres API Admin, une authentification par jeton d'accès est requise. Le jeton d'accès doit disposer de la permission ``Radmin-api`` (configurée via ``api.admin.access.permissions``, valeur par défaut : ``Radmin-api``).
+Indiquez le jeton d'accès dans l'en-tête de la requête.
 
 ::
 
-    Authorization: Bearer <jeton d'acces>
+    Authorization: Bearer <jeton d'accès>
 
-Pour plus de details sur l'authentification et l'obtention d'un jeton d'acces, consultez :doc:`api-admin-overview`.
+Pour plus de détails sur l'authentification et l'obtention d'un jeton d'accès, consultez :doc:`api-admin-overview`.
 
 Liste des endpoints
 ===================
@@ -34,7 +34,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
@@ -42,26 +42,26 @@ Liste des endpoints
      - Obtention de la liste des fichiers journaux
    * - GET
      - /file/{id}
-     - Telechargement d'un fichier journal
+     - Téléchargement d'un fichier journal
 
 Obtention de la liste des fichiers journaux
 ===========================================
 
-Renvoie la liste des fichiers journaux (``.log`` et ``.log.gz``) presents dans le repertoire de sortie des journaux du serveur.
-Les fichiers sont retournes tries par ordre croissant de nom de fichier.
+Renvoie la liste des fichiers journaux (``.log`` et ``.log.gz``) présents dans le répertoire de sortie des journaux du serveur.
+Les fichiers sont retournés triés par ordre croissant de nom de fichier.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/log/files
 
-Reponse
+Réponse
 -------
 
-``files`` contient un tableau d'objets representant les informations de chaque fichier journal, et ``total`` contient le nombre d'elements.
-Chaque objet possede les champs suivants.
+``files`` contient un tableau d'objets représentant les informations de chaque fichier journal, et ``total`` contient le nombre d'éléments.
+Chaque objet possède les champs suivants.
 
 .. list-table::
    :header-rows: 1
@@ -70,11 +70,11 @@ Chaque objet possede les champs suivants.
    * - Champ
      - Description
    * - ``id``
-     - Valeur du nom de fichier encode en Base64 URL (utilisee comme ``{id}`` lors du telechargement)
+     - Valeur du nom de fichier encodé en Base64 URL (utilisée comme ``{id}`` lors du téléchargement)
    * - ``name``
      - Nom du fichier journal
    * - ``lastModified``
-     - Date et heure de derniere modification
+     - Date et heure de dernière modification
 
 .. code-block:: json
 
@@ -100,27 +100,27 @@ Chaque objet possede les champs suivants.
 
 .. note::
 
-   ``version`` contient la version du produit |Fess| en cours d'execution. Le contenu de ``files``
-   et le nombre d'elements varient selon les fichiers journaux presents sur le serveur ;
-   l'exemple ci-dessus est fourni a titre indicatif.
+   ``version`` contient la version du produit |Fess| en cours d'exécution. Le contenu de ``files``
+   et le nombre d'éléments varient selon les fichiers journaux présents sur le serveur ;
+   l'exemple ci-dessus est fourni à titre indicatif.
 
-Telechargement d'un fichier journal
+Téléchargement d'un fichier journal
 ===================================
 
-Telecharge le contenu du fichier journal specifie.
-Pour ``{id}``, indiquez tel quel l'``id`` retourne lors de l'obtention de la liste (la valeur du nom de fichier encodee en Base64 URL).
-La reponse est renvoyee sous forme de flux ``application/octet-stream``.
-Pour des raisons de securite, seuls les noms se terminant par ``.log`` ou ``.log.gz`` sont acceptes ; les noms contenant des sequences de manipulation de chemin telles que ``..`` sont rejetes.
-Si vous specifiez un nom de fichier inexistant ou un nom non autorise en tant que fichier journal, une reponse vide est renvoyee.
+Télécharge le contenu du fichier journal spécifié.
+Pour ``{id}``, indiquez tel quel l'``id`` retourné lors de l'obtention de la liste (la valeur du nom de fichier encodée en Base64 URL).
+La réponse est renvoyée sous forme de flux ``application/octet-stream``.
+Pour des raisons de sécurité, seuls les noms se terminant par ``.log`` ou ``.log.gz`` sont acceptés ; les noms contenant des séquences de manipulation de chemin telles que ``..`` sont rejetés.
+Si vous spécifiez un nom de fichier inexistant ou un nom non autorisé en tant que fichier journal, une réponse vide est renvoyée.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/log/file/{id}
 
-Reponse
+Réponse
 -------
 
 Flux binaire du fichier journal (``Content-Type: application/octet-stream``).
@@ -136,7 +136,7 @@ Obtention de la liste des fichiers journaux
     curl -X GET "http://localhost:8080/api/admin/log/files" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Telechargement d'un fichier journal
+Téléchargement d'un fichier journal
 -----------------------------------
 
 .. code-block:: bash
@@ -145,7 +145,7 @@ Telechargement d'un fichier journal
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o fess.log
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.7/api/admin/api-admin-overview.rst
+++ b/fr/15.7/api/admin/api-admin-overview.rst
@@ -5,10 +5,10 @@ Vue d'ensemble de l'API Admin
 Vue d'ensemble
 ==============
 
-L'API d'administration |Fess| est une API RESTful permettant d'acceder aux fonctions d'administration par programmation.
-Les configurations de crawl, la gestion des utilisateurs, le controle du planificateur et la plupart des operations disponibles dans l'interface d'administration peuvent etre executees via l'API.
+L'API d'administration |Fess| est une API RESTful permettant d'accéder aux fonctions d'administration par programmation.
+Les configurations de crawl, la gestion des utilisateurs, le contrôle du planificateur et la plupart des opérations disponibles dans l'interface d'administration peuvent être exécutées via l'API.
 
-En utilisant cette API, vous pouvez automatiser la configuration de |Fess| ou l'integrer a des systemes externes.
+En utilisant cette API, vous pouvez automatiser la configuration de |Fess| ou l'intégrer à des systèmes externes.
 
 URL de base
 ===========
@@ -28,37 +28,37 @@ Par exemple, dans un environnement local :
 Authentification
 ================
 
-L'acces a l'API d'administration necessite une authentification par jeton d'acces.
+L'accès à l'API d'administration nécessite une authentification par jeton d'accès.
 
-Obtention d'un jeton d'acces
+Obtention d'un jeton d'accès
 ----------------------------
 
-1. Connectez-vous a l'interface d'administration
-2. Allez dans "Systeme" -> "Jetons d'acces"
+1. Connectez-vous à l'interface d'administration
+2. Allez dans "Système" -> "Jetons d'accès"
 3. Cliquez sur "Nouveau"
-4. Entrez un nom de jeton et definissez, dans le champ "Permissions", les permissions a accorder au jeton (pour utiliser l'API d'administration, saisissez ``{role}admin-api``)
-5. Cliquez sur "Creer" pour obtenir le jeton
+4. Entrez un nom de jeton et définissez, dans le champ "Permissions", les permissions à accorder au jeton (pour utiliser l'API d'administration, saisissez ``{role}admin-api``)
+5. Cliquez sur "Créer" pour obtenir le jeton
 
 Utilisation du jeton
 --------------------
 
-Incluez le jeton d'acces dans l'en-tete de la requete :
+Incluez le jeton d'accès dans l'en-tête de la requête :
 
 ::
 
-    Authorization: Bearer <jeton d'acces>
+    Authorization: Bearer <jeton d'accès>
 
-Vous pouvez aussi omettre ``Bearer`` et ne specifier que le jeton :
-
-::
-
-    Authorization: <jeton d'acces>
-
-La specification via un parametre de requete est egalement possible, mais elle est desactivee par defaut. Si vous definissez un nom de parametre dans ``api.access.token.request.parameter`` du fichier ``fess_config.properties``, vous pourrez transmettre le jeton sous ce nom (la valeur par defaut etant vide, seule la specification par en-tete est active). Par exemple, si vous definissez ``api.access.token.request.parameter=token`` :
+Vous pouvez aussi omettre ``Bearer`` et ne spécifier que le jeton :
 
 ::
 
-    ?token=<jeton d'acces>
+    Authorization: <jeton d'accès>
+
+La spécification via un paramètre de requête est également possible, mais elle est désactivée par défaut. Si vous définissez un nom de paramètre dans ``api.access.token.request.parameter`` du fichier ``fess_config.properties``, vous pourrez transmettre le jeton sous ce nom (la valeur par défaut étant vide, seule la spécification par en-tête est active). Par exemple, si vous définissez ``api.access.token.request.parameter=token`` :
+
+::
+
+    ?token=<jeton d'accès>
 
 Exemple cURL
 ~~~~~~~~~~~~
@@ -71,52 +71,52 @@ Exemple cURL
 Permissions requises
 --------------------
 
-L'acces a l'API d'administration n'est pas controle par fonction, mais par un unique jeu de permissions. Pour utiliser l'un quelconque des endpoints de l'API d'administration, le jeton d'acces doit s'etre vu accorder l'une des permissions definies dans ``api.admin.access.permissions`` du fichier ``fess_config.properties``.
+L'accès à l'API d'administration n'est pas contrôlé par fonction, mais par un unique jeu de permissions. Pour utiliser l'un quelconque des endpoints de l'API d'administration, le jeton d'accès doit s'être vu accorder l'une des permissions définies dans ``api.admin.access.permissions`` du fichier ``fess_config.properties``.
 
-La valeur par defaut est ``Radmin-api``, qui est la forme encodee du role ``admin-api`` (le ``R`` initial est la valeur de ``role.search.role.prefix``). Lors de la creation du jeton d'acces, si vous saisissez ``{role}admin-api`` dans le champ des permissions, il est enregistre en interne sous la forme ``Radmin-api``.
+La valeur par défaut est ``Radmin-api``, qui est la forme encodée du rôle ``admin-api`` (le ``R`` initial est la valeur de ``role.search.role.prefix``). Lors de la création du jeton d'accès, si vous saisissez ``{role}admin-api`` dans le champ des permissions, il est enregistré en interne sous la forme ``Radmin-api``.
 
 .. note::
 
-   Il n'existe pas de permissions distinctes par ressource (telles que ``admin-scheduler`` ou ``admin-user``), ni de caractere generique (``admin-*``). Un jeton disposant de la permission configuree peut acceder a tous les endpoints de l'API d'administration. Si vous souhaitez modifier les permissions qui autorisent l'acces, changez la valeur de ``api.admin.access.permissions``.
+   Il n'existe pas de permissions distinctes par ressource (telles que ``admin-scheduler`` ou ``admin-user``), ni de caractère générique (``admin-*``). Un jeton disposant de la permission configurée peut accéder à tous les endpoints de l'API d'administration. Si vous souhaitez modifier les permissions qui autorisent l'accès, changez la valeur de ``api.admin.access.permissions``.
 
 Patterns communs
 ================
 
-Les ressources possedant des parametres (webconfig, user, role, etc.) suivent le
+Les ressources possédant des paramètres (webconfig, user, role, etc.) suivent le
 pattern CRUD commun ci-dessous. Toutefois, certaines ressources (systeminfo, stats,
 storage, plugin, log, backup, documents, suggest, racine dict, etc.) disposent d'une
-structure d'endpoints propre, differente de ce pattern commun ; reportez-vous a la
+structure d'endpoints propre, différente de ce pattern commun ; reportez-vous à la
 page de chaque ressource.
 
 Obtention de la liste (GET /settings)
 -------------------------------------
 
-Obtient la liste des parametres.
+Obtient la liste des paramètres.
 
-Requete
+Requête
 ~~~~~~~
 
 ::
 
     GET /api/admin/<resource>/settings
 
-Parametres (pagination) :
+Paramètres (pagination) :
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 65
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Description
    * - ``size``
      - Integer
-     - Nombre d'elements par page (par defaut : 25 ; modifiable via ``paging.page.size`` du fichier ``fess_config.properties``)
+     - Nombre d'éléments par page (par défaut : 25 ; modifiable via ``paging.page.size`` du fichier ``fess_config.properties``)
    * - ``page``
      - Integer
-     - Numero de page (commence a 1 ; par defaut : 1 ; une valeur inferieure ou egale a 0 est traitee comme 1)
+     - Numéro de page (commence à 1 ; par défaut : 1 ; une valeur inférieure ou égale à 0 est traitée comme 1)
 
-Reponse
+Réponse
 ~~~~~~~
 
 .. code-block:: json
@@ -132,23 +132,23 @@ Reponse
 
 .. note::
 
-   L'objet ``response`` de toutes les reponses contient toujours ``version``
+   L'objet ``response`` de toutes les réponses contient toujours ``version``
    (par exemple ``"15.7.0"``), indiquant la version du produit. Dans les exemples
-   suivants, il peut etre omis par souci de concision.
+   suivants, il peut être omis par souci de concision.
 
-Obtention d'un parametre unique (GET /setting/{id})
+Obtention d'un paramètre unique (GET /setting/{id})
 ---------------------------------------------------
 
-Obtient un parametre unique en specifiant son ID.
+Obtient un paramètre unique en spécifiant son ID.
 
-Requete
+Requête
 ~~~~~~~
 
 ::
 
     GET /api/admin/<resource>/setting/{id}
 
-Reponse
+Réponse
 ~~~~~~~
 
 .. code-block:: json
@@ -160,12 +160,12 @@ Reponse
       }
     }
 
-Creation (POST /setting)
+Création (POST /setting)
 ------------------------
 
-Cree un nouveau parametre.
+Crée un nouveau paramètre.
 
-Requete
+Requête
 ~~~~~~~
 
 ::
@@ -178,7 +178,7 @@ Requete
       "...": "..."
     }
 
-Reponse
+Réponse
 ~~~~~~~
 
 .. code-block:: json
@@ -191,12 +191,12 @@ Reponse
       }
     }
 
-Mise a jour (PUT /setting)
+Mise à jour (PUT /setting)
 --------------------------
 
-Met a jour un parametre existant.
+Met à jour un paramètre existant.
 
-Requete
+Requête
 ~~~~~~~
 
 ::
@@ -210,7 +210,7 @@ Requete
       "...": "..."
     }
 
-Reponse
+Réponse
 ~~~~~~~
 
 .. code-block:: json
@@ -226,19 +226,19 @@ Reponse
 Suppression (DELETE /setting/{id})
 ----------------------------------
 
-Supprime un parametre.
+Supprime un paramètre.
 
-Requete
+Requête
 ~~~~~~~
 
 ::
 
     DELETE /api/admin/<resource>/setting/{id}
 
-Reponse
+Réponse
 ~~~~~~~
 
-Le format de la reponse de suppression varie selon la ressource (l'action). De
+Le format de la réponse de suppression varie selon la ressource (l'action). De
 nombreuses ressources ne retournent que ``status``.
 
 .. code-block:: json
@@ -249,8 +249,8 @@ nombreuses ressources ne retournent que ``status``.
       }
     }
 
-Pour certaines ressources, le resultat de la suppression est retourne sous forme
-de ``ApiUpdateResponse``, avec l'``id`` du parametre supprime et ``created``
+Pour certaines ressources, le résultat de la suppression est retourné sous forme
+de ``ApiUpdateResponse``, avec l'``id`` du paramètre supprimé et ``created``
 (``false`` lors d'une suppression).
 
 .. code-block:: json
@@ -264,15 +264,15 @@ de ``ApiUpdateResponse``, avec l'``id`` du parametre supprime et ``created``
     }
 
 De plus, pour les ressources qui retournent un ``ApiDeleteResponse``, un champ
-``count`` indiquant le nombre d'elements supprimes (valeur par defaut ``1``) peut
-etre ajoute. Reportez-vous a la page de chaque ressource pour le format exact.
+``count`` indiquant le nombre d'éléments supprimés (valeur par défaut ``1``) peut
+être ajouté. Reportez-vous à la page de chaque ressource pour le format exact.
 
-Format des reponses
+Format des réponses
 ===================
 
-Toutes les reponses sont encapsulees dans un objet ``response`` et contiennent
+Toutes les réponses sont encapsulées dans un objet ``response`` et contiennent
 toujours ``version``, indiquant la version du produit, ainsi que ``status``,
-indiquant le resultat du traitement.
+indiquant le résultat du traitement.
 
 Les valeurs de ``status`` sont les suivantes.
 
@@ -283,17 +283,17 @@ Les valeurs de ``status`` sont les suivantes.
    * - Valeur
      - Description
    * - ``0``
-     - OK (succes)
+     - OK (succès)
    * - ``1``
-     - BAD_REQUEST (requete invalide)
+     - BAD_REQUEST (requête invalide)
    * - ``2``
-     - SYSTEM_ERROR (erreur systeme)
+     - SYSTEM_ERROR (erreur système)
    * - ``3``
      - UNAUTHORIZED (erreur d'authentification)
    * - ``9``
-     - FAILED (echec du traitement)
+     - FAILED (échec du traitement)
 
-Reponse de succes
+Réponse de succès
 -----------------
 
 .. code-block:: json
@@ -306,12 +306,12 @@ Reponse de succes
       }
     }
 
-``status: 0`` indique un succes.
+``status: 0`` indique un succès.
 
-Reponse d'erreur
+Réponse d'erreur
 ----------------
 
-En cas d'erreur, ``status`` est defini sur une valeur differente de 0 et
+En cas d'erreur, ``status`` est défini sur une valeur différente de 0 et
 ``message`` contient le message d'erreur.
 
 .. code-block:: json
@@ -328,11 +328,11 @@ Codes de statut HTTP
 --------------------
 
 L'API d'administration retourne dans la plupart des cas le statut HTTP ``200``, et
-le resultat du traitement est exprime par le champ ``status`` du corps de la reponse.
-Par consequent, determinez le succes ou l'echec non pas a partir du code de statut HTTP,
-mais a partir de la valeur de ``status`` dans le corps.
+le résultat du traitement est exprimé par le champ ``status`` du corps de la réponse.
+Par conséquent, déterminez le succès ou l'échec non pas à partir du code de statut HTTP,
+mais à partir de la valeur de ``status`` dans le corps.
 
-Les codes de statut HTTP reellement retournes sont les suivants.
+Les codes de statut HTTP réellement retournés sont les suivants.
 
 .. list-table::
    :header-rows: 1
@@ -341,25 +341,25 @@ Les codes de statut HTTP reellement retournes sont les suivants.
    * - Code
      - Description
    * - 200
-     - Reponse normale. Outre les cas de succes (``status: 0``), la plupart des erreurs
-       sont egalement retournees avec ce code. Par exemple, si le jeton d'acces est absent
-       ou invalide, ou si les permissions sont insuffisantes, ``status: 3`` est retourne ;
-       une erreur systeme renvoie ``status: 2`` ; dans tous ces cas avec le statut HTTP ``200``.
+     - Réponse normale. Outre les cas de succès (``status: 0``), la plupart des erreurs
+       sont également retournées avec ce code. Par exemple, si le jeton d'accès est absent
+       ou invalide, ou si les permissions sont insuffisantes, ``status: 3`` est retourné ;
+       une erreur système renvoie ``status: 2`` ; dans tous ces cas avec le statut HTTP ``200``.
    * - 400
-     - Erreur de validation des parametres de requete. Le ``status`` du corps de la reponse
-       est ``1``. Ce code est egalement retourne lorsque l'on tente d'obtenir une ressource
+     - Erreur de validation des paramètres de requête. Le ``status`` du corps de la réponse
+       est ``1``. Ce code est également retourné lorsque l'on tente d'obtenir une ressource
        inexistante.
    * - 401
-     - Lorsqu'une exception liee a l'authentification de connexion se produit. Le ``status``
-       du corps de la reponse est ``3``. A noter que si le jeton d'acces est absent ou
-       invalide, ce n'est pas ce code qui est retourne, mais le statut HTTP ``200`` avec
+     - Lorsqu'une exception liée à l'authentification de connexion se produit. Le ``status``
+       du corps de la réponse est ``3``. À noter que si le jeton d'accès est absent ou
+       invalide, ce n'est pas ce code qui est retourné, mais le statut HTTP ``200`` avec
        ``status: 3``.
 
 .. note::
 
    L'API d'administration ne retourne pas de codes de statut HTTP tels que ``403``,
    ``404`` ou ``500``. L'insuffisance de permissions et l'inexistence d'une ressource
-   sont egalement indiquees par le ``status`` contenu dans le corps de la reponse HTTP
+   sont également indiquées par le ``status`` contenu dans le corps de la réponse HTTP
    ``200`` ou ``400``.
 
 APIs disponibles
@@ -386,11 +386,11 @@ Configuration du crawl
 .. note::
 
    Outre celles-ci, les ressources suivantes relatives aux informations
-   d'authentification et au controle du crawl sont egalement fournies en tant
-   qu'API (pour l'instant, aucune page dediee n'est disponible) : ``webauth``
+   d'authentification et au contrôle du crawl sont également fournies en tant
+   qu'API (pour l'instant, aucune page dédiée n'est disponible) : ``webauth``
    (authentification Web), ``fileauth`` (authentification de fichiers),
-   ``reqheader`` (en-tetes de requete), ``pathmap`` (mappage de chemins),
-   ``duplicatehost`` (hotes en double), ``searchlist`` (operations de
+   ``reqheader`` (en-têtes de requête), ``pathmap`` (mappage de chemins),
+   ``duplicatehost`` (hôtes en double), ``searchlist`` (opérations de
    recherche/liste de documents).
 
 Gestion de l'index
@@ -403,11 +403,11 @@ Gestion de l'index
    * - Endpoint
      - Description
    * - :doc:`api-admin-documents`
-     - Operations groupees sur les documents
+     - Opérations groupées sur les documents
    * - :doc:`api-admin-crawlinginfo`
      - Informations de crawl
    * - :doc:`api-admin-failureurl`
-     - Gestion des URLs en echec
+     - Gestion des URLs en échec
    * - :doc:`api-admin-backup`
      - Sauvegarde/Restauration
 
@@ -421,9 +421,9 @@ Planificateur
    * - Endpoint
      - Description
    * - :doc:`api-admin-scheduler`
-     - Planification des taches
+     - Planification des tâches
    * - :doc:`api-admin-joblog`
-     - Obtention des journaux de taches
+     - Obtention des journaux de tâches
 
 Gestion des utilisateurs et des droits
 --------------------------------------
@@ -437,7 +437,7 @@ Gestion des utilisateurs et des droits
    * - :doc:`api-admin-user`
      - Gestion des utilisateurs
    * - :doc:`api-admin-role`
-     - Gestion des roles
+     - Gestion des rôles
    * - :doc:`api-admin-group`
      - Gestion des groupes
    * - :doc:`api-admin-accesstoken`
@@ -459,17 +459,17 @@ Optimisation de la recherche
    * - :doc:`api-admin-boostdoc`
      - Boost de documents
    * - :doc:`api-admin-elevateword`
-     - Mots eleves
+     - Mots élevés
    * - :doc:`api-admin-badword`
      - Mots interdits
    * - :doc:`api-admin-relatedcontent`
-     - Contenus associes
+     - Contenus associés
    * - :doc:`api-admin-relatedquery`
-     - Requetes associees
+     - Requêtes associées
    * - :doc:`api-admin-suggest`
      - Gestion des suggestions
 
-Systeme
+Système
 -------
 
 .. list-table::
@@ -479,11 +479,11 @@ Systeme
    * - Endpoint
      - Description
    * - :doc:`api-admin-general`
-     - Parametres generaux
+     - Paramètres généraux
    * - :doc:`api-admin-systeminfo`
-     - Informations systeme
+     - Informations système
    * - :doc:`api-admin-stats`
-     - Statistiques systeme
+     - Statistiques système
    * - :doc:`api-admin-log`
      - Obtention des journaux
    * - :doc:`api-admin-searchlist`
@@ -508,7 +508,7 @@ Dictionnaire
 Exemples d'utilisation
 ======================
 
-Creation d'une configuration de crawl Web
+Création d'une configuration de crawl Web
 -----------------------------------------
 
 .. code-block:: bash
@@ -533,13 +533,13 @@ Creation d'une configuration de crawl Web
 
 .. note::
 
-   Pour la creation d'une configuration de crawl Web, les champs ``name``, ``urls``,
+   Pour la création d'une configuration de crawl Web, les champs ``name``, ``urls``,
    ``userAgent``, ``numOfThread``, ``intervalTime``, ``boost``, ``available`` et
    ``sortOrder`` sont obligatoires. Les omettre provoque une erreur de validation
-   (``status: 1``). ``available`` se specifie sous forme de chaine de caracteres,
-   en y placant ``"true"`` ou ``"false"``.
+   (``status: 1``). ``available`` se spécifie sous forme de chaîne de caractères,
+   en y plaçant ``"true"`` ou ``"false"``.
 
-Demarrage d'une tache planifiee
+Démarrage d'une tâche planifiée
 -------------------------------
 
 .. code-block:: bash
@@ -555,8 +555,8 @@ Obtention de la liste des utilisateurs
     curl "http://localhost:8080/api/admin/user/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`../api-overview` - Vue d'ensemble de l'API
-- :doc:`../../admin/accesstoken-guide` - Guide de gestion des jetons d'acces
+- :doc:`../../admin/accesstoken-guide` - Guide de gestion des jetons d'accès

--- a/fr/15.7/api/admin/api-admin-relatedcontent.rst
+++ b/fr/15.7/api/admin/api-admin-relatedcontent.rst
@@ -5,8 +5,8 @@ RelatedContent API
 Vue d'ensemble
 ==============
 
-L'API RelatedContent est une API permettant de gerer les contenus associes dans |Fess|.
-Vous pouvez afficher des contenus personnalises associes a des mots-cles specifiques.
+L'API RelatedContent est une API permettant de gérer les contenus associés dans |Fess|.
+Vous pouvez afficher des contenus personnalisés associés à des mots-clés spécifiques.
 
 URL de base
 ===========
@@ -22,64 +22,64 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /settings
-     - Lister les contenus associes
+     - Lister les contenus associés
    * - GET
      - /setting/{id}
-     - Obtenir un contenu associe
+     - Obtenir un contenu associé
    * - POST
      - /setting
-     - Creer un contenu associe
+     - Créer un contenu associé
    * - PUT
      - /setting
-     - Mettre a jour un contenu associe
+     - Mettre à jour un contenu associé
    * - DELETE
      - /setting/{id}
-     - Supprimer un contenu associe
+     - Supprimer un contenu associé
 
-Lister les contenus associes
+Lister les contenus associés
 ============================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/relatedcontent/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 25 ; modifiable via ``paging.page.size`` du fichier ``fess_config.properties``)
+     - Nombre d'éléments par page (par défaut : 25 ; modifiable via ``paging.page.size`` du fichier ``fess_config.properties``)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1 ; par defaut : 1 ; une valeur inferieure ou egale a 0 est traitee comme 1)
+     - Numéro de page (commence à 1 ; par défaut : 1 ; une valeur inférieure ou égale à 0 est traitée comme 1)
    * - ``term``
      - String
      - Non
-     - Filtrer par mot-cle de recherche (recherche avec caracteres generiques)
+     - Filtrer par mot-clé de recherche (recherche avec caractères génériques)
    * - ``content``
      - String
      - Non
-     - Filtrer par contenu (recherche avec caracteres generiques)
+     - Filtrer par contenu (recherche avec caractères génériques)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -108,27 +108,27 @@ Reponse
 
 .. note::
 
-   Chaque element de ``settings`` ainsi que l'objet ``setting`` retourne par
-   l'endpoint d'obtention contiennent les champs de l'entite stockee tels quels.
+   Chaque élément de ``settings`` ainsi que l'objet ``setting`` retourné par
+   l'endpoint d'obtention contiennent les champs de l'entité stockée tels quels.
    En plus de ``term``, ``content``, ``sortOrder`` et ``virtualHost``, les champs
    d'audit ``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime`` ainsi que
-   le champ de verrouillage optimiste ``versionNo`` sont egalement retournes.
-   ``createdTime`` et ``updatedTime`` sont exprimes en millisecondes depuis l'epoque
-   (nombres). Les champs non renseignes (null) sont omis de la reponse. De plus,
-   l'objet ``response`` de toutes les reponses contient toujours ``version``, qui
-   indique la version du produit (voir :doc:`api-admin-overview` pour les details).
+   le champ de verrouillage optimiste ``versionNo`` sont également retournés.
+   ``createdTime`` et ``updatedTime`` sont exprimés en millisecondes depuis l'époque
+   (nombres). Les champs non renseignés (null) sont omis de la réponse. De plus,
+   l'objet ``response`` de toutes les réponses contient toujours ``version``, qui
+   indique la version du produit (voir :doc:`api-admin-overview` pour les détails).
 
-Obtenir un contenu associe
+Obtenir un contenu associé
 ==========================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/relatedcontent/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -154,13 +154,13 @@ Reponse
 
 .. note::
 
-   La valeur de ``versionNo`` requise lors d'une mise a jour (PUT) est celle
-   incluse dans cette reponse d'obtention.
+   La valeur de ``versionNo`` requise lors d'une mise à jour (PUT) est celle
+   incluse dans cette réponse d'obtention.
 
-Creer un contenu associe
+Créer un contenu associé
 ========================
 
-Requete
+Requête
 -------
 
 ::
@@ -168,7 +168,7 @@ Requete
     POST /api/admin/relatedcontent/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -192,18 +192,18 @@ Description des champs
      - Description
    * - ``term``
      - **Oui**
-     - Mot-cle de recherche (maximum 10000 caracteres)
+     - Mot-clé de recherche (maximum 10000 caractères)
    * - ``content``
      - **Oui**
-     - Contenu HTML a afficher (maximum 10000 caracteres)
+     - Contenu HTML à afficher (maximum 10000 caractères)
    * - ``sortOrder``
      - **Non**
      - Ordre d'affichage (entier compris entre 0 et 2147483647)
    * - ``virtualHost``
      - **Non**
-     - Hote virtuel (maximum 1000 caracteres)
+     - Hôte virtuel (maximum 1000 caractères)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -217,10 +217,10 @@ Reponse
       }
     }
 
-Mettre a jour un contenu associe
+Mettre à jour un contenu associé
 =================================
 
-Requete
+Requête
 -------
 
 ::
@@ -228,7 +228,7 @@ Requete
     PUT /api/admin/relatedcontent/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -254,24 +254,24 @@ Description des champs
      - Description
    * - ``id``
      - **Oui**
-     - Identifiant du contenu associe a mettre a jour (maximum 1000 caracteres)
+     - Identifiant du contenu associé à mettre à jour (maximum 1000 caractères)
    * - ``term``
      - **Oui**
-     - Mot-cle de recherche (maximum 10000 caracteres)
+     - Mot-clé de recherche (maximum 10000 caractères)
    * - ``content``
      - **Oui**
-     - Contenu HTML a afficher (maximum 10000 caracteres)
+     - Contenu HTML à afficher (maximum 10000 caractères)
    * - ``sortOrder``
      - **Non**
      - Ordre d'affichage (entier compris entre 0 et 2147483647)
    * - ``virtualHost``
      - **Non**
-     - Hote virtuel (maximum 1000 caracteres)
+     - Hôte virtuel (maximum 1000 caractères)
    * - ``versionNo``
      - **Oui**
-     - Numero de version pour le verrouillage optimiste. Specifier la valeur incluse dans la reponse de ``setting/{id}``.
+     - Numéro de version pour le verrouillage optimiste. Spécifier la valeur incluse dans la réponse de ``setting/{id}``.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -288,21 +288,21 @@ Reponse
 .. note::
 
    Les champs d'audit tels que ``createdBy``, ``createdTime``, ``updatedBy``,
-   ``updatedTime`` et ``crudMode`` sont ignores meme s'ils sont inclus dans le
-   corps de la requete, car ils sont definis automatiquement cote serveur. Il
-   n'est pas necessaire de les specifier lors de la creation ou de la mise a jour.
+   ``updatedTime`` et ``crudMode`` sont ignorés même s'ils sont inclus dans le
+   corps de la requête, car ils sont définis automatiquement côté serveur. Il
+   n'est pas nécessaire de les spécifier lors de la création ou de la mise à jour.
 
-Supprimer un contenu associe
+Supprimer un contenu associé
 ============================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/relatedcontent/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -317,7 +317,7 @@ Reponse
 Exemples d'utilisation
 ======================
 
-Contenu associe pour les informations produit
+Contenu associé pour les informations produit
 ---------------------------------------------
 
 .. code-block:: bash
@@ -331,7 +331,7 @@ Contenu associe pour les informations produit
            "sortOrder": 0
          }'
 
-Contenu associe pour les informations de support
+Contenu associé pour les informations de support
 ------------------------------------------------
 
 .. code-block:: bash
@@ -345,9 +345,9 @@ Contenu associe pour les informations de support
            "sortOrder": 0
          }'
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
-- :doc:`api-admin-relatedquery` - API des requetes associees
-- :doc:`../../admin/relatedcontent-guide` - Guide de gestion des contenus associes
+- :doc:`api-admin-relatedquery` - API des requêtes associées
+- :doc:`../../admin/relatedcontent-guide` - Guide de gestion des contenus associés

--- a/fr/15.7/api/admin/api-admin-relatedquery.rst
+++ b/fr/15.7/api/admin/api-admin-relatedquery.rst
@@ -5,13 +5,13 @@ API RelatedQuery
 Vue d'ensemble
 ==============
 
-L'API RelatedQuery est une API permettant de gerer les requetes associees dans |Fess|.
-Pour un mot-cle de recherche saisi par l'utilisateur (``term``), vous pouvez enregistrer et
-gerer des suggestions de mots-cles de recherche associes (``queries``). Les requetes associees
-enregistrees sont affichees comme suggestions de recherche associees sur l'ecran de recherche.
+L'API RelatedQuery est une API permettant de gérer les requêtes associées dans |Fess|.
+Pour un mot-clé de recherche saisi par l'utilisateur (``term``), vous pouvez enregistrer et
+gérer des suggestions de mots-clés de recherche associés (``queries``). Les requêtes associées
+enregistrées sont affichées comme suggestions de recherche associées sur l'écran de recherche.
 
-Pour les details sur l'authentification, le format de reponse commun (champ ``version`` et
-codes ``status``), la pagination et les reponses d'erreur, consultez :doc:`api-admin-overview`.
+Pour les détails sur l'authentification, le format de réponse commun (champ ``version`` et
+codes ``status``), la pagination et les réponses d'erreur, consultez :doc:`api-admin-overview`.
 
 URL de base
 ===========
@@ -27,56 +27,56 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /settings
-     - Obtention de la liste des requetes associees
+     - Obtention de la liste des requêtes associées
    * - GET
      - /setting/{id}
-     - Obtention d'une requete associee
+     - Obtention d'une requête associée
    * - POST
      - /setting
-     - Creation d'une requete associee
+     - Création d'une requête associée
    * - PUT
      - /setting
-     - Mise a jour d'une requete associee
+     - Mise à jour d'une requête associée
    * - DELETE
      - /setting/{id}
-     - Suppression d'une requete associee
+     - Suppression d'une requête associée
 
-Obtention de la liste des requetes associees
+Obtention de la liste des requêtes associées
 ============================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/relatedquery/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 25 ; modifiable via ``paging.page.size`` du fichier ``fess_config.properties``)
+     - Nombre d'éléments par page (par défaut : 25 ; modifiable via ``paging.page.size`` du fichier ``fess_config.properties``)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1 ; par defaut : 1)
+     - Numéro de page (commence à 1 ; par défaut : 1)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -99,22 +99,22 @@ Reponse
 
 .. note::
 
-   Chaque parametre contient ``versionNo`` (numero de version utilise pour le verrouillage
+   Chaque paramètre contient ``versionNo`` (numéro de version utilisé pour le verrouillage
    optimiste). ``virtualHost`` et les champs d'audit (``createdBy``, ``createdTime``,
-   ``updatedBy``, ``updatedTime``) ne sont inclus que lorsqu'une valeur est definie.
-   Un ``virtualHost`` vide n'est pas inclus dans la reponse.
+   ``updatedBy``, ``updatedTime``) ne sont inclus que lorsqu'une valeur est définie.
+   Un ``virtualHost`` vide n'est pas inclus dans la réponse.
 
-Obtention d'une requete associee
+Obtention d'une requête associée
 =================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/relatedquery/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -133,10 +133,10 @@ Reponse
       }
     }
 
-Creation d'une requete associee
+Création d'une requête associée
 ================================
 
-Requete
+Requête
 -------
 
 ::
@@ -144,7 +144,7 @@ Requete
     POST /api/admin/relatedquery/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -167,19 +167,19 @@ Description des champs
      - Description
    * - ``term``
      - Oui
-     - Mot-cle de recherche (10 000 caracteres maximum)
+     - Mot-clé de recherche (10 000 caractères maximum)
    * - ``queries``
      - Oui
-     - Requetes associees. Chaine separee par des sauts de ligne, une par ligne (les lignes vides sont ignorees ; 10 000 caracteres maximum)
+     - Requêtes associées. Chaîne séparée par des sauts de ligne, une par ligne (les lignes vides sont ignorées ; 10 000 caractères maximum)
    * - ``virtualHost``
      - Non
-     - Hote virtuel (1 000 caracteres maximum)
+     - Hôte virtuel (1 000 caractères maximum)
 
 .. note::
 
-   ``crudMode`` etant defini automatiquement cote API, il n'est pas necessaire de l'inclure dans le corps de la requete.
+   ``crudMode`` étant défini automatiquement côté API, il n'est pas nécessaire de l'inclure dans le corps de la requête.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -193,10 +193,10 @@ Reponse
       }
     }
 
-Mise a jour d'une requete associee
+Mise à jour d'une requête associée
 ===================================
 
-Requete
+Requête
 -------
 
 ::
@@ -204,7 +204,7 @@ Requete
     PUT /api/admin/relatedquery/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -229,21 +229,21 @@ Description des champs
      - Description
    * - ``id``
      - Oui
-     - ID de la requete associee a mettre a jour (1 000 caracteres maximum)
+     - ID de la requête associée à mettre à jour (1 000 caractères maximum)
    * - ``term``
      - Oui
-     - Mot-cle de recherche (10 000 caracteres maximum)
+     - Mot-clé de recherche (10 000 caractères maximum)
    * - ``queries``
      - Oui
-     - Requetes associees. Chaine separee par des sauts de ligne, une par ligne (les lignes vides sont ignorees ; 10 000 caracteres maximum)
+     - Requêtes associées. Chaîne séparée par des sauts de ligne, une par ligne (les lignes vides sont ignorées ; 10 000 caractères maximum)
    * - ``virtualHost``
      - Non
-     - Hote virtuel (1 000 caracteres maximum)
+     - Hôte virtuel (1 000 caractères maximum)
    * - ``versionNo``
      - Oui
-     - Numero de version utilise pour le verrouillage optimiste. Specifiez la valeur incluse dans la reponse lors de l'obtention du parametre
+     - Numéro de version utilisé pour le verrouillage optimiste. Spécifiez la valeur incluse dans la réponse lors de l'obtention du paramètre
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -257,17 +257,17 @@ Reponse
       }
     }
 
-Suppression d'une requete associee
+Suppression d'une requête associée
 ====================================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/relatedquery/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -279,11 +279,11 @@ Reponse
       }
     }
 
-Reponse d'erreur
+Réponse d'erreur
 ================
 
-En cas d'echec de la requete, ``status`` est defini sur une valeur differente de 0 et
-``message`` contient le detail de l'erreur. Par exemple, pour une erreur de validation
+En cas d'échec de la requête, ``status`` est défini sur une valeur différente de 0 et
+``message`` contient le détail de l'erreur. Par exemple, pour une erreur de validation
 telle qu'un champ obligatoire manquant, ``status`` vaut ``1``. Pour la liste des codes
 de statut, consultez :doc:`api-admin-overview`.
 
@@ -300,7 +300,7 @@ de statut, consultez :doc:`api-admin-overview`.
 Exemples d'utilisation
 ======================
 
-Requetes associees pour les produits
+Requêtes associées pour les produits
 -------------------------------------
 
 .. code-block:: bash
@@ -313,7 +313,7 @@ Requetes associees pour les produits
            "queries": "product features\nproduct pricing\nproduct comparison\nproduct reviews"
          }'
 
-Requetes associees pour l'aide
+Requêtes associées pour l'aide
 -------------------------------
 
 .. code-block:: bash
@@ -326,10 +326,10 @@ Requetes associees pour l'aide
            "queries": "help center\nhelp documentation\nhelp contact support"
          }'
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
-- :doc:`api-admin-relatedcontent` - API des contenus associes
+- :doc:`api-admin-relatedcontent` - API des contenus associés
 - :doc:`api-admin-suggest` - API de gestion des suggestions
-- :doc:`../../admin/relatedquery-guide` - Guide de gestion des requetes associees
+- :doc:`../../admin/relatedquery-guide` - Guide de gestion des requêtes associées

--- a/fr/15.7/api/admin/api-admin-role.rst
+++ b/fr/15.7/api/admin/api-admin-role.rst
@@ -5,8 +5,8 @@ API Role
 Vue d'ensemble
 ==============
 
-L'API Role permet de gerer les roles de |Fess|.
-Vous pouvez creer, mettre a jour et supprimer des roles.
+L'API Role permet de gérer les rôles de |Fess|.
+Vous pouvez créer, mettre à jour et supprimer des rôles.
 
 URL de base
 ===========
@@ -22,60 +22,60 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /settings
-     - Obtention de la liste des roles
+     - Obtention de la liste des rôles
    * - GET
      - /setting/{id}
-     - Obtention d'un role
+     - Obtention d'un rôle
    * - POST
      - /setting
-     - Creation d'un role
+     - Création d'un rôle
    * - PUT
      - /setting
-     - Mise a jour d'un role
+     - Mise à jour d'un rôle
    * - DELETE
      - /setting/{id}
-     - Suppression d'un role
+     - Suppression d'un rôle
 
-Obtention de la liste des roles
+Obtention de la liste des rôles
 ================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/role/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 25. Modifiable via la propriete ``paging.page.size`` dans ``fess_config.properties``)
+     - Nombre d'éléments par page (par défaut : 25. Modifiable via la propriété ``paging.page.size`` dans ``fess_config.properties``)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1, par defaut : 1. Les valeurs de 0 ou moins sont traitees comme 1)
+     - Numéro de page (commence à 1, par défaut : 1. Les valeurs de 0 ou moins sont traitées comme 1)
    * - ``id``
      - String
      - Non
-     - Filtre par correspondance exacte sur l'ID de role specifie
+     - Filtre par correspondance exacte sur l'ID de rôle spécifié
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -99,17 +99,17 @@ Reponse
       }
     }
 
-Obtention d'un role
+Obtention d'un rôle
 ===================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/role/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -125,10 +125,10 @@ Reponse
       }
     }
 
-Creation d'un role
+Création d'un rôle
 ==================
 
-Requete
+Requête
 -------
 
 ::
@@ -136,7 +136,7 @@ Requete
     POST /api/admin/role/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -157,12 +157,12 @@ Description des champs
      - Description
    * - ``name``
      - Oui
-     - Nom du role (maximum 100 caracteres)
+     - Nom du rôle (maximum 100 caractères)
    * - ``attributes``
      - Non
-     - Map d'attributs. Les valeurs sont specifiees sous forme de chaines de caracteres
+     - Map d'attributs. Les valeurs sont spécifiées sous forme de chaînes de caractères
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -175,10 +175,10 @@ Reponse
       }
     }
 
-Mise a jour d'un role
+Mise à jour d'un rôle
 =====================
 
-Requete
+Requête
 -------
 
 ::
@@ -186,7 +186,7 @@ Requete
     PUT /api/admin/role/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -209,18 +209,18 @@ Description des champs
      - Description
    * - ``id``
      - Oui
-     - ID du role a mettre a jour
+     - ID du rôle à mettre à jour
    * - ``name``
      - Oui
-     - Nom du role (maximum 100 caracteres)
+     - Nom du rôle (maximum 100 caractères)
    * - ``attributes``
      - Non
-     - Map d'attributs. Les valeurs sont specifiees sous forme de chaines de caracteres
+     - Map d'attributs. Les valeurs sont spécifiées sous forme de chaînes de caractères
    * - ``versionNo``
      - Oui
-     - Numero de version pour le verrouillage optimiste. Specifiez la valeur de ``versionNo`` obtenue lors de l'obtention du role
+     - Numéro de version pour le verrouillage optimiste. Spécifiez la valeur de ``versionNo`` obtenue lors de l'obtention du rôle
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -233,17 +233,17 @@ Reponse
       }
     }
 
-Suppression d'un role
+Suppression d'un rôle
 =====================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/role/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -259,7 +259,7 @@ Reponse
 Exemples d'utilisation
 ======================
 
-Creation d'un nouveau role
+Création d'un nouveau rôle
 --------------------------
 
 .. code-block:: bash
@@ -271,7 +271,7 @@ Creation d'un nouveau role
            "name": "content_manager"
          }'
 
-Obtention de la liste des roles
+Obtention de la liste des rôles
 --------------------------------
 
 .. code-block:: bash
@@ -279,10 +279,10 @@ Obtention de la liste des roles
     curl -X GET "http://localhost:8080/api/admin/role/settings?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
 - :doc:`api-admin-user` - API de gestion des utilisateurs
 - :doc:`api-admin-group` - API de gestion des groupes
-- :doc:`../../admin/role-guide` - Guide de gestion des roles
+- :doc:`../../admin/role-guide` - Guide de gestion des rôles

--- a/fr/15.7/api/admin/api-admin-scheduler.rst
+++ b/fr/15.7/api/admin/api-admin-scheduler.rst
@@ -5,8 +5,8 @@ API Scheduler
 Vue d'ensemble
 ==============
 
-L'API Scheduler permet de gerer les taches planifiees de |Fess|.
-Vous pouvez demarrer/arreter les taches de crawl, creer/modifier/supprimer des configurations de planification, etc.
+L'API Scheduler permet de gérer les tâches planifiées de |Fess|.
+Vous pouvez démarrer/arrêter les tâches de crawl, créer/modifier/supprimer des configurations de planification, etc.
 
 URL de base
 ===========
@@ -22,62 +22,62 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /settings
-     - Obtention de la liste des taches planifiees
+     - Obtention de la liste des tâches planifiées
    * - GET
      - /setting/{id}
-     - Obtention d'une tache planifiee
+     - Obtention d'une tâche planifiée
    * - POST
      - /setting
-     - Creation d'une tache planifiee
+     - Création d'une tâche planifiée
    * - PUT
      - /setting
-     - Mise a jour d'une tache planifiee
+     - Mise à jour d'une tâche planifiée
    * - DELETE
      - /setting/{id}
-     - Suppression d'une tache planifiee
+     - Suppression d'une tâche planifiée
    * - PUT
      - /{id}/start
-     - Demarrage d'une tache
+     - Démarrage d'une tâche
    * - PUT
      - /{id}/stop
-     - Arret d'une tache
+     - Arrêt d'une tâche
 
-Obtention de la liste des taches planifiees
+Obtention de la liste des tâches planifiées
 ===========================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/scheduler/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (defaut : 25 ; configurable via ``paging.page.size`` dans ``fess_config.properties``)
+     - Nombre d'éléments par page (défaut : 25 ; configurable via ``paging.page.size`` dans ``fess_config.properties``)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (base 1 ; defaut : 1)
+     - Numéro de page (base 1 ; défaut : 1)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -108,23 +108,23 @@ Reponse
 
 .. note::
 
-   L'objet ``response`` contient toujours ``version`` (version du produit) et ``status`` (code de resultat). Consultez :doc:`api-admin-overview` pour le format de reponse commun. Les exemples suivants peuvent omettre ``version`` par souci de concision.
+   L'objet ``response`` contient toujours ``version`` (version du produit) et ``status`` (code de résultat). Consultez :doc:`api-admin-overview` pour le format de réponse commun. Les exemples suivants peuvent omettre ``version`` par souci de concision.
 
 .. note::
 
-   Dans les reponses, ``jobLogging`` / ``crawler`` / ``available`` sont retournes sous forme de chaines de caracteres (``"true"`` / ``"false"``). ``running`` est un champ booleen, specifique aux reponses, indiquant si la tache est en cours d'execution (ne peut pas etre specifie dans les requetes). ``total`` est le nombre total de taches correspondant a la requete.
+   Dans les réponses, ``jobLogging`` / ``crawler`` / ``available`` sont retournés sous forme de chaînes de caractères (``"true"`` / ``"false"``). ``running`` est un champ booléen, spécifique aux réponses, indiquant si la tâche est en cours d'exécution (ne peut pas être spécifié dans les requêtes). ``total`` est le nombre total de tâches correspondant à la requête.
 
-Obtention d'une tache planifiee
+Obtention d'une tâche planifiée
 ===============================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/scheduler/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -149,10 +149,10 @@ Reponse
       }
     }
 
-Creation d'une tache planifiee
+Création d'une tâche planifiée
 ==============================
 
-Requete
+Requête
 -------
 
 ::
@@ -160,7 +160,7 @@ Requete
     POST /api/admin/scheduler/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -189,41 +189,41 @@ Description des champs
      - Description
    * - ``name``
      - Oui
-     - Nom de la tache (max 100 caracteres)
+     - Nom de la tâche (max 100 caractères)
    * - ``target``
      - Oui
-     - Cible d'execution (max 100 caracteres). Specifier ``all`` ou un nom de cible specifique
+     - Cible d'exécution (max 100 caractères). Spécifier ``all`` ou un nom de cible spécifique
    * - ``cronExpression``
      - Non
-     - Expression Cron (seconde minute heure jour mois jour-semaine). Max 100 caracteres, validee en tant qu'expression cron. Si vide, la tache n'est pas planifiee et ne peut etre demarree que manuellement
+     - Expression Cron (seconde minute heure jour mois jour-semaine). Max 100 caractères, validée en tant qu'expression cron. Si vide, la tâche n'est pas planifiée et ne peut être démarrée que manuellement
    * - ``scriptType``
      - Oui
-     - Type de script (max 100 caracteres). Actuellement seul ``groovy`` est supporte
+     - Type de script (max 100 caractères). Actuellement seul ``groovy`` est supporté
    * - ``scriptData``
      - Non
-     - Script a executer. La taille maximale est definie par ``form.admin.max.input.size`` dans ``fess_config.properties``
+     - Script à exécuter. La taille maximale est définie par ``form.admin.max.input.size`` dans ``fess_config.properties``
    * - ``jobLogging``
      - Non
-     - Activer la journalisation des taches (chaine)
+     - Activer la journalisation des tâches (chaîne)
    * - ``crawler``
      - Non
-     - S'il s'agit d'une tache de crawl (chaine)
+     - S'il s'agit d'une tâche de crawl (chaîne)
    * - ``available``
      - Non
-     - Active/Desactive (chaine)
+     - Activé/Désactivé (chaîne)
    * - ``sortOrder``
      - Oui
      - Ordre d'affichage (entier entre 0 et 2147483647)
 
 .. note::
 
-   ``jobLogging`` / ``crawler`` / ``available`` sont des champs de type chaine. Dans les requetes, specifier ``"on"`` ou ``"true"`` (insensible a la casse) les active ; toute autre valeur (``"false"``, chaine vide ou non specifie) est traitee comme desactivee. Dans les reponses, ils sont retournes sous la forme ``"true"`` / ``"false"``.
+   ``jobLogging`` / ``crawler`` / ``available`` sont des champs de type chaîne. Dans les requêtes, spécifier ``"on"`` ou ``"true"`` (insensible à la casse) les active ; toute autre valeur (``"false"``, chaîne vide ou non spécifié) est traitée comme désactivée. Dans les réponses, ils sont retournés sous la forme ``"true"`` / ``"false"``.
 
 .. note::
 
-   ``crudMode`` est defini automatiquement cote serveur et n'a pas besoin d'etre specifie dans les requetes. Les champs d'audit tels que ``createdBy`` / ``createdTime`` sont egalement definis cote serveur.
+   ``crudMode`` est défini automatiquement côté serveur et n'a pas besoin d'être spécifié dans les requêtes. Les champs d'audit tels que ``createdBy`` / ``createdTime`` sont également définis côté serveur.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -246,18 +246,18 @@ Exemples d'expressions Cron
    * - Expression Cron
      - Description
    * - ``0 0 2 * * ?``
-     - Execution tous les jours a 2h du matin
+     - Exécution tous les jours à 2h du matin
    * - ``0 0 0/6 * * ?``
-     - Execution toutes les 6 heures
+     - Exécution toutes les 6 heures
    * - ``0 0 2 * * MON``
-     - Execution tous les lundis a 2h du matin
+     - Exécution tous les lundis à 2h du matin
    * - ``0 0 2 1 * ?``
-     - Execution le 1er de chaque mois a 2h du matin
+     - Exécution le 1er de chaque mois à 2h du matin
 
-Mise a jour d'une tache planifiee
+Mise à jour d'une tâche planifiée
 =================================
 
-Requete
+Requête
 -------
 
 ::
@@ -265,7 +265,7 @@ Requete
     PUT /api/admin/scheduler/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -286,9 +286,9 @@ Corps de la requete
 
 .. note::
 
-   Pour les mises a jour, ``id`` (max 1000 caracteres) et ``versionNo`` sont obligatoires. ``versionNo`` est utilise pour le verrouillage optimiste ; specifier la valeur retournee dans la reponse de recuperation. Si la valeur ne correspond pas, la mise a jour echoue. Les autres champs obligatoires (``name`` / ``target`` / ``scriptType`` / ``sortOrder``) sont identiques a ceux de la creation.
+   Pour les mises à jour, ``id`` (max 1000 caractères) et ``versionNo`` sont obligatoires. ``versionNo`` est utilisé pour le verrouillage optimiste ; spécifier la valeur retournée dans la réponse de récupération. Si la valeur ne correspond pas, la mise à jour échoue. Les autres champs obligatoires (``name`` / ``target`` / ``scriptType`` / ``sortOrder``) sont identiques à ceux de la création.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -301,17 +301,17 @@ Reponse
       }
     }
 
-Suppression d'une tache planifiee
+Suppression d'une tâche planifiée
 =================================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/scheduler/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -324,19 +324,19 @@ Reponse
       }
     }
 
-Demarrage d'une tache
+Démarrage d'une tâche
 =====================
 
-Execute immediatement une tache planifiee.
+Exécute immédiatement une tâche planifiée.
 
-Requete
+Requête
 -------
 
 ::
 
     PUT /api/admin/scheduler/{id}/start
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -348,7 +348,7 @@ Reponse
       }
     }
 
-Champs de la reponse
+Champs de la réponse
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -358,28 +358,28 @@ Champs de la reponse
    * - Champ
      - Description
    * - ``jobLogId``
-     - ID du journal de la tache demarree. Emis lorsque la journalisation des taches est activee. Vaut ``null`` lorsque la journalisation des taches est desactivee.
+     - ID du journal de la tâche démarrée. Émis lorsque la journalisation des tâches est activée. Vaut ``null`` lorsque la journalisation des tâches est désactivée.
 
 Notes
 -----
 
-- Si la tache est deja en cours d'execution, le demarrage echoue et une erreur est retournee (``status`` different de ``0``).
-- Si la tache est desactivee (``available`` n'est pas active), le demarrage echoue egalement avec une erreur.
-- ``jobLogId`` est emis uniquement lorsque la journalisation des taches est activee (``jobLogging`` est active).
+- Si la tâche est déjà en cours d'exécution, le démarrage échoue et une erreur est retournée (``status`` différent de ``0``).
+- Si la tâche est désactivée (``available`` n'est pas activé), le démarrage échoue également avec une erreur.
+- ``jobLogId`` est émis uniquement lorsque la journalisation des tâches est activée (``jobLogging`` est activé).
 
-Arret d'une tache
+Arrêt d'une tâche
 =================
 
-Arrete une tache en cours d'execution.
+Arrête une tâche en cours d'exécution.
 
-Requete
+Requête
 -------
 
 ::
 
     PUT /api/admin/scheduler/{id}/stop
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -393,12 +393,12 @@ Reponse
 Exemples d'utilisation
 ======================
 
-Creation et execution d'une tache de crawl
+Création et exécution d'une tâche de crawl
 ------------------------------------------
 
 .. code-block:: bash
 
-    # Creer la tache
+    # Créer la tâche
     curl -X POST "http://localhost:8080/api/admin/scheduler/setting" \
          -H "Authorization: Bearer YOUR_TOKEN" \
          -H "Content-Type: application/json" \
@@ -414,24 +414,24 @@ Creation et execution d'une tache de crawl
            "sortOrder": 1
          }'
 
-    # Executer la tache immediatement
+    # Exécuter la tâche immédiatement
     curl -X PUT "http://localhost:8080/api/admin/scheduler/{job_id}/start" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Verification de l'etat des taches
+Vérification de l'état des tâches
 ---------------------------------
 
 .. code-block:: bash
 
-    # Verifier l'etat de toutes les taches
+    # Vérifier l'état de toutes les tâches
     curl "http://localhost:8080/api/admin/scheduler/settings" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-    # Le champ running indique si la tache est en cours d'execution
+    # Le champ running indique si la tâche est en cours d'exécution
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
-- :doc:`api-admin-joblog` - API des journaux de taches
+- :doc:`api-admin-joblog` - API des journaux de tâches
 - :doc:`../../admin/scheduler-guide` - Guide de gestion du planificateur

--- a/fr/15.7/api/admin/api-admin-searchlist.rst
+++ b/fr/15.7/api/admin/api-admin-searchlist.rst
@@ -5,10 +5,10 @@ SearchList API
 Vue d'ensemble
 ==============
 
-L'API SearchList est une API d'administration de |Fess| permettant de rechercher et de gerer les documents dans l'index.
-Elle permet de rechercher, obtenir, creer, mettre a jour et supprimer des documents.
+L'API SearchList est une API d'administration de |Fess| permettant de rechercher et de gérer les documents dans l'index.
+Elle permet de rechercher, obtenir, créer, mettre à jour et supprimer des documents.
 
-Tous les noms de champs dans la reponse sont en ``snake_case``. Les champs dont la valeur est ``null`` sont omis de la reponse.
+Tous les noms de champs dans la réponse sont en ``snake_case``. Les champs dont la valeur est ``null`` sont omis de la réponse.
 
 URL de base
 ===========
@@ -20,9 +20,9 @@ URL de base
 Authentification
 ================
 
-Pour appeler cette API, une authentification par jeton d'acces est requise, comme explique dans :doc:`api-admin-overview`.
-Le jeton doit disposer des permissions d'acces a l'API d'administration (par defaut ``Radmin-api``).
-Cette permission peut etre modifiee via la cle de configuration ``api.admin.access.permissions``.
+Pour appeler cette API, une authentification par jeton d'accès est requise, comme expliqué dans :doc:`api-admin-overview`.
+Le jeton doit disposer des permissions d'accès à l'API d'administration (par défaut ``Radmin-api``).
+Cette permission peut être modifiée via la clé de configuration ``api.admin.access.permissions``.
 
 Liste des endpoints
 ===================
@@ -31,7 +31,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET / PUT
@@ -42,23 +42,23 @@ Liste des endpoints
      - Obtention d'un document
    * - POST
      - /doc
-     - Creation d'un document
+     - Création d'un document
    * - PUT
      - /doc
-     - Mise a jour d'un document
+     - Mise à jour d'un document
    * - DELETE
      - /doc/{id}
      - Suppression d'un document (par ID)
    * - DELETE
      - /query
-     - Suppression de documents (par requete)
+     - Suppression de documents (par requête)
 
 Recherche de documents
 ======================
 
-Recherche les documents correspondant aux criteres de recherche.
+Recherche les documents correspondant aux critères de recherche.
 
-Requete
+Requête
 -------
 
 ::
@@ -66,21 +66,21 @@ Requete
     GET /api/admin/searchlist/docs
     PUT /api/admin/searchlist/docs
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``q``
      - String
      - Non
-     - Requete de recherche (1000 caracteres maximum). Si elle n'est pas specifiee, tous les documents sont concernes.
+     - Requête de recherche (1000 caractères maximum). Si elle n'est pas spécifiée, tous les documents sont concernés.
    * - ``sort``
      - String
      - Non
@@ -88,39 +88,39 @@ Parametres
    * - ``start``
      - Integer
      - Non
-     - Position de depart a base zero (par defaut ``0``).
+     - Position de départ à base zéro (par défaut ``0``).
    * - ``offset``
      - Integer
      - Non
-     - Decalage depuis ``start`` (par defaut ``0``).
+     - Décalage depuis ``start`` (par défaut ``0``).
    * - ``pn``
      - Integer
      - Non
-     - Numero de page.
+     - Numéro de page.
    * - ``num``
      - Integer
      - Non
-     - Nombre d'elements a obtenir (par defaut ``10``). Les valeurs depassant le maximum configure (par defaut ``100``) ou les valeurs inferieures ou egales a ``0`` sont ramenees au maximum.
+     - Nombre d'éléments à obtenir (par défaut ``10``). Les valeurs dépassant le maximum configuré (par défaut ``100``) ou les valeurs inférieures ou égales à ``0`` sont ramenées au maximum.
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements a obtenir (alias de ``num``, fourni pour compatibilite avec les autres API d'administration).
+     - Nombre d'éléments à obtenir (alias de ``num``, fourni pour compatibilité avec les autres API d'administration).
    * - ``lang``
      - String[]
      - Non
-     - Langue de recherche. Peut etre specifie plusieurs fois (tableau). Ex. ``en``.
+     - Langue de recherche. Peut être spécifié plusieurs fois (tableau). Ex. ``en``.
    * - ``ex_q``
      - String[]
      - Non
-     - Expressions de requete supplementaires. Peut etre specifie plusieurs fois (tableau).
+     - Expressions de requête supplémentaires. Peut être spécifié plusieurs fois (tableau).
    * - ``fields.<name>``
      - String[]
      - Non
-     - Filtre par valeur de champ. Le cas le plus courant est ``fields.label`` (filtre par nom d'etiquette) ; tout ``fields.<name>`` restreint les resultats aux documents dont le champ ``<name>`` correspond a la valeur donnee. Peut etre specifie plusieurs fois.
+     - Filtre par valeur de champ. Le cas le plus courant est ``fields.label`` (filtre par nom d'étiquette) ; tout ``fields.<name>`` restreint les résultats aux documents dont le champ ``<name>`` correspond à la valeur donnée. Peut être spécifié plusieurs fois.
    * - ``as.<name>``
      - String[]
      - Non
-     - Conditions de recherche avancee. Tout ``as.<name>`` (ex. ``as.q``) est transmis au generateur de conditions de recherche avancee. Peut etre specifie plusieurs fois par nom.
+     - Conditions de recherche avancée. Tout ``as.<name>`` (ex. ``as.q``) est transmis au générateur de conditions de recherche avancée. Peut être spécifié plusieurs fois par nom.
    * - ``sdh``
      - String
      - Non
@@ -128,9 +128,9 @@ Parametres
 
 .. note::
 
-   Cet endpoint ne prend pas en charge les facettes, la mise en evidence ou la recherche geographique. Ces parametres sont ignores s'ils sont specifies.
+   Cet endpoint ne prend pas en charge les facettes, la mise en évidence ou la recherche géographique. Ces paramètres sont ignorés s'ils sont spécifiés.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -166,7 +166,7 @@ Reponse
       }
     }
 
-Champs de la reponse
+Champs de la réponse
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -176,75 +176,75 @@ Champs de la reponse
    * - Champ
      - Description
    * - ``version``
-     - Version de |Fess| en cours d'execution (la valeur d'exemple est indicative).
+     - Version de |Fess| en cours d'exécution (la valeur d'exemple est indicative).
    * - ``status``
-     - Code de statut (``0`` en cas de succes ; voir "Codes de statut").
+     - Code de statut (``0`` en cas de succès ; voir "Codes de statut").
    * - ``query_id``
-     - ID de la requete de recherche.
+     - ID de la requête de recherche.
    * - ``docs``
-     - Tableau des documents resultats de la recherche. Chaque document est une carte de noms de champs et de valeurs, utilisant les noms de champs de l'index tels quels (``doc_id``, ``url``, ``title``, ``content_description``, etc.).
+     - Tableau des documents résultats de la recherche. Chaque document est une carte de noms de champs et de valeurs, utilisant les noms de champs de l'index tels quels (``doc_id``, ``url``, ``title``, ``content_description``, etc.).
    * - ``exec_time``
-     - Temps d'execution de la recherche (secondes, chaine de caracteres).
+     - Temps d'exécution de la recherche (secondes, chaîne de caractères).
    * - ``query_time``
-     - Temps de requete du moteur de recherche (millisecondes).
+     - Temps de requête du moteur de recherche (millisecondes).
    * - ``page_size``
-     - Nombre d'elements par page.
+     - Nombre d'éléments par page.
    * - ``page_number``
-     - Numero de la page courante.
+     - Numéro de la page courante.
    * - ``record_count``
-     - Nombre d'elements correspondants.
+     - Nombre d'éléments correspondants.
    * - ``record_count_relation``
-     - Relation du nombre d'elements correspondants. ``eq`` indique un comptage exact, ``gte`` indique que seule la borne inferieure est connue.
+     - Relation du nombre d'éléments correspondants. ``eq`` indique un comptage exact, ``gte`` indique que seule la borne inférieure est connue.
    * - ``page_count``
      - Nombre total de pages.
    * - ``next_page``
      - Indique s'il existe une page suivante (bool).
    * - ``prev_page``
-     - Indique s'il existe une page precedente (bool).
+     - Indique s'il existe une page précédente (bool).
    * - ``start_record_number``
-     - Numero du premier enregistrement de cette page.
+     - Numéro du premier enregistrement de cette page.
    * - ``end_record_number``
-     - Numero du dernier enregistrement de cette page.
+     - Numéro du dernier enregistrement de cette page.
    * - ``page_numbers``
-     - Tableau des numeros de page a afficher dans le paginateur (chaines de caracteres).
+     - Tableau des numéros de page à afficher dans le paginateur (chaînes de caractères).
    * - ``partial``
-     - Indique si les resultats sont partiels (bool).
+     - Indique si les résultats sont partiels (bool).
    * - ``search_query``
-     - Requete de recherche reellement executee.
+     - Requête de recherche réellement exécutée.
    * - ``requested_time``
-     - Horodatage de la requete (epoch en millisecondes).
+     - Horodatage de la requête (epoch en millisecondes).
    * - ``highlight_params``
-     - Chaine de parametres de requete pour la mise en evidence (generalement vide pour cette API d'administration).
+     - Chaîne de paramètres de requête pour la mise en évidence (généralement vide pour cette API d'administration).
 
 Obtention d'un document
 =======================
 
-Obtient un seul document en specifiant son ID de document.
+Obtient un seul document en spécifiant son ID de document.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/searchlist/doc/{id}
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``id``
      - String
      - Oui
-     - ID du document (valeur de ``doc_id``, parametre de chemin).
+     - ID du document (valeur de ``doc_id``, paramètre de chemin).
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -261,14 +261,14 @@ Reponse
       }
     }
 
-Si aucun document n'existe pour l'ID specifie, une reponse d'erreur (``status`` = ``1``) est retournee.
+Si aucun document n'existe pour l'ID spécifié, une réponse d'erreur (``status`` = ``1``) est retournée.
 
-Creation d'un document
+Création d'un document
 ======================
 
-Cree un nouveau document dans l'index.
+Crée un nouveau document dans l'index.
 
-Requete
+Requête
 -------
 
 ::
@@ -276,7 +276,7 @@ Requete
     POST /api/admin/searchlist/doc
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -303,20 +303,20 @@ Description des champs
      - Description
    * - ``doc``
      - Oui
-     - Document a enregistrer. Specifie sous forme de carte de noms de champs d'index et de valeurs.
+     - Document à enregistrer. Spécifié sous forme de carte de noms de champs d'index et de valeurs.
 
-Parmi les champs specifies dans ``doc``, tous les champs obligatoires configures dans ``index.admin.required.fields`` (par defaut ``url,title,role,boost``) doivent etre fournis.
-Contrairement a l'API :doc:`Documents API <api-admin-documents>` par lot, cet endpoint ne complete pas automatiquement les valeurs par defaut telles que ``role`` ou ``boost``, de sorte que les champs obligatoires doivent etre specifies explicitement dans la requete.
-``doc_id`` est genere automatiquement cote serveur et n'est pas specifie lors de la creation.
+Parmi les champs spécifiés dans ``doc``, tous les champs obligatoires configurés dans ``index.admin.required.fields`` (par défaut ``url,title,role,boost``) doivent être fournis.
+Contrairement à l'API :doc:`Documents API <api-admin-documents>` par lot, cet endpoint ne complète pas automatiquement les valeurs par défaut telles que ``role`` ou ``boost``, de sorte que les champs obligatoires doivent être spécifiés explicitement dans la requête.
+``doc_id`` est généré automatiquement côté serveur et n'est pas spécifié lors de la création.
 
-La valeur de chaque champ est validee en fonction de la configuration du type de champ. Si le type ne correspond pas, une erreur (``status`` = ``1``) est retournee.
+La valeur de chaque champ est validée en fonction de la configuration du type de champ. Si le type ne correspond pas, une erreur (``status`` = ``1``) est retournée.
 
 .. list-table::
    :header-rows: 1
    :widths: 40 60
 
-   * - Cle de configuration
-     - Valeur par defaut
+   * - Clé de configuration
+     - Valeur par défaut
    * - ``index.admin.array.fields``
      - ``lang,role,label,anchor,virtual_host``
    * - ``index.admin.date.fields``
@@ -330,7 +330,7 @@ La valeur de chaque champ est validee en fonction de la configuration du type de
    * - ``index.admin.double.fields``
      - (vide)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -351,16 +351,16 @@ Reponse
    * - Champ
      - Description
    * - ``id``
-     - Le ``doc_id`` du document enregistre.
+     - Le ``doc_id`` du document enregistré.
    * - ``created``
-     - ``true`` lors de la creation.
+     - ``true`` lors de la création.
 
-Mise a jour d'un document
+Mise à jour d'un document
 =========================
 
-Met a jour un document existant.
+Met à jour un document existant.
 
-Requete
+Requête
 -------
 
 ::
@@ -368,7 +368,7 @@ Requete
     PUT /api/admin/searchlist/doc
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -396,12 +396,12 @@ Description des champs
      - Description
    * - ``doc``
      - Oui
-     - Document a mettre a jour. Specifie sous forme de carte de noms de champs d'index et de valeurs.
+     - Document à mettre à jour. Spécifié sous forme de carte de noms de champs d'index et de valeurs.
 
-Le document a mettre a jour est identifie par ``doc_id`` dans ``doc``. Si ``doc_id`` n'est pas specifie, ou si aucun document correspondant n'existe, une erreur (``status`` = ``1``) est retournee.
-Comme pour la creation, tous les champs obligatoires configures dans ``index.admin.required.fields`` (par defaut ``url,title,role,boost``) doivent etre fournis, et la valeur de chaque champ est validee en fonction de la configuration du type.
+Le document à mettre à jour est identifié par ``doc_id`` dans ``doc``. Si ``doc_id`` n'est pas spécifié, ou si aucun document correspondant n'existe, une erreur (``status`` = ``1``) est retournée.
+Comme pour la création, tous les champs obligatoires configurés dans ``index.admin.required.fields`` (par défaut ``url,title,role,boost``) doivent être fournis, et la valeur de chaque champ est validée en fonction de la configuration du type.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -422,39 +422,39 @@ Reponse
    * - Champ
      - Description
    * - ``id``
-     - Le ``doc_id`` du document mis a jour.
+     - Le ``doc_id`` du document mis à jour.
    * - ``created``
-     - ``false`` lors de la mise a jour.
+     - ``false`` lors de la mise à jour.
 
 Suppression d'un document (par ID)
 ===================================
 
-Supprime un document en specifiant son ID de document.
+Supprime un document en spécifiant son ID de document.
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/searchlist/doc/{id}
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``id``
      - String
      - Oui
-     - ID du document (valeur de ``doc_id``, parametre de chemin).
+     - ID du document (valeur de ``doc_id``, paramètre de chemin).
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -466,40 +466,40 @@ Reponse
       }
     }
 
-Suppression de documents (par requete)
+Suppression de documents (par requête)
 =======================================
 
-Supprime en masse les documents correspondant a une requete de recherche.
+Supprime en masse les documents correspondant à une requête de recherche.
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/searchlist/query
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``q``
      - String
      - Oui
-     - Requete de recherche des documents a supprimer.
+     - Requête de recherche des documents à supprimer.
 
-La cible de suppression est construite avec la meme requete que "Recherche de documents", de sorte que les parametres de filtrage tels que ``fields.<name>`` et ``ex_q`` peuvent etre utilises conjointement. Si ``q`` n'est pas specifie, une erreur (``status`` = ``1``) est retournee.
+La cible de suppression est construite avec la même requête que "Recherche de documents", de sorte que les paramètres de filtrage tels que ``fields.<name>`` et ``ex_q`` peuvent être utilisés conjointement. Si ``q`` n'est pas spécifié, une erreur (``status`` = ``1``) est retournée.
 
-Reponse
+Réponse
 -------
 
-Retourne le nombre de documents supprimes dans ``count``.
+Retourne le nombre de documents supprimés dans ``count``.
 
 .. code-block:: json
 
@@ -514,7 +514,7 @@ Retourne le nombre de documents supprimes dans ``count``.
 Codes de statut
 ===============
 
-Le champ ``status`` dans la reponse prend l'une des valeurs suivantes.
+Le champ ``status`` dans la réponse prend l'une des valeurs suivantes.
 
 .. list-table::
    :header-rows: 1
@@ -525,19 +525,19 @@ Le champ ``status`` dans la reponse prend l'une des valeurs suivantes.
      - Description
    * - ``0``
      - OK
-     - Succes.
+     - Succès.
    * - ``1``
      - BAD_REQUEST
-     - La requete est invalide (champ obligatoire manquant, type incorrect, document cible introuvable, requete invalide, etc.).
+     - La requête est invalide (champ obligatoire manquant, type incorrect, document cible introuvable, requête invalide, etc.).
    * - ``2``
      - SYSTEM_ERROR
-     - Erreur systeme.
+     - Erreur système.
    * - ``3``
      - UNAUTHORIZED
      - Erreur d'authentification.
    * - ``9``
      - FAILED
-     - Le traitement a echoue.
+     - Le traitement a échoué.
 
 Exemples d'utilisation
 ======================
@@ -558,7 +558,7 @@ Obtention d'un document
     curl -X GET "http://localhost:8080/api/admin/searchlist/doc/abcdef0123456789" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Creation d'un document
+Création d'un document
 ----------------------
 
 .. code-block:: bash
@@ -576,7 +576,7 @@ Creation d'un document
            }
          }'
 
-Suppression de documents par requete
+Suppression de documents par requête
 -------------------------------------
 
 .. code-block:: bash
@@ -584,7 +584,7 @@ Suppression de documents par requete
     curl -X DELETE "http://localhost:8080/api/admin/searchlist/query?q=url:example.com" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informations complementaires
+Informations complémentaires
 =============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.7/api/admin/api-admin-stats.rst
+++ b/fr/15.7/api/admin/api-admin-stats.rst
@@ -5,12 +5,12 @@ API Stats
 Vue d'ensemble
 ==============
 
-L'API Stats est une API permettant d'obtenir les metriques systeme du serveur sur lequel |Fess| s'execute.
-Elle permet de consulter les statistiques de la JVM, du systeme d'exploitation, du processus, du cluster du moteur de recherche (OpenSearch) et du systeme de fichiers.
+L'API Stats est une API permettant d'obtenir les métriques système du serveur sur lequel |Fess| s'exécute.
+Elle permet de consulter les statistiques de la JVM, du système d'exploitation, du processus, du cluster du moteur de recherche (OpenSearch) et du système de fichiers.
 
 .. note::
 
-   Cette API ne retourne pas de donnees d'analyse de recherche telles que les requetes de recherche ou les clics.
+   Cette API ne retourne pas de données d'analyse de recherche telles que les requêtes de recherche ou les clics.
    Pour la recherche et la gestion des documents dans l'index, consultez :doc:`api-admin-searchlist`.
 
 URL de base
@@ -20,8 +20,8 @@ URL de base
 
     /api/admin/stats
 
-L'acces a cette API necessite un jeton d'acces disposant de la permission ``Radmin-api``.
-Pour plus de details sur l'authentification, consultez :doc:`api-admin-overview`.
+L'accès à cette API nécessite un jeton d'accès disposant de la permission ``Radmin-api``.
+Pour plus de détails sur l'authentification, consultez :doc:`api-admin-overview`.
 
 Liste des endpoints
 ===================
@@ -30,36 +30,36 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /
-     - Obtention des statistiques systeme
+     - Obtention des statistiques système
 
-Obtention des statistiques systeme
+Obtention des statistiques système
 ===================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/stats
 
-Cet endpoint n'accepte pas de parametres de requete.
+Cet endpoint n'accepte pas de paramètres de requête.
 
-Reponse
+Réponse
 -------
 
-La reponse contient ``version`` indiquant la version du produit, ``status`` indiquant
-le resultat du traitement, et un objet ``stats`` contenant les metriques systeme.
-``stats`` possede cinq cles : ``jvm`` / ``os`` / ``process`` / ``engine`` / ``fs``.
+La réponse contient ``version`` indiquant la version du produit, ``status`` indiquant
+le résultat du traitement, et un objet ``stats`` contenant les métriques système.
+``stats`` possède cinq clés : ``jvm`` / ``os`` / ``process`` / ``engine`` / ``fs``.
 
 .. note::
 
-   Les noms de champs des objets sous ``stats`` sont ecrits en snake_case (mots en minuscules separes par des tirets bas, par exemple ``non_heap``).
-   Les champs dont la valeur est ``null`` sont omis de la reponse.
+   Les noms de champs des objets sous ``stats`` sont écrits en snake_case (mots en minuscules séparés par des tirets bas, par exemple ``non_heap``).
+   Les champs dont la valeur est ``null`` sont omis de la réponse.
 
 .. code-block:: json
 
@@ -135,7 +135,7 @@ le resultat du traitement, et un objet ``stats`` contenant les metriques systeme
       }
     }
 
-Champs de la reponse (niveau superieur)
+Champs de la réponse (niveau supérieur)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -147,9 +147,9 @@ Champs de la reponse (niveau superieur)
    * - ``version``
      - La version du produit |Fess| (par exemple ``15.7.0``).
    * - ``status``
-     - Un code indiquant le resultat du traitement. ``0`` indique un succes.
+     - Un code indiquant le résultat du traitement. ``0`` indique un succès.
    * - ``stats``
-     - Un objet contenant les metriques systeme. Il possede cinq cles : ``jvm`` / ``os`` / ``process`` / ``engine`` / ``fs``.
+     - Un objet contenant les métriques système. Il possède cinq clés : ``jvm`` / ``os`` / ``process`` / ``engine`` / ``fs``.
 
 ``jvm`` : Statistiques JVM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -161,39 +161,39 @@ Champs de la reponse (niveau superieur)
    * - Champ
      - Description
    * - ``memory.heap.used``
-     - Memoire heap utilisee (octets).
+     - Mémoire heap utilisée (octets).
    * - ``memory.heap.committed``
-     - Memoire heap allouee (octets).
+     - Mémoire heap allouée (octets).
    * - ``memory.heap.max``
-     - Memoire heap maximale (octets).
+     - Mémoire heap maximale (octets).
    * - ``memory.heap.percent``
-     - Pourcentage d'utilisation de la memoire heap (%).
+     - Pourcentage d'utilisation de la mémoire heap (%).
    * - ``memory.non_heap.used``
-     - Memoire non-heap utilisee (octets).
+     - Mémoire non-heap utilisée (octets).
    * - ``memory.non_heap.committed``
-     - Memoire non-heap allouee (octets).
+     - Mémoire non-heap allouée (octets).
    * - ``memory.non_heap.max``
-     - Memoire non-heap maximale (octets). Dans l'implementation actuelle, cette valeur n'est pas definie et retourne toujours ``0``.
+     - Mémoire non-heap maximale (octets). Dans l'implémentation actuelle, cette valeur n'est pas définie et retourne toujours ``0``.
    * - ``memory.non_heap.percent``
-     - Pourcentage d'utilisation de la memoire non-heap (%). Dans l'implementation actuelle, cette valeur n'est pas definie et retourne toujours ``0``.
+     - Pourcentage d'utilisation de la mémoire non-heap (%). Dans l'implémentation actuelle, cette valeur n'est pas définie et retourne toujours ``0``.
    * - ``pools``
-     - Tableau des pools de tampons. Chaque element contient ``key`` (nom du pool), ``count`` (nombre de tampons), ``used`` (memoire utilisee, octets) et ``capacity`` (capacite totale, octets).
+     - Tableau des pools de tampons. Chaque élément contient ``key`` (nom du pool), ``count`` (nombre de tampons), ``used`` (mémoire utilisée, octets) et ``capacity`` (capacité totale, octets).
    * - ``gc``
-     - Tableau des ramasse-miettes. Chaque element contient ``key`` (nom du collecteur), ``count`` (nombre de collections) et ``time`` (temps de collection cumule, millisecondes).
+     - Tableau des ramasse-miettes. Chaque élément contient ``key`` (nom du collecteur), ``count`` (nombre de collections) et ``time`` (temps de collection cumulé, millisecondes).
    * - ``threads.count``
      - Nombre actuel de threads.
    * - ``threads.peak``
      - Nombre maximal de threads atteint.
    * - ``classes.loaded``
-     - Nombre de classes actuellement chargees.
+     - Nombre de classes actuellement chargées.
    * - ``classes.total_loaded``
-     - Nombre total de classes chargees depuis le demarrage de la JVM.
+     - Nombre total de classes chargées depuis le démarrage de la JVM.
    * - ``classes.unloaded``
-     - Nombre total de classes dechargees.
+     - Nombre total de classes déchargées.
    * - ``uptime``
-     - Duree de fonctionnement de la JVM (millisecondes).
+     - Durée de fonctionnement de la JVM (millisecondes).
 
-``os`` : Statistiques du systeme d'exploitation
+``os`` : Statistiques du système d'exploitation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -203,17 +203,17 @@ Champs de la reponse (niveau superieur)
    * - Champ
      - Description
    * - ``memory.physical.free``
-     - Memoire physique disponible (octets).
+     - Mémoire physique disponible (octets).
    * - ``memory.physical.total``
-     - Memoire physique totale (octets).
+     - Mémoire physique totale (octets).
    * - ``memory.swap_space.free``
-     - Espace d'echange disponible (octets).
+     - Espace d'échange disponible (octets).
    * - ``memory.swap_space.total``
-     - Espace d'echange total (octets).
+     - Espace d'échange total (octets).
    * - ``cpu.percent``
      - Pourcentage d'utilisation globale du processeur (%).
    * - ``load_averages``
-     - Tableau des charges moyennes (1, 5 et 15 minutes). Les valeurs qui ne peuvent pas etre obtenues peuvent valoir ``-1``.
+     - Tableau des charges moyennes (1, 5 et 15 minutes). Les valeurs qui ne peuvent pas être obtenues peuvent valoir ``-1``.
 
 ``process`` : Statistiques du processus
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -227,24 +227,24 @@ Champs de la reponse (niveau superieur)
    * - ``file_fescriptor.open``
      - Nombre de descripteurs de fichiers actuellement ouverts.
    * - ``file_fescriptor.max``
-     - Nombre maximal de descripteurs de fichiers pouvant etre ouverts.
+     - Nombre maximal de descripteurs de fichiers pouvant être ouverts.
    * - ``cpu.percent``
      - Pourcentage d'utilisation du processeur par le processus (%).
    * - ``cpu.total``
-     - Temps CPU cumule utilise par le processus (millisecondes).
+     - Temps CPU cumulé utilisé par le processus (millisecondes).
    * - ``virtual_memory.total``
-     - Taille totale de la memoire virtuelle du processus (octets).
+     - Taille totale de la mémoire virtuelle du processus (octets).
 
 .. note::
 
-   Le nom de cle ``process.file_fescriptor`` est la conversion en snake_case du nom de champ du code source
-   ``fileFescriptor`` (qui provient d'une faute d'orthographe de ``fileDescriptor``). Il correspond a
-   l'implementation et n'est pas une erreur dans ce document.
+   Le nom de clé ``process.file_fescriptor`` est la conversion en snake_case du nom de champ du code source
+   ``fileFescriptor`` (qui provient d'une faute d'orthographe de ``fileDescriptor``). Il correspond à
+   l'implémentation et n'est pas une erreur dans ce document.
 
 ``engine`` : Statistiques du cluster du moteur de recherche
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Informations sur l'etat de sante du cluster du moteur de recherche (OpenSearch).
+Informations sur l'état de santé du cluster du moteur de recherche (OpenSearch).
 
 .. list-table::
    :header-rows: 1
@@ -257,7 +257,7 @@ Informations sur l'etat de sante du cluster du moteur de recherche (OpenSearch).
    * - ``number_of_nodes``
      - Nombre total de noeuds dans le cluster.
    * - ``number_of_data_nodes``
-     - Nombre de noeuds de donnees.
+     - Nombre de noeuds de données.
    * - ``active_primary_shards``
      - Nombre de shards primaires actifs.
    * - ``active_shards``
@@ -265,23 +265,23 @@ Informations sur l'etat de sante du cluster du moteur de recherche (OpenSearch).
    * - ``active_shards_percent``
      - Pourcentage de shards actifs (%).
    * - ``relocating_shards``
-     - Nombre de shards en cours de deplacement.
+     - Nombre de shards en cours de déplacement.
    * - ``initializing_shards``
      - Nombre de shards en cours d'initialisation.
    * - ``unassigned_shards``
-     - Nombre de shards non assignes.
+     - Nombre de shards non assignés.
    * - ``delayed_unassigned_shards``
-     - Nombre de shards non assignes avec delai.
+     - Nombre de shards non assignés avec délai.
    * - ``number_of_pending_tasks``
-     - Nombre de taches en attente.
+     - Nombre de tâches en attente.
    * - ``number_of_in_flight_fetch``
-     - Nombre d'operations de recuperation en cours.
+     - Nombre d'opérations de récupération en cours.
    * - ``status``
-     - Etat de sante du cluster (``green`` / ``yellow`` / ``red``).
+     - État de santé du cluster (``green`` / ``yellow`` / ``red``).
    * - ``exception``
      - Message d'erreur inclus uniquement en cas d'erreur, par exemple lorsque le cluster est inaccessible. Dans ce cas, ``status`` prend la valeur ``red``.
 
-``fs`` : Statistiques du systeme de fichiers
+``fs`` : Statistiques du système de fichiers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tableau des statistiques pour chaque racine (les racines obtenues par ``File.listRoots()``).
@@ -295,20 +295,20 @@ Tableau des statistiques pour chaque racine (les racines obtenues par ``File.lis
    * - ``path``
      - Chemin absolu de la racine.
    * - ``total``
-     - Capacite totale (octets).
+     - Capacité totale (octets).
    * - ``free``
-     - Capacite disponible (octets).
+     - Capacité disponible (octets).
    * - ``usable``
-     - Capacite utilisable (octets).
+     - Capacité utilisable (octets).
    * - ``used``
-     - Capacite utilisee (octets). Correspond a ``total`` moins ``usable``.
+     - Capacité utilisée (octets). Correspond à ``total`` moins ``usable``.
    * - ``percent``
      - Pourcentage d'utilisation (%).
 
 Exemples d'utilisation
 ======================
 
-Obtention des statistiques systeme
+Obtention des statistiques système
 -----------------------------------
 
 .. code-block:: bash
@@ -316,7 +316,7 @@ Obtention des statistiques systeme
     curl -X GET "http://localhost:8080/api/admin/stats" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Verification du taux d'utilisation du heap JVM
+Vérification du taux d'utilisation du heap JVM
 ------------------------------------------------
 
 .. code-block:: bash
@@ -325,7 +325,7 @@ Verification du taux d'utilisation du heap JVM
          -H "Authorization: Bearer YOUR_TOKEN" \
          | jq '.response.stats.jvm.memory.heap.percent'
 
-Verification de l'etat du cluster du moteur de recherche
+Vérification de l'état du cluster du moteur de recherche
 ---------------------------------------------------------
 
 .. code-block:: bash
@@ -334,9 +334,9 @@ Verification de l'etat du cluster du moteur de recherche
          -H "Authorization: Bearer YOUR_TOKEN" \
          | jq '.response.stats.engine.status'
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
-- :doc:`api-admin-systeminfo` - API d'informations systeme
+- :doc:`api-admin-systeminfo` - API d'informations système
 - :doc:`api-admin-searchlist` - API de recherche et de gestion des documents

--- a/fr/15.7/api/admin/api-admin-storage.rst
+++ b/fr/15.7/api/admin/api-admin-storage.rst
@@ -5,8 +5,8 @@ Storage API
 Vue d'ensemble
 ==============
 
-L'API Storage est une API permettant de gerer le stockage d'objets de |Fess|.
-Elle permet de lister les fichiers et repertoires dans le stockage, ainsi que de telecharger, supprimer et envoyer des fichiers.
+L'API Storage est une API permettant de gérer le stockage d'objets de |Fess|.
+Elle permet de lister les fichiers et répertoires dans le stockage, ainsi que de télécharger, supprimer et envoyer des fichiers.
 
 URL de base
 ===========
@@ -18,14 +18,14 @@ URL de base
 Authentification
 ================
 
-Tous les endpoints de l'API Admin, y compris l'API Storage, necessitent une authentification par jeton d'acces.
-Indiquez le jeton d'acces dans l'en-tete ``Authorization`` de la requete.
+Tous les endpoints de l'API Admin, y compris l'API Storage, nécessitent une authentification par jeton d'accès.
+Indiquez le jeton d'accès dans l'en-tête ``Authorization`` de la requête.
 
 ::
 
-    Authorization: Bearer <jeton d'acces>
+    Authorization: Bearer <jeton d'accès>
 
-Pour plus d'informations sur l'obtention d'un jeton d'acces et sur les permissions requises (par defaut, le role ``admin-api``), consultez :doc:`api-admin-overview`.
+Pour plus d'informations sur l'obtention d'un jeton d'accès et sur les permissions requises (par défaut, le rôle ``admin-api``), consultez :doc:`api-admin-overview`.
 
 Liste des endpoints
 ===================
@@ -34,15 +34,15 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /list/{id}
-     - Obtention de la liste des fichiers et repertoires
+     - Obtention de la liste des fichiers et répertoires
    * - GET
      - /download/{id}
-     - Telechargement d'un fichier
+     - Téléchargement d'un fichier
    * - DELETE
      - /delete/{id}
      - Suppression d'un fichier
@@ -50,24 +50,24 @@ Liste des endpoints
      - /upload
      - Envoi d'un fichier
 
-Obtention de la liste des fichiers et repertoires
+Obtention de la liste des fichiers et répertoires
 =================================================
 
-Retourne la liste des fichiers et repertoires situes sous le repertoire specifie.
-Indiquez dans ``{id}`` l'``id`` du repertoire obtenu lors d'un appel de listage. Si ``{id}`` est omis, la liste du repertoire racine est retournee.
+Retourne la liste des fichiers et répertoires situés sous le répertoire spécifié.
+Indiquez dans ``{id}`` l'``id`` du répertoire obtenu lors d'un appel de listage. Si ``{id}`` est omis, la liste du répertoire racine est retournée.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/storage/list/{id}
 
-Reponse
+Réponse
 -------
 
-Le champ ``items`` contient un tableau d'objets representant les fichiers et repertoires (les repertoires apparaissent avant les fichiers).
-Chaque objet possede les champs suivants.
+Le champ ``items`` contient un tableau d'objets représentant les fichiers et répertoires (les répertoires apparaissent avant les fichiers).
+Chaque objet possède les champs suivants.
 
 .. list-table::
    :header-rows: 1
@@ -76,19 +76,19 @@ Chaque objet possede les champs suivants.
    * - Champ
      - Description
    * - ``id``
-     - Identifiant encode. Chaine de caracteres representant le chemin de l'objet encode en Base64 URL-safe, utilisee comme ``{id}`` lors du telechargement ou de la suppression.
+     - Identifiant encodé. Chaîne de caractères représentant le chemin de l'objet encodé en Base64 URL-safe, utilisée comme ``{id}`` lors du téléchargement ou de la suppression.
    * - ``path``
-     - Chemin du repertoire parent
+     - Chemin du répertoire parent
    * - ``name``
-     - Nom du fichier ou du repertoire
+     - Nom du fichier ou du répertoire
    * - ``hashCode``
-     - Valeur de hachage utilisee en interne (il ne s'agit pas d'une valeur stable representant le contenu de l'objet)
+     - Valeur de hachage utilisée en interne (il ne s'agit pas d'une valeur stable représentant le contenu de l'objet)
    * - ``size``
      - Taille (en octets)
    * - ``directory``
-     - Indique s'il s'agit d'un repertoire (boolean)
+     - Indique s'il s'agit d'un répertoire (boolean)
    * - ``lastModified``
-     - Date et heure de la derniere modification (format ISO 8601 ; presente uniquement pour les fichiers)
+     - Date et heure de la dernière modification (format ISO 8601 ; présente uniquement pour les fichiers)
 
 .. code-block:: json
 
@@ -118,42 +118,42 @@ Chaque objet possede les champs suivants.
       }
     }
 
-Telechargement d'un fichier
+Téléchargement d'un fichier
 ============================
 
-Telecharge un fichier depuis le stockage. Indiquez dans ``{id}`` l'``id`` obtenu lors du listage.
-La reponse est retournee sous forme de flux ``application/octet-stream``.
+Télécharge un fichier depuis le stockage. Indiquez dans ``{id}`` l'``id`` obtenu lors du listage.
+La réponse est retournée sous forme de flux ``application/octet-stream``.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/storage/download/{id}
 
-Reponse
+Réponse
 -------
 
 Flux binaire du fichier (``Content-Type: application/octet-stream``).
 
 .. note::
 
-   La reponse de cette API ne contient pas d'en-tete ``Content-Disposition``.
-   Le nom du fichier a enregistrer doit etre specifie cote client (avec l'option ``-o`` pour cURL).
+   La réponse de cette API ne contient pas d'en-tête ``Content-Disposition``.
+   Le nom du fichier à enregistrer doit être spécifié côté client (avec l'option ``-o`` pour cURL).
 
 Suppression d'un fichier
 =========================
 
 Supprime un fichier du stockage. Indiquez dans ``{id}`` l'``id`` obtenu lors du listage.
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/storage/delete/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -169,9 +169,9 @@ Envoi d'un fichier
 ==================
 
 Envoie un fichier vers le stockage au format ``multipart/form-data``.
-Le repertoire de destination est specifie via le champ de formulaire ``path``, et non dans le chemin de l'URL.
+Le répertoire de destination est spécifié via le champ de formulaire ``path``, et non dans le chemin de l'URL.
 
-Requete
+Requête
 -------
 
 ::
@@ -191,12 +191,12 @@ Description des champs
      - Description
    * - ``path``
      - Non
-     - Chemin du repertoire de destination (sans slash initial ni final). Si non specifie, le fichier est enregistre a la racine (directement sous le bucket).
+     - Chemin du répertoire de destination (sans slash initial ni final). Si non spécifié, le fichier est enregistré à la racine (directement sous le bucket).
    * - ``file``
      - Oui
-     - Fichier a envoyer
+     - Fichier à envoyer
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -211,8 +211,8 @@ Reponse
 Erreurs
 =======
 
-En cas d'echec du traitement, chaque endpoint retourne une reponse avec un ``status`` different de 0 (``1`` en cas d'erreur de validation).
-Le champ ``message`` du corps de la reponse contient le detail de l'erreur. Pour plus de details sur les valeurs de status et les codes de statut HTTP, consultez :doc:`api-admin-overview`.
+En cas d'échec du traitement, chaque endpoint retourne une réponse avec un ``status`` différent de 0 (``1`` en cas d'erreur de validation).
+Le champ ``message`` du corps de la réponse contient le détail de l'erreur. Pour plus de détails sur les valeurs de status et les codes de statut HTTP, consultez :doc:`api-admin-overview`.
 
 Les principaux cas d'erreur sont les suivants.
 
@@ -222,19 +222,19 @@ Les principaux cas d'erreur sont les suivants.
 
    * - Endpoint
      - Principaux cas d'erreur
-   * - Obtention de la liste des fichiers et repertoires
-     - Lorsque le nombre d'elements recuperes depasse la limite maximale
-   * - Telechargement d'un fichier
-     - Lorsque l'``id`` est invalide ou que le telechargement echoue
+   * - Obtention de la liste des fichiers et répertoires
+     - Lorsque le nombre d'éléments récupérés dépasse la limite maximale
+   * - Téléchargement d'un fichier
+     - Lorsque l'``id`` est invalide ou que le téléchargement échoue
    * - Suppression d'un fichier
-     - Lorsque l'``id`` est invalide ou que la suppression echoue
+     - Lorsque l'``id`` est invalide ou que la suppression échoue
    * - Envoi d'un fichier
-     - Lorsque ``file`` n'est pas specifie ou que l'envoi echoue
+     - Lorsque ``file`` n'est pas spécifié ou que l'envoi échoue
 
 Exemples d'utilisation
 ======================
 
-Obtention de la liste du repertoire racine
+Obtention de la liste du répertoire racine
 ------------------------------------------
 
 .. code-block:: bash
@@ -242,7 +242,7 @@ Obtention de la liste du repertoire racine
     curl -X GET "http://localhost:8080/api/admin/storage/list/" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Telechargement d'un fichier
+Téléchargement d'un fichier
 ----------------------------
 
 .. code-block:: bash
@@ -269,7 +269,7 @@ Envoi d'un fichier
          -F "path=subdir" \
          -F "file=@sample.txt"
 
-Informations complementaires
+Informations complémentaires
 =============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.7/api/admin/api-admin-systeminfo.rst
+++ b/fr/15.7/api/admin/api-admin-systeminfo.rst
@@ -5,8 +5,8 @@ API SystemInfo
 Vue d'ensemble
 ==============
 
-L'API SystemInfo permet d'obtenir les informations systeme de |Fess|.
-Vous pouvez consulter les variables d'environnement, les proprietes systeme Java, les proprietes de configuration de |Fess| et les informations destinees aux rapports de bogues.
+L'API SystemInfo permet d'obtenir les informations système de |Fess|.
+Vous pouvez consulter les variables d'environnement, les propriétés système Java, les propriétés de configuration de |Fess| et les informations destinées aux rapports de bogues.
 
 URL de base
 ===========
@@ -15,8 +15,8 @@ URL de base
 
     /api/admin/systeminfo
 
-L'acces a cette API necessite un jeton d'acces disposant de la permission ``Radmin-api``.
-Pour les details sur l'authentification, consultez :doc:`api-admin-overview`.
+L'accès à cette API nécessite un jeton d'accès disposant de la permission ``Radmin-api``.
+Pour les détails sur l'authentification, consultez :doc:`api-admin-overview`.
 
 Liste des endpoints
 ===================
@@ -25,29 +25,29 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /
-     - Obtention des informations systeme
+     - Obtention des informations système
 
-Obtention des informations systeme
+Obtention des informations système
 ==================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/systeminfo
 
-Cet endpoint n'accepte aucun parametre de requete.
+Cet endpoint n'accepte aucun paramètre de requête.
 
-Reponse
+Réponse
 -------
 
-La reponse contient ``version`` indiquant la version du produit, ``status`` indiquant le resultat du traitement, ainsi que les quatre groupes de proprietes suivants. Chaque groupe de proprietes est un tableau d'objets possedant ``label`` et ``value``.
+La réponse contient ``version`` indiquant la version du produit, ``status`` indiquant le résultat du traitement, ainsi que les quatre groupes de propriétés suivants. Chaque groupe de propriétés est un tableau d'objets possédant ``label`` et ``value``.
 
 .. code-block:: json
 
@@ -77,7 +77,7 @@ La reponse contient ``version`` indiquant la version du produit, ``status`` indi
       }
     }
 
-Champs de la reponse
+Champs de la réponse
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -89,33 +89,33 @@ Champs de la reponse
    * - ``version``
      - Version du produit |Fess| (ex. : ``15.7.0``).
    * - ``status``
-     - Code indiquant le resultat du traitement. ``0`` signifie une terminaison normale.
+     - Code indiquant le résultat du traitement. ``0`` signifie une terminaison normale.
    * - ``envProps``
-     - Liste des variables d'environnement (tableau de ``label`` / ``value``). Les valeurs retournees sont celles obtenues via ``System.getenv()``, sans modification.
+     - Liste des variables d'environnement (tableau de ``label`` / ``value``). Les valeurs retournées sont celles obtenues via ``System.getenv()``, sans modification.
    * - ``systemProps``
-     - Liste des proprietes systeme Java (tableau de ``label`` / ``value``). Les valeurs retournees sont celles obtenues via ``System.getProperties()``, sans modification.
+     - Liste des propriétés système Java (tableau de ``label`` / ``value``). Les valeurs retournées sont celles obtenues via ``System.getProperties()``, sans modification.
    * - ``fessProps``
-     - Liste des proprietes de configuration de |Fess| (tableau de ``label`` / ``value``). Inclut les valeurs de ``fess_config.properties`` ainsi que les proprietes systeme definies via l'interface d'administration. Les elements sensibles sont masques (voir la note ci-dessous).
+     - Liste des propriétés de configuration de |Fess| (tableau de ``label`` / ``value``). Inclut les valeurs de ``fess_config.properties`` ainsi que les propriétés système définies via l'interface d'administration. Les éléments sensibles sont masqués (voir la note ci-dessous).
    * - ``bugReportProps``
-     - Liste des informations collectees pour les rapports de bogues (tableau de ``label`` / ``value``). Inclut les principales proprietes systeme relatives au systeme d'exploitation et a l'environnement d'execution Java (``os.name``, ``os.version``, ``java.vm.version``, etc.) ainsi que les valeurs des proprietes systeme de |Fess|.
+     - Liste des informations collectées pour les rapports de bogues (tableau de ``label`` / ``value``). Inclut les principales propriétés système relatives au système d'exploitation et à l'environnement d'exécution Java (``os.name``, ``os.version``, ``java.vm.version``, etc.) ainsi que les valeurs des propriétés système de |Fess|.
 
 .. note::
 
-   Dans ``fessProps``, les valeurs de configuration suivantes, jugees sensibles, sont masquees et retournees sous la forme ``XXXXXXXX`` :
+   Dans ``fessProps``, les valeurs de configuration suivantes, jugées sensibles, sont masquées et retournées sous la forme ``XXXXXXXX`` :
    ``http.proxy.password``, ``ldap.admin.security.credentials``, ``spnego.preauth.password``,
    ``app.cipher.key``, ``oic.client.id``, ``oic.client.secret``.
 
 .. warning::
 
-   ``envProps`` (variables d'environnement) et ``systemProps`` (proprietes systeme Java) ne sont pas masquees :
-   les valeurs configurees sont retournees telles quelles. Si des informations confidentielles (identifiants,
-   mots de passe, etc.) sont stockees dans des variables d'environnement ou des proprietes systeme, elles
-   apparaitront dans la reponse.
+   ``envProps`` (variables d'environnement) et ``systemProps`` (propriétés système Java) ne sont pas masquées :
+   les valeurs configurées sont retournées telles quelles. Si des informations confidentielles (identifiants,
+   mots de passe, etc.) sont stockées dans des variables d'environnement ou des propriétés système, elles
+   apparaîtront dans la réponse.
 
 Exemples d'utilisation
 ======================
 
-Obtention des informations systeme
+Obtention des informations système
 ----------------------------------
 
 .. code-block:: bash
@@ -123,7 +123,7 @@ Obtention des informations systeme
     curl -X GET "http://localhost:8080/api/admin/systeminfo" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Extraction d'une propriete systeme specifique
+Extraction d'une propriété système spécifique
 ---------------------------------------------
 
 .. code-block:: bash
@@ -143,10 +143,10 @@ Affichage de la liste des variables d'environnement
          -H "Authorization: Bearer YOUR_TOKEN" \
          | jq -r '.response.envProps[] | "\(.label)=\(.value)"'
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
 - :doc:`api-admin-stats` - API de statistiques
-- :doc:`api-admin-general` - API de configuration generale
-- :doc:`../../admin/systeminfo-guide` - Guide des informations systeme
+- :doc:`api-admin-general` - API de configuration générale
+- :doc:`../../admin/systeminfo-guide` - Guide des informations système

--- a/fr/15.7/api/admin/index.rst
+++ b/fr/15.7/api/admin/index.rst
@@ -1,8 +1,8 @@
 ==================================
-Reference de l'API d'administration
+Référence de l'API d'administration
 ==================================
 
-L'API d'administration |Fess| est une API RESTful permettant d'acceder aux fonctions d'administration par programmation.
+L'API d'administration |Fess| est une API RESTful permettant d'accéder aux fonctions d'administration par programmation.
 
 .. toctree::
    :maxdepth: 2
@@ -58,7 +58,7 @@ L'API d'administration |Fess| est une API RESTful permettant d'acceder aux fonct
 
 .. toctree::
    :maxdepth: 2
-   :caption: Systeme
+   :caption: Système
 
    api-admin-general
    api-admin-systeminfo

--- a/fr/15.7/config/datastore/ds-atlassian.rst
+++ b/fr/15.7/config/datastore/ds-atlassian.rst
@@ -2,12 +2,12 @@
 Connecteur Atlassian
 ==================================
 
-Apercu
+Aperçu
 ======
 
-Le connecteur Atlassian fournit une fonctionnalite pour recuperer des donnees depuis les produits Atlassian (Jira, Confluence) et les enregistrer dans l'index de |Fess|.
+Le connecteur Atlassian fournit une fonctionnalité pour récupérer des données depuis les produits Atlassian (Jira, Confluence) et les enregistrer dans l'index de |Fess|.
 
-Cette fonctionnalite necessite le plugin ``fess-ds-atlassian``.
+Cette fonctionnalité nécessite le plugin ``fess-ds-atlassian``.
 
 Produits pris en charge
 =======================
@@ -15,23 +15,23 @@ Produits pris en charge
 - Jira (Cloud / Server / Data Center)
 - Confluence (Cloud / Server / Data Center)
 
-Prerequis
+Prérequis
 =========
 
 1. L'installation du plugin est requise
-2. Les informations d'authentification appropriees pour les produits Atlassian sont necessaires
+2. Les informations d'authentification appropriées pour les produits Atlassian sont nécessaires
 3. Pour la version Cloud, OAuth 2.0 est disponible ; pour la version Server, OAuth 1.0a ou l'authentification basique sont disponibles
 
 Installation du plugin
 ----------------------
 
-Installez depuis l'interface d'administration sous "Systeme" -> "Plugins" :
+Installez depuis l'interface d'administration sous "Système" -> "Plugins" :
 
-1. Telechargez ``fess-ds-atlassian-X.X.X.jar`` depuis Maven Central
+1. Téléchargez ``fess-ds-atlassian-X.X.X.jar`` depuis Maven Central
 2. Uploadez et installez depuis l'interface de gestion des plugins
-3. Redemarrez |Fess|
+3. Redémarrez |Fess|
 
-Methode de configuration
+Méthode de configuration
 ========================
 
 Configurez depuis l'interface d'administration : "Crawler" -> "DataStore" -> "Nouveau".
@@ -43,7 +43,7 @@ Configuration de base
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
+   * - Élément
      - Exemple de configuration
    * - Nom
      - Company Jira/Confluence
@@ -52,7 +52,7 @@ Configuration de base
    * - Actif
      - Oui
 
-Configuration des parametres
+Configuration des paramètres
 ----------------------------
 
 Exemple version Cloud (OAuth 2.0) :
@@ -89,14 +89,14 @@ Exemple version Server (OAuth 1.0a) :
     oauth.secret=verification_code
     oauth.access_token=your_access_token
 
-Liste des parametres
+Liste des paramètres
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``home``
@@ -104,22 +104,22 @@ Liste des parametres
      - URL de l'instance Atlassian
    * - ``is_cloud``
      - Non
-     - ``true`` pour la version Cloud, ``false`` pour la version Server (defaut : ``true``). Utilise uniquement pour la selection du point de terminaison lors de l'authentification OAuth 2.0 ; ignore pour les authentifications basique et OAuth 1.0a.
+     - ``true`` pour la version Cloud, ``false`` pour la version Server (défaut : ``true``). Utilisé uniquement pour la sélection du point de terminaison lors de l'authentification OAuth 2.0 ; ignoré pour les authentifications basique et OAuth 1.0a.
    * - ``auth_type``
      - Oui
      - Type d'authentification : ``oauth``, ``oauth2``, ``basic``
    * - ``oauth.consumer_key``
      - Pour OAuth 1.0a
-     - Cle consommateur (generalement ``OauthKey``)
+     - Clé consommateur (généralement ``OauthKey``)
    * - ``oauth.private_key``
      - Pour OAuth 1.0a
-     - Cle privee RSA (format PEM)
+     - Clé privée RSA (format PEM)
    * - ``oauth.secret``
      - Pour OAuth 1.0a
-     - Code de verification
+     - Code de vérification
    * - ``oauth.access_token``
      - Pour OAuth 1.0a
-     - Token d'acces
+     - Token d'accès
    * - ``oauth2.client_id``
      - Pour OAuth 2.0
      - ID client
@@ -128,13 +128,13 @@ Liste des parametres
      - Secret client
    * - ``oauth2.access_token``
      - Pour OAuth 2.0
-     - Token d'acces
+     - Token d'accès
    * - ``oauth2.refresh_token``
      - Non
-     - Token de rafraichissement (OAuth 2.0)
+     - Token de rafraîchissement (OAuth 2.0)
    * - ``oauth2.token_url``
      - Non
-     - URL du token (OAuth 2.0, defaut : ``https://auth.atlassian.com/oauth/token``)
+     - URL du token (OAuth 2.0, défaut : ``https://auth.atlassian.com/oauth/token``)
    * - ``basic.username``
      - Pour auth basique
      - Nom d'utilisateur
@@ -143,40 +143,40 @@ Liste des parametres
      - Mot de passe
    * - ``issue.jql``
      - Non
-     - JQL (Jira uniquement, conditions de recherche avancees). Si non specifie, tous les tickets (``created is not empty``) sont cibles.
+     - JQL (Jira uniquement, conditions de recherche avancées). Si non spécifié, tous les tickets (``created is not empty``) sont ciblés.
    * - ``issue_max_results``
      - Non
-     - Nombre maximum de resultats par requete API Jira (defaut : ``50``, Jira uniquement)
+     - Nombre maximum de résultats par requête API Jira (défaut : ``50``, Jira uniquement)
    * - ``content_limit``
      - Non
-     - Nombre maximum d'elements par requete API Confluence (defaut : ``25``, Confluence uniquement)
+     - Nombre maximum d'éléments par requête API Confluence (défaut : ``25``, Confluence uniquement)
    * - ``ignore_error``
      - Non
-     - Continuer le traitement en cas d'erreur (defaut : ``true``)
+     - Continuer le traitement en cas d'erreur (défaut : ``true``)
    * - ``include_pattern``
      - Non
-     - Modele d'inclusion d'URL (regex)
+     - Modèle d'inclusion d'URL (regex)
    * - ``exclude_pattern``
      - Non
-     - Modele d'exclusion d'URL (regex)
+     - Modèle d'exclusion d'URL (regex)
    * - ``number_of_threads``
      - Non
-     - Nombre de threads pour le traitement parallele (defaut : ``1``)
+     - Nombre de threads pour le traitement parallèle (défaut : ``1``)
    * - ``proxy_host``
      - Non
-     - Nom d'hote du proxy HTTP
+     - Nom d'hôte du proxy HTTP
    * - ``proxy_port``
      - Non
-     - Numero de port du proxy HTTP
+     - Numéro de port du proxy HTTP
    * - ``connection_timeout``
      - Non
-     - Delai de connexion HTTP (millisecondes)
+     - Délai de connexion HTTP (millisecondes)
    * - ``read_timeout``
      - Non
-     - Delai de lecture HTTP (millisecondes)
+     - Délai de lecture HTTP (millisecondes)
    * - ``readInterval``
      - Non
-     - Intervalle entre le traitement de chaque document (en millisecondes, defaut : ``0``)
+     - Intervalle entre le traitement de chaque document (en millisecondes, défaut : ``0``)
 
 Configuration du script
 -----------------------
@@ -194,10 +194,10 @@ Pour Jira
 Champs disponibles :
 
 - ``issue.view_url`` - URL du ticket
-- ``issue.summary`` - Resume du ticket
+- ``issue.summary`` - Résumé du ticket
 - ``issue.description`` - Description du ticket
 - ``issue.comments`` - Commentaires du ticket
-- ``issue.last_modified`` - Date de derniere modification
+- ``issue.last_modified`` - Date de dernière modification
 
 Pour Confluence
 ~~~~~~~~~~~~~~~
@@ -215,25 +215,25 @@ Champs disponibles :
 - ``content.title`` - Titre de la page
 - ``content.body`` - Corps de la page
 - ``content.comments`` - Commentaires de la page
-- ``content.last_modified`` - Date de derniere modification
+- ``content.last_modified`` - Date de dernière modification
 
 .. note::
-   Le connecteur Confluence recupere a la fois les pages normales (page) et les articles de blog (blogpost).
+   Le connecteur Confluence récupère à la fois les pages normales (page) et les articles de blog (blogpost).
 
 Configuration de l'authentification OAuth 2.0
 =============================================
 
-Pour la version Cloud (recommande)
+Pour la version Cloud (recommandé)
 ----------------------------------
 
-1. Creez une application dans Atlassian Developer Console
+1. Créez une application dans Atlassian Developer Console
 2. Obtenez les informations d'authentification OAuth 2.0
-3. Configurez les scopes necessaires :
+3. Configurez les scopes nécessaires :
 
    - Jira : ``read:jira-work``, ``read:jira-user``
    - Confluence : ``read:confluence-content.all``, ``read:confluence-user``
 
-4. Obtenez le token d'acces et le token de rafraichissement
+4. Obtenez le token d'accès et le token de rafraîchissement
 
 Configuration de l'authentification OAuth 1.0a
 ==============================================
@@ -241,16 +241,16 @@ Configuration de l'authentification OAuth 1.0a
 Pour la version Server
 ----------------------
 
-1. Creez un Application Link dans Jira ou Confluence
-2. Generez une paire de cles RSA :
+1. Créez un Application Link dans Jira ou Confluence
+2. Générez une paire de clés RSA :
 
    ::
 
        openssl genrsa -out private_key.pem 2048
        openssl rsa -in private_key.pem -pubout -out public_key.pem
 
-3. Enregistrez la cle publique dans l'Application Link
-4. Configurez la cle privee dans les parametres
+3. Enregistrez la clé publique dans l'Application Link
+4. Configurez la clé privée dans les paramètres
 
 Configuration de l'authentification basique
 ===========================================
@@ -259,21 +259,21 @@ Configuration simple pour la version Server
 -------------------------------------------
 
 .. warning::
-   L'authentification basique n'est pas recommandee pour des raisons de securite. Utilisez l'authentification OAuth autant que possible.
+   L'authentification basique n'est pas recommandée pour des raisons de sécurité. Utilisez l'authentification OAuth autant que possible.
 
 Pour utiliser l'authentification basique :
 
-1. Preparez un compte utilisateur avec des privileges d'administration
-2. Configurez le nom d'utilisateur et le mot de passe dans les parametres
-3. Utilisez HTTPS pour assurer une connexion securisee
+1. Préparez un compte utilisateur avec des privilèges d'administration
+2. Configurez le nom d'utilisateur et le mot de passe dans les paramètres
+3. Utilisez HTTPS pour assurer une connexion sécurisée
 
-Recherche avancee avec JQL
+Recherche avancée avec JQL
 ==========================
 
 Filtrer les tickets Jira avec JQL
 ---------------------------------
 
-Explorer uniquement les tickets correspondant a des conditions specifiques :
+Explorer uniquement les tickets correspondant à des conditions spécifiques :
 
 ::
 
@@ -289,7 +289,7 @@ Explorer uniquement les tickets correspondant a des conditions specifiques :
     # Combinaison de conditions multiples
     issue.jql=project IN ("PROJ1", "PROJ2") AND updated >= -90d AND status != "Done"
 
-Pour plus de details sur JQL, consultez la `documentation JQL Atlassian <https://confluence.atlassian.com/jirasoftwarecloud/advanced-searching-764478330.html>`_.
+Pour plus de détails sur JQL, consultez la `documentation JQL Atlassian <https://confluence.atlassian.com/jirasoftwarecloud/advanced-searching-764478330.html>`_.
 
 Exemples d'utilisation
 ======================
@@ -297,7 +297,7 @@ Exemples d'utilisation
 Exploration de Jira Cloud
 -------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -322,7 +322,7 @@ Script :
 Exploration de Confluence Server
 --------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -342,64 +342,64 @@ Script :
     last_modified=content.last_modified
     digest=content.title
 
-Depannage
+Dépannage
 =========
 
 Erreur d'authentification
 -------------------------
 
-**Symptome** : ``401 Unauthorized`` ou ``403 Forbidden``
+**Symptôme** : ``401 Unauthorized`` ou ``403 Forbidden``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifiez que les informations d'authentification sont correctes
-2. Pour la version Cloud, verifiez que les scopes appropries sont configures
-3. Pour la version Server, verifiez que l'utilisateur dispose des autorisations appropriees
-4. Pour OAuth 2.0, verifiez la date d'expiration du token
+1. Vérifiez que les informations d'authentification sont correctes
+2. Pour la version Cloud, vérifiez que les scopes appropriés sont configurés
+3. Pour la version Server, vérifiez que l'utilisateur dispose des autorisations appropriées
+4. Pour OAuth 2.0, vérifiez la date d'expiration du token
 
 Erreur de connexion
 -------------------
 
-**Symptome** : ``Connection refused`` ou timeout de connexion
+**Symptôme** : ``Connection refused`` ou timeout de connexion
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifiez que l'URL ``home`` est correcte
-2. Verifiez les parametres du pare-feu
-3. Verifiez que l'instance Atlassian est en cours d'execution
-4. Verifiez que le parametre ``is_cloud`` est correctement configure
+1. Vérifiez que l'URL ``home`` est correcte
+2. Vérifiez les paramètres du pare-feu
+3. Vérifiez que l'instance Atlassian est en cours d'exécution
+4. Vérifiez que le paramètre ``is_cloud`` est correctement configuré
 
-Impossible de recuperer les donnees
+Impossible de récupérer les données
 -----------------------------------
 
-**Symptome** : L'exploration reussit mais 0 document
+**Symptôme** : L'exploration réussit mais 0 document
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifiez que le JQL n'est pas trop restrictif
-2. Verifiez que l'utilisateur a des droits de lecture sur les projets/espaces
-3. Verifiez la configuration du script
-4. Verifiez les erreurs dans les logs
+1. Vérifiez que le JQL n'est pas trop restrictif
+2. Vérifiez que l'utilisateur a des droits de lecture sur les projets/espaces
+3. Vérifiez la configuration du script
+4. Vérifiez les erreurs dans les logs
 
-Rafraichissement du token OAuth 2.0
+Rafraîchissement du token OAuth 2.0
 -----------------------------------
 
-**Symptome** : Des erreurs d'authentification se produisent apres un certain temps
+**Symptôme** : Des erreurs d'authentification se produisent après un certain temps
 
 **Solution** :
 
-Les tokens d'acces OAuth 2.0 ont une date d'expiration. Configurez le token de rafraichissement pour permettre le renouvellement automatique :
+Les tokens d'accès OAuth 2.0 ont une date d'expiration. Configurez le token de rafraîchissement pour permettre le renouvellement automatique :
 
 ::
 
     oauth2.refresh_token=your_refresh_token
 
-Lors du renouvellement des tokens, le nouveau token d'acces et le nouveau token de rafraichissement sont automatiquement enregistres dans la configuration du data store, de sorte que les explorations suivantes utilisent les tokens mis a jour (aucune mise a jour manuelle n'est necessaire).
+Lors du renouvellement des tokens, le nouveau token d'accès et le nouveau token de rafraîchissement sont automatiquement enregistrés dans la configuration du data store, de sorte que les explorations suivantes utilisent les tokens mis à jour (aucune mise à jour manuelle n'est nécessaire).
 
-Informations de reference
+Informations de référence
 =========================
 
-- :doc:`ds-overview` - Apercu des connecteurs DataStore
-- :doc:`ds-database` - Connecteur base de donnees
+- :doc:`ds-overview` - Aperçu des connecteurs DataStore
+- :doc:`ds-database` - Connecteur base de données
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration DataStore
 - `Atlassian Developer <https://developer.atlassian.com/>`_

--- a/fr/15.7/config/datastore/ds-elasticsearch.rst
+++ b/fr/15.7/config/datastore/ds-elasticsearch.rst
@@ -2,13 +2,13 @@
 Connecteur Elasticsearch/OpenSearch
 =====================================
 
-Apercu
+Aperçu
 ======
 
-Le connecteur Elasticsearch/OpenSearch fournit la fonctionnalite permettant de recuperer des donnees
-a partir d'un cluster Elasticsearch ou OpenSearch et de les enregistrer dans l'index |Fess|.
+Le connecteur Elasticsearch/OpenSearch fournit la fonctionnalité permettant de récupérer des données
+à partir d'un cluster Elasticsearch ou OpenSearch et de les enregistrer dans l'index |Fess|.
 
-Cette fonctionnalite necessite le plugin ``fess-ds-elasticsearch``.
+Cette fonctionnalité nécessite le plugin ``fess-ds-elasticsearch``.
 
 Versions prises en charge
 =========================
@@ -16,17 +16,17 @@ Versions prises en charge
 - Elasticsearch 7.x / 8.x
 - OpenSearch 1.x / 2.x
 
-Prerequis
+Prérequis
 =========
 
 1. L'installation du plugin est requise
-2. L'acces en lecture au cluster Elasticsearch/OpenSearch est necessaire
-3. Les droits d'execution de requetes sont necessaires
+2. L'accès en lecture au cluster Elasticsearch/OpenSearch est nécessaire
+3. Les droits d'exécution de requêtes sont nécessaires
 
 Installation du plugin
 ----------------------
 
-Methode 1 : Placement direct du fichier JAR
+Méthode 1 : Placement direct du fichier JAR
 
 ::
 
@@ -38,11 +38,11 @@ Methode 1 : Placement direct du fichier JAR
     # ou
     cp fess-ds-elasticsearch-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Methode 2 : Installation depuis l'interface d'administration
+Méthode 2 : Installation depuis l'interface d'administration
 
-1. Ouvrir "Systeme" -> "Plugins"
-2. Telecharger le fichier JAR
-3. Redemarrer |Fess|
+1. Ouvrir "Système" -> "Plugins"
+2. Télécharger le fichier JAR
+3. Redémarrer |Fess|
 
 Configuration
 =============
@@ -56,7 +56,7 @@ Configuration de base
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
+   * - Élément
      - Exemple
    * - Nom
      - External Elasticsearch
@@ -66,10 +66,10 @@ Configuration de base
      - Oui
 
 .. note::
-   ``ElasticsearchListDataStore`` est un gestionnaire qui etend ``ElasticsearchDataStore``. Il traite les donnees recuperees sous forme de liste de fichiers et prend en charge l'indexation multi-thread.
-   Le nombre de threads peut etre specifie avec le parametre ``numOfThreads`` (par defaut : 1).
+   ``ElasticsearchListDataStore`` est un gestionnaire qui étend ``ElasticsearchDataStore``. Il traite les données récupérées sous forme de liste de fichiers et prend en charge l'indexation multi-thread.
+   Le nombre de threads peut être spécifié avec le paramètre ``numOfThreads`` (par défaut : 1).
 
-Configuration des parametres
+Configuration des paramètres
 -----------------------------
 
 Connexion de base :
@@ -92,19 +92,19 @@ Connexion avec authentification :
     size=100
     scroll=1m
 
-Liste des parametres
+Liste des paramètres
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``settings.http.hosts``
      - Non
-     - URL des hotes Elasticsearch/OpenSearch. Plusieurs hotes peuvent etre specifies en les separant par des virgules (ex : ``http://host1:9200,http://host2:9200``). Une erreur de connexion se produit si non specifie
+     - URL des hôtes Elasticsearch/OpenSearch. Plusieurs hôtes peuvent être spécifiés en les séparant par des virgules (ex : ``http://host1:9200,http://host2:9200``). Une erreur de connexion se produit si non spécifié
    * - ``settings.fesen.username``
      - Non
      - Nom d'utilisateur pour l'authentification
@@ -113,59 +113,59 @@ Liste des parametres
      - Mot de passe pour l'authentification
    * - ``index``
      - Non
-     - Nom de l'index cible (par defaut : ``_all``). Plusieurs index peuvent etre specifies en les separant par des virgules
+     - Nom de l'index cible (par défaut : ``_all``). Plusieurs index peuvent être spécifiés en les séparant par des virgules
    * - ``size``
      - Non
-     - Nombre d'elements recuperes lors du scroll (si non specifie, la valeur par defaut du serveur Elasticsearch/OpenSearch est utilisee)
+     - Nombre d'éléments récupérés lors du scroll (si non spécifié, la valeur par défaut du serveur Elasticsearch/OpenSearch est utilisée)
    * - ``scroll``
      - Non
-     - Timeout du scroll (par defaut : 1m)
+     - Timeout du scroll (par défaut : 1m)
    * - ``timeout``
      - Non
-     - Timeout de la requete (par defaut : 1m)
+     - Timeout de la requête (par défaut : 1m)
    * - ``query``
      - Non
-     - JSON de requete (par defaut : match_all). Specifier uniquement le corps de la requete (le wrapper externe ``{"query":...}`` n'est pas necessaire)
+     - JSON de requête (par défaut : match_all). Spécifier uniquement le corps de la requête (le wrapper externe ``{"query":...}`` n'est pas nécessaire)
    * - ``fields``
      - Non
-     - Champs a recuperer (separes par des virgules)
+     - Champs à récupérer (séparés par des virgules)
    * - ``preference``
      - Non
-     - Preference de replique de shard pour l'execution de la recherche (par defaut : ``_local``)
+     - Préférence de réplique de shard pour l'exécution de la recherche (par défaut : ``_local``)
    * - ``delete.processed.doc``
      - Non
-     - Supprimer les documents traites de l'index source (par defaut : false)
+     - Supprimer les documents traités de l'index source (par défaut : false)
    * - ``readInterval``
      - Non
-     - Temps d'attente entre le traitement de chaque document en millisecondes (par defaut : 0)
+     - Temps d'attente entre le traitement de chaque document en millisecondes (par défaut : 0)
    * - ``numOfThreads``
      - Non
-     - Nombre de threads pour l'indexation (valide uniquement pour ``ElasticsearchListDataStore``, par defaut : 1)
+     - Nombre de threads pour l'indexation (valide uniquement pour ``ElasticsearchListDataStore``, par défaut : 1)
 
-Parametres de connexion supplementaires
+Paramètres de connexion supplémentaires
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Les parametres prefixes par ``settings.`` sont transmis comme configuration du client HTTP Elasticsearch/OpenSearch interne (client HTTP fesen).
-Les principaux parametres supplementaires sont les suivants.
+Les paramètres préfixés par ``settings.`` sont transmis comme configuration du client HTTP Elasticsearch/OpenSearch interne (client HTTP fesen).
+Les principaux paramètres supplémentaires sont les suivants.
 
 .. list-table::
    :header-rows: 1
    :widths: 40 60
 
-   * - Parametre
+   * - Paramètre
      - Description
    * - ``settings.http.ssl.certificate_authorities``
      - Chemin du fichier de certificat CA de confiance (format X.509) pour les connexions HTTPS
    * - ``settings.http.compression``
-     - Activer la compression HTTP (par defaut : true)
+     - Activer la compression HTTP (par défaut : true)
    * - ``settings.http.proxy_host``
-     - Nom d'hote du serveur proxy (``settings.https.proxy_host`` est egalement accepte)
+     - Nom d'hôte du serveur proxy (``settings.https.proxy_host`` est également accepté)
    * - ``settings.http.proxy_port``
-     - Numero de port du serveur proxy (``settings.https.proxy_port`` est egalement accepte)
+     - Numéro de port du serveur proxy (``settings.https.proxy_port`` est également accepté)
    * - ``settings.http.proxy_username``
-     - Nom d'utilisateur pour l'authentification proxy (``settings.https.proxy_username`` est egalement accepte)
+     - Nom d'utilisateur pour l'authentification proxy (``settings.https.proxy_username`` est également accepté)
    * - ``settings.http.proxy_password``
-     - Mot de passe pour l'authentification proxy (``settings.https.proxy_password`` est egalement accepte)
+     - Mot de passe pour l'authentification proxy (``settings.https.proxy_password`` est également accepté)
 
 Configuration du script
 -----------------------
@@ -179,7 +179,7 @@ Mapping de base :
     content=source.content
     last_modified=source.timestamp
 
-Acces aux champs imbriques :
+Accès aux champs imbriqués :
 
 ::
 
@@ -198,28 +198,28 @@ Champs disponibles
 - ``index`` - Nom de l'index
 - ``score`` - Score de recherche
 - ``version`` - Version du document
-- ``seqNo`` - Numero de sequence
+- ``seqNo`` - Numéro de séquence
 - ``primaryTerm`` - Terme primaire
 - ``clusterAlias`` - Alias du cluster (pour la recherche inter-clusters)
-- ``hit`` - Objet SearchHit (utilisation avancee)
+- ``hit`` - Objet SearchHit (utilisation avancée)
 
-Configuration des requetes
+Configuration des requêtes
 ==========================
 
-Recuperation de tous les documents
+Récupération de tous les documents
 ------------------------------------
 
-Par defaut, tous les documents sont recuperes.
-Si le parametre ``query`` n'est pas specifie, ``match_all`` est utilise.
+Par défaut, tous les documents sont récupérés.
+Si le paramètre ``query`` n'est pas spécifié, ``match_all`` est utilisé.
 
-Filtrage par conditions specifiques
+Filtrage par conditions spécifiques
 ------------------------------------
 
 ::
 
     query={"term":{"status":"published"}}
 
-Specification de plage :
+Spécification de plage :
 
 ::
 
@@ -232,13 +232,13 @@ Conditions multiples :
     query={"bool":{"must":[{"term":{"category":"news"}},{"range":{"views":{"gte":100}}}]}}
 
 .. note::
-   Le parametre ``query`` n'accepte que le corps de la requete. Le wrapper externe ``{"query":...}`` n'est pas necessaire.
-   Les options de niveau recherche telles que le tri ne peuvent pas etre specifiees dans ce parametre.
+   Le paramètre ``query`` n'accepte que le corps de la requête. Le wrapper externe ``{"query":...}`` n'est pas nécessaire.
+   Les options de niveau recherche telles que le tri ne peuvent pas être spécifiées dans ce paramètre.
 
-Recuperation de champs specifiques uniquement
+Récupération de champs spécifiques uniquement
 =============================================
 
-Limitation des champs avec le parametre fields
+Limitation des champs avec le paramètre fields
 -----------------------------------------------
 
 ::
@@ -248,7 +248,7 @@ Limitation des champs avec le parametre fields
     fields=title,content,url,timestamp
     size=100
 
-Pour recuperer tous les champs, ne specifiez pas ``fields`` ou laissez-le vide.
+Pour récupérer tous les champs, ne spécifiez pas ``fields`` ou laissez-le vide.
 
 Exemples d'utilisation
 ======================
@@ -256,7 +256,7 @@ Exemples d'utilisation
 Crawl d'un index de base
 -------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -278,7 +278,7 @@ Script :
 Crawl d'un cluster avec authentification
 -----------------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -302,7 +302,7 @@ Script :
 Crawl de plusieurs index
 --------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -324,7 +324,7 @@ Script :
 Crawl d'un cluster OpenSearch
 -------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -347,7 +347,7 @@ Script :
 Crawl avec limitation de champs
 ---------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -365,12 +365,12 @@ Script :
     content=source.content
     last_modified=source.timestamp
 
-Repartition de charge multi-hotes
+Répartition de charge multi-hôtes
 -----------------------------------
 
-En specifiant plusieurs hotes separes par des virgules dans ``settings.http.hosts``, les requetes sont distribuees entre chaque hote.
+En spécifiant plusieurs hôtes séparés par des virgules dans ``settings.http.hosts``, les requêtes sont distribuées entre chaque hôte.
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -388,63 +388,63 @@ Script :
     content=source.content
     last_modified=source.timestamp
 
-Depannage
+Dépannage
 =========
 
 Erreur de connexion
 --------------------
 
-**Symptome** : ``Connection refused`` ou ``No route to host``
+**Symptôme** : ``Connection refused`` ou ``No route to host``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si l'URL de l'hote est correcte (protocole, nom d'hote, port)
-2. Verifier si Elasticsearch/OpenSearch est en cours d'execution
-3. Verifier les parametres du pare-feu
-4. Pour HTTPS, verifier si le certificat est valide
+1. Vérifier si l'URL de l'hôte est correcte (protocole, nom d'hôte, port)
+2. Vérifier si Elasticsearch/OpenSearch est en cours d'exécution
+3. Vérifier les paramètres du pare-feu
+4. Pour HTTPS, vérifier si le certificat est valide
 
 Erreur d'authentification
 --------------------------
 
-**Symptome** : ``401 Unauthorized`` ou ``403 Forbidden``
+**Symptôme** : ``401 Unauthorized`` ou ``403 Forbidden``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si le nom d'utilisateur et le mot de passe sont corrects
-2. Verifier si l'utilisateur a les droits appropries :
+1. Vérifier si le nom d'utilisateur et le mot de passe sont corrects
+2. Vérifier si l'utilisateur a les droits appropriés :
 
    - Droits de lecture sur l'index
    - Droits d'utilisation de l'API scroll
 
-3. Si Elasticsearch Security (X-Pack) est active, verifier si la configuration est correcte
+3. Si Elasticsearch Security (X-Pack) est activé, vérifier si la configuration est correcte
 
 Index introuvable
 ------------------
 
-**Symptome** : ``index_not_found_exception``
+**Symptôme** : ``index_not_found_exception``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si le nom de l'index est correct (incluant la casse)
-2. Verifier si l'index existe :
+1. Vérifier si le nom de l'index est correct (incluant la casse)
+2. Vérifier si l'index existe :
 
    ::
 
        GET /_cat/indices
 
-3. Verifier si le pattern wildcard est correct (ex : ``logs-*``)
+3. Vérifier si le pattern wildcard est correct (ex : ``logs-*``)
 
-Erreur de requete
+Erreur de requête
 ------------------
 
-**Symptome** : ``parsing_exception`` ou ``search_phase_execution_exception``
+**Symptôme** : ``parsing_exception`` ou ``search_phase_execution_exception``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si le JSON de la requete est correct
-2. Verifier si la requete est compatible avec la version d'Elasticsearch/OpenSearch
-3. Verifier si les noms de champs sont corrects
-4. Tester la requete directement sur Elasticsearch/OpenSearch :
+1. Vérifier si le JSON de la requête est correct
+2. Vérifier si la requête est compatible avec la version d'Elasticsearch/OpenSearch
+3. Vérifier si les noms de champs sont corrects
+4. Tester la requête directement sur Elasticsearch/OpenSearch :
 
    ::
 
@@ -456,7 +456,7 @@ Erreur de requete
 Timeout du scroll
 ------------------
 
-**Symptome** : ``No search context found`` ou ``Scroll timeout``
+**Symptôme** : ``No search context found`` ou ``Scroll timeout``
 
 **Solution** :
 
@@ -466,18 +466,18 @@ Timeout du scroll
 
        scroll=10m
 
-2. Reduire ``size`` :
+2. Réduire ``size`` :
 
    ::
 
        size=50
 
-3. Verifier les ressources du cluster
+3. Vérifier les ressources du cluster
 
-Crawl de donnees volumineuses
+Crawl de données volumineuses
 ------------------------------
 
-**Symptome** : Le crawl est lent ou expire
+**Symptôme** : Le crawl est lent ou expire
 
 **Solution** :
 
@@ -488,34 +488,34 @@ Crawl de donnees volumineuses
        size=100
        size=500  # Plus grand
 
-2. Limiter les champs recuperes avec ``fields``
-3. Filtrer les documents necessaires avec ``query``
-4. Diviser en plusieurs data stores (par index, par periode, etc.)
+2. Limiter les champs récupérés avec ``fields``
+3. Filtrer les documents nécessaires avec ``query``
+4. Diviser en plusieurs data stores (par index, par période, etc.)
 
-Memoire insuffisante
+Mémoire insuffisante
 ---------------------
 
-**Symptome** : OutOfMemoryError
+**Symptôme** : OutOfMemoryError
 
 **Solution** :
 
-1. Reduire ``size``
-2. Limiter les champs recuperes avec ``fields``
+1. Réduire ``size``
+2. Limiter les champs récupérés avec ``fields``
 3. Augmenter la taille du tas de |Fess|
-4. Exclure les champs volumineux (donnees binaires, etc.)
+4. Exclure les champs volumineux (données binaires, etc.)
 
 Connexion SSL/TLS
 =================
 
-Cas de certificat auto-signe
+Cas de certificat auto-signé
 ------------------------------
 
 .. warning::
-   Utilisez des certificats signes de maniere appropriee en environnement de production.
+   Utilisez des certificats signés de manière appropriée en environnement de production.
 
-Methode 1 : Specifier le certificat CA avec le parametre ``settings.http.ssl.certificate_authorities`` (recommande)
+Méthode 1 : Spécifier le certificat CA avec le paramètre ``settings.http.ssl.certificate_authorities`` (recommandé)
 
-Indiquez le chemin du fichier de certificat CA de confiance (format X.509). Cette methode n'affecte pas le keystore global de |Fess|.
+Indiquez le chemin du fichier de certificat CA de confiance (format X.509). Cette méthode n'affecte pas le keystore global de |Fess|.
 
 ::
 
@@ -523,9 +523,9 @@ Indiquez le chemin du fichier de certificat CA de confiance (format X.509). Cett
     settings.http.ssl.certificate_authorities=/path/to/es-cert.crt
     index=myindex
 
-Methode 2 : Ajouter le certificat au keystore Java
+Méthode 2 : Ajouter le certificat au keystore Java
 
-Ajoutez le certificat au trust store de la JVM qui demarre |Fess|.
+Ajoutez le certificat au trust store de la JVM qui démarre |Fess|.
 
 ::
 
@@ -534,7 +534,7 @@ Ajoutez le certificat au trust store de la JVM qui demarre |Fess|.
 Connexion via un proxy
 -----------------------
 
-Pour se connecter via un serveur proxy, specifiez ``settings.http.proxy_host`` et ``settings.http.proxy_port``.
+Pour se connecter via un serveur proxy, spécifiez ``settings.http.proxy_host`` et ``settings.http.proxy_port``.
 
 ::
 
@@ -543,29 +543,29 @@ Pour se connecter via un serveur proxy, specifiez ``settings.http.proxy_host`` e
     settings.http.proxy_port=8080
     index=myindex
 
-Exemples de requetes avancees
+Exemples de requêtes avancées
 ==============================
 
-Requete avec agregation
+Requête avec agrégation
 ------------------------
 
 .. note::
-   Le parametre ``query`` n'accepte que le corps de la requete. Les agregations (aggs), le tri et autres
-   options de niveau recherche ne peuvent pas etre specifies. Seuls les documents sont recuperes.
+   Le paramètre ``query`` n'accepte que le corps de la requête. Les agrégations (aggs), le tri et autres
+   options de niveau recherche ne peuvent pas être spécifiés. Seuls les documents sont récupérés.
 
 Champs de script
 -----------------
 
 .. note::
    Les champs de script Elasticsearch/OpenSearch ne sont pas inclus dans ``_source`` et ne peuvent donc pas
-   etre accedes via le prefixe ``source.*``. Pour utiliser les champs de script, accedez-y via l'objet
+   être accédés via le préfixe ``source.*``. Pour utiliser les champs de script, accédez-y via l'objet
    ``hit`` en utilisant ``hit.getFields()``.
 
-Informations de reference
+Informations de référence
 ==========================
 
-- :doc:`ds-overview` - Apercu des connecteurs Data Store
-- :doc:`ds-database` - Connecteur de base de donnees
+- :doc:`ds-overview` - Aperçu des connecteurs Data Store
+- :doc:`ds-database` - Connecteur de base de données
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration Data Store
 - `Elasticsearch Documentation <https://www.elastic.co/guide/>`_
 - `OpenSearch Documentation <https://opensearch.org/docs/>`_

--- a/fr/15.7/config/datastore/ds-gsuite.rst
+++ b/fr/15.7/config/datastore/ds-gsuite.rst
@@ -2,32 +2,32 @@
 Connecteur Google Workspace
 ==================================
 
-Apercu
+Aperçu
 ====
 
-Le connecteur Google Workspace fournit la fonctionnalite permettant de recuperer les fichiers
+Le connecteur Google Workspace fournit la fonctionnalité permettant de récupérer les fichiers
 depuis Google Drive (anciennement G Suite) et de les enregistrer dans l'index |Fess|.
 
-Cette fonctionnalite necessite le plugin ``fess-ds-gsuite``.
+Cette fonctionnalité nécessite le plugin ``fess-ds-gsuite``.
 
 Services pris en charge
 ============
 
-- Google Drive (Mon Drive, Drive partages)
+- Google Drive (Mon Drive, Drive partagés)
 - Google Docs, Sheets, Slides, Forms, etc.
 
-Prerequis
+Prérequis
 ========
 
 1. L'installation du plugin est requise
-2. La creation d'un projet Google Cloud Platform est necessaire
-3. La creation d'un compte de service et l'obtention des identifiants sont necessaires
-4. La configuration de la delegation a l'echelle du domaine Google Workspace est necessaire
+2. La création d'un projet Google Cloud Platform est nécessaire
+3. La création d'un compte de service et l'obtention des identifiants sont nécessaires
+4. La configuration de la délégation à l'échelle du domaine Google Workspace est nécessaire
 
 Installation du plugin
 ------------------------
 
-Methode 1 : Placement direct du fichier JAR
+Méthode 1 : Placement direct du fichier JAR
 
 ::
 
@@ -39,11 +39,11 @@ Methode 1 : Placement direct du fichier JAR
     # ou
     cp fess-ds-gsuite-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Methode 2 : Installation depuis l'interface d'administration
+Méthode 2 : Installation depuis l'interface d'administration
 
-1. Ouvrir "Systeme" -> "Plugins"
-2. Telecharger le fichier JAR
-3. Redemarrer |Fess|
+1. Ouvrir "Système" -> "Plugins"
+2. Télécharger le fichier JAR
+3. Redémarrer |Fess|
 
 Configuration
 ========
@@ -57,7 +57,7 @@ Configuration de base
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
+   * - Élément
      - Exemple
    * - Nom
      - Company Google Drive
@@ -66,7 +66,7 @@ Configuration de base
    * - Active
      - Oui
 
-Configuration des parametres
+Configuration des paramètres
 ----------------
 
 ::
@@ -75,79 +75,79 @@ Configuration des parametres
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project.iam.gserviceaccount.com
 
-Liste des parametres
+Liste des paramètres
 ~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``private_key``
      - Oui
-     - Cle privee du compte de service (format PEM, sauts de ligne en ``\n``)
+     - Clé privée du compte de service (format PEM, sauts de ligne en ``\n``)
    * - ``private_key_id``
      - Oui
-     - ID de la cle privee
+     - ID de la clé privée
    * - ``client_email``
      - Oui
      - Adresse email du compte de service
    * - ``max_size``
      - Non
-     - Taille maximale des fichiers a indexer (en octets). Par defaut : ``10000000`` (environ 10 Mo)
+     - Taille maximale des fichiers à indexer (en octets). Par défaut : ``10000000`` (environ 10 Mo)
    * - ``ignore_folder``
      - Non
-     - Ignorer les dossiers ou non. Par defaut : ``true``
+     - Ignorer les dossiers ou non. Par défaut : ``true``
    * - ``ignore_error``
      - Non
-     - Continuer le traitement en cas d'erreur. Par defaut : ``true``
+     - Continuer le traitement en cas d'erreur. Par défaut : ``true``
    * - ``supported_mimetypes``
      - Non
-     - Types MIME a indexer (expression reguliere, separes par des virgules). Par defaut : ``.*`` (tous les types)
+     - Types MIME à indexer (expression régulière, séparés par des virgules). Par défaut : ``.*`` (tous les types)
    * - ``include_pattern``
      - Non
-     - Expression reguliere des URL a inclure dans l'indexation
+     - Expression régulière des URL à inclure dans l'indexation
    * - ``exclude_pattern``
      - Non
-     - Expression reguliere des URL a exclure de l'indexation
+     - Expression régulière des URL à exclure de l'indexation
    * - ``default_permissions``
      - Non
-     - Permissions par defaut (separees par des virgules, ex : ``{role}drive-users``)
+     - Permissions par défaut (séparées par des virgules, ex : ``{role}drive-users``)
    * - ``number_of_threads``
      - Non
-     - Nombre de threads de traitement parallele. Par defaut : ``1``
+     - Nombre de threads de traitement parallèle. Par défaut : ``1``
    * - ``query``
      - Non
-     - Chaine de requete de recherche de l'API Google Drive
+     - Chaîne de requête de recherche de l'API Google Drive
    * - ``corpora``
      - Non
-     - Corpus a rechercher. Par defaut : ``allDrives``
+     - Corpus à rechercher. Par défaut : ``allDrives``
    * - ``spaces``
      - Non
-     - Espaces a rechercher (parametre ``spaces`` de l'API Google Drive, par ex. ``drive``, ``appDataFolder``). Par defaut : non defini (valeur par defaut de l'API).
+     - Espaces à rechercher (paramètre ``spaces`` de l'API Google Drive, par ex. ``drive``, ``appDataFolder``). Par défaut : non défini (valeur par défaut de l'API).
    * - ``fields``
      - Non
-     - Champs de fichier a demander a l'API Google Drive. Par defaut : ``*`` (tous les champs).
+     - Champs de fichier à demander à l'API Google Drive. Par défaut : ``*`` (tous les champs).
    * - ``read_timeout``
      - Non
-     - Delai de lecture HTTP (en millisecondes). Par defaut : ``20000``
+     - Délai de lecture HTTP (en millisecondes). Par défaut : ``20000``
    * - ``connect_timeout``
      - Non
-     - Delai de connexion HTTP (en millisecondes). Par defaut : ``20000``
+     - Délai de connexion HTTP (en millisecondes). Par défaut : ``20000``
    * - ``refresh_token_interval``
      - Non
-     - Intervalle (en secondes) pour renouveler le jeton d'acces OAuth. Par defaut : ``3540`` (59 minutes).
+     - Intervalle (en secondes) pour renouveler le jeton d'accès OAuth. Par défaut : ``3540`` (59 minutes).
    * - ``max_cached_content_size``
      - Non
-     - Taille maximale (en octets) du contenu conserve en memoire ; un contenu plus volumineux est decharge dans un fichier temporaire. Par defaut : ``1048576`` (1 Mo).
+     - Taille maximale (en octets) du contenu conservé en mémoire ; un contenu plus volumineux est déchargé dans un fichier temporaire. Par défaut : ``1048576`` (1 Mo).
    * - ``proxy_host``
      - Non
-     - Nom d'hote du serveur proxy
+     - Nom d'hôte du serveur proxy
    * - ``proxy_port``
      - Non
-     - Numero de port du serveur proxy
+     - Numéro de port du serveur proxy
 
 Configuration du script
 --------------
@@ -186,9 +186,9 @@ Champs disponibles
    * - ``file.filetype``
      - Type de fichier
    * - ``file.created_time``
-     - Date de creation
+     - Date de création
    * - ``file.modified_time``
-     - Date de derniere modification
+     - Date de dernière modification
    * - ``file.web_view_link``
      - Lien pour ouvrir dans le navigateur
    * - ``file.url``
@@ -198,68 +198,68 @@ Champs disponibles
    * - ``file.size``
      - Taille du fichier (octets)
    * - ``file.roles``
-     - Permissions d'acces
+     - Permissions d'accès
 
-Pour plus de details, consultez `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_.
+Pour plus de détails, consultez `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_.
 
 Configuration Google Cloud Platform
 =========================
 
-1. Creation du projet
+1. Création du projet
 ---------------------
 
-Accedez a https://console.cloud.google.com/ :
+Accédez à https://console.cloud.google.com/ :
 
-1. Creez un nouveau projet
+1. Créez un nouveau projet
 2. Entrez le nom du projet
-3. Selectionnez l'organisation et l'emplacement
+3. Sélectionnez l'organisation et l'emplacement
 
 2. Activation de l'API Google Drive
 ---------------------------
 
-Dans "APIs et services" -> "Bibliotheque" :
+Dans "APIs et services" -> "Bibliothèque" :
 
 1. Recherchez "Google Drive API"
 2. Cliquez sur "Activer"
 
-3. Creation du compte de service
+3. Création du compte de service
 ---------------------------
 
 Dans "APIs et services" -> "Identifiants" :
 
-1. Selectionnez "Creer des identifiants" -> "Compte de service"
+1. Sélectionnez "Créer des identifiants" -> "Compte de service"
 2. Entrez le nom du compte de service (ex: fess-crawler)
-3. Cliquez sur "Creer et continuer"
-4. Les roles ne sont pas necessaires (ignorez)
+3. Cliquez sur "Créer et continuer"
+4. Les rôles ne sont pas nécessaires (ignorez)
 5. Cliquez sur "Terminer"
 
-4. Creation de la cle du compte de service
+4. Création de la clé du compte de service
 -------------------------------
 
-Pour le compte de service cree :
+Pour le compte de service créé :
 
 1. Cliquez sur le compte de service
-2. Ouvrez l'onglet "Cles"
-3. "Ajouter une cle" -> "Creer une nouvelle cle"
-4. Selectionnez le format JSON
-5. Enregistrez le fichier JSON telecharge
+2. Ouvrez l'onglet "Clés"
+3. "Ajouter une clé" -> "Créer une nouvelle clé"
+4. Sélectionnez le format JSON
+5. Enregistrez le fichier JSON téléchargé
 
-5. Activation de la delegation a l'echelle du domaine
+5. Activation de la délégation à l'échelle du domaine
 -----------------------------
 
-Dans les parametres du compte de service :
+Dans les paramètres du compte de service :
 
-1. Cochez "Activer la delegation a l'echelle du domaine"
+1. Cochez "Activer la délégation à l'échelle du domaine"
 2. Cliquez sur "Enregistrer"
 3. Copiez "l'ID client OAuth 2"
 
 6. Autorisation dans la console d'administration Google Workspace
 ---------------------------------------
 
-Accedez a https://admin.google.com/ :
+Accédez à https://admin.google.com/ :
 
-1. Ouvrez "Securite" -> "Acces et controle des donnees" -> "Controles d'API"
-2. Selectionnez "Delegation a l'echelle du domaine"
+1. Ouvrez "Sécurité" -> "Accès et contrôle des données" -> "Contrôles d'API"
+2. Sélectionnez "Délégation à l'échelle du domaine"
 3. Cliquez sur "Ajouter nouveau"
 4. Entrez l'ID client
 5. Entrez les scopes OAuth :
@@ -276,7 +276,7 @@ Configuration des identifiants
 Obtention des informations depuis le fichier JSON
 --------------------------
 
-Fichier JSON telecharge :
+Fichier JSON téléchargé :
 
 ::
 
@@ -293,13 +293,13 @@ Fichier JSON telecharge :
       "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/..."
     }
 
-Configurez les informations suivantes dans les parametres :
+Configurez les informations suivantes dans les paramètres :
 
 - ``private_key_id`` -> ``private_key_id``
 - ``private_key`` -> ``private_key`` (conservez les sauts de ligne en ``\n``)
 - ``client_email`` -> ``client_email``
 
-Format de la cle privee
+Format de la clé privée
 ~~~~~~~~~~~~
 
 ``private_key`` conserve les sauts de ligne en ``\n`` :
@@ -314,7 +314,7 @@ Exemples d'utilisation
 Crawl de l'ensemble de Google Drive
 --------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -340,7 +340,7 @@ Script :
 Crawl avec permissions
 ----------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -378,72 +378,72 @@ Google Docs uniquement :
         url=file.web_view_link
     }
 
-Depannage
+Dépannage
 ======================
 
 Erreur d'authentification
 ----------
 
-**Symptome** : ``401 Unauthorized`` ou ``403 Forbidden``
+**Symptôme** : ``401 Unauthorized`` ou ``403 Forbidden``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si les identifiants du compte de service sont corrects :
+1. Vérifier si les identifiants du compte de service sont corrects :
 
    - Les sauts de ligne de ``private_key`` sont-ils en ``\n`` ?
    - ``private_key_id`` est-il correct ?
    - ``client_email`` est-il correct ?
 
-2. Verifier si l'API Google Drive est activee
-3. Verifier si la delegation a l'echelle du domaine est configuree
-4. Verifier si l'autorisation a ete accordee dans la console d'administration Google Workspace
-5. Verifier si le scope OAuth est correct (``https://www.googleapis.com/auth/drive``)
+2. Vérifier si l'API Google Drive est activée
+3. Vérifier si la délégation à l'échelle du domaine est configurée
+4. Vérifier si l'autorisation a été accordée dans la console d'administration Google Workspace
+5. Vérifier si le scope OAuth est correct (``https://www.googleapis.com/auth/drive``)
 
-Erreur de delegation a l'echelle du domaine
+Erreur de délégation à l'échelle du domaine
 ------------------------
 
-**Symptome** : ``Not Authorized to access this resource/api``
+**Symptôme** : ``Not Authorized to access this resource/api``
 
 **Solution** :
 
-1. Verifier l'autorisation dans la console d'administration Google Workspace :
+1. Vérifier l'autorisation dans la console d'administration Google Workspace :
 
-   - L'ID client est-il correctement enregistre ?
+   - L'ID client est-il correctement enregistré ?
    - Le scope OAuth est-il correct ? (``https://www.googleapis.com/auth/drive``)
 
-2. Verifier si la delegation a l'echelle du domaine est activee sur le compte de service
+2. Vérifier si la délégation à l'échelle du domaine est activée sur le compte de service
 
-Impossible de recuperer les fichiers
+Impossible de récupérer les fichiers
 ----------------------
 
-**Symptome** : Le crawl reussit mais 0 fichiers
+**Symptôme** : Le crawl réussit mais 0 fichiers
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si des fichiers existent dans Google Drive
-2. Verifier si le compte de service a les droits de lecture
-3. Verifier si la delegation a l'echelle du domaine est correctement configuree
-4. Verifier si le Drive de l'utilisateur cible est accessible
+1. Vérifier si des fichiers existent dans Google Drive
+2. Vérifier si le compte de service a les droits de lecture
+3. Vérifier si la délégation à l'échelle du domaine est correctement configurée
+4. Vérifier si le Drive de l'utilisateur cible est accessible
 
 Erreur de quota API
 -----------------
 
-**Symptome** : ``403 Rate Limit Exceeded`` ou ``429 Too Many Requests``
+**Symptôme** : ``403 Rate Limit Exceeded`` ou ``429 Too Many Requests``
 
 **Solution** :
 
-1. Verifier le quota dans Google Cloud Platform
+1. Vérifier le quota dans Google Cloud Platform
 2. Augmenter l'intervalle de crawl
-3. Demander une augmentation de quota si necessaire
+3. Demander une augmentation de quota si nécessaire
 
-Erreur de format de cle privee
+Erreur de format de clé privée
 --------------------------
 
-**Symptome** : ``Invalid private key format``
+**Symptôme** : ``Invalid private key format``
 
 **Solution** :
 
-Verifier si les sauts de ligne sont correctement en ``\n`` :
+Vérifier si les sauts de ligne sont correctement en ``\n`` :
 
 ::
 
@@ -455,39 +455,39 @@ Verifier si les sauts de ligne sont correctement en ``\n`` :
     MIIEvgIBADANBgkqhkiG9w0BAQE...
     -----END PRIVATE KEY-----
 
-Crawl des Drive partages
+Crawl des Drive partagés
 ----------------------
 
 .. note::
-   Pour crawler les Drive partages avec un compte de service,
-   vous devez ajouter le compte de service comme membre du Drive partage.
+   Pour crawler les Drive partagés avec un compte de service,
+   vous devez ajouter le compte de service comme membre du Drive partagé.
 
-1. Ouvrez le Drive partage dans Google Drive
-2. Cliquez sur "Gerer les membres"
+1. Ouvrez le Drive partagé dans Google Drive
+2. Cliquez sur "Gérer les membres"
 3. Ajoutez l'adresse email du compte de service
-4. Definissez le niveau de permission sur "Lecteur"
+4. Définissez le niveau de permission sur "Lecteur"
 
 Cas de nombreux fichiers
 ------------------------
 
-**Symptome** : Le crawl prend du temps ou expire
+**Symptôme** : Le crawl prend du temps ou expire
 
 **Solution** :
 
 1. Diviser en plusieurs data stores
-2. Repartir la charge avec les parametres de planification
+2. Répartir la charge avec les paramètres de planification
 3. Ajuster l'intervalle de crawl
-4. Crawler uniquement des dossiers specifiques
+4. Crawler uniquement des dossiers spécifiques
 
-Permissions et controle d'acces
+Permissions et contrôle d'accès
 ==================
 
 Reflet des permissions de partage Google Drive
 ----------------------------
 
-Reflet des parametres de partage Google Drive dans les permissions Fess :
+Reflet des paramètres de partage Google Drive dans les permissions Fess :
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -510,10 +510,10 @@ Script :
 
 ``file.roles`` contient les informations de partage Google Drive.
 
-Informations de reference
+Informations de référence
 ========
 
-- :doc:`ds-overview` - Apercu des connecteurs Data Store
+- :doc:`ds-overview` - Aperçu des connecteurs Data Store
 - :doc:`ds-microsoft365` - Connecteur Microsoft 365
 - :doc:`ds-box` - Connecteur Box
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration Data Store

--- a/fr/15.7/config/datastore/ds-overview.rst
+++ b/fr/15.7/config/datastore/ds-overview.rst
@@ -1,25 +1,25 @@
 ==================================
-Apercu des connecteurs DataStore
+Aperçu des connecteurs DataStore
 ==================================
 
-Apercu
+Aperçu
 ======
 
-Les connecteurs DataStore de |Fess| fournissent une fonctionnalite permettant de recuperer
-et d'indexer du contenu depuis des sources de donnees autres que les sites web ou les systemes de fichiers.
+Les connecteurs DataStore de |Fess| fournissent une fonctionnalité permettant de récupérer
+et d'indexer du contenu depuis des sources de données autres que les sites web ou les systèmes de fichiers.
 
-En utilisant les connecteurs DataStore, vous pouvez rendre recherchables les donnees provenant des sources suivantes :
+En utilisant les connecteurs DataStore, vous pouvez rendre recherchables les données provenant des sources suivantes :
 
 - Stockage cloud (Box, Dropbox, Google Drive, OneDrive)
 - Outils de collaboration (Confluence, Jira, Slack)
-- Bases de donnees (MySQL, PostgreSQL, Oracle, etc.)
-- Autres systemes (Git, Salesforce, Elasticsearch, etc.)
+- Bases de données (MySQL, PostgreSQL, Oracle, etc.)
+- Autres systèmes (Git, Salesforce, Elasticsearch, etc.)
 
 Connecteurs disponibles
 =======================
 
-|Fess| fournit des connecteurs pour diverses sources de donnees.
-La plupart des connecteurs sont fournis sous forme de plugins et peuvent etre installes selon les besoins.
+|Fess| fournit des connecteurs pour diverses sources de données.
+La plupart des connecteurs sont fournis sous forme de plugins et peuvent être installés selon les besoins.
 
 Stockage cloud
 --------------
@@ -61,7 +61,7 @@ Outils de collaboration
      - fess-ds-slack
      - Exploration des messages et fichiers Slack
 
-Outils de developpement et operations
+Outils de développement et opérations
 -------------------------------------
 
 .. list-table::
@@ -73,15 +73,15 @@ Outils de developpement et operations
      - Description
    * - :doc:`ds-git`
      - fess-ds-git
-     - Exploration du code source des depots Git
+     - Exploration du code source des dépôts Git
    * - :doc:`ds-elasticsearch`
      - fess-ds-elasticsearch
-     - Recuperation de donnees depuis Elasticsearch/OpenSearch
+     - Récupération de données depuis Elasticsearch/OpenSearch
    * - :doc:`ds-salesforce`
      - fess-ds-salesforce
      - Exploration des objets Salesforce
 
-Bases de donnees et fichiers
+Bases de données et fichiers
 ----------------------------
 
 .. list-table::
@@ -93,13 +93,13 @@ Bases de donnees et fichiers
      - Description
    * - :doc:`ds-database`
      - fess-ds-db
-     - Recuperation de donnees depuis les bases de donnees compatibles JDBC
+     - Récupération de données depuis les bases de données compatibles JDBC
    * - :doc:`ds-csv`
      - fess-ds-csv
-     - Recuperation de donnees depuis les fichiers CSV
+     - Récupération de données depuis les fichiers CSV
    * - :doc:`ds-json`
      - fess-ds-json
-     - Recuperation de donnees depuis les fichiers JSON
+     - Récupération de données depuis les fichiers JSON
 
 Installation des connecteurs
 ============================
@@ -107,59 +107,59 @@ Installation des connecteurs
 Installation des plugins
 ------------------------
 
-Les plugins de connecteurs DataStore peuvent etre installes depuis l'interface d'administration.
+Les plugins de connecteurs DataStore peuvent être installés depuis l'interface d'administration.
 
 Depuis l'interface d'administration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Connectez-vous a l'interface d'administration
-2. Naviguez vers "Systeme" -> "Plugin"
+1. Connectez-vous à l'interface d'administration
+2. Naviguez vers "Système" -> "Plugin"
 3. Cliquez sur le bouton "Installer"
-4. Selectionnez le plugin dans l'onglet "Distant" (ou telechargez un fichier JAR depuis l'onglet "Local")
+4. Sélectionnez le plugin dans l'onglet "Distant" (ou téléchargez un fichier JAR depuis l'onglet "Local")
 5. Cliquez sur "Installer"
-6. Redemarrez |Fess|
+6. Redémarrez |Fess|
 
 Configuration de base des DataStores
 ====================================
 
 La configuration des connecteurs DataStore s'effectue dans l'interface d'administration sous "Crawler" -> "DataStore".
 
-Elements de configuration communs
+Éléments de configuration communs
 ---------------------------------
 
-Elements de configuration communs a tous les connecteurs DataStore :
+Éléments de configuration communs à tous les connecteurs DataStore :
 
 .. list-table::
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
+   * - Élément
      - Description
    * - Nom
      - Nom d'identification de la configuration
    * - Description
      - Description de la configuration
    * - Nom du handler
-     - Nom du handler du connecteur a utiliser (ex: ``CsvDataStore``)
-   * - Parametres
-     - Parametres de configuration specifiques au connecteur (format key=value)
+     - Nom du handler du connecteur à utiliser (ex: ``CsvDataStore``)
+   * - Paramètres
+     - Paramètres de configuration spécifiques au connecteur (format key=value)
    * - Script
      - Script de mapping des champs d'index
    * - Boost
-     - Priorite dans les resultats de recherche
+     - Priorité dans les résultats de recherche
    * - Autorisations
-     - Autorisations d'acces aux documents recuperes par ce connecteur
-   * - Hotes virtuels
-     - Hote virtuel auquel cette configuration s'applique
+     - Autorisations d'accès aux documents récupérés par ce connecteur
+   * - Hôtes virtuels
+     - Hôte virtuel auquel cette configuration s'applique
    * - Ordre d'affichage
      - Ordre d'affichage dans la liste des configurations
    * - Actif
      - Activer ou non cette configuration
 
-Configuration des parametres
+Configuration des paramètres
 ----------------------------
 
-Les parametres sont specifies au format ``key=value`` separes par des retours a la ligne :
+Les paramètres sont spécifiés au format ``key=value`` séparés par des retours à la ligne :
 
 ::
 
@@ -170,10 +170,10 @@ Les parametres sont specifies au format ``key=value`` separes par des retours a 
 Configuration du script
 -----------------------
 
-Le script permet de mapper les donnees recuperees vers les champs d'index de |Fess|.
+Le script permet de mapper les données récupérées vers les champs d'index de |Fess|.
 Chaque ligne du script associe un champ d'index |Fess| (membre gauche) au champ fourni par le connecteur (membre droit).
 
-Voici un exemple pour le connecteur CSV avec les colonnes d'en-tete ``link``, ``subject`` et ``body`` :
+Voici un exemple pour le connecteur CSV avec les colonnes d'en-tête ``link``, ``subject`` et ``body`` :
 
 ::
 
@@ -184,72 +184,72 @@ Voici un exemple pour le connecteur CSV avec les colonnes d'en-tete ``link``, ``
 .. note::
 
    Les noms de champs utilisables dans le script varient selon le connecteur.
-   Box/Dropbox/Google Drive/OneDrive referencent l'objet recupere avec le prefixe ``file.*`` ; Slack utilise ``message.*`` ; Jira utilise ``issue.*``.
-   En revanche, les connecteurs CSV, JSON et Base de donnees n'utilisent aucun prefixe ; les champs sont references directement :
+   Box/Dropbox/Google Drive/OneDrive référencent l'objet récupéré avec le préfixe ``file.*`` ; Slack utilise ``message.*`` ; Jira utilise ``issue.*``.
+   En revanche, les connecteurs CSV, JSON et Base de données n'utilisent aucun préfixe ; les champs sont référencés directement :
 
-   - CSV : noms des colonnes d'en-tete (si ``has_header_line=true``), ou ``cell1``, ``cell2``, ... (index base 1) ; ainsi que ``csvfile`` et ``csvfilename``.
+   - CSV : noms des colonnes d'en-tête (si ``has_header_line=true``), ou ``cell1``, ``cell2``, ... (index base 1) ; ainsi que ``csvfile`` et ``csvfilename``.
    - JSON : noms des champs de l'objet JSON.
-   - Base de donnees : noms des colonnes (alias) du resultat SELECT.
+   - Base de données : noms des colonnes (alias) du résultat SELECT.
 
-   Consultez la documentation individuelle de chaque connecteur pour plus de details.
+   Consultez la documentation individuelle de chaque connecteur pour plus de détails.
 
 Configuration de l'authentification
 ===================================
 
-La plupart des connecteurs DataStore necessitent une authentification (OAuth 2.0, cle API, compte de service, etc.).
+La plupart des connecteurs DataStore nécessitent une authentification (OAuth 2.0, clé API, compte de service, etc.).
 
-Les parametres d'authentification varient selon le connecteur.
-Consultez la documentation de chaque connecteur pour les details de configuration de l'authentification.
+Les paramètres d'authentification varient selon le connecteur.
+Consultez la documentation de chaque connecteur pour les détails de configuration de l'authentification.
 
-Parametres communs
+Paramètres communs
 ==================
 
-Parametres communs a tous les connecteurs DataStore :
+Paramètres communs à tous les connecteurs DataStore :
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 65
 
-   * - Parametre
-     - Defaut
+   * - Paramètre
+     - Défaut
      - Description
    * - ``readInterval``
      - ``0``
-     - Delai d'attente entre le traitement de chaque enregistrement (en millisecondes). Utilisez ce parametre pour reduire la charge du serveur lors du traitement de grandes quantites de donnees.
+     - Délai d'attente entre le traitement de chaque enregistrement (en millisecondes). Utilisez ce paramètre pour réduire la charge du serveur lors du traitement de grandes quantités de données.
    * - ``script_type``
      - ``groovy``
-     - Type de moteur de script utilise pour le mappage des champs d'index. Par defaut, seul ``groovy`` est disponible.
+     - Type de moteur de script utilisé pour le mappage des champs d'index. Par défaut, seul ``groovy`` est disponible.
 
-Depannage
+Dépannage
 =========
 
-Le connecteur n'apparait pas
+Le connecteur n'apparaît pas
 ----------------------------
 
-1. Verifiez que le plugin est correctement installe
-2. Redemarrez |Fess|
-3. Verifiez les erreurs dans les logs
+1. Vérifiez que le plugin est correctement installé
+2. Redémarrez |Fess|
+3. Vérifiez les erreurs dans les logs
 
 Erreur d'authentification
 -------------------------
 
-1. Verifiez que les informations d'authentification sont correctes
-2. Verifiez la date d'expiration du token
-3. Verifiez que les autorisations necessaires sont accordees
-4. Verifiez que l'acces API est autorise cote service
+1. Vérifiez que les informations d'authentification sont correctes
+2. Vérifiez la date d'expiration du token
+3. Vérifiez que les autorisations nécessaires sont accordées
+4. Vérifiez que l'accès API est autorisé côté service
 
-Impossible de recuperer les donnees
+Impossible de récupérer les données
 -----------------------------------
 
-1. Verifiez le format des parametres
-2. Verifiez les droits d'acces aux dossiers/fichiers cibles
-3. Verifiez les parametres de filtre
-4. Verifiez les messages d'erreur detailles dans les logs
+1. Vérifiez le format des paramètres
+2. Vérifiez les droits d'accès aux dossiers/fichiers cibles
+3. Vérifiez les paramètres de filtre
+4. Vérifiez les messages d'erreur détaillés dans les logs
 
-Configuration de debogage
+Configuration de débogage
 -------------------------
 
-Pour investiguer les problemes, ajustez le niveau de log. Le crawling des datastores s'execute dans le processus crawler ; c'est donc le fichier de configuration des logs du crawler qu'il faut modifier :
+Pour investiguer les problèmes, ajustez le niveau de log. Le crawling des datastores s'exécute dans le processus crawler ; c'est donc le fichier de configuration des logs du crawler qu'il faut modifier :
 
 ``app/WEB-INF/env/crawler/resources/log4j2.xml`` :
 
@@ -257,7 +257,7 @@ Pour investiguer les problemes, ajustez le niveau de log. Le crawling des datast
 
     <Logger name="org.codelibs.fess.ds" level="DEBUG"/>
 
-Informations de reference
+Informations de référence
 =========================
 
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration DataStore

--- a/fr/15.7/config/datastore/ds-salesforce.rst
+++ b/fr/15.7/config/datastore/ds-salesforce.rst
@@ -2,28 +2,28 @@
 Connecteur Salesforce
 ==================================
 
-Apercu
+Aperçu
 ====
 
-Le connecteur Salesforce fournit la fonctionnalite permettant de recuperer des donnees
-depuis les objets Salesforce (objets standard, objets personnalises) et de les enregistrer dans l'index |Fess|.
+Le connecteur Salesforce fournit la fonctionnalité permettant de récupérer des données
+depuis les objets Salesforce (objets standard, objets personnalisés) et de les enregistrer dans l'index |Fess|.
 
-Cette fonctionnalite necessite le plugin ``fess-ds-salesforce``.
+Cette fonctionnalité nécessite le plugin ``fess-ds-salesforce``.
 
 Objets pris en charge
 ================
 
-- **Objets standard** : objets standard predefinis (Account, Contact, Lead, Opportunity, Case, Solution, etc.). L'ensemble des objets standard est fixe et la totalite d'entre eux est recuperee a chaque crawl.
-- **Objets personnalises** : objets definis par l'utilisateur, specifies via le parametre ``custom`` (objets dont le nom API se termine par ``__c``).
+- **Objets standard** : objets standard prédéfinis (Account, Contact, Lead, Opportunity, Case, Solution, etc.). L'ensemble des objets standard est fixe et la totalité d'entre eux est récupérée à chaque crawl.
+- **Objets personnalisés** : objets définis par l'utilisateur, spécifiés via le paramètre ``custom`` (objets dont le nom API se termine par ``__c``).
 
 .. note::
 
-   Les objets standard sont toujours crawles integralement (il n'est pas possible de selectionner individuellement les objets standard a crawler). Pour exclure des objets indesirables, utilisez le filtrage par URL via ``include_pattern`` / ``exclude_pattern``.
+   Les objets standard sont toujours crawlés intégralement (il n'est pas possible de sélectionner individuellement les objets standard à crawler). Pour exclure des objets indésirables, utilisez le filtrage par URL via ``include_pattern`` / ``exclude_pattern``.
 
 Liste des objets standard
 -------------------------
 
-Les objets standard suivants sont crawles. La colonne "Nom de l'objet" est l'identifiant utilise dans le mapping des champs (par exemple ``<NomObjet>.title``) ; ``object.type`` est la valeur du type d'objet que vous pouvez referencer dans les scripts.
+Les objets standard suivants sont crawlés. La colonne "Nom de l'objet" est l'identifiant utilisé dans le mapping des champs (par exemple ``<NomObjet>.title``) ; ``object.type`` est la valeur du type d'objet que vous pouvez référencer dans les scripts.
 
 .. list-table::
    :header-rows: 1
@@ -102,20 +102,20 @@ Les objets standard suivants sont crawles. La colonne "Nom de l'objet" est l'ide
      - ``DandBCompany``
      - D&B Company
 
-Prerequis
+Prérequis
 ========
 
 1. L'installation du plugin est requise
-2. La creation d'une application connectee (Connected App) Salesforce est necessaire
-3. La configuration de l'authentification OAuth est necessaire
-4. L'acces en lecture aux objets est requis
+2. La création d'une application connectée (Connected App) Salesforce est nécessaire
+3. La configuration de l'authentification OAuth est nécessaire
+4. L'accès en lecture aux objets est requis
 
 Installation du plugin
 ------------------------
 
-Installez depuis l'interface d'administration via "Systeme" -> "Plugins".
+Installez depuis l'interface d'administration via "Système" -> "Plugins".
 
-Ou consultez :doc:`../../admin/plugin-guide` pour plus de details.
+Ou consultez :doc:`../../admin/plugin-guide` pour plus de détails.
 
 Configuration
 ========
@@ -129,7 +129,7 @@ Configuration de base
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
+   * - Élément
      - Exemple
    * - Nom
      - Salesforce CRM
@@ -138,10 +138,10 @@ Configuration de base
    * - Active
      - Oui
 
-Configuration des parametres
+Configuration des paramètres
 ----------------
 
-Authentification OAuth Token (recommandee) :
+Authentification OAuth Token (recommandée) :
 
 ::
 
@@ -172,19 +172,19 @@ Authentification OAuth Password :
     number_of_threads=1
     ignore_error=true
 
-Liste des parametres
+Liste des paramètres
 ~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``base_url``
      - Non
-     - URL Salesforce (par defaut : ``https://login.salesforce.com``, Sandbox : ``https://test.salesforce.com``)
+     - URL Salesforce (par défaut : ``https://login.salesforce.com``, Sandbox : ``https://test.salesforce.com``)
    * - ``auth_type``
      - Oui
      - Type d'authentification (``oauth_token`` ou ``oauth_password``)
@@ -196,52 +196,52 @@ Liste des parametres
      - Mot de passe Salesforce
    * - ``client_id``
      - Oui
-     - Consumer Key de l'application connectee
+     - Consumer Key de l'application connectée
    * - ``private_key``
      - Pour oauth_token
-     - Cle privee (format PEM, sauts de ligne en ``\n``)
+     - Clé privée (format PEM, sauts de ligne en ``\n``)
    * - ``client_secret``
      - Pour oauth_password
-     - Consumer Secret de l'application connectee
+     - Consumer Secret de l'application connectée
    * - ``security_token``
      - Pour oauth_password
-     - Token de securite de l'utilisateur
+     - Token de sécurité de l'utilisateur
    * - ``number_of_threads``
      - Non
-     - Nombre de threads de traitement parallele (par defaut : 1)
+     - Nombre de threads de traitement parallèle (par défaut : 1)
    * - ``ignore_error``
      - Non
-     - Continuer le traitement en cas d'erreur (par defaut : true)
+     - Continuer le traitement en cas d'erreur (par défaut : true)
    * - ``custom``
      - Non
-     - Noms des objets personnalises (separes par des virgules)
+     - Noms des objets personnalisés (séparés par des virgules)
    * - ``<objet>.title``
      - Non
-     - Nom du champ a utiliser pour le titre
+     - Nom du champ à utiliser pour le titre
    * - ``<objet>.contents``
      - Non
-     - Noms des champs a utiliser pour le contenu (separes par des virgules)
+     - Noms des champs à utiliser pour le contenu (séparés par des virgules)
    * - ``<objet>.descriptions``
      - Non
-     - Noms de champs pour la description (separes par des virgules)
+     - Noms de champs pour la description (séparés par des virgules)
    * - ``<objet>.thumbnail``
      - Non
      - Nom du champ pour la miniature
    * - ``include_pattern``
      - Non
-     - Modele d'inclusion du filtre URL (regex)
+     - Modèle d'inclusion du filtre URL (regex)
    * - ``exclude_pattern``
      - Non
-     - Modele d'exclusion du filtre URL (regex)
+     - Modèle d'exclusion du filtre URL (regex)
    * - ``refresh_token_interval``
      - Non
-     - Intervalle d'actualisation du jeton en secondes (par defaut : 3540)
+     - Intervalle d'actualisation du jeton en secondes (par défaut : 3540)
    * - ``proxy_host``
      - Non
-     - Nom d'hote du proxy HTTP
+     - Nom d'hôte du proxy HTTP
    * - ``proxy_port``
-     - Si proxy_host est defini
-     - Numero de port du proxy HTTP
+     - Si proxy_host est défini
+     - Numéro de port du proxy HTTP
 
 Configuration du script
 --------------
@@ -277,40 +277,40 @@ Champs disponibles
    * - ``object.content_length``
      - Longueur du contenu
    * - ``object.created``
-     - Date de creation
+     - Date de création
    * - ``object.last_modified``
-     - Date de derniere modification
+     - Date de dernière modification
    * - ``object.url``
      - URL de l'objet
    * - ``object.thumbnail``
      - URL de la miniature
 
-Configuration de l'application connectee Salesforce
+Configuration de l'application connectée Salesforce
 ====================================
 
-1. Creation de l'application connectee
+1. Création de l'application connectée
 -----------------------------
 
 Dans Salesforce Setup :
 
 1. Ouvrez "Gestionnaire d'applications"
-2. Cliquez sur "Nouvelle application connectee"
+2. Cliquez sur "Nouvelle application connectée"
 3. Entrez les informations de base :
 
-   - Nom de l'application connectee : Fess Crawler
+   - Nom de l'application connectée : Fess Crawler
    - Nom de l'API : Fess_Crawler
    - Email de contact : your-email@example.com
 
-4. Cochez "Activer les parametres OAuth (Activer OAuth)"
+4. Cochez "Activer les paramètres OAuth (Activer OAuth)"
 
-2. Configuration de l'authentification OAuth Token (recommandee)
+2. Configuration de l'authentification OAuth Token (recommandée)
 --------------------------------
 
-Dans les parametres OAuth :
+Dans les paramètres OAuth :
 
-1. Cochez "Utiliser les signatures numeriques"
-2. Telechargez un certificat (cree selon les etapes ci-dessous)
-3. Scopes OAuth selectionnes :
+1. Cochez "Utiliser les signatures numériques"
+2. Téléchargez un certificat (créé selon les étapes ci-dessous)
+3. Scopes OAuth sélectionnés :
 
    - Full access (full)
    - Perform requests on your behalf at any time (refresh_token, offline_access)
@@ -318,7 +318,7 @@ Dans les parametres OAuth :
 4. Cliquez sur "Enregistrer"
 5. Copiez la Consumer Key
 
-Creation du certificat :
+Création du certificat :
 
 ::
 
@@ -331,16 +331,16 @@ Creation du certificat :
     # Verification de la cle privee
     cat private_key.pem
 
-Telechargez le certificat (certificate.crt) sur Salesforce et
-configurez le contenu de la cle privee (private_key.pem) dans les parametres.
+Téléchargez le certificat (certificate.crt) sur Salesforce et
+configurez le contenu de la clé privée (private_key.pem) dans les paramètres.
 
 3. Configuration de l'authentification OAuth Password
 ---------------------------
 
-Dans les parametres OAuth :
+Dans les paramètres OAuth :
 
-1. URL de callback : ``https://localhost`` (non utilisee mais requise)
-2. Scopes OAuth selectionnes :
+1. URL de callback : ``https://localhost`` (non utilisée mais requise)
+2. Scopes OAuth sélectionnés :
 
    - Full access (full)
    - Perform requests on your behalf at any time (refresh_token, offline_access)
@@ -348,29 +348,29 @@ Dans les parametres OAuth :
 3. Cliquez sur "Enregistrer"
 4. Copiez la Consumer Key et le Consumer Secret
 
-Obtention du token de securite :
+Obtention du token de sécurité :
 
-1. Ouvrez les parametres personnels dans Salesforce
-2. Cliquez sur "Reinitialiser mon token de securite"
-3. Copiez le token envoye par email
+1. Ouvrez les paramètres personnels dans Salesforce
+2. Cliquez sur "Réinitialiser mon token de sécurité"
+3. Copiez le token envoyé par email
 
-4. Autorisation de l'application connectee
+4. Autorisation de l'application connectée
 -----------------------------
 
-Dans "Administration" -> "Gerer les applications connectees" :
+Dans "Administration" -> "Gérer les applications connectées" :
 
-1. Selectionnez l'application connectee creee
+1. Sélectionnez l'application connectée créée
 2. Cliquez sur "Modifier"
-3. Changez "Utilisateurs autorises" en "Les utilisateurs approuves par l'administrateur sont preautorises"
+3. Changez "Utilisateurs autorisés" en "Les utilisateurs approuvés par l'administrateur sont préautorisés"
 4. Attribuez des profils ou des ensembles de permissions
 
-Configuration des objets personnalises
+Configuration des objets personnalisés
 ==========================
 
-Crawl des objets personnalises
+Crawl des objets personnalisés
 ------------------------------
 
-Specifiez les noms des objets personnalises avec le parametre ``custom`` :
+Spécifiez les noms des objets personnalisés avec le paramètre ``custom`` :
 
 ::
 
@@ -389,20 +389,20 @@ Mapping des champs pour chaque objet :
     ProjectTask.title=Task_Name__c
     ProjectTask.contents=Task_Name__c,Task_Description__c
 
-Regles de mapping des champs
+Règles de mapping des champs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``<nom_objet>.title`` - Champ a utiliser pour le titre (champ unique)
-- ``<nom_objet>.contents`` - Champs a utiliser pour le contenu (plusieurs separes par des virgules)
-- ``<nom_objet>.descriptions`` - Champs a utiliser pour la description (plusieurs separes par des virgules)
-- ``<nom_objet>.thumbnail`` - Champ a utiliser pour la miniature (champ unique)
+- ``<nom_objet>.title`` - Champ à utiliser pour le titre (champ unique)
+- ``<nom_objet>.contents`` - Champs à utiliser pour le contenu (plusieurs séparés par des virgules)
+- ``<nom_objet>.descriptions`` - Champs à utiliser pour la description (plusieurs séparés par des virgules)
+- ``<nom_objet>.thumbnail`` - Champ à utiliser pour la miniature (champ unique)
 
 .. note::
 
    Pour le mapping des champs des objets standard, le nom de l'objet utilise la notation UPPER_SNAKE_CASE
    (la valeur de la colonne "Nom de l'objet" dans la section `Liste des objets standard`_)
    (ex. : ``ACCOUNT.title=Name``, ``DAND_B_COMPANY.title=Name``).
-   Pour les objets personnalises, le nom de reference API est utilise tel quel (ex. : ``Product__c.title=Name``).
+   Pour les objets personnalisés, le nom de référence API est utilisé tel quel (ex. : ``Product__c.title=Name``).
 
 Exemples d'utilisation
 ======
@@ -410,7 +410,7 @@ Exemples d'utilisation
 Crawl des objets standard
 --------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -433,10 +433,10 @@ Script :
     timestamp=object.last_modified
     url=object.url
 
-Crawl des objets personnalises
+Crawl des objets personnalisés
 ------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -466,7 +466,7 @@ Script :
 Crawl d'un environnement Sandbox
 ---------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -489,106 +489,106 @@ Script :
     timestamp=object.last_modified
     url=object.url
 
-Depannage
+Dépannage
 ======================
 
 Erreur d'authentification
 ----------
 
-**Symptome** : ``Authentication failed`` ou ``invalid_grant``
+**Symptôme** : ``Authentication failed`` ou ``invalid_grant``
 
-**Points a verifier** :
+**Points à vérifier** :
 
 1. Pour l'authentification OAuth Token :
 
-   - Verifier si la Consumer Key est correcte
-   - Verifier si la cle privee est correctement copiee (sauts de ligne en ``\n``)
-   - Verifier si le certificat a ete telecharge sur Salesforce
-   - Verifier si le nom d'utilisateur est correct
+   - Vérifier si la Consumer Key est correcte
+   - Vérifier si la clé privée est correctement copiée (sauts de ligne en ``\n``)
+   - Vérifier si le certificat a été téléchargé sur Salesforce
+   - Vérifier si le nom d'utilisateur est correct
 
 2. Pour l'authentification OAuth Password :
 
-   - Verifier si la Consumer Key et le Consumer Secret sont corrects
-   - Verifier si le token de securite est correct
-   - Verifier que le mot de passe et le token de securite ne sont pas concatenes (configurer separement)
+   - Vérifier si la Consumer Key et le Consumer Secret sont corrects
+   - Vérifier si le token de sécurité est correct
+   - Vérifier que le mot de passe et le token de sécurité ne sont pas concaténés (configurer séparément)
 
 3. Commun :
 
-   - Verifier si base_url est correct (environnement de production ou Sandbox)
-   - Verifier si l'application connectee est autorisee
+   - Vérifier si base_url est correct (environnement de production ou Sandbox)
+   - Vérifier si l'application connectée est autorisée
 
-Impossible de recuperer les objets
+Impossible de récupérer les objets
 --------------------------
 
-**Symptome** : Le crawl reussit mais 0 objets
+**Symptôme** : Le crawl réussit mais 0 objets
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si l'utilisateur a les droits de lecture sur l'objet
-2. Pour les objets personnalises, verifier si le nom de l'objet est correct (nom de reference API)
-3. Verifier si le mapping des champs est correct
-4. Verifier les messages d'erreur dans les logs
+1. Vérifier si l'utilisateur a les droits de lecture sur l'objet
+2. Pour les objets personnalisés, vérifier si le nom de l'objet est correct (nom de référence API)
+3. Vérifier si le mapping des champs est correct
+4. Vérifier les messages d'erreur dans les logs
 
-Nom des objets personnalises
+Nom des objets personnalisés
 --------------------------
 
-Verifier le nom de reference API de l'objet personnalise :
+Vérifier le nom de référence API de l'objet personnalisé :
 
 1. Ouvrez "Gestionnaire d'objets" dans Salesforce Setup
-2. Selectionnez l'objet personnalise
-3. Copiez le "Nom de l'API" (se termine generalement par ``__c``)
+2. Sélectionnez l'objet personnalisé
+3. Copiez le "Nom de l'API" (se termine généralement par ``__c``)
 
 Exemple :
 
 - Label d'affichage : Product
 - Nom de l'API : Product__c (utilisez celui-ci)
 
-Verification des noms de champs
+Vérification des noms de champs
 ------------------
 
-Verifier le nom de reference API des champs personnalises :
+Vérifier le nom de référence API des champs personnalisés :
 
 1. Ouvrez "Champs et relations" de l'objet
-2. Selectionnez le champ personnalise
-3. Copiez le "Nom du champ" (se termine generalement par ``__c``)
+2. Sélectionnez le champ personnalisé
+3. Copiez le "Nom du champ" (se termine généralement par ``__c``)
 
 Exemple :
 
 - Label d'affichage du champ : Product Description
 - Nom du champ : Product_Description__c (utilisez celui-ci)
 
-Limitation de debit API
+Limitation de débit API
 -------------
 
-**Symptome** : ``REQUEST_LIMIT_EXCEEDED``
+**Symptôme** : ``REQUEST_LIMIT_EXCEEDED``
 
 **Solution** :
 
-1. Reduire ``number_of_threads`` (definir a 1)
+1. Réduire ``number_of_threads`` (définir à 1)
 2. Augmenter l'intervalle de crawl
-3. Verifier l'utilisation de l'API Salesforce
-4. Acheter des limites API supplementaires si necessaire
+3. Vérifier l'utilisation de l'API Salesforce
+4. Acheter des limites API supplémentaires si nécessaire
 
-Cas de nombreuses donnees
+Cas de nombreuses données
 ----------------------
 
-**Symptome** : Le crawl prend du temps ou expire
+**Symptôme** : Le crawl prend du temps ou expire
 
 **Solution** :
 
 1. Diviser les objets en plusieurs data stores
 2. Ajuster ``number_of_threads`` (environ 2-4)
-3. Repartir le calendrier de crawl
-4. Mapper uniquement les champs necessaires
+3. Répartir le calendrier de crawl
+4. Mapper uniquement les champs nécessaires
 
-Erreur de format de cle privee
+Erreur de format de clé privée
 --------------------------
 
-**Symptome** : ``Invalid private key format``
+**Symptôme** : ``Invalid private key format``
 
 **Solution** :
 
-Verifier si les sauts de ligne de la cle privee sont correctement en ``\n`` :
+Vérifier si les sauts de ligne de la clé privée sont correctement en ``\n`` :
 
 ::
 
@@ -600,11 +600,11 @@ Verifier si les sauts de ligne de la cle privee sont correctement en ``\n`` :
     MIIEvgIBADANBgkqhkiG9w0BAQE...
     -----END PRIVATE KEY-----
 
-Informations de reference
+Informations de référence
 ========
 
-- :doc:`ds-overview` - Apercu des connecteurs Data Store
-- :doc:`ds-database` - Connecteur de base de donnees
+- :doc:`ds-overview` - Aperçu des connecteurs Data Store
+- :doc:`ds-database` - Connecteur de base de données
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration Data Store
 - `Salesforce REST API <https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/>`_
 - `Salesforce OAuth 2.0 JWT Bearer Flow <https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm>`_

--- a/fr/15.7/config/llm-gemini.rst
+++ b/fr/15.7/config/llm-gemini.rst
@@ -2,70 +2,70 @@
 Configuration Google Gemini
 ===========================
 
-Apercu
+Aperçu
 ======
 
-Google Gemini est un grand modele de langage (LLM) de pointe fourni par Google.
-|Fess| peut utiliser l'API Google AI (Generative Language API) pour realiser la fonctionnalite de mode de recherche IA avec les modeles Gemini.
+Google Gemini est un grand modèle de langage (LLM) de pointe fourni par Google.
+|Fess| peut utiliser l'API Google AI (Generative Language API) pour réaliser la fonctionnalité de mode de recherche IA avec les modèles Gemini.
 
-L'utilisation de Gemini permet de generer des reponses de haute qualite en tirant parti de la derniere technologie IA de Google.
+L'utilisation de Gemini permet de générer des réponses de haute qualité en tirant parti de la dernière technologie IA de Google.
 
-Caracteristiques principales
+Caractéristiques principales
 -----------------------------
 
 - **Prise en charge multimodale** : Peut traiter les images en plus du texte
-- **Long contexte** : Fenetre de contexte longue permettant de traiter de grandes quantites de documents a la fois
-- **Efficacite des couts** : Le modele Flash est rapide et peu couteux
-- **Integration Google** : Integration facile avec les services Google Cloud
+- **Long contexte** : Fenêtre de contexte longue permettant de traiter de grandes quantités de documents à la fois
+- **Efficacité des coûts** : Le modèle Flash est rapide et peu coûteux
+- **Intégration Google** : Intégration facile avec les services Google Cloud
 
-Modeles pris en charge
+Modèles pris en charge
 -----------------------
 
-Principaux modeles disponibles avec Gemini :
+Principaux modèles disponibles avec Gemini :
 
-- ``gemini-3.1-flash-lite-preview`` - Modele rapide leger et a faible cout (par defaut)
-- ``gemini-3-flash-preview`` - Modele Flash standard
-- ``gemini-3.1-pro`` / ``gemini-3-pro`` - Modeles de raisonnement avance
-- ``gemini-2.5-flash`` - Version stable du modele rapide
-- ``gemini-2.5-pro`` - Version stable du modele de raisonnement
+- ``gemini-3.1-flash-lite-preview`` - Modèle rapide léger et à faible coût (par défaut)
+- ``gemini-3-flash-preview`` - Modèle Flash standard
+- ``gemini-3.1-pro`` / ``gemini-3-pro`` - Modèles de raisonnement avancé
+- ``gemini-2.5-flash`` - Version stable du modèle rapide
+- ``gemini-2.5-pro`` - Version stable du modèle de raisonnement
 
 .. note::
-   Pour les derniers modeles disponibles, consultez `Google AI for Developers <https://ai.google.dev/models/gemini>`__.
+   Pour les derniers modèles disponibles, consultez `Google AI for Developers <https://ai.google.dev/models/gemini>`__.
 
-Prerequis
+Prérequis
 =========
 
-Avant d'utiliser Gemini, preparez les elements suivants.
+Avant d'utiliser Gemini, préparez les éléments suivants.
 
 1. **Compte Google** : Un compte Google est requis
-2. **Acces Google AI Studio** : Accedez a `https://aistudio.google.com/ <https://aistudio.google.com/>`__
-3. **Cle API** : Generez une cle API dans Google AI Studio
+2. **Accès Google AI Studio** : Accédez à `https://aistudio.google.com/ <https://aistudio.google.com/>`__
+3. **Clé API** : Générez une clé API dans Google AI Studio
 
-Obtention de la cle API
+Obtention de la clé API
 ------------------------
 
-1. Accedez a `Google AI Studio <https://aistudio.google.com/>`__
+1. Accédez à `Google AI Studio <https://aistudio.google.com/>`__
 2. Cliquez sur "Get API key"
-3. Selectionnez "Create API key"
-4. Selectionnez ou creez un projet
-5. Enregistrez la cle API generee en lieu sur
+3. Sélectionnez "Create API key"
+4. Sélectionnez ou créez un projet
+5. Enregistrez la clé API générée en lieu sûr
 
 .. warning::
-   La cle API est une information confidentielle. Faites attention aux points suivants :
+   La clé API est une information confidentielle. Faites attention aux points suivants :
 
-   - Ne pas la commiter dans un systeme de gestion de versions
+   - Ne pas la commiter dans un système de gestion de versions
    - Ne pas l'afficher dans les logs
-   - La gerer via des variables d'environnement ou des fichiers de configuration securises
+   - La gérer via des variables d'environnement ou des fichiers de configuration sécurisés
 
 Installation du plugin
 ======================
 
-La fonctionnalite d'integration Gemini est fournie sous forme de plugin ``fess-llm-gemini``.
-Pour utiliser Gemini, l'installation du plugin est necessaire.
+La fonctionnalité d'intégration Gemini est fournie sous forme de plugin ``fess-llm-gemini``.
+Pour utiliser Gemini, l'installation du plugin est nécessaire.
 
-1. Telechargez `fess-llm-gemini-15.7.0.jar`
-2. Placez-le dans le repertoire ``app/WEB-INF/plugin/`` de |Fess|
-3. Redemarrez |Fess|
+1. Téléchargez `fess-llm-gemini-15.7.0.jar`
+2. Placez-le dans le répertoire ``app/WEB-INF/plugin/`` de |Fess|
+3. Redémarrez |Fess|
 
 ::
 
@@ -73,17 +73,17 @@ Pour utiliser Gemini, l'installation du plugin est necessaire.
     cp fess-llm-gemini-15.7.0.jar /path/to/fess/app/WEB-INF/plugin/
 
 .. note::
-   La version du plugin doit correspondre a la version de |Fess|.
+   La version du plugin doit correspondre à la version de |Fess|.
 
 Configuration de base
 =====================
 
-La selection du fournisseur LLM ( ``rag.llm.name`` ) s'effectue via l'administration ou dans ``system.properties``, et l'activation de la fonctionnalite de mode de recherche IA ainsi que les parametres specifiques a Gemini s'effectuent dans ``fess_config.properties``.
+La sélection du fournisseur LLM ( ``rag.llm.name`` ) s'effectue via l'administration ou dans ``system.properties``, et l'activation de la fonctionnalité de mode de recherche IA ainsi que les paramètres spécifiques à Gemini s'effectuent dans ``fess_config.properties``.
 
 Configuration de fess_config.properties
 -----------------------------------------
 
-Ajoutez la configuration d'activation de la fonctionnalite de mode de recherche IA dans ``app/WEB-INF/conf/fess_config.properties``.
+Ajoutez la configuration d'activation de la fonctionnalité de mode de recherche IA dans ``app/WEB-INF/conf/fess_config.properties``.
 
 ::
 
@@ -93,12 +93,12 @@ Ajoutez la configuration d'activation de la fonctionnalite de mode de recherche 
 Configuration du fournisseur LLM
 ----------------------------------
 
-Le nom du fournisseur LLM ( ``rag.llm.name`` ) se configure via l'administration (Administration > Systeme > General) ou dans ``system.properties``. Les parametres specifiques a Gemini se decrivent dans ``fess_config.properties``.
+Le nom du fournisseur LLM ( ``rag.llm.name`` ) se configure via l'administration (Administration > Système > Général) ou dans ``system.properties``. Les paramètres spécifiques à Gemini se décrivent dans ``fess_config.properties``.
 
 Configuration minimale
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-``system.properties`` (configurable egalement via Administration > Systeme > General) :
+``system.properties`` (configurable également via Administration > Système > Général) :
 
 ::
 
@@ -118,10 +118,10 @@ Configuration minimale
     # Modele a utiliser
     rag.llm.gemini.model=gemini-3.1-flash-lite-preview
 
-Configuration recommandee (environnement de production)
+Configuration recommandée (environnement de production)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``system.properties`` (configurable egalement via Administration > Systeme > General) :
+``system.properties`` (configurable également via Administration > Système > Général) :
 
 ::
 
@@ -147,91 +147,91 @@ Configuration recommandee (environnement de production)
     # Configuration du timeout
     rag.llm.gemini.timeout=60000
 
-Elements de configuration
+Éléments de configuration
 =========================
 
-Tous les elements de configuration disponibles pour le client Gemini. Tous sauf ``rag.llm.name`` se configurent dans ``fess_config.properties``.
+Tous les éléments de configuration disponibles pour le client Gemini. Tous sauf ``rag.llm.name`` se configurent dans ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rag.llm.gemini.api.key``
-     - Cle API Google AI (doit etre definie pour utiliser l'API Gemini)
+     - Clé API Google AI (doit être définie pour utiliser l'API Gemini)
      - ``""``
    * - ``rag.llm.gemini.model``
-     - Nom du modele a utiliser
+     - Nom du modèle à utiliser
      - ``gemini-3.1-flash-lite-preview``
    * - ``rag.llm.gemini.api.url``
      - URL de base de l'API
      - ``https://generativelanguage.googleapis.com/v1beta``
    * - ``rag.llm.gemini.timeout``
-     - Timeout de la requete (millisecondes)
+     - Timeout de la requête (millisecondes)
      - ``60000``
    * - ``rag.llm.gemini.availability.check.interval``
-     - Intervalle de verification de disponibilite (secondes)
+     - Intervalle de vérification de disponibilité (secondes)
      - ``60``
    * - ``rag.llm.gemini.max.concurrent.requests``
-     - Nombre maximum de requetes simultanees
+     - Nombre maximum de requêtes simultanées
      - ``5``
    * - ``rag.llm.gemini.chat.evaluation.max.relevant.docs``
-     - Nombre maximum de documents pertinents lors de l'evaluation
+     - Nombre maximum de documents pertinents lors de l'évaluation
      - ``3``
    * - ``rag.llm.gemini.chat.evaluation.description.max.chars``
-     - Nombre maximum de caracteres pour la description du document lors de l'evaluation
+     - Nombre maximum de caractères pour la description du document lors de l'évaluation
      - ``500``
    * - ``rag.llm.gemini.concurrency.wait.timeout``
-     - Delai d'attente des requetes simultanees (millisecondes)
+     - Délai d'attente des requêtes simultanées (millisecondes)
      - ``30000``
    * - ``rag.llm.gemini.history.max.chars``
-     - Nombre maximum de caracteres de l'historique de chat
+     - Nombre maximum de caractères de l'historique de chat
      - ``10000``
    * - ``rag.llm.gemini.intent.history.max.messages``
-     - Nombre maximum de messages d'historique pour la determination d'intention
+     - Nombre maximum de messages d'historique pour la détermination d'intention
      - ``10``
    * - ``rag.llm.gemini.intent.history.max.chars``
-     - Nombre maximum de caracteres d'historique pour la determination d'intention
+     - Nombre maximum de caractères d'historique pour la détermination d'intention
      - ``5000``
    * - ``rag.llm.gemini.history.assistant.max.chars``
-     - Nombre maximum de caracteres de l'historique de l'assistant
+     - Nombre maximum de caractères de l'historique de l'assistant
      - ``1000``
    * - ``rag.llm.gemini.history.assistant.summary.max.chars``
-     - Nombre maximum de caracteres du resume de l'historique de l'assistant
+     - Nombre maximum de caractères du résumé de l'historique de l'assistant
      - ``1000``
    * - ``rag.llm.gemini.retry.max``
      - Nombre maximum de tentatives HTTP (lors d'erreurs ``429`` et ``5xx``)
      - ``10``
    * - ``rag.llm.gemini.retry.base.delay.ms``
-     - Delai de base du backoff exponentiel (millisecondes)
+     - Délai de base du backoff exponentiel (millisecondes)
      - ``2000``
 
-Methode d'authentification
+Méthode d'authentification
 ===========================
 
-La cle API est transmise via l'en-tete HTTP ``x-goog-api-key`` (methode recommandee par Google).
-Elle n'est plus ajoutee a l'URL en tant que parametre de requete ``?key=...`` comme auparavant ; la cle API ne reste donc plus dans les journaux d'acces.
+La clé API est transmise via l'en-tête HTTP ``x-goog-api-key`` (méthode recommandée par Google).
+Elle n'est plus ajoutée à l'URL en tant que paramètre de requête ``?key=...`` comme auparavant ; la clé API ne reste donc plus dans les journaux d'accès.
 
-Comportement de reessai
+Comportement de réessai
 ========================
 
-Les requetes vers l'API Gemini sont automatiquement reessayees pour les codes de statut HTTP suivants :
+Les requêtes vers l'API Gemini sont automatiquement réessayées pour les codes de statut HTTP suivants :
 
-- ``429`` Resource Exhausted (depassement de quota / limitation de debit)
+- ``429`` Resource Exhausted (dépassement de quota / limitation de débit)
 - ``500`` Internal Server Error
 - ``503`` Service Unavailable
 - ``504`` Gateway Timeout
 
-Lors d'un reessai, |Fess| attend selon un backoff exponentiel (valeur de base ``rag.llm.gemini.retry.base.delay.ms`` millisecondes, jusqu'a ``rag.llm.gemini.retry.max`` tentatives, avec une gigue de +/-20%).
-Pour les requetes en streaming, seule la connexion initiale est sujette aux reessais ; les erreurs survenant apres le debut de la reception du corps de la reponse sont propagees immediatement.
+Lors d'un réessai, |Fess| attend selon un backoff exponentiel (valeur de base ``rag.llm.gemini.retry.base.delay.ms`` millisecondes, jusqu'à ``rag.llm.gemini.retry.max`` tentatives, avec une gigue de +/-20%).
+Pour les requêtes en streaming, seule la connexion initiale est sujette aux réessais ; les erreurs survenant après le début de la réception du corps de la réponse sont propagées immédiatement.
 
 Configuration par type de prompt
 ==================================
 
-Dans |Fess|, les parametres du LLM peuvent etre configures finement par type de prompt.
-La configuration par type de prompt s'ecrit dans ``fess_config.properties``.
+Dans |Fess|, les paramètres du LLM peuvent être configurés finement par type de prompt.
+La configuration par type de prompt s'écrit dans ``fess_config.properties``.
 
 Format de configuration
 ------------------------
@@ -253,30 +253,30 @@ Types de prompt disponibles
    * - Type de prompt
      - Description
    * - ``intent``
-     - Prompt pour determiner l'intention de l'utilisateur
+     - Prompt pour déterminer l'intention de l'utilisateur
    * - ``evaluation``
-     - Prompt pour evaluer la pertinence des documents
+     - Prompt pour évaluer la pertinence des documents
    * - ``unclear``
-     - Prompt pour le cas ou la question est peu claire
+     - Prompt pour le cas où la question est peu claire
    * - ``noresults``
-     - Prompt pour le cas ou il n'y a pas de resultats de recherche
+     - Prompt pour le cas où il n'y a pas de résultats de recherche
    * - ``docnotfound``
-     - Prompt pour le cas ou le document n'est pas trouve
+     - Prompt pour le cas où le document n'est pas trouvé
    * - ``answer``
-     - Prompt de generation de reponse
+     - Prompt de génération de réponse
    * - ``summary``
-     - Prompt de generation de resume
+     - Prompt de génération de résumé
    * - ``faq``
-     - Prompt de generation de FAQ
+     - Prompt de génération de FAQ
    * - ``direct``
-     - Prompt de reponse directe
+     - Prompt de réponse directe
    * - ``queryregeneration``
-     - Prompt de regeneration de requete
+     - Prompt de régénération de requête
 
-Valeurs par defaut par type de prompt
+Valeurs par défaut par type de prompt
 ---------------------------------------
 
-Valeurs par defaut pour chaque type de prompt. Ces valeurs sont utilisees lorsqu'aucune configuration explicite n'est definie.
+Valeurs par défaut pour chaque type de prompt. Ces valeurs sont utilisées lorsqu'aucune configuration explicite n'est définie.
 
 .. list-table::
    :header-rows: 1
@@ -348,16 +348,16 @@ Exemple de configuration
     rag.llm.gemini.faq.context.max.chars=10000
 
 .. note::
-   La valeur par defaut de ``context.max.chars`` varie selon le type de prompt.
-   ``answer`` et ``summary`` sont a 16000, ``faq`` est a 10000, et les autres types de prompt sont a 10000.
+   La valeur par défaut de ``context.max.chars`` varie selon le type de prompt.
+   ``answer`` et ``summary`` sont à 16000, ``faq`` est à 10000, et les autres types de prompt sont à 10000.
 
-Prise en charge des modeles de reflexion
+Prise en charge des modèles de réflexion
 ==========================================
 
-Gemini prend en charge les modeles de reflexion (Thinking Model).
-L'utilisation de modeles de reflexion permet au modele d'executer un processus de raisonnement interne avant de generer une reponse, produisant ainsi des reponses plus precises.
+Gemini prend en charge les modèles de réflexion (Thinking Model).
+L'utilisation de modèles de réflexion permet au modèle d'exécuter un processus de raisonnement interne avant de générer une réponse, produisant ainsi des réponses plus précises.
 
-Le budget de reflexion se configure par type de prompt dans ``fess_config.properties``. |Fess| convertit automatiquement la valeur entiere (nombre de tokens) de ``rag.llm.gemini.{promptType}.thinking.budget`` vers le champ d'API approprie en fonction de la generation du modele resolue lors de la requete.
+Le budget de réflexion se configure par type de prompt dans ``fess_config.properties``. |Fess| convertit automatiquement la valeur entière (nombre de tokens) de ``rag.llm.gemini.{promptType}.thinking.budget`` vers le champ d'API approprié en fonction de la génération du modèle résolue lors de la requête.
 
 ::
 
@@ -367,11 +367,11 @@ Le budget de reflexion se configure par type de prompt dans ``fess_config.proper
     # Budget de reflexion pour la generation de resume
     rag.llm.gemini.summary.thinking.budget=1024
 
-Mappage selon la generation du modele
+Mappage selon la génération du modèle
 ---------------------------------------
 
-- **Gemini 2.x** (par exemple ``gemini-2.5-flash``) : la valeur entiere configuree est envoyee telle quelle en tant que ``thinkingConfig.thinkingBudget``. Specifier ``0`` desactive completement la reflexion.
-- **Gemini 3.x** (par exemple ``gemini-3.1-flash-lite-preview``) : la valeur entiere est regroupee en compartiments et envoyee comme valeur enumeree de ``thinkingConfig.thinkingLevel`` (``MINIMAL`` / ``LOW`` / ``MEDIUM`` / ``HIGH``).
+- **Gemini 2.x** (par exemple ``gemini-2.5-flash``) : la valeur entière configurée est envoyée telle quelle en tant que ``thinkingConfig.thinkingBudget``. Spécifier ``0`` désactive complètement la réflexion.
+- **Gemini 3.x** (par exemple ``gemini-3.1-flash-lite-preview``) : la valeur entière est regroupée en compartiments et envoyée comme valeur énumérée de ``thinkingConfig.thinkingLevel`` (``MINIMAL`` / ``LOW`` / ``MEDIUM`` / ``HIGH``).
 
 Le mappage des compartiments pour Gemini 3.x est le suivant :
 
@@ -384,7 +384,7 @@ Le mappage des compartiments pour Gemini 3.x est le suivant :
      - Remarques
    * - ``<=0``
      - ``MINIMAL`` ou ``LOW``
-     - ``MINIMAL`` pour les modeles Flash / Flash-Lite ; ``LOW`` pour les modeles de la famille Pro qui ne prennent pas en charge ``MINIMAL`` (``gemini-3-pro`` / ``gemini-3.1-pro``)
+     - ``MINIMAL`` pour les modèles Flash / Flash-Lite ; ``LOW`` pour les modèles de la famille Pro qui ne prennent pas en charge ``MINIMAL`` (``gemini-3-pro`` / ``gemini-3.1-pro``)
    * - ``<=4096``
      - ``MEDIUM``
      -
@@ -393,32 +393,32 @@ Le mappage des compartiments pour Gemini 3.x est le suivant :
      -
 
 .. note::
-   Gemini 3.x consomme toujours un certain nombre de tokens de reflexion, quel que soit le compartiment (meme avec ``thinkingLevel=MINIMAL``, plusieurs centaines de tokens peuvent etre consommes).
-   Pour cette raison, lors de l'utilisation d'un modele Gemini 3.x, |Fess| ajoute automatiquement une marge supplementaire (1024 tokens) a la valeur ``maxOutputTokens`` par defaut, afin d'eviter une troncature de la reponse due a ``finishReason=MAX_TOKENS``.
-   Avec Gemini 2.x, ``thinkingBudget=0`` desactive la reflexion elle-meme, donc aucune marge supplementaire n'est ajoutee.
+   Gemini 3.x consomme toujours un certain nombre de tokens de réflexion, quel que soit le compartiment (même avec ``thinkingLevel=MINIMAL``, plusieurs centaines de tokens peuvent être consommés).
+   Pour cette raison, lors de l'utilisation d'un modèle Gemini 3.x, |Fess| ajoute automatiquement une marge supplémentaire (1024 tokens) à la valeur ``maxOutputTokens`` par défaut, afin d'éviter une troncature de la réponse due à ``finishReason=MAX_TOKENS``.
+   Avec Gemini 2.x, ``thinkingBudget=0`` désactive la réflexion elle-même, donc aucune marge supplémentaire n'est ajoutée.
 
 .. note::
-   Configurer un budget de reflexion eleve peut allonger le temps de reponse.
-   Configurez une valeur appropriee selon l'usage.
+   Configurer un budget de réflexion élevé peut allonger le temps de réponse.
+   Configurez une valeur appropriée selon l'usage.
 
 Configuration via options JVM
 ==============================
 
-Pour des raisons de securite, il est recommande de configurer la cle API via
-l'environnement d'execution (options JVM) plutot que via des fichiers de configuration.
+Pour des raisons de sécurité, il est recommandé de configurer la clé API via
+l'environnement d'exécution (options JVM) plutôt que via des fichiers de configuration.
 
 Environnement Docker
 ---------------------
 
-Le depot officiel `docker-fess <https://github.com/codelibs/docker-fess>`__
-inclut un overlay Gemini (``compose-gemini.yaml``). Etapes minimales :
+Le dépôt officiel `docker-fess <https://github.com/codelibs/docker-fess>`__
+inclut un overlay Gemini (``compose-gemini.yaml``). Étapes minimales :
 
 ::
 
     export GEMINI_API_KEY="AIzaSy..."
     docker compose -f compose.yaml -f compose-opensearch3.yaml -f compose-gemini.yaml up -d
 
-Contenu de ``compose-gemini.yaml`` (reference pour un setup equivalent) :
+Contenu de ``compose-gemini.yaml`` (référence pour un setup équivalent) :
 
 .. code-block:: yaml
 
@@ -428,19 +428,19 @@ Contenu de ``compose-gemini.yaml`` (reference pour un setup equivalent) :
           - "FESS_PLUGINS=fess-llm-gemini:15.7.0"
           - "FESS_JAVA_OPTS=-Dfess.config.rag.chat.enabled=true -Dfess.config.rag.llm.gemini.api.key=${GEMINI_API_KEY:-} -Dfess.config.rag.llm.gemini.model=${GEMINI_MODEL:-gemini-3.1-flash-lite-preview} -Dfess.system.rag.llm.name=gemini"
 
-Points cles :
+Points clés :
 
-- ``FESS_PLUGINS=fess-llm-gemini:15.7.0`` fait que ``run.sh`` telecharge automatiquement le plugin JAR et le place dans ``app/WEB-INF/plugin/``
+- ``FESS_PLUGINS=fess-llm-gemini:15.7.0`` fait que ``run.sh`` télécharge automatiquement le plugin JAR et le place dans ``app/WEB-INF/plugin/``
 - ``-Dfess.config.rag.chat.enabled=true`` active le mode de recherche IA
-- ``-Dfess.config.rag.llm.gemini.api.key=...`` definit la cle API, ``-Dfess.config.rag.llm.gemini.model=...`` choisit le modele
-- ``-Dfess.system.rag.llm.name=gemini`` n'agit que comme valeur par defaut initiale avant qu'une valeur ne soit persistee dans OpenSearch. Apres demarrage, le parametre peut aussi etre modifie sous Administration > Systeme > General (section RAG)
+- ``-Dfess.config.rag.llm.gemini.api.key=...`` définit la clé API, ``-Dfess.config.rag.llm.gemini.model=...`` choisit le modèle
+- ``-Dfess.system.rag.llm.name=gemini`` n'agit que comme valeur par défaut initiale avant qu'une valeur ne soit persistée dans OpenSearch. Après démarrage, le paramètre peut aussi être modifié sous Administration > Système > Général (section RAG)
 
-Si l'acces Internet passe par un proxy, specifiez la configuration ``http.proxy.*`` de |Fess| via ``FESS_JAVA_OPTS`` (voir la section "Utilisation via un proxy HTTP" ci-dessous).
+Si l'accès Internet passe par un proxy, spécifiez la configuration ``http.proxy.*`` de |Fess| via ``FESS_JAVA_OPTS`` (voir la section "Utilisation via un proxy HTTP" ci-dessous).
 
 Environnement systemd
 ----------------------
 
-Ajouter a ``FESS_JAVA_OPTS`` dans ``/etc/sysconfig/fess`` (ou ``/etc/default/fess``) :
+Ajouter à ``FESS_JAVA_OPTS`` dans ``/etc/sysconfig/fess`` (ou ``/etc/default/fess``) :
 
 ::
 
@@ -449,108 +449,108 @@ Ajouter a ``FESS_JAVA_OPTS`` dans ``/etc/sysconfig/fess`` (ou ``/etc/default/fes
 Utilisation via un proxy HTTP
 ==============================
 
-Le client Gemini partage la configuration de proxy HTTP commune a |Fess|. Specifiez les proprietes suivantes dans ``fess_config.properties``.
+Le client Gemini partage la configuration de proxy HTTP commune à |Fess|. Spécifiez les propriétés suivantes dans ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``http.proxy.host``
-     - Nom d'hote du proxy (chaine vide pour ne pas utiliser de proxy)
+     - Nom d'hôte du proxy (chaîne vide pour ne pas utiliser de proxy)
      - ``""``
    * - ``http.proxy.port``
-     - Numero de port du proxy
+     - Numéro de port du proxy
      - ``8080``
    * - ``http.proxy.username``
-     - Nom d'utilisateur pour l'authentification du proxy (facultatif ; lorsqu'il est renseigne, l'authentification Basic est activee)
+     - Nom d'utilisateur pour l'authentification du proxy (facultatif ; lorsqu'il est renseigné, l'authentification Basic est activée)
      - ``""``
    * - ``http.proxy.password``
      - Mot de passe pour l'authentification du proxy
      - ``""``
 
-Dans un environnement Docker, specifiez ce qui suit dans ``FESS_JAVA_OPTS``::
+Dans un environnement Docker, spécifiez ce qui suit dans ``FESS_JAVA_OPTS``::
 
     -Dfess.config.http.proxy.host=proxy.example.com
     -Dfess.config.http.proxy.port=8080
 
 .. note::
-   Cette configuration s'applique egalement a tous les acces HTTP de |Fess|, notamment ceux du crawler.
-   Les proprietes systeme Java traditionnelles (``-Dhttps.proxyHost``, etc.) ne sont pas prises en compte par le client Gemini.
+   Cette configuration s'applique également à tous les accès HTTP de |Fess|, notamment ceux du crawler.
+   Les propriétés système Java traditionnelles (``-Dhttps.proxyHost``, etc.) ne sont pas prises en compte par le client Gemini.
 
 Utilisation via Vertex AI
 ==========================
 
-Si vous utilisez Google Cloud Platform, vous pouvez egalement utiliser Gemini via Vertex AI.
-Pour Vertex AI, le point de terminaison API et la methode d'authentification different.
+Si vous utilisez Google Cloud Platform, vous pouvez également utiliser Gemini via Vertex AI.
+Pour Vertex AI, le point de terminaison API et la méthode d'authentification diffèrent.
 
 .. note::
    |Fess| actuel utilise l'API Google AI (generativelanguage.googleapis.com).
-   Si l'utilisation via Vertex AI est necessaire, une implementation personnalisee peut etre requise.
+   Si l'utilisation via Vertex AI est nécessaire, une implémentation personnalisée peut être requise.
 
-Guide de selection des modeles
+Guide de sélection des modèles
 ================================
 
-Guide pour la selection du modele selon l'usage.
+Guide pour la sélection du modèle selon l'usage.
 
 .. list-table::
    :header-rows: 1
    :widths: 25 20 20 35
 
-   * - Modele
+   * - Modèle
      - Vitesse
-     - Qualite
+     - Qualité
      - Usage
    * - ``gemini-3.1-flash-lite-preview``
      - Rapide
-     - Elevee
-     - Leger et a faible cout (par defaut, prend en charge ``thinkingLevel=MINIMAL``)
+     - Élevée
+     - Léger et à faible coût (par défaut, prend en charge ``thinkingLevel=MINIMAL``)
    * - ``gemini-3-flash-preview``
      - Rapide
      - Maximale
-     - Usage general (prend en charge ``thinkingLevel=MINIMAL``)
+     - Usage général (prend en charge ``thinkingLevel=MINIMAL``)
    * - ``gemini-3.1-pro`` / ``gemini-3-pro``
      - Moyenne
      - Maximale
      - Raisonnement complexe (``MINIMAL`` non pris en charge ; au minimum ``LOW``)
    * - ``gemini-2.5-flash``
      - Rapide
-     - Elevee
-     - Version stable, priorite au cout
+     - Élevée
+     - Version stable, priorité au coût
    * - ``gemini-2.5-pro``
      - Moyenne
-     - Elevee
+     - Élevée
      - Version stable, long contexte
 
-Fenetre de contexte
+Fenêtre de contexte
 --------------------
 
-Les modeles Gemini prennent en charge des fenetres de contexte tres longues :
+Les modèles Gemini prennent en charge des fenêtres de contexte très longues :
 
 - **Gemini 3 Flash / 2.5 Flash** : Maximum 1 million de tokens
 - **Gemini 3.1 Pro / 2.5 Pro** : Maximum 1 million de tokens (3.1 Pro) / 2 millions de tokens (2.5 Pro)
 
-Cette caracteristique permet d'inclure davantage de resultats de recherche dans le contexte.
+Cette caractéristique permet d'inclure davantage de résultats de recherche dans le contexte.
 
 ::
 
     # Inclure davantage de documents dans le contexte (a configurer dans fess_config.properties)
     rag.llm.gemini.answer.context.max.chars=20000
 
-Estimation des couts
+Estimation des coûts
 ---------------------
 
-L'API Google AI est facturee a l'usage (avec une offre gratuite).
+L'API Google AI est facturée à l'usage (avec une offre gratuite).
 
 .. list-table::
    :header-rows: 1
    :widths: 30 35 35
 
-   * - Modele
-     - Entree (1M caracteres)
-     - Sortie (1M caracteres)
+   * - Modèle
+     - Entrée (1M caractères)
+     - Sortie (1M caractères)
    * - Gemini 3 Flash Preview
      - $0.50
      - $3.00
@@ -567,73 +567,73 @@ L'API Google AI est facturee a l'usage (avec une offre gratuite).
 .. note::
    Pour les derniers prix et informations sur l'offre gratuite, consultez `Google AI Pricing <https://ai.google.dev/pricing>`__.
 
-Controle des requetes simultanees
+Contrôle des requêtes simultanées
 ===================================
 
-Dans |Fess|, le nombre de requetes simultanees vers Gemini peut etre controle.
-Configurez la propriete suivante dans ``fess_config.properties``.
+Dans |Fess|, le nombre de requêtes simultanées vers Gemini peut être contrôlé.
+Configurez la propriété suivante dans ``fess_config.properties``.
 
 ::
 
     # Nombre maximum de requetes simultanees (par defaut : 5)
     rag.llm.gemini.max.concurrent.requests=5
 
-Cette configuration permet d'eviter les requetes excessives vers l'API Google AI et de prevenir les erreurs de limitation de debit.
+Cette configuration permet d'éviter les requêtes excessives vers l'API Google AI et de prévenir les erreurs de limitation de débit.
 
-Limites de l'offre gratuite (a titre indicatif)
+Limites de l'offre gratuite (à titre indicatif)
 -------------------------------------------------
 
 L'API Google AI dispose d'une offre gratuite avec les limites suivantes :
 
-- Requetes/minute : 15 RPM
+- Requêtes/minute : 15 RPM
 - Tokens/minute : 1 million TPM
-- Requetes/jour : 1,500 RPD
+- Requêtes/jour : 1,500 RPD
 
-Lors de l'utilisation de l'offre gratuite, il est recommande de configurer ``rag.llm.gemini.max.concurrent.requests`` a une valeur basse.
+Lors de l'utilisation de l'offre gratuite, il est recommandé de configurer ``rag.llm.gemini.max.concurrent.requests`` à une valeur basse.
 
-Depannage
+Dépannage
 ==========
 
 Erreur d'authentification
 --------------------------
 
-**Symptome** : Erreur liee a la cle API
+**Symptôme** : Erreur liée à la clé API
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si la cle API est correctement configuree
-2. Verifier si la cle API est valide dans Google AI Studio
-3. Verifier si la cle API a les permissions necessaires
-4. Verifier si l'API est activee dans le projet
+1. Vérifier si la clé API est correctement configurée
+2. Vérifier si la clé API est valide dans Google AI Studio
+3. Vérifier si la clé API a les permissions nécessaires
+4. Vérifier si l'API est activée dans le projet
 
-Erreur de limitation de debit
+Erreur de limitation de débit
 -------------------------------
 
-**Symptome** : Erreur "429 Resource has been exhausted"
+**Symptôme** : Erreur "429 Resource has been exhausted"
 
 **Solution** :
 
-1. Reduire le nombre de requetes simultanees dans ``fess_config.properties``::
+1. Réduire le nombre de requêtes simultanées dans ``fess_config.properties``::
 
     rag.llm.gemini.max.concurrent.requests=3
 
-2. Attendre quelques minutes avant de reessayer
-3. Demander une augmentation de quota si necessaire
+2. Attendre quelques minutes avant de réessayer
+3. Demander une augmentation de quota si nécessaire
 
-Restriction de region
+Restriction de région
 ----------------------
 
-**Symptome** : Erreur indiquant que le service n'est pas disponible
+**Symptôme** : Erreur indiquant que le service n'est pas disponible
 
-**Points a verifier** :
+**Points à vérifier** :
 
-L'API Google AI n'est disponible que dans certaines regions. Consultez la documentation Google
-pour les regions prises en charge.
+L'API Google AI n'est disponible que dans certaines régions. Consultez la documentation Google
+pour les régions prises en charge.
 
 Timeout
 --------
 
-**Symptome** : La requete expire
+**Symptôme** : La requête expire
 
 **Solution** :
 
@@ -641,12 +641,12 @@ Timeout
 
     rag.llm.gemini.timeout=120000
 
-2. Envisager l'utilisation du modele Flash (plus rapide)
+2. Envisager l'utilisation du modèle Flash (plus rapide)
 
-Configuration de debogage
+Configuration de débogage
 --------------------------
 
-Pour investiguer les problemes, ajustez le niveau de log de |Fess| pour afficher des logs detailles lies a Gemini.
+Pour investiguer les problèmes, ajustez le niveau de log de |Fess| pour afficher des logs détaillés liés à Gemini.
 
 ``app/WEB-INF/classes/log4j2.xml`` :
 
@@ -654,22 +654,22 @@ Pour investiguer les problemes, ajustez le niveau de log de |Fess| pour afficher
 
     <Logger name="org.codelibs.fess.llm.gemini" level="DEBUG"/>
 
-Notes de securite
+Notes de sécurité
 ==================
 
-Lors de l'utilisation de l'API Google AI, faites attention aux points de securite suivants.
+Lors de l'utilisation de l'API Google AI, faites attention aux points de sécurité suivants.
 
-1. **Confidentialite des donnees** : Le contenu des resultats de recherche est envoye aux serveurs Google
-2. **Gestion des cles API** : La fuite de cles peut entrainer une utilisation non autorisee
-3. **Conformite** : Si les donnees contiennent des informations confidentielles, verifiez les politiques de votre organisation
+1. **Confidentialité des données** : Le contenu des résultats de recherche est envoyé aux serveurs Google
+2. **Gestion des clés API** : La fuite de clés peut entraîner une utilisation non autorisée
+3. **Conformité** : Si les données contiennent des informations confidentielles, vérifiez les politiques de votre organisation
 4. **Conditions d'utilisation** : Respectez les conditions d'utilisation et la Politique d'utilisation acceptable de Google
 
-Informations de reference
+Informations de référence
 ==========================
 
 - `Google AI for Developers <https://ai.google.dev/>`__
 - `Google AI Studio <https://aistudio.google.com/>`__
 - `Gemini API Documentation <https://ai.google.dev/docs>`__
 - `Google AI Pricing <https://ai.google.dev/pricing>`__
-- :doc:`llm-overview` - Apercu de l'integration LLM
-- :doc:`rag-chat` - Details de la fonctionnalite de mode de recherche IA
+- :doc:`llm-overview` - Aperçu de l'intégration LLM
+- :doc:`rag-chat` - Détails de la fonctionnalité de mode de recherche IA

--- a/fr/15.7/config/llm-ollama.rst
+++ b/fr/15.7/config/llm-ollama.rst
@@ -2,44 +2,44 @@
 Configuration Ollama
 ==========================
 
-Apercu
+Aperçu
 ======
 
-Ollama est une plateforme open source permettant d'executer des grands modeles de langage (LLM) en local.
-La fonctionnalite d'integration Ollama de |Fess| est fournie sous forme de plugin ``fess-llm-ollama``, et convient a une utilisation en environnement prive.
+Ollama est une plateforme open source permettant d'exécuter des grands modèles de langage (LLM) en local.
+La fonctionnalité d'intégration Ollama de |Fess| est fournie sous forme de plugin ``fess-llm-ollama``, et convient à une utilisation en environnement privé.
 
-L'utilisation d'Ollama permet d'utiliser la fonctionnalite du mode de recherche IA sans envoyer de donnees a l'exterieur.
+L'utilisation d'Ollama permet d'utiliser la fonctionnalité du mode de recherche IA sans envoyer de données à l'extérieur.
 
-Caracteristiques principales
+Caractéristiques principales
 -----------------------------
 
-- **Execution locale** : Les donnees ne sont pas envoyees a l'exterieur, garantissant la confidentialite
-- **Modeles varies** : Prise en charge de nombreux modeles dont Llama, Mistral, Gemma, CodeLlama
-- **Efficacite des couts** : Pas de cout API (seulement les couts materiels)
-- **Personnalisation** : Possibilite d'utiliser des modeles affines independamment
+- **Exécution locale** : Les données ne sont pas envoyées à l'extérieur, garantissant la confidentialité
+- **Modèles variés** : Prise en charge de nombreux modèles dont Llama, Mistral, Gemma, CodeLlama
+- **Efficacité des coûts** : Pas de coût API (seulement les coûts matériels)
+- **Personnalisation** : Possibilité d'utiliser des modèles affinés indépendamment
 
-Modeles pris en charge
+Modèles pris en charge
 -----------------------
 
-Principaux modeles disponibles avec Ollama :
+Principaux modèles disponibles avec Ollama :
 
-- ``llama3.3:70b`` - Llama 3.3 de Meta (70B parametres)
-- ``gemma4:e4b`` - Gemma 4 de Google (E4B parametres, par defaut)
-- ``mistral:7b`` - Mistral de Mistral AI (7B parametres)
-- ``codellama:13b`` - Code Llama de Meta (13B parametres)
-- ``phi3:3.8b`` - Phi-3 de Microsoft (3.8B parametres)
+- ``llama3.3:70b`` - Llama 3.3 de Meta (70B paramètres)
+- ``gemma4:e4b`` - Gemma 4 de Google (E4B paramètres, par défaut)
+- ``mistral:7b`` - Mistral de Mistral AI (7B paramètres)
+- ``codellama:13b`` - Code Llama de Meta (13B paramètres)
+- ``phi3:3.8b`` - Phi-3 de Microsoft (3.8B paramètres)
 
 .. note::
-   Pour la derniere liste des modeles disponibles, consultez `Ollama Library <https://ollama.com/library>`__.
+   Pour la dernière liste des modèles disponibles, consultez `Ollama Library <https://ollama.com/library>`__.
 
-Prerequis
+Prérequis
 =========
 
-Avant d'utiliser Ollama, verifiez les points suivants.
+Avant d'utiliser Ollama, vérifiez les points suivants.
 
-1. **Installation d'Ollama** : Telechargez et installez depuis `https://ollama.com/ <https://ollama.com/>`__
-2. **Telechargement du modele** : Telechargez le modele a utiliser dans Ollama
-3. **Demarrage du serveur Ollama** : Verifiez qu'Ollama fonctionne
+1. **Installation d'Ollama** : Téléchargez et installez depuis `https://ollama.com/ <https://ollama.com/>`__
+2. **Téléchargement du modèle** : Téléchargez le modèle à utiliser dans Ollama
+3. **Démarrage du serveur Ollama** : Vérifiez qu'Ollama fonctionne
 
 Installation d'Ollama
 ---------------------
@@ -54,7 +54,7 @@ Linux/macOS
 Windows
 ~~~~~~~
 
-Telechargez et executez l'installateur depuis le site officiel.
+Téléchargez et exécutez l'installateur depuis le site officiel.
 
 Docker
 ~~~~~~
@@ -63,7 +63,7 @@ Docker
 
     docker run -d -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
 
-Telechargement du modele
+Téléchargement du modèle
 ------------------------
 
 ::
@@ -80,30 +80,30 @@ Telechargement du modele
 Installation du plugin
 ======================
 
-La fonctionnalite d'integration Ollama est fournie sous forme de plugin.
-Pour utiliser Ollama, l'installation du plugin ``fess-llm-ollama`` est necessaire.
+La fonctionnalité d'intégration Ollama est fournie sous forme de plugin.
+Pour utiliser Ollama, l'installation du plugin ``fess-llm-ollama`` est nécessaire.
 
-1. Telechargez `fess-llm-ollama-15.7.0.jar`.
-2. Placez-le dans le repertoire ``app/WEB-INF/plugin/`` du repertoire d'installation de |Fess|.
+1. Téléchargez `fess-llm-ollama-15.7.0.jar`.
+2. Placez-le dans le répertoire ``app/WEB-INF/plugin/`` du répertoire d'installation de |Fess|.
 
 ::
 
     cp fess-llm-ollama-15.7.0.jar /path/to/fess/app/WEB-INF/plugin/
 
-3. Redemarrez |Fess|.
+3. Redémarrez |Fess|.
 
 .. note::
-   La version du plugin doit correspondre a la version de |Fess|.
+   La version du plugin doit correspondre à la version de |Fess|.
 
 Configuration de base
 =====================
 
-Les configurations LLM sont reparties dans plusieurs fichiers de configuration.
+Les configurations LLM sont réparties dans plusieurs fichiers de configuration.
 
 Configuration minimale
 ----------------------
 
-``system.properties`` (configurable egalement via Administration > Systeme > General) :
+``system.properties`` (configurable également via Administration > Système > Général) :
 
 ::
 
@@ -124,12 +124,12 @@ Configuration minimale
     rag.llm.ollama.model=gemma4:e4b
 
 .. note::
-   La configuration du fournisseur LLM peut egalement etre effectuee via l'administration (Administration > Systeme > General) en configurant ``rag.llm.name``.
+   La configuration du fournisseur LLM peut également être effectuée via l'administration (Administration > Système > Général) en configurant ``rag.llm.name``.
 
-Configuration recommandee (environnement de production)
+Configuration recommandée (environnement de production)
 -------------------------------------------------------
 
-``system.properties`` (configurable egalement via Administration > Systeme > General) :
+``system.properties`` (configurable également via Administration > Système > Général) :
 
 ::
 
@@ -155,105 +155,105 @@ Configuration recommandee (environnement de production)
     # Controle du nombre de requetes simultanees
     rag.llm.ollama.max.concurrent.requests=5
 
-Elements de configuration
+Éléments de configuration
 =========================
 
-Tous les elements de configuration disponibles pour le client Ollama. Tous sauf ``rag.llm.name`` se configurent dans ``fess_config.properties``.
+Tous les éléments de configuration disponibles pour le client Ollama. Tous sauf ``rag.llm.name`` se configurent dans ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rag.llm.ollama.api.url``
      - URL de base du serveur Ollama
      - ``http://localhost:11434``
    * - ``rag.llm.ollama.model``
-     - Nom du modele a utiliser (modele telecharge dans Ollama)
+     - Nom du modèle à utiliser (modèle téléchargé dans Ollama)
      - ``gemma4:e4b``
    * - ``rag.llm.ollama.timeout``
-     - Timeout de la requete (millisecondes)
+     - Timeout de la requête (millisecondes)
      - ``60000``
    * - ``rag.llm.ollama.availability.check.interval``
-     - Intervalle de verification de disponibilite (secondes). Une valeur inferieure ou egale a ``0`` desactive la verification periodique de disponibilite
+     - Intervalle de vérification de disponibilité (secondes). Une valeur inférieure ou égale à ``0`` désactive la vérification périodique de disponibilité
      - ``60``
    * - ``rag.llm.ollama.max.concurrent.requests``
-     - Nombre maximum de requetes simultanees
+     - Nombre maximum de requêtes simultanées
      - ``5``
    * - ``rag.llm.ollama.chat.evaluation.max.relevant.docs``
-     - Nombre maximum de documents pertinents lors de l'evaluation
+     - Nombre maximum de documents pertinents lors de l'évaluation
      - ``3``
    * - ``rag.llm.ollama.concurrency.wait.timeout``
-     - Delai d'attente de l'acquisition d'un permis de controle de concurrence (millisecondes)
+     - Délai d'attente de l'acquisition d'un permis de contrôle de concurrence (millisecondes)
      - ``30000``
    * - ``rag.llm.ollama.connect.timeout``
-     - Timeout de connexion TCP (millisecondes). Peut etre specifie separement de ``rag.llm.ollama.timeout``
+     - Timeout de connexion TCP (millisecondes). Peut être spécifié séparément de ``rag.llm.ollama.timeout``
      - ``5000``
    * - ``rag.llm.ollama.retry.max``
      - Nombre maximum de tentatives HTTP (lors d'erreurs ``429`` et ``5xx``)
      - ``3``
    * - ``rag.llm.ollama.retry.base.delay.ms``
-     - Delai de base du backoff exponentiel (millisecondes)
+     - Délai de base du backoff exponentiel (millisecondes)
      - ``2000``
 
-Configuration avancee
+Configuration avancée
 ---------------------
 
-Elements de configuration avances relatifs a l'historique et a la taille du contexte.
+Éléments de configuration avancés relatifs à l'historique et à la taille du contexte.
 
 .. list-table::
    :header-rows: 1
    :widths: 45 35 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rag.llm.ollama.chat.evaluation.description.max.chars``
-     - Nombre maximum de caracteres de la description lors de l'evaluation
+     - Nombre maximum de caractères de la description lors de l'évaluation
      - ``500``
    * - ``rag.llm.ollama.history.max.chars``
-     - Nombre maximum de caracteres de l'historique de conversation
+     - Nombre maximum de caractères de l'historique de conversation
      - ``4000``
    * - ``rag.llm.ollama.intent.history.max.messages``
-     - Nombre maximum de messages dans l'historique lors de la determination d'intention
+     - Nombre maximum de messages dans l'historique lors de la détermination d'intention
      - ``6``
    * - ``rag.llm.ollama.intent.history.max.chars``
-     - Nombre maximum de caracteres dans l'historique lors de la determination d'intention
+     - Nombre maximum de caractères dans l'historique lors de la détermination d'intention
      - ``3000``
    * - ``rag.llm.ollama.history.assistant.max.chars``
-     - Nombre maximum de caracteres de l'historique des reponses de l'assistant
+     - Nombre maximum de caractères de l'historique des réponses de l'assistant
      - ``500``
    * - ``rag.llm.ollama.history.assistant.summary.max.chars``
-     - Nombre maximum de caracteres de l'historique des resumes de l'assistant
+     - Nombre maximum de caractères de l'historique des résumés de l'assistant
      - ``500``
 
-Controle de la concurrence
+Contrôle de la concurrence
 --------------------------
 
-``rag.llm.ollama.max.concurrent.requests`` permet de controler le nombre de requetes simultanees vers Ollama.
-La valeur par defaut est 5. Ajustez-la en fonction des ressources du serveur Ollama.
-Un nombre trop eleve de requetes simultanees peut surcharger le serveur Ollama et reduire la vitesse de reponse.
+``rag.llm.ollama.max.concurrent.requests`` permet de contrôler le nombre de requêtes simultanées vers Ollama.
+La valeur par défaut est 5. Ajustez-la en fonction des ressources du serveur Ollama.
+Un nombre trop élevé de requêtes simultanées peut surcharger le serveur Ollama et réduire la vitesse de réponse.
 
 Configuration par type de prompt
 =================================
 
-Dans |Fess|, les parametres du LLM peuvent etre personnalises par type de prompt.
-La configuration s'ecrit dans ``fess_config.properties``.
+Dans |Fess|, les paramètres du LLM peuvent être personnalisés par type de prompt.
+La configuration s'écrit dans ``fess_config.properties``.
 
-Les parametres suivants peuvent etre configures par type de prompt :
+Les paramètres suivants peuvent être configurés par type de prompt :
 
-- ``rag.llm.ollama.{promptType}.temperature`` - Temperature lors de la generation
-- ``rag.llm.ollama.{promptType}.max.tokens`` - Nombre maximum de tokens (mappe sur ``num_predict`` dans l'API Ollama)
-- ``rag.llm.ollama.{promptType}.context.max.chars`` - Nombre maximum de caracteres du contexte
-- ``rag.llm.ollama.{promptType}.thinking.budget`` - Budget de reflexion (controle de la reflexion en forme booleenne ; voir « Prise en charge des modeles de reflexion »)
-- ``rag.llm.ollama.{promptType}.thinking.level`` - Niveau de reflexion (chaine de caracteres ``high`` / ``medium`` / ``low`` ; voir « Prise en charge des modeles de reflexion »)
-- ``rag.llm.ollama.{promptType}.top.p`` - Valeur d'echantillonnage Top-P
-- ``rag.llm.ollama.{promptType}.top.k`` - Valeur d'echantillonnage Top-K
-- ``rag.llm.ollama.{promptType}.num.ctx`` - Taille de la fenetre de contexte
+- ``rag.llm.ollama.{promptType}.temperature`` - Température lors de la génération
+- ``rag.llm.ollama.{promptType}.max.tokens`` - Nombre maximum de tokens (mappé sur ``num_predict`` dans l'API Ollama)
+- ``rag.llm.ollama.{promptType}.context.max.chars`` - Nombre maximum de caractères du contexte
+- ``rag.llm.ollama.{promptType}.thinking.budget`` - Budget de réflexion (contrôle de la réflexion en forme booléenne ; voir « Prise en charge des modèles de réflexion »)
+- ``rag.llm.ollama.{promptType}.thinking.level`` - Niveau de réflexion (chaîne de caractères ``high`` / ``medium`` / ``low`` ; voir « Prise en charge des modèles de réflexion »)
+- ``rag.llm.ollama.{promptType}.top.p`` - Valeur d'échantillonnage Top-P
+- ``rag.llm.ollama.{promptType}.top.k`` - Valeur d'échantillonnage Top-K
+- ``rag.llm.ollama.{promptType}.num.ctx`` - Taille de la fenêtre de contexte
 
-Chaque parametre est resolu dans l'ordre suivant : ``rag.llm.ollama.{promptType}.<param>`` (configuration specifique au type de prompt) → ``rag.llm.ollama.default.<param>`` (repli commun a tous les types de prompt) → valeur par defaut codee en dur pour chaque type de prompt. Les valeurs explicitement specifiees dans la requete sont toujours prioritaires.
+Chaque paramètre est résolu dans l'ordre suivant : ``rag.llm.ollama.{promptType}.<param>`` (configuration spécifique au type de prompt) → ``rag.llm.ollama.default.<param>`` (repli commun à tous les types de prompt) → valeur par défaut codée en dur pour chaque type de prompt. Les valeurs explicitement spécifiées dans la requête sont toujours prioritaires.
 
 Types de prompt disponibles :
 
@@ -264,27 +264,27 @@ Types de prompt disponibles :
    * - Type de prompt
      - Description
    * - ``intent``
-     - Prompt pour determiner l'intention de l'utilisateur
+     - Prompt pour déterminer l'intention de l'utilisateur
    * - ``evaluation``
-     - Prompt d'evaluation des resultats de recherche
+     - Prompt d'évaluation des résultats de recherche
    * - ``unclear``
-     - Prompt de reponse pour les requetes peu claires
+     - Prompt de réponse pour les requêtes peu claires
    * - ``noresults``
-     - Prompt pour le cas ou il n'y a pas de resultats de recherche
+     - Prompt pour le cas où il n'y a pas de résultats de recherche
    * - ``docnotfound``
-     - Prompt pour le cas ou le document n'est pas trouve
+     - Prompt pour le cas où le document n'est pas trouvé
    * - ``answer``
-     - Prompt de generation de reponse
+     - Prompt de génération de réponse
    * - ``summary``
-     - Prompt de generation de resume
+     - Prompt de génération de résumé
    * - ``faq``
-     - Prompt de generation de FAQ
+     - Prompt de génération de FAQ
    * - ``direct``
-     - Prompt de reponse directe
+     - Prompt de réponse directe
    * - ``queryregeneration``
-     - Prompt de regeneration de requete
+     - Prompt de régénération de requête
 
-Chaque type de prompt dispose de valeurs par defaut codees en dur qui s'appliquent si aucune configuration n'est fournie.
+Chaque type de prompt dispose de valeurs par défaut codées en dur qui s'appliquent si aucune configuration n'est fournie.
 
 .. list-table::
    :header-rows: 1
@@ -357,44 +357,44 @@ Exemple de configuration ::
     # Configurer le nombre maximum de caracteres du contexte lors de la determination d'intention
     rag.llm.ollama.intent.context.max.chars=4000
 
-Options du modele Ollama
+Options du modèle Ollama
 ========================
 
-Les parametres du modele Ollama peuvent etre configures dans ``fess_config.properties``.
-En utilisant le format ``rag.llm.ollama.default.<param>``, la valeur est utilisee comme repli commun a tous les types de prompt.
-Le repli via ``default`` s'applique non seulement a ``top.p`` / ``top.k`` / ``num.ctx``, mais aussi a ``temperature`` / ``max.tokens`` / ``thinking.budget`` / ``thinking.level``.
+Les paramètres du modèle Ollama peuvent être configurés dans ``fess_config.properties``.
+En utilisant le format ``rag.llm.ollama.default.<param>``, la valeur est utilisée comme repli commun à tous les types de prompt.
+Le repli via ``default`` s'applique non seulement à ``top.p`` / ``top.k`` / ``num.ctx``, mais aussi à ``temperature`` / ``max.tokens`` / ``thinking.budget`` / ``thinking.level``.
 
 .. list-table::
    :header-rows: 1
    :widths: 40 40 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rag.llm.ollama.default.top.p``
-     - Valeur d'echantillonnage Top-P (0.0 a 1.0). Peut etre remplacee par type de prompt avec ``rag.llm.ollama.{promptType}.top.p``
-     - (non defini)
+     - Valeur d'échantillonnage Top-P (0.0 à 1.0). Peut être remplacée par type de prompt avec ``rag.llm.ollama.{promptType}.top.p``
+     - (non défini)
    * - ``rag.llm.ollama.default.top.k``
-     - Valeur d'echantillonnage Top-K. Peut etre remplacee par type de prompt avec ``rag.llm.ollama.{promptType}.top.k``
-     - (non defini)
+     - Valeur d'échantillonnage Top-K. Peut être remplacée par type de prompt avec ``rag.llm.ollama.{promptType}.top.k``
+     - (non défini)
    * - ``rag.llm.ollama.default.num.ctx``
-     - Taille de la fenetre de contexte. Peut etre remplacee par type de prompt avec ``rag.llm.ollama.{promptType}.num.ctx``
-     - (non defini)
+     - Taille de la fenêtre de contexte. Peut être remplacée par type de prompt avec ``rag.llm.ollama.{promptType}.num.ctx``
+     - (non défini)
    * - ``rag.llm.ollama.default.temperature``
-     - Valeur de repli de la temperature de generation. Peut etre remplacee par type de prompt avec ``rag.llm.ollama.{promptType}.temperature``
-     - (non defini)
+     - Valeur de repli de la température de génération. Peut être remplacée par type de prompt avec ``rag.llm.ollama.{promptType}.temperature``
+     - (non défini)
    * - ``rag.llm.ollama.default.max.tokens``
-     - Valeur de repli du nombre maximum de tokens. Peut etre remplacee par type de prompt avec ``rag.llm.ollama.{promptType}.max.tokens``
-     - (non defini)
+     - Valeur de repli du nombre maximum de tokens. Peut être remplacée par type de prompt avec ``rag.llm.ollama.{promptType}.max.tokens``
+     - (non défini)
    * - ``rag.llm.ollama.default.thinking.budget``
-     - Valeur de repli du budget de reflexion. Peut etre remplacee par type de prompt avec ``rag.llm.ollama.{promptType}.thinking.budget``
-     - (non defini)
+     - Valeur de repli du budget de réflexion. Peut être remplacée par type de prompt avec ``rag.llm.ollama.{promptType}.thinking.budget``
+     - (non défini)
    * - ``rag.llm.ollama.default.thinking.level``
-     - Valeur de repli du niveau de reflexion (``high`` / ``medium`` / ``low``). Peut etre remplacee par type de prompt avec ``rag.llm.ollama.{promptType}.thinking.level``
-     - (non defini)
+     - Valeur de repli du niveau de réflexion (``high`` / ``medium`` / ``low``). Peut être remplacée par type de prompt avec ``rag.llm.ollama.{promptType}.thinking.level``
+     - (non défini)
    * - ``rag.llm.ollama.options.*``
-     - Options globales transmises directement a l'API Ollama. Le suffixe est utilise comme nom d'option (ex. : ``rag.llm.ollama.options.repeat_penalty=1.1``). Les valeurs sont automatiquement converties en Integer, Double, Boolean ou String
-     - (non defini)
+     - Options globales transmises directement à l'API Ollama. Le suffixe est utilisé comme nom d'option (ex. : ``rag.llm.ollama.options.repeat_penalty=1.1``). Les valeurs sont automatiquement converties en Integer, Double, Boolean ou String
+     - (non défini)
 
 Exemple de configuration ::
 
@@ -413,12 +413,12 @@ Exemple de configuration ::
     # Options globales (transmises directement a l'API Ollama)
     rag.llm.ollama.options.repeat_penalty=1.1
 
-Prise en charge des modeles de reflexion
+Prise en charge des modèles de réflexion
 =========================================
 
-Lors de l'utilisation de modeles de reflexion (thinking model) tels que gemma4 ou qwen3, |Fess| prend en charge la configuration du budget de reflexion (thinking budget).
+Lors de l'utilisation de modèles de réflexion (thinking model) tels que gemma4 ou qwen3, |Fess| prend en charge la configuration du budget de réflexion (thinking budget).
 
-Le budget de reflexion se configure par type de prompt dans ``fess_config.properties`` :
+Le budget de réflexion se configure par type de prompt dans ``fess_config.properties`` :
 
 ::
 
@@ -428,16 +428,16 @@ Le budget de reflexion se configure par type de prompt dans ``fess_config.proper
     # Configuration du budget de reflexion lors de la generation de resume
     rag.llm.ollama.summary.thinking.budget=1024
 
-La configuration du budget de reflexion permet de controler le nombre de tokens alloues a l'etape de « reflexion » du modele avant la generation de la reponse.
+La configuration du budget de réflexion permet de contrôler le nombre de tokens alloués à l'étape de « réflexion » du modèle avant la génération de la réponse.
 
 .. note::
-   Avec Ollama, le budget de reflexion est converti en indicateur booleen (``think: true`` si la valeur est superieure a 0, ``think: false`` si la valeur est 0). Le controle fin par nombre de tokens n'est pas disponible en raison des contraintes de l'API Ollama.
+   Avec Ollama, le budget de réflexion est converti en indicateur booléen (``think: true`` si la valeur est supérieure à 0, ``think: false`` si la valeur est 0). Le contrôle fin par nombre de tokens n'est pas disponible en raison des contraintes de l'API Ollama.
 
-Niveau de reflexion (thinking level)
+Niveau de réflexion (thinking level)
 --------------------------------------
 
-Certains modeles comme gpt-oss ignorent l'indicateur ``think`` booleen et requierent la specification du niveau de reflexion sous forme de chaine de caracteres ``high`` / ``medium`` / ``low``.
-Pour ces modeles, utilisez ``rag.llm.ollama.{promptType}.thinking.level``.
+Certains modèles comme gpt-oss ignorent l'indicateur ``think`` booléen et requièrent la spécification du niveau de réflexion sous forme de chaîne de caractères ``high`` / ``medium`` / ``low``.
+Pour ces modèles, utilisez ``rag.llm.ollama.{promptType}.thinking.level``.
 
 ::
 
@@ -447,25 +447,25 @@ Pour ces modeles, utilisez ``rag.llm.ollama.{promptType}.thinking.level``.
     # Configuration du niveau de reflexion lors de la generation de resume
     rag.llm.ollama.summary.thinking.level=medium
 
-Les valeurs acceptees pour ``thinking.level`` sont ``high`` / ``medium`` / ``low`` (insensible a la casse). Une valeur non valide est ignoree et un avertissement est emis dans les journaux.
+Les valeurs acceptées pour ``thinking.level`` sont ``high`` / ``medium`` / ``low`` (insensible à la casse). Une valeur non valide est ignorée et un avertissement est émis dans les journaux.
 
 .. note::
-   Si ``thinking.level`` (forme chaine) et ``thinking.budget`` (forme booleenne) sont tous les deux configures, ``thinking.level`` est prioritaire. Utilisez ``thinking.level`` pour les modeles de la famille GPT-OSS, et ``thinking.budget`` pour les autres modeles de reflexion.
+   Si ``thinking.level`` (forme chaîne) et ``thinking.budget`` (forme booléenne) sont tous les deux configurés, ``thinking.level`` est prioritaire. Utilisez ``thinking.level`` pour les modèles de la famille GPT-OSS, et ``thinking.budget`` pour les autres modèles de réflexion.
 
-Configuration reseau
+Configuration réseau
 ====================
 
 Configuration Docker
 --------------------
 
-Le depot officiel `docker-fess <https://github.com/codelibs/docker-fess>`__ de |Fess| inclut un overlay Ollama ``compose-ollama.yaml``. Les etapes minimales sont les suivantes.
+Le dépôt officiel `docker-fess <https://github.com/codelibs/docker-fess>`__ de |Fess| inclut un overlay Ollama ``compose-ollama.yaml``. Les étapes minimales sont les suivantes.
 
 ::
 
     docker compose -f compose.yaml -f compose-opensearch3.yaml -f compose-ollama.yaml up -d
     docker exec -it ollama01 ollama pull gemma4:e4b
 
-``compose-ollama.yaml`` est configure pour utiliser un GPU NVIDIA (NVIDIA Container Toolkit requis). Son contenu est le suivant.
+``compose-ollama.yaml`` est configuré pour utiliser un GPU NVIDIA (NVIDIA Container Toolkit requis). Son contenu est le suivant.
 
 .. code-block:: yaml
 
@@ -501,140 +501,140 @@ Le depot officiel `docker-fess <https://github.com/codelibs/docker-fess>`__ de |
 
 Points importants :
 
-- ``FESS_PLUGINS=fess-llm-ollama:15.7.0`` fait que le script de demarrage recupere automatiquement le JAR du plugin et le place dans ``app/WEB-INF/plugin/`` (adaptez la version a votre installation |Fess|)
+- ``FESS_PLUGINS=fess-llm-ollama:15.7.0`` fait que le script de démarrage récupère automatiquement le JAR du plugin et le place dans ``app/WEB-INF/plugin/`` (adaptez la version à votre installation |Fess|)
 - ``-Dfess.config.rag.chat.enabled=true`` active le mode de recherche IA
-- ``-Dfess.config.rag.llm.ollama.api.url=...`` specifie l'URL du serveur Ollama (dans le reseau Docker Compose, le nom de service tel que ``ollama01`` est utilise pour la resolution)
-- Le fournisseur LLM par defaut (``rag.llm.name``) etant ``ollama``, aucune specification explicite n'est necessaire si Ollama est le seul fournisseur utilise. En cas de basculement depuis un autre fournisseur, ajoutez ``-Dfess.system.rag.llm.name=ollama`` dans ``FESS_JAVA_OPTS``, ou configurez-le apres le demarrage dans l'administration sous « Systeme > General », section RAG
-- Le bloc ``deploy.resources.reservations.devices`` configure l'utilisation du GPU. Si vous n'utilisez pas de GPU (execution CPU uniquement), supprimez ce bloc
+- ``-Dfess.config.rag.llm.ollama.api.url=...`` spécifie l'URL du serveur Ollama (dans le réseau Docker Compose, le nom de service tel que ``ollama01`` est utilisé pour la résolution)
+- Le fournisseur LLM par défaut (``rag.llm.name``) étant ``ollama``, aucune spécification explicite n'est nécessaire si Ollama est le seul fournisseur utilisé. En cas de basculement depuis un autre fournisseur, ajoutez ``-Dfess.system.rag.llm.name=ollama`` dans ``FESS_JAVA_OPTS``, ou configurez-le après le démarrage dans l'administration sous « Système > Général », section RAG
+- Le bloc ``deploy.resources.reservations.devices`` configure l'utilisation du GPU. Si vous n'utilisez pas de GPU (exécution CPU uniquement), supprimez ce bloc
 
 .. note::
-   Les variables d'environnement en majuscules de type ``RAG_CHAT_ENABLED`` ou ``RAG_LLM_NAME`` ne sont pas reconnues directement par |Fess|. Les valeurs de configuration doivent imperativement etre transmises dans ``FESS_JAVA_OPTS`` sous la forme ``-Dfess.config.<key>`` (famille ``fess_config.properties``) ou ``-Dfess.system.<key>`` (famille ``system.properties``).
+   Les variables d'environnement en majuscules de type ``RAG_CHAT_ENABLED`` ou ``RAG_LLM_NAME`` ne sont pas reconnues directement par |Fess|. Les valeurs de configuration doivent impérativement être transmises dans ``FESS_JAVA_OPTS`` sous la forme ``-Dfess.config.<key>`` (famille ``fess_config.properties``) ou ``-Dfess.system.<key>`` (famille ``system.properties``).
 
 Serveur Ollama distant
 ----------------------
 
-Lorsqu'Ollama s'execute sur un serveur different de Fess :
+Lorsqu'Ollama s'exécute sur un serveur différent de Fess :
 
 ::
 
     rag.llm.ollama.api.url=http://ollama-server.example.com:11434
 
 .. warning::
-   Ollama n'a pas de fonctionnalite d'authentification par defaut. Si vous le rendez accessible de l'exterieur,
-   envisagez des mesures de securite au niveau reseau (pare-feu, VPN, etc.).
+   Ollama n'a pas de fonctionnalité d'authentification par défaut. Si vous le rendez accessible de l'extérieur,
+   envisagez des mesures de sécurité au niveau réseau (pare-feu, VPN, etc.).
 
 Utilisation via un proxy HTTP
 ==============================
 
-Le client Ollama partage la configuration de proxy HTTP commune a |Fess|. Si une connexion au serveur Ollama doit passer par un proxy (par exemple lors de l'utilisation d'un serveur Ollama distant), specifiez les proprietes suivantes dans ``fess_config.properties``.
+Le client Ollama partage la configuration de proxy HTTP commune à |Fess|. Si une connexion au serveur Ollama doit passer par un proxy (par exemple lors de l'utilisation d'un serveur Ollama distant), spécifiez les propriétés suivantes dans ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``http.proxy.host``
-     - Nom d'hote du proxy (chaine vide pour ne pas utiliser de proxy)
+     - Nom d'hôte du proxy (chaîne vide pour ne pas utiliser de proxy)
      - ``""``
    * - ``http.proxy.port``
-     - Numero de port du proxy
+     - Numéro de port du proxy
      - ``8080``
    * - ``http.proxy.username``
-     - Nom d'utilisateur pour l'authentification du proxy (facultatif ; lorsqu'il est renseigne, l'authentification Basic est activee)
+     - Nom d'utilisateur pour l'authentification du proxy (facultatif ; lorsqu'il est renseigné, l'authentification Basic est activée)
      - ``""``
    * - ``http.proxy.password``
      - Mot de passe pour l'authentification du proxy
      - ``""``
 
 .. note::
-   Comme Ollama s'execute generalement en local ou sur un reseau interne, la configuration d'un proxy n'est necessaire que dans des cas limites (par exemple, lors de l'utilisation d'un serveur Ollama distant uniquement accessible via un proxy d'entreprise).
-   Cette configuration s'applique egalement a tous les acces HTTP de |Fess|, notamment ceux du crawler.
+   Comme Ollama s'exécute généralement en local ou sur un réseau interne, la configuration d'un proxy n'est nécessaire que dans des cas limités (par exemple, lors de l'utilisation d'un serveur Ollama distant uniquement accessible via un proxy d'entreprise).
+   Cette configuration s'applique également à tous les accès HTTP de |Fess|, notamment ceux du crawler.
 
-Guide de selection des modeles
+Guide de sélection des modèles
 ================================
 
-Guide pour la selection du modele selon l'usage.
+Guide pour la sélection du modèle selon l'usage.
 
 .. list-table::
    :header-rows: 1
    :widths: 25 20 20 35
 
-   * - Modele
+   * - Modèle
      - Taille
      - VRAM requise
      - Usage
    * - ``phi3:3.8b``
      - Petit
      - 4GB+
-     - Environnement leger, questions-reponses simples
+     - Environnement léger, questions-réponses simples
    * - ``gemma4:e4b``
      - Petit-Moyen
      - 8GB+
-     - Usage general equilibre, support du mode reflexion (par defaut)
+     - Usage général équilibré, support du mode réflexion (par défaut)
    * - ``mistral:7b``
      - Moyen
      - 8GB+
-     - Reponses de haute qualite requises
+     - Réponses de haute qualité requises
    * - ``llama3.3:70b``
      - Grand
      - 48GB+
-     - Reponses de meilleure qualite, raisonnement complexe
+     - Réponses de meilleure qualité, raisonnement complexe
 
 Prise en charge GPU
 -------------------
 
-Ollama prend en charge l'acceleration GPU. L'utilisation d'un GPU NVIDIA
-ameliore considerablement la vitesse d'inference.
+Ollama prend en charge l'accélération GPU. L'utilisation d'un GPU NVIDIA
+améliore considérablement la vitesse d'inférence.
 
 ::
 
     # Verification de la prise en charge GPU
     ollama run gemma4:e4b --verbose
 
-Depannage
+Dépannage
 =========
 
 Erreur de connexion
 -------------------
 
-**Symptome** : Erreur dans la fonctionnalite de chat, LLM affiche comme indisponible
+**Symptôme** : Erreur dans la fonctionnalité de chat, LLM affiche comme indisponible
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si Ollama fonctionne ::
+1. Vérifier si Ollama fonctionne ::
 
     curl http://localhost:11434/api/tags
 
-2. Verifier si le modele est telecharge ::
+2. Vérifier si le modèle est téléchargé ::
 
     ollama list
 
-3. Verifier les parametres du pare-feu
+3. Vérifier les paramètres du pare-feu
 
-4. Verifier si le plugin ``fess-llm-ollama`` est bien place dans ``app/WEB-INF/plugin/``
+4. Vérifier si le plugin ``fess-llm-ollama`` est bien placé dans ``app/WEB-INF/plugin/``
 
-Modele introuvable
+Modèle introuvable
 ------------------
 
-**Symptome** : Le journal affiche « Configured model not found »
+**Symptôme** : Le journal affiche « Configured model not found »
 
 **Solution** :
 
-1. Verifier si le nom du modele est exact (peut necessiter le tag ``:latest``) ::
+1. Vérifier si le nom du modèle est exact (peut nécessiter le tag ``:latest``) ::
 
     # Verifier la liste des modeles
     ollama list
 
-2. Telecharger le modele necessaire ::
+2. Télécharger le modèle nécessaire ::
 
     ollama pull gemma4:e4b
 
 Timeout
 -------
 
-**Symptome** : La requete expire
+**Symptôme** : La requête expire
 
 **Solution** :
 
@@ -642,12 +642,12 @@ Timeout
 
     rag.llm.ollama.timeout=120000
 
-2. Envisager un modele plus petit ou un environnement GPU
+2. Envisager un modèle plus petit ou un environnement GPU
 
-Configuration de debogage
+Configuration de débogage
 --------------------------
 
-Pour investiguer les problemes, ajustez le niveau de log de |Fess| pour afficher des logs detailles lies a Ollama.
+Pour investiguer les problèmes, ajustez le niveau de log de |Fess| pour afficher des logs détaillés liés à Ollama.
 
 ``app/WEB-INF/classes/log4j2.xml`` :
 
@@ -655,11 +655,11 @@ Pour investiguer les problemes, ajustez le niveau de log de |Fess| pour afficher
 
     <Logger name="org.codelibs.fess.llm.ollama" level="DEBUG"/>
 
-Informations de reference
+Informations de référence
 ==========================
 
 - `Site officiel Ollama <https://ollama.com/>`__
-- `Bibliotheque de modeles Ollama <https://ollama.com/library>`__
+- `Bibliothèque de modèles Ollama <https://ollama.com/library>`__
 - `Ollama GitHub <https://github.com/ollama/ollama>`__
-- :doc:`llm-overview` - Apercu de l'integration LLM
-- :doc:`rag-chat` - Details de la fonctionnalite de mode de recherche IA
+- :doc:`llm-overview` - Aperçu de l'intégration LLM
+- :doc:`rag-chat` - Détails de la fonctionnalité de mode de recherche IA

--- a/fr/15.7/config/llm-openai.rst
+++ b/fr/15.7/config/llm-openai.rst
@@ -2,87 +2,87 @@
 Configuration OpenAI
 ==========================
 
-Apercu
+Aperçu
 ====
 
-OpenAI est un service cloud fournissant des grands modeles de langage (LLM) haute performance,
-dont GPT-4. |Fess| peut utiliser l'API OpenAI pour realiser la fonctionnalite de mode de recherche IA.
+OpenAI est un service cloud fournissant des grands modèles de langage (LLM) haute performance,
+dont GPT-4. |Fess| peut utiliser l'API OpenAI pour réaliser la fonctionnalité de mode de recherche IA.
 
-L'utilisation d'OpenAI permet de generer des reponses de haute qualite avec les modeles d'IA les plus avances.
+L'utilisation d'OpenAI permet de générer des réponses de haute qualité avec les modèles d'IA les plus avancés.
 
-Caracteristiques principales
+Caractéristiques principales
 --------
 
-- **Reponses de haute qualite** : Generation de reponses precises avec les derniers modeles GPT
-- **Evolutivite** : Mise a l'echelle facile grace au service cloud
-- **Amelioration continue** : Performances ameliorees grace aux mises a jour regulieres des modeles
-- **Fonctionnalites riches** : Prise en charge de diverses taches comme la generation de texte, le resume, la traduction
+- **Réponses de haute qualité** : Génération de réponses précises avec les derniers modèles GPT
+- **Évolutivité** : Mise à l'échelle facile grâce au service cloud
+- **Amélioration continue** : Performances améliorées grâce aux mises à jour régulières des modèles
+- **Fonctionnalités riches** : Prise en charge de diverses tâches comme la génération de texte, le résumé, la traduction
 
-Modeles pris en charge
+Modèles pris en charge
 ----------
 
-Principaux modeles disponibles avec OpenAI :
+Principaux modèles disponibles avec OpenAI :
 
-- ``gpt-5`` - Dernier modele haute performance
-- ``gpt-5-mini`` - Version allegee de GPT-5 (bon rapport cout-efficacite)
-- ``gpt-4o`` - Modele multimodal haute performance
-- ``gpt-4o-mini`` - Version allegee de GPT-4o
-- ``o3-mini`` - Modele leger specialise dans le raisonnement
-- ``o4-mini`` - Modele leger de nouvelle generation specialise dans le raisonnement
-
-.. note::
-   Pour les derniers modeles disponibles, consultez `OpenAI Models <https://platform.openai.com/docs/models>`__.
+- ``gpt-5`` - Dernier modèle haute performance
+- ``gpt-5-mini`` - Version allégée de GPT-5 (bon rapport coût-efficacité)
+- ``gpt-4o`` - Modèle multimodal haute performance
+- ``gpt-4o-mini`` - Version allégée de GPT-4o
+- ``o3-mini`` - Modèle léger spécialisé dans le raisonnement
+- ``o4-mini`` - Modèle léger de nouvelle génération spécialisé dans le raisonnement
 
 .. note::
-   Lors de l'utilisation de modeles de la serie o1/o3/o4 ou de la serie gpt-5, |Fess| utilise automatiquement le parametre ``max_completion_tokens`` de l'API OpenAI. Aucune modification de configuration n'est necessaire.
+   Pour les derniers modèles disponibles, consultez `OpenAI Models <https://platform.openai.com/docs/models>`__.
 
-Prerequis
+.. note::
+   Lors de l'utilisation de modèles de la série o1/o3/o4 ou de la série gpt-5, |Fess| utilise automatiquement le paramètre ``max_completion_tokens`` de l'API OpenAI. Aucune modification de configuration n'est nécessaire.
+
+Prérequis
 ========
 
-Avant d'utiliser OpenAI, preparez les elements suivants.
+Avant d'utiliser OpenAI, préparez les éléments suivants.
 
-1. **Compte OpenAI** : Creez un compte sur `https://platform.openai.com/ <https://platform.openai.com/>`__
-2. **Cle API** : Generez une cle API dans le tableau de bord OpenAI
+1. **Compte OpenAI** : Créez un compte sur `https://platform.openai.com/ <https://platform.openai.com/>`__
+2. **Clé API** : Générez une clé API dans le tableau de bord OpenAI
 3. **Configuration de facturation** : Configurez les informations de facturation car l'utilisation de l'API est payante
 
-Obtention de la cle API
+Obtention de la clé API
 -------------
 
-1. Connectez-vous a `OpenAI Platform <https://platform.openai.com/>`__
-2. Accedez a la section "API keys"
+1. Connectez-vous à `OpenAI Platform <https://platform.openai.com/>`__
+2. Accédez à la section "API keys"
 3. Cliquez sur "Create new secret key"
-4. Entrez un nom pour la cle et creez-la
-5. Enregistrez la cle affichee en lieu sur (elle ne sera affichee qu'une seule fois)
+4. Entrez un nom pour la clé et créez-la
+5. Enregistrez la clé affichée en lieu sûr (elle ne sera affichée qu'une seule fois)
 
 .. warning::
-   La cle API est une information confidentielle. Faites attention aux points suivants :
+   La clé API est une information confidentielle. Faites attention aux points suivants :
 
-   - Ne pas la commiter dans un systeme de gestion de versions
+   - Ne pas la commiter dans un système de gestion de versions
    - Ne pas l'afficher dans les logs
-   - La gerer via des variables d'environnement ou des fichiers de configuration securises
+   - La gérer via des variables d'environnement ou des fichiers de configuration sécurisés
 
 Installation du plugin
 ========================
 
-La fonctionnalite d'integration OpenAI est fournie sous forme de plugin. Pour l'utiliser, l'installation du plugin ``fess-llm-openai`` est necessaire.
+La fonctionnalité d'intégration OpenAI est fournie sous forme de plugin. Pour l'utiliser, l'installation du plugin ``fess-llm-openai`` est nécessaire.
 
-1. Telechargez `fess-llm-openai-15.7.0.jar`
-2. Placez le fichier JAR dans le repertoire ``app/WEB-INF/plugin/`` du repertoire d'installation de |Fess|::
+1. Téléchargez `fess-llm-openai-15.7.0.jar`
+2. Placez le fichier JAR dans le répertoire ``app/WEB-INF/plugin/`` du répertoire d'installation de |Fess|::
 
     cp fess-llm-openai-15.7.0.jar /path/to/fess/app/WEB-INF/plugin/
 
-3. Redemarrez |Fess|
+3. Redémarrez |Fess|
 
 .. note::
-   La version du plugin doit correspondre a la version de |Fess|.
+   La version du plugin doit correspondre à la version de |Fess|.
 
 Configuration de base
 ========
 
-Les elements de configuration sont repartis dans les deux fichiers suivants selon leur usage.
+Les éléments de configuration sont répartis dans les deux fichiers suivants selon leur usage.
 
-- ``app/WEB-INF/conf/fess_config.properties`` - Configuration principale de |Fess| et configuration specifique au fournisseur LLM
-- ``system.properties`` - Selection du fournisseur LLM (``rag.llm.name``), a configurer via l'administration (Administration > Systeme > General) ou directement dans le fichier
+- ``app/WEB-INF/conf/fess_config.properties`` - Configuration principale de |Fess| et configuration spécifique au fournisseur LLM
+- ``system.properties`` - Sélection du fournisseur LLM (``rag.llm.name``), à configurer via l'administration (Administration > Système > Général) ou directement dans le fichier
 
 Configuration minimale
 --------
@@ -100,14 +100,14 @@ Configuration minimale
     # Modele a utiliser
     rag.llm.openai.model=gpt-5-mini
 
-``system.properties`` (configurable egalement via Administration > Systeme > General) :
+``system.properties`` (configurable également via Administration > Système > Général) :
 
 ::
 
     # Definir le fournisseur LLM sur OpenAI
     rag.llm.name=openai
 
-Configuration recommandee (environnement de production)
+Configuration recommandée (environnement de production)
 --------------------
 
 ``app/WEB-INF/conf/fess_config.properties`` :
@@ -132,36 +132,36 @@ Configuration recommandee (environnement de production)
     # Limite du nombre de requetes simultanees
     rag.llm.openai.max.concurrent.requests=5
 
-``system.properties`` (configurable egalement via Administration > Systeme > General) :
+``system.properties`` (configurable également via Administration > Système > Général) :
 
 ::
 
     # Configuration du fournisseur LLM
     rag.llm.name=openai
 
-Elements de configuration
+Éléments de configuration
 ========
 
-Tous les elements de configuration disponibles pour le client OpenAI. Sauf ``rag.llm.name``, tous se configurent dans ``fess_config.properties``.
+Tous les éléments de configuration disponibles pour le client OpenAI. Sauf ``rag.llm.name``, tous se configurent dans ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 35 15 15
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
      - Emplacement
    * - ``rag.llm.name``
-     - Nom du fournisseur LLM (specifier ``openai``)
+     - Nom du fournisseur LLM (spécifier ``openai``)
      - ``ollama``
      - system.properties
    * - ``rag.llm.openai.api.key``
-     - Cle API OpenAI
+     - Clé API OpenAI
      - (Requis)
      - fess_config.properties
    * - ``rag.llm.openai.model``
-     - Nom du modele a utiliser
+     - Nom du modèle à utiliser
      - ``gpt-5-mini``
      - fess_config.properties
    * - ``rag.llm.openai.api.url``
@@ -169,27 +169,27 @@ Tous les elements de configuration disponibles pour le client OpenAI. Sauf ``rag
      - ``https://api.openai.com/v1``
      - fess_config.properties
    * - ``rag.llm.openai.timeout``
-     - Timeout de la requete (millisecondes)
+     - Timeout de la requête (millisecondes)
      - ``120000``
      - fess_config.properties
    * - ``rag.llm.openai.availability.check.interval``
-     - Intervalle de verification de disponibilite (secondes)
+     - Intervalle de vérification de disponibilité (secondes)
      - ``60``
      - fess_config.properties
    * - ``rag.llm.openai.max.concurrent.requests``
-     - Nombre maximum de requetes simultanees
+     - Nombre maximum de requêtes simultanées
      - ``5``
      - fess_config.properties
    * - ``rag.llm.openai.chat.evaluation.max.relevant.docs``
-     - Nombre maximum de documents pertinents lors de l'evaluation
+     - Nombre maximum de documents pertinents lors de l'évaluation
      - ``3``
      - fess_config.properties
    * - ``rag.llm.openai.concurrency.wait.timeout``
-     - Timeout d'attente des requetes simultanees (ms)
+     - Timeout d'attente des requêtes simultanées (ms)
      - ``30000``
      - fess_config.properties
    * - ``rag.llm.openai.reasoning.token.multiplier``
-     - Multiplicateur de max tokens pour les modeles de raisonnement
+     - Multiplicateur de max tokens pour les modèles de raisonnement
      - ``4``
      - fess_config.properties
    * - ``rag.llm.openai.retry.max``
@@ -197,7 +197,7 @@ Tous les elements de configuration disponibles pour le client OpenAI. Sauf ``rag
      - ``10``
      - fess_config.properties
    * - ``rag.llm.openai.retry.base.delay.ms``
-     - Delai de base du backoff exponentiel (millisecondes)
+     - Délai de base du backoff exponentiel (millisecondes)
      - ``2000``
      - fess_config.properties
    * - ``rag.llm.openai.stream.include.usage``
@@ -205,47 +205,47 @@ Tous les elements de configuration disponibles pour le client OpenAI. Sauf ``rag
      - ``true``
      - fess_config.properties
    * - ``rag.llm.openai.history.max.chars``
-     - Nombre maximum de caracteres pour l'historique de conversation
+     - Nombre maximum de caractères pour l'historique de conversation
      - ``8000``
      - fess_config.properties
    * - ``rag.llm.openai.intent.history.max.messages``
-     - Nombre maximum de messages d'historique pour la detection d'intention
+     - Nombre maximum de messages d'historique pour la détection d'intention
      - ``8``
      - fess_config.properties
    * - ``rag.llm.openai.intent.history.max.chars``
-     - Nombre maximum de caracteres d'historique pour la detection d'intention
+     - Nombre maximum de caractères d'historique pour la détection d'intention
      - ``4000``
      - fess_config.properties
    * - ``rag.llm.openai.history.assistant.max.chars``
-     - Nombre maximum de caracteres pour les messages de l'assistant
+     - Nombre maximum de caractères pour les messages de l'assistant
      - ``800``
      - fess_config.properties
    * - ``rag.llm.openai.history.assistant.summary.max.chars``
-     - Nombre maximum de caracteres pour le resume de l'assistant
+     - Nombre maximum de caractères pour le résumé de l'assistant
      - ``800``
      - fess_config.properties
    * - ``rag.llm.openai.chat.evaluation.description.max.chars``
-     - Nombre maximum de caracteres pour la description de document en evaluation
+     - Nombre maximum de caractères pour la description de document en évaluation
      - ``500``
      - fess_config.properties
    * - ``rag.chat.enabled``
-     - Activation de la fonctionnalite de mode de recherche IA
+     - Activation de la fonctionnalité de mode de recherche IA
      - ``false``
      - fess_config.properties
 
 Configuration par type de prompt
 ======================
 
-Dans |Fess|, des parametres individuels peuvent etre configures pour chaque type de prompt. La configuration s'effectue dans ``fess_config.properties``.
+Dans |Fess|, des paramètres individuels peuvent être configurés pour chaque type de prompt. La configuration s'effectue dans ``fess_config.properties``.
 
 Patterns de configuration
 ------------
 
-La configuration par type de prompt se specifie selon les patterns suivants :
+La configuration par type de prompt se spécifie selon les patterns suivants :
 
-- ``rag.llm.openai.{promptType}.temperature`` - Caractere aleatoire de la generation (0.0 a 2.0). Ignore pour les modeles de raisonnement (serie o1/o3/o4/gpt-5)
+- ``rag.llm.openai.{promptType}.temperature`` - Caractère aléatoire de la génération (0.0 à 2.0). Ignoré pour les modèles de raisonnement (série o1/o3/o4/gpt-5)
 - ``rag.llm.openai.{promptType}.max.tokens`` - Nombre maximum de tokens
-- ``rag.llm.openai.{promptType}.context.max.chars`` - Nombre maximum de caracteres du contexte (defaut : ``16000`` pour answer/summary, ``10000`` pour les autres)
+- ``rag.llm.openai.{promptType}.context.max.chars`` - Nombre maximum de caractères du contexte (défaut : ``16000`` pour answer/summary, ``10000`` pour les autres)
 
 Types de prompt
 ----------------
@@ -259,47 +259,47 @@ Types de prompt disponibles :
    * - Type de prompt
      - Description
    * - ``intent``
-     - Prompt pour determiner l'intention de l'utilisateur
+     - Prompt pour déterminer l'intention de l'utilisateur
    * - ``evaluation``
-     - Prompt pour evaluer la pertinence des resultats de recherche
+     - Prompt pour évaluer la pertinence des résultats de recherche
    * - ``unclear``
-     - Prompt de reponse pour les requetes peu claires
+     - Prompt de réponse pour les requêtes peu claires
    * - ``noresults``
-     - Prompt de reponse lorsqu'il n'y a pas de resultats de recherche
+     - Prompt de réponse lorsqu'il n'y a pas de résultats de recherche
    * - ``docnotfound``
-     - Prompt de reponse lorsque le document n'est pas trouve
+     - Prompt de réponse lorsque le document n'est pas trouvé
    * - ``answer``
-     - Prompt pour generer une reponse
+     - Prompt pour générer une réponse
    * - ``summary``
-     - Prompt pour generer un resume
+     - Prompt pour générer un résumé
    * - ``faq``
-     - Prompt pour generer une FAQ
+     - Prompt pour générer une FAQ
    * - ``direct``
-     - Prompt pour repondre directement
+     - Prompt pour répondre directement
    * - ``queryregeneration``
-     - Prompt de regeneration de requetes
+     - Prompt de régénération de requêtes
 
-Valeurs par defaut
+Valeurs par défaut
 ------------------
 
-Valeurs par defaut pour chaque type de prompt. La configuration de temperature est ignoree pour les modeles de raisonnement (serie o1/o3/o4/gpt-5).
+Valeurs par défaut pour chaque type de prompt. La configuration de température est ignorée pour les modèles de raisonnement (série o1/o3/o4/gpt-5).
 
 .. list-table::
    :header-rows: 1
    :widths: 25 20 20 35
 
    * - Type de prompt
-     - Temperature
+     - Température
      - Max Tokens
      - Remarques
    * - ``intent``
      - 0.1
      - 256
-     - Detection d'intention deterministe
+     - Détection d'intention déterministe
    * - ``evaluation``
      - 0.1
      - 256
-     - Evaluation de pertinence deterministe
+     - Évaluation de pertinence déterministe
    * - ``unclear``
      - 0.7
      - 512
@@ -323,15 +323,15 @@ Valeurs par defaut pour chaque type de prompt. La configuration de temperature e
    * - ``answer``
      - 0.5
      - 2048
-     - Generation de reponse principale
+     - Génération de réponse principale
    * - ``summary``
      - 0.3
      - 2048
-     - Generation de resume
+     - Génération de résumé
    * - ``queryregeneration``
      - 0.3
      - 256
-     - Regeneration de requetes
+     - Régénération de requêtes
 
 Exemple de configuration
 ------
@@ -350,88 +350,88 @@ Exemple de configuration
     # Configuration de la temperature pour le prompt intent (configurer bas pour la determination d'intention)
     rag.llm.openai.intent.temperature=0.1
 
-Comportement de reessai
+Comportement de réessai
 =======================
 
-Les requetes vers l'API OpenAI sont automatiquement reessayees pour les codes de statut HTTP suivants :
+Les requêtes vers l'API OpenAI sont automatiquement réessayées pour les codes de statut HTTP suivants :
 
-- ``429`` Too Many Requests (limitation de debit)
+- ``429`` Too Many Requests (limitation de débit)
 - ``500`` Internal Server Error
 - ``502`` Bad Gateway (qu'OpenAI peut renvoyer en cas de surcharge en amont)
 - ``503`` Service Unavailable
 - ``504`` Gateway Timeout
 
-Lors d'un reessai, |Fess| attend selon un backoff exponentiel (valeur de base ``rag.llm.openai.retry.base.delay.ms`` millisecondes, jusqu'a ``rag.llm.openai.retry.max`` tentatives, avec une gigue de +/-20%).
-Si le serveur renvoie un en-tete ``Retry-After`` (en secondes entieres, plafonne a ``600`` secondes), cette valeur prend le pas sur le backoff exponentiel. Cela suit les recommandations officielles d'OpenAI.
+Lors d'un réessai, |Fess| attend selon un backoff exponentiel (valeur de base ``rag.llm.openai.retry.base.delay.ms`` millisecondes, jusqu'à ``rag.llm.openai.retry.max`` tentatives, avec une gigue de +/-20%).
+Si le serveur renvoie un en-tête ``Retry-After`` (en secondes entières, plafonné à ``600`` secondes), cette valeur prend le pas sur le backoff exponentiel. Cela suit les recommandations officielles d'OpenAI.
 
-A noter, les ``IOException`` (timeouts de connexion, reinitialisations de socket, echecs DNS) ne sont pas reessayees. Si la requete a pu atteindre le serveur, un reessai pourrait entrainer une double facturation.
-Pour les requetes en streaming, seule la connexion initiale est sujette aux reessais ; les erreurs survenant apres le debut de la reception du corps de la reponse sont propagees immediatement.
+À noter, les ``IOException`` (timeouts de connexion, réinitialisations de socket, échecs DNS) ne sont pas réessayées. Si la requête a pu atteindre le serveur, un réessai pourrait entraîner une double facturation.
+Pour les requêtes en streaming, seule la connexion initiale est sujette aux réessais ; les erreurs survenant après le début de la réception du corps de la réponse sont propagées immédiatement.
 
 .. note::
-   Avec les valeurs par defaut (10 tentatives maximum, base de 2 secondes), le pire cas pour la somme des 9 backoffs est ``2 + 4 + 8 + ... + 512 ~= 1022 secondes (environ 17 minutes)``. Lorsque ``Retry-After`` (jusqu'a 600 secondes) est renvoye a chaque tentative, le pire cas atteint ``9 x 600 secondes = 90 minutes``. Pour un controle plus strict de la latence, reduisez ``rag.llm.openai.retry.max``.
+   Avec les valeurs par défaut (10 tentatives maximum, base de 2 secondes), le pire cas pour la somme des 9 backoffs est ``2 + 4 + 8 + ... + 512 ~= 1022 secondes (environ 17 minutes)``. Lorsque ``Retry-After`` (jusqu'à 600 secondes) est renvoyé à chaque tentative, le pire cas atteint ``9 x 600 secondes = 90 minutes``. Pour un contrôle plus strict de la latence, réduisez ``rag.llm.openai.retry.max``.
 
 Streaming et informations d'utilisation
 =======================================
 
-Par defaut, ``stream_options.include_usage=true`` est ajoute aux requetes, ce qui permet de recevoir l'objet ``usage`` (incluant ``completion_tokens_details.reasoning_tokens`` pour les modeles de raisonnement et ``prompt_tokens_details.cached_tokens`` lorsque la mise en cache du prompt est utilisee) dans le dernier chunk SSE de la reponse en streaming.
+Par défaut, ``stream_options.include_usage=true`` est ajouté aux requêtes, ce qui permet de recevoir l'objet ``usage`` (incluant ``completion_tokens_details.reasoning_tokens`` pour les modèles de raisonnement et ``prompt_tokens_details.cached_tokens`` lorsque la mise en cache du prompt est utilisée) dans le dernier chunk SSE de la réponse en streaming.
 
-Pour les backends qui n'acceptent pas le champ ``stream_options.include_usage`` (par exemple vLLM ou certaines passerelles compatibles Azure OpenAI), desactivez cette option ainsi::
+Pour les backends qui n'acceptent pas le champ ``stream_options.include_usage`` (par exemple vLLM ou certaines passerelles compatibles Azure OpenAI), désactivez cette option ainsi::
 
     rag.llm.openai.stream.include.usage=false
 
-Logs et detection d'anomalies
+Logs et détection d'anomalies
 =============================
 
-Le client OpenAI emet les logs structures suivants. Cela permet de surveiller l'utilisation des tokens et les anomalies de reponse sans activer le niveau ``DEBUG``.
+Le client OpenAI émet les logs structurés suivants. Cela permet de surveiller l'utilisation des tokens et les anomalies de réponse sans activer le niveau ``DEBUG``.
 
-- ``[LLM:OPENAI] Stream completed.`` (INFO) - emis a la fin d'une reponse en streaming, avec le nombre de chunks, le delai jusqu'au premier chunk et les informations d'utilisation des tokens
-- ``[LLM:OPENAI] Chat response received.`` (INFO) - emis a la fin d'une reponse non-streaming, avec des informations equivalentes
-- ``[LLM:OPENAI] Chat finished abnormally`` / ``Stream finished abnormally`` (WARN) - emis lorsque ``finish_reason`` est autre que ``stop`` (``length`` : troncature par max_tokens ; ``content_filter`` : moderation ; ``tool_calls`` / ``function_call`` : configuration d'appel d'outil non intentionnelle, etc.)
-- ``[LLM:OPENAI] Stream refusal.`` (WARN) - emis lorsque ``delta.refusal`` est renvoye par une sortie structuree
+- ``[LLM:OPENAI] Stream completed.`` (INFO) - émis à la fin d'une réponse en streaming, avec le nombre de chunks, le délai jusqu'au premier chunk et les informations d'utilisation des tokens
+- ``[LLM:OPENAI] Chat response received.`` (INFO) - émis à la fin d'une réponse non-streaming, avec des informations équivalentes
+- ``[LLM:OPENAI] Chat finished abnormally`` / ``Stream finished abnormally`` (WARN) - émis lorsque ``finish_reason`` est autre que ``stop`` (``length`` : troncature par max_tokens ; ``content_filter`` : modération ; ``tool_calls`` / ``function_call`` : configuration d'appel d'outil non intentionnelle, etc.)
+- ``[LLM:OPENAI] Stream refusal.`` (WARN) - émis lorsque ``delta.refusal`` est renvoyé par une sortie structurée
 
-Ces logs WARN peuvent etre exploites pour ajuster ``max_tokens``, auditer le filtre de contenu et detecter une mauvaise configuration de ``extra_params``.
+Ces logs WARN peuvent être exploités pour ajuster ``max_tokens``, auditer le filtre de contenu et détecter une mauvaise configuration de ``extra_params``.
 
 Masquage des informations d'authentification dans les URL des logs
 ------------------------------------------------------------------
 
-Les URL emises dans les logs voient automatiquement leurs parametres de requete contenant des informations d'authentification (``api_key``, ``apikey``, ``api-key``, ``key``, ``token``, ``access_token``, ``access-token``, sans distinction de casse) masques par ``***``.
+Les URL émises dans les logs voient automatiquement leurs paramètres de requête contenant des informations d'authentification (``api_key``, ``apikey``, ``api-key``, ``key``, ``token``, ``access_token``, ``access-token``, sans distinction de casse) masqués par ``***``.
 
-Le point de terminaison officiel OpenAI (``https://api.openai.com``) s'authentifie via l'en-tete ``Authorization: Bearer`` et n'inclut donc pas d'informations d'authentification dans l'URL. Toutefois, si vous configurez ``rag.llm.openai.api.url`` vers un proxy personnalise qui accepte les informations d'authentification en tant que parametres de requete (certains deploiements Azure, passerelles vLLM, etc.), cela empeche egalement la fuite de la cle API dans les logs.
+Le point de terminaison officiel OpenAI (``https://api.openai.com``) s'authentifie via l'en-tête ``Authorization: Bearer`` et n'inclut donc pas d'informations d'authentification dans l'URL. Toutefois, si vous configurez ``rag.llm.openai.api.url`` vers un proxy personnalisé qui accepte les informations d'authentification en tant que paramètres de requête (certains déploiements Azure, passerelles vLLM, etc.), cela empêche également la fuite de la clé API dans les logs.
 
-Prise en charge des modeles de raisonnement
+Prise en charge des modèles de raisonnement
 ==============
 
-Lors de l'utilisation de modeles de raisonnement de la serie o1/o3/o4 ou de la serie gpt-5, |Fess| utilise automatiquement le parametre ``max_completion_tokens`` de l'API OpenAI a la place de ``max_tokens``. Aucune modification de configuration supplementaire n'est necessaire.
+Lors de l'utilisation de modèles de raisonnement de la série o1/o3/o4 ou de la série gpt-5, |Fess| utilise automatiquement le paramètre ``max_completion_tokens`` de l'API OpenAI à la place de ``max_tokens``. Aucune modification de configuration supplémentaire n'est nécessaire.
 
 .. note::
-   Les modeles de raisonnement (serie o1/o3/o4/gpt-5) ignorent le parametre ``temperature`` et utilisent une valeur fixe (1). De plus, lors de l'utilisation de modeles de raisonnement, le ``max_tokens`` par defaut est multiplie par ``reasoning.token.multiplier`` (defaut : 4).
+   Les modèles de raisonnement (série o1/o3/o4/gpt-5) ignorent le paramètre ``temperature`` et utilisent une valeur fixe (1). De plus, lors de l'utilisation de modèles de raisonnement, le ``max_tokens`` par défaut est multiplié par ``reasoning.token.multiplier`` (défaut : 4).
 
-Parametres supplementaires pour les modeles de raisonnement
+Paramètres supplémentaires pour les modèles de raisonnement
 ----------------------------
 
-Lors de l'utilisation de modeles de raisonnement, les parametres supplementaires suivants peuvent etre configures dans ``fess_config.properties`` :
+Lors de l'utilisation de modèles de raisonnement, les paramètres supplémentaires suivants peuvent être configurés dans ``fess_config.properties`` :
 
 .. list-table::
    :header-rows: 1
    :widths: 40 40 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rag.llm.openai.{promptType}.reasoning.effort``
-     - Parametre d'effort de raisonnement pour les modeles de serie o (``low``, ``medium``, ``high``)
-     - ``low`` (intent/evaluation/docnotfound/unclear/noresults/queryregeneration), non defini (autres)
+     - Paramètre d'effort de raisonnement pour les modèles de série o (``low``, ``medium``, ``high``)
+     - ``low`` (intent/evaluation/docnotfound/unclear/noresults/queryregeneration), non défini (autres)
    * - ``rag.llm.openai.{promptType}.top.p``
-     - Seuil de probabilite pour la selection de tokens (0.0 a 1.0)
-     - (Non defini)
+     - Seuil de probabilité pour la sélection de tokens (0.0 à 1.0)
+     - (Non défini)
    * - ``rag.llm.openai.{promptType}.frequency.penalty``
-     - Penalite de frequence (-2.0 a 2.0)
-     - (Non defini)
+     - Pénalité de fréquence (-2.0 à 2.0)
+     - (Non défini)
    * - ``rag.llm.openai.{promptType}.presence.penalty``
-     - Penalite de presence (-2.0 a 2.0)
-     - (Non defini)
+     - Pénalité de présence (-2.0 à 2.0)
+     - (Non défini)
 
-``{promptType}`` peut etre ``intent``, ``evaluation``, ``answer``, ``summary``, etc.
+``{promptType}`` peut être ``intent``, ``evaluation``, ``answer``, ``summary``, etc.
 
 Exemple de configuration
 ------
@@ -450,21 +450,21 @@ Exemple de configuration
 Configuration via options JVM
 =============================
 
-Pour des raisons de securite, il est recommande de configurer la cle API via
-l'environnement d'execution (options JVM) plutot que via des fichiers versionnes.
+Pour des raisons de sécurité, il est recommandé de configurer la clé API via
+l'environnement d'exécution (options JVM) plutôt que via des fichiers versionnés.
 
 Environnement Docker
 --------------------
 
-Le depot officiel `docker-fess <https://github.com/codelibs/docker-fess>`__
-fournit un overlay OpenAI (``compose-openai.yaml``). Etapes minimales :
+Le dépôt officiel `docker-fess <https://github.com/codelibs/docker-fess>`__
+fournit un overlay OpenAI (``compose-openai.yaml``). Étapes minimales :
 
 ::
 
     export OPENAI_API_KEY="sk-..."
     docker compose -f compose.yaml -f compose-opensearch3.yaml -f compose-openai.yaml up -d
 
-Contenu de ``compose-openai.yaml`` (reference pour un setup equivalent) :
+Contenu de ``compose-openai.yaml`` (référence pour un setup équivalent) :
 
 .. code-block:: yaml
 
@@ -476,17 +476,17 @@ Contenu de ``compose-openai.yaml`` (reference pour un setup equivalent) :
 
 Notes :
 
-- ``FESS_PLUGINS=fess-llm-openai:15.7.0`` fait que ``run.sh`` du conteneur telecharge et installe automatiquement le plugin dans ``app/WEB-INF/plugin/``
+- ``FESS_PLUGINS=fess-llm-openai:15.7.0`` fait que ``run.sh`` du conteneur télécharge et installe automatiquement le plugin dans ``app/WEB-INF/plugin/``
 - ``-Dfess.config.rag.chat.enabled=true`` active le mode IA
-- ``-Dfess.config.rag.llm.openai.api.key=...`` definit la cle API, ``-Dfess.config.rag.llm.openai.model=...`` choisit le modele
-- ``-Dfess.system.rag.llm.name=openai`` n'agit que comme valeur par defaut initiale avant qu'une valeur ne soit persistee dans OpenSearch. Apres demarrage, le parametre peut aussi etre modifie sous Administration > Systeme > General (section RAG)
+- ``-Dfess.config.rag.llm.openai.api.key=...`` définit la clé API, ``-Dfess.config.rag.llm.openai.model=...`` choisit le modèle
+- ``-Dfess.system.rag.llm.name=openai`` n'agit que comme valeur par défaut initiale avant qu'une valeur ne soit persistée dans OpenSearch. Après démarrage, le paramètre peut aussi être modifié sous Administration > Système > Général (section RAG)
 
-Si l'acces Internet passe par un proxy, specifiez la configuration ``http.proxy.*`` de |Fess| via ``FESS_JAVA_OPTS`` (voir la section "Utilisation via un proxy HTTP" ci-dessous).
+Si l'accès Internet passe par un proxy, spécifiez la configuration ``http.proxy.*`` de |Fess| via ``FESS_JAVA_OPTS`` (voir la section "Utilisation via un proxy HTTP" ci-dessous).
 
 Environnement systemd
 ---------------------
 
-Ajouter a ``FESS_JAVA_OPTS`` dans ``/etc/sysconfig/fess`` (ou ``/etc/default/fess``) :
+Ajouter à ``FESS_JAVA_OPTS`` dans ``/etc/sysconfig/fess`` (ou ``/etc/default/fess``) :
 
 ::
 
@@ -495,41 +495,41 @@ Ajouter a ``FESS_JAVA_OPTS`` dans ``/etc/sysconfig/fess`` (ou ``/etc/default/fes
 Utilisation via un proxy HTTP
 =============================
 
-Le client OpenAI partage la configuration de proxy HTTP commune a |Fess|. Specifiez les proprietes suivantes dans ``fess_config.properties``.
+Le client OpenAI partage la configuration de proxy HTTP commune à |Fess|. Spécifiez les propriétés suivantes dans ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``http.proxy.host``
-     - Nom d'hote du proxy (chaine vide pour ne pas utiliser de proxy)
+     - Nom d'hôte du proxy (chaîne vide pour ne pas utiliser de proxy)
      - ``""``
    * - ``http.proxy.port``
-     - Numero de port du proxy
+     - Numéro de port du proxy
      - ``8080``
    * - ``http.proxy.username``
-     - Nom d'utilisateur pour l'authentification du proxy (facultatif ; lorsqu'il est renseigne, l'authentification Basic est activee)
+     - Nom d'utilisateur pour l'authentification du proxy (facultatif ; lorsqu'il est renseigné, l'authentification Basic est activée)
      - ``""``
    * - ``http.proxy.password``
      - Mot de passe pour l'authentification du proxy
      - ``""``
 
-Dans un environnement Docker, specifiez ce qui suit dans ``FESS_JAVA_OPTS``::
+Dans un environnement Docker, spécifiez ce qui suit dans ``FESS_JAVA_OPTS``::
 
     -Dfess.config.http.proxy.host=proxy.example.com
     -Dfess.config.http.proxy.port=8080
 
 .. note::
-   Cette configuration s'applique egalement a tous les acces HTTP de |Fess|, notamment ceux du crawler.
-   Les proprietes systeme Java traditionnelles (``-Dhttps.proxyHost``, etc.) ne sont pas prises en compte par le client OpenAI.
+   Cette configuration s'applique également à tous les accès HTTP de |Fess|, notamment ceux du crawler.
+   Les propriétés système Java traditionnelles (``-Dhttps.proxyHost``, etc.) ne sont pas prises en compte par le client OpenAI.
 
 Utilisation d'Azure OpenAI
 ==================
 
-Pour utiliser les modeles OpenAI via Microsoft Azure, modifiez le point de terminaison API.
+Pour utiliser les modèles OpenAI via Microsoft Azure, modifiez le point de terminaison API.
 
 ::
 
@@ -543,116 +543,116 @@ Pour utiliser les modeles OpenAI via Microsoft Azure, modifiez le point de termi
     rag.llm.openai.model=your-deployment-name
 
 .. note::
-   Lors de l'utilisation d'Azure OpenAI, le format des requetes API peut differer legerement.
-   Consultez la documentation Azure OpenAI pour plus de details.
+   Lors de l'utilisation d'Azure OpenAI, le format des requêtes API peut différer légèrement.
+   Consultez la documentation Azure OpenAI pour plus de détails.
 
-Guide de selection des modeles
+Guide de sélection des modèles
 ==================
 
-Guide pour la selection du modele selon l'usage.
+Guide pour la sélection du modèle selon l'usage.
 
 .. list-table::
    :header-rows: 1
    :widths: 25 20 20 35
 
-   * - Modele
-     - Cout
-     - Qualite
+   * - Modèle
+     - Coût
+     - Qualité
      - Usage
    * - ``gpt-5-mini``
      - Moyen
-     - Elevee
-     - Usage equilibre (recommande)
+     - Élevée
+     - Usage équilibré (recommandé)
    * - ``gpt-4o-mini``
      - Bas-Moyen
-     - Elevee
-     - Usage prioritaire au cout
+     - Élevée
+     - Usage prioritaire au coût
    * - ``gpt-5``
-     - Eleve
+     - Élevé
      - Maximale
-     - Raisonnement complexe, haute qualite requise
+     - Raisonnement complexe, haute qualité requise
    * - ``gpt-4o``
-     - Moyen-Eleve
+     - Moyen-Élevé
      - Maximale
      - Lorsque la prise en charge multimodale est requise
    * - ``o3-mini`` / ``o4-mini``
      - Moyen
      - Maximale
-     - Taches de raisonnement comme les mathematiques et la programmation
+     - Tâches de raisonnement comme les mathématiques et la programmation
 
-Estimation des couts
+Estimation des coûts
 ------------
 
-L'API OpenAI est facturee a l'usage.
+L'API OpenAI est facturée à l'usage.
 
 .. note::
    Pour les derniers prix, consultez `OpenAI Pricing <https://openai.com/pricing>`__.
 
-Controle des requetes simultanees
+Contrôle des requêtes simultanées
 ==================
 
-Dans |Fess|, le nombre de requetes simultanees vers l'API OpenAI peut etre controle via ``rag.llm.openai.max.concurrent.requests`` dans ``fess_config.properties``. La valeur par defaut est ``5``.
+Dans |Fess|, le nombre de requêtes simultanées vers l'API OpenAI peut être contrôlé via ``rag.llm.openai.max.concurrent.requests`` dans ``fess_config.properties``. La valeur par défaut est ``5``.
 
 ::
 
     # Configurer le nombre maximum de requetes simultanees
     rag.llm.openai.max.concurrent.requests=5
 
-Cette configuration permet d'eviter les requetes excessives vers l'API OpenAI et de prevenir les erreurs de limitation de debit.
+Cette configuration permet d'éviter les requêtes excessives vers l'API OpenAI et de prévenir les erreurs de limitation de débit.
 
 Limites par niveau OpenAI
 ------------------
 
 Les limites varient selon le niveau de votre compte OpenAI :
 
-- **Free** : 3 RPM (requetes/minute)
+- **Free** : 3 RPM (requêtes/minute)
 - **Tier 1** : 500 RPM
 - **Tier 2** : 5,000 RPM
-- **Tier 3+** : Limites plus elevees
+- **Tier 3+** : Limites plus élevées
 
-Ajustez ``rag.llm.openai.max.concurrent.requests`` de maniere appropriee selon le niveau de votre compte OpenAI.
+Ajustez ``rag.llm.openai.max.concurrent.requests`` de manière appropriée selon le niveau de votre compte OpenAI.
 
-Depannage
+Dépannage
 ======================
 
 Erreur d'authentification
 ----------
 
-**Symptome** : Erreur "401 Unauthorized"
+**Symptôme** : Erreur "401 Unauthorized"
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si la cle API est correctement configuree
-2. Verifier si la cle API est valide (verifier dans le tableau de bord OpenAI)
-3. Verifier si la cle API a les permissions necessaires
+1. Vérifier si la clé API est correctement configurée
+2. Vérifier si la clé API est valide (vérifier dans le tableau de bord OpenAI)
+3. Vérifier si la clé API a les permissions nécessaires
 
-Erreur de limitation de debit
+Erreur de limitation de débit
 ----------------
 
-**Symptome** : Erreur "429 Too Many Requests"
+**Symptôme** : Erreur "429 Too Many Requests"
 
 **Solution** :
 
-1. Reduire la valeur de ``rag.llm.openai.max.concurrent.requests``::
+1. Réduire la valeur de ``rag.llm.openai.max.concurrent.requests``::
 
     rag.llm.openai.max.concurrent.requests=3
 
-2. Mettre a niveau le niveau de votre compte OpenAI
+2. Mettre à niveau le niveau de votre compte OpenAI
 
-Depassement de quota
+Dépassement de quota
 ------------
 
-**Symptome** : Erreur "You exceeded your current quota"
+**Symptôme** : Erreur "You exceeded your current quota"
 
 **Solution** :
 
-1. Verifier l'usage dans le tableau de bord OpenAI
-2. Verifier les parametres de facturation et augmenter la limite si necessaire
+1. Vérifier l'usage dans le tableau de bord OpenAI
+2. Vérifier les paramètres de facturation et augmenter la limite si nécessaire
 
 Timeout
 ------------
 
-**Symptome** : La requete expire
+**Symptôme** : La requête expire
 
 **Solution** :
 
@@ -660,12 +660,12 @@ Timeout
 
     rag.llm.openai.timeout=180000
 
-2. Envisager un modele plus rapide (gpt-5-mini, etc.)
+2. Envisager un modèle plus rapide (gpt-5-mini, etc.)
 
-Configuration de debogage
+Configuration de débogage
 ------------
 
-Pour investiguer les problemes, ajustez le niveau de log de |Fess| pour afficher des logs detailles lies a OpenAI.
+Pour investiguer les problèmes, ajustez le niveau de log de |Fess| pour afficher des logs détaillés liés à OpenAI.
 
 ``app/WEB-INF/classes/log4j2.xml`` :
 
@@ -673,21 +673,21 @@ Pour investiguer les problemes, ajustez le niveau de log de |Fess| pour afficher
 
     <Logger name="org.codelibs.fess.llm.openai" level="DEBUG"/>
 
-Notes de securite
+Notes de sécurité
 ========================
 
-Lors de l'utilisation de l'API OpenAI, faites attention aux points de securite suivants.
+Lors de l'utilisation de l'API OpenAI, faites attention aux points de sécurité suivants.
 
-1. **Confidentialite des donnees** : Le contenu des resultats de recherche est envoye aux serveurs OpenAI
-2. **Gestion des cles API** : La fuite de cles peut entrainer une utilisation non autorisee
-3. **Conformite** : Si les donnees contiennent des informations confidentielles, verifiez les politiques de votre organisation
+1. **Confidentialité des données** : Le contenu des résultats de recherche est envoyé aux serveurs OpenAI
+2. **Gestion des clés API** : La fuite de clés peut entraîner une utilisation non autorisée
+3. **Conformité** : Si les données contiennent des informations confidentielles, vérifiez les politiques de votre organisation
 4. **Politique d'utilisation** : Respectez les conditions d'utilisation d'OpenAI
 
-Informations de reference
+Informations de référence
 ========
 
 - `OpenAI Platform <https://platform.openai.com/>`__
 - `OpenAI API Reference <https://platform.openai.com/docs/api-reference>`__
 - `OpenAI Pricing <https://openai.com/pricing>`__
-- :doc:`llm-overview` - Apercu de l'integration LLM
-- :doc:`rag-chat` - Details de la fonctionnalite de mode de recherche IA
+- :doc:`llm-overview` - Aperçu de l'intégration LLM
+- :doc:`rag-chat` - Détails de la fonctionnalité de mode de recherche IA

--- a/fr/15.7/config/load-control.rst
+++ b/fr/15.7/config/load-control.rst
@@ -1,31 +1,31 @@
 =====================================
-Configuration du controle de charge
+Configuration du contrôle de charge
 =====================================
 
-Apercu
+Aperçu
 ======
 
-|Fess| dispose de deux types de fonctionnalites de controle de charge qui protegent la stabilite du systeme en fonction de l'utilisation CPU.
+|Fess| dispose de deux types de fonctionnalités de contrôle de charge qui protègent la stabilité du système en fonction de l'utilisation CPU.
 
-**Controle de charge des requetes HTTP** (``web.load.control`` / ``api.load.control``) :
+**Contrôle de charge des requêtes HTTP** (``web.load.control`` / ``api.load.control``) :
 
-- Surveillance en temps reel de l'utilisation CPU du cluster OpenSearch
-- Seuils independants configurables pour les requetes web et les requetes API
-- Retourne HTTP 429 (Too Many Requests) lorsque les seuils sont depasses
-- Le panneau d'administration, la connexion et les ressources statiques sont exclus du controle
-- Desactive par defaut (seuil=100)
+- Surveillance en temps réel de l'utilisation CPU du cluster OpenSearch
+- Seuils indépendants configurables pour les requêtes web et les requêtes API
+- Retourne HTTP 429 (Too Many Requests) lorsque les seuils sont dépassés
+- Le panneau d'administration, la connexion et les ressources statiques sont exclus du contrôle
+- Désactivé par défaut (seuil=100)
 
-**Controle de charge adaptatif** (``adaptive.load.control``) :
+**Contrôle de charge adaptatif** (``adaptive.load.control``) :
 
-- Surveille l'utilisation CPU systeme du serveur Fess lui-meme
-- Ralentit automatiquement les taches en arriere-plan telles que le crawling, l'indexation, les mises a jour de suggestions et la generation de vignettes
-- Lorsque l'utilisation CPU atteint ou depasse le seuil, les threads de traitement sont mis en pause et reprennent lorsqu'elle descend en dessous du seuil
-- Active par defaut (seuil=50)
+- Surveille l'utilisation CPU système du serveur Fess lui-même
+- Ralentit automatiquement les tâches en arrière-plan telles que le crawling, l'indexation, les mises à jour de suggestions et la génération de vignettes
+- Lorsque l'utilisation CPU atteint ou dépasse le seuil, les threads de traitement sont mis en pause et reprennent lorsqu'elle descend en dessous du seuil
+- Activé par défaut (seuil=50)
 
-Configuration du controle de charge des requetes HTTP
+Configuration du contrôle de charge des requêtes HTTP
 =====================================================
 
-Definissez les proprietes suivantes dans ``fess_config.properties`` :
+Définissez les propriétés suivantes dans ``fess_config.properties`` :
 
 ::
 
@@ -45,57 +45,57 @@ Definissez les proprietes suivantes dans ``fess_config.properties`` :
     load.control.monitor.interval=1
 
 .. note::
-   Lorsque ``web.load.control`` et ``api.load.control`` sont tous deux definis a 100 (defaut),
-   la surveillance CPU d'OpenSearch ne demarre pas.
+   Lorsque ``web.load.control`` et ``api.load.control`` sont tous deux définis à 100 (défaut),
+   la surveillance CPU d'OpenSearch ne démarre pas.
 
 Fonctionnement
 ==============
 
-Mecanisme de surveillance
+Mécanisme de surveillance
 -------------------------
 
-Lorsque le controle de charge est active (l'un ou l'autre des seuils est inferieur a 100), LoadControlMonitorTarget surveille periodiquement l'utilisation CPU du cluster OpenSearch.
+Lorsque le contrôle de charge est activé (l'un ou l'autre des seuils est inférieur à 100), LoadControlMonitorTarget surveille périodiquement l'utilisation CPU du cluster OpenSearch.
 
-- Recupere les statistiques OS de tous les noeuds du cluster OpenSearch
-- Enregistre l'utilisation CPU la plus elevee parmi tous les noeuds
-- Surveille a l'intervalle specifie par ``load.control.monitor.interval`` (defaut : 1 seconde)
-- La surveillance demarre de maniere differee lors de la premiere requete
+- Récupère les statistiques OS de tous les noeuds du cluster OpenSearch
+- Enregistre l'utilisation CPU la plus élevée parmi tous les noeuds
+- Surveille à l'intervalle spécifié par ``load.control.monitor.interval`` (défaut : 1 seconde)
+- La surveillance démarre de manière différée lors de la première requête
 
 .. note::
-   Si la recuperation des informations de surveillance echoue, l'utilisation CPU est reinitialisee a 0.
-   Les trois premiers echecs consecutifs sont enregistres au niveau WARNING dans les logs ; a partir
-   du quatrieme echec, le niveau passe a DEBUG (afin d'eviter une inflation des logs en cas d'echecs
-   persistants). Le compteur d'echecs est reinitialise des qu'une surveillance reussit.
+   Si la récupération des informations de surveillance échoue, l'utilisation CPU est réinitialisée à 0.
+   Les trois premiers échecs consécutifs sont enregistrés au niveau WARNING dans les logs ; à partir
+   du quatrième échec, le niveau passe à DEBUG (afin d'éviter une inflation des logs en cas d'échecs
+   persistants). Le compteur d'échecs est réinitialisé dès qu'une surveillance réussit.
 
-Controle des requetes
+Contrôle des requêtes
 ---------------------
 
-Lorsqu'une requete arrive, LoadControlFilter la traite dans l'ordre suivant :
+Lorsqu'une requête arrive, LoadControlFilter la traite dans l'ordre suivant :
 
-1. Verifier si le chemin est exclu (si exclu, laisser passer)
-2. Determiner le type de requete (Web / API)
+1. Vérifier si le chemin est exclu (si exclu, laisser passer)
+2. Déterminer le type de requête (Web / API)
 3. Obtenir le seuil correspondant
-4. Si le seuil est de 100 ou plus, ne pas controler (laisser passer)
+4. Si le seuil est de 100 ou plus, ne pas contrôler (laisser passer)
 5. Comparer l'utilisation CPU actuelle avec le seuil
 6. Si l'utilisation CPU >= seuil, retourner HTTP 429
 
-**Requetes exclues :**
+**Requêtes exclues :**
 
-- Chemins commencant par ``/admin`` (panneau d'administration)
-- Chemins commencant par ``/error`` (pages d'erreur)
-- Chemins commencant par ``/login`` (pages de connexion)
+- Chemins commençant par ``/admin`` (panneau d'administration)
+- Chemins commençant par ``/error`` (pages d'erreur)
+- Chemins commençant par ``/login`` (pages de connexion)
 - Ressources statiques (``.css``, ``.js``, ``.png``, ``.jpg``, ``.gif``, ``.ico``, ``.svg``, ``.woff``, ``.woff2``, ``.ttf``, ``.eot``)
 
-**Pour les requetes web :**
+**Pour les requêtes web :**
 
 - Retourne le code de statut HTTP 429
 - Affiche la page d'erreur (``busy.jsp``)
 
-**Pour les requetes API :**
+**Pour les requêtes API :**
 
 - Retourne le code de statut HTTP 429
-- Ajoute l'en-tete de reponse HTTP ``Retry-After: 60``
-- Retourne une reponse JSON :
+- Ajoute l'en-tete de réponse HTTP ``Retry-After: 60``
+- Retourne une réponse JSON :
 
 ::
 
@@ -108,17 +108,17 @@ Lorsqu'une requete arrive, LoadControlFilter la traite dans l'ordre suivant :
     }
 
 .. note::
-   Lorsqu'une requete est rejetee, le message suivant est enregistre au niveau INFO dans les logs du serveur :
+   Lorsqu'une requête est rejetée, le message suivant est enregistré au niveau INFO dans les logs du serveur :
    ``Rejecting request due to high CPU load: path=..., cpu=...%, threshold=...%``
-   Cela permet de verifier quel chemin a ete rejete et pour quel seuil.
+   Cela permet de vérifier quel chemin a été rejeté et pour quel seuil.
 
 Exemples de configuration
 =========================
 
-Limiter uniquement les requetes web
+Limiter uniquement les requêtes web
 ------------------------------------
 
-Configuration qui limite uniquement les requetes de recherche web sans restreindre l'API :
+Configuration qui limite uniquement les requêtes de recherche web sans restreindre l'API :
 
 ::
 
@@ -131,10 +131,10 @@ Configuration qui limite uniquement les requetes de recherche web sans restreind
     # Intervalle de surveillance : 1 seconde
     load.control.monitor.interval=1
 
-Limiter a la fois le web et l'API
+Limiter à la fois le web et l'API
 ----------------------------------
 
-Exemple avec des seuils differents pour le web et l'API :
+Exemple avec des seuils différents pour le web et l'API :
 
 ::
 
@@ -148,46 +148,46 @@ Exemple avec des seuils differents pour le web et l'API :
     load.control.monitor.interval=2
 
 .. note::
-   En definissant le seuil API plus haut que le seuil web, vous pouvez realiser un controle progressif
-   ou les requetes web sont restreintes en premier lors d'une charge elevee, et les requetes API sont
-   egalement restreintes lorsque la charge augmente davantage.
+   En définissant le seuil API plus haut que le seuil web, vous pouvez réaliser un contrôle progressif
+   où les requêtes web sont restreintes en premier lors d'une charge élevée, et les requêtes API sont
+   également restreintes lorsque la charge augmente davantage.
 
-Difference avec la limitation de debit
+Différence avec la limitation de débit
 =======================================
 
-|Fess| dispose d'une fonctionnalite de :doc:`rate-limiting` separee du controle de charge.
-Ces deux mecanismes protegent le systeme avec des approches differentes.
+|Fess| dispose d'une fonctionnalité de :doc:`rate-limiting` séparée du contrôle de charge.
+Ces deux mécanismes protègent le système avec des approches différentes.
 
 .. list-table::
    :header-rows: 1
    :widths: 20 40 40
 
    * - Aspect
-     - Limitation de debit
-     - Controle de charge
-   * - Base de controle
-     - Nombre de requetes (par unite de temps)
+     - Limitation de débit
+     - Contrôle de charge
+   * - Base de contrôle
+     - Nombre de requêtes (par unité de temps)
      - Utilisation CPU d'OpenSearch
    * - Objectif
-     - Prevention des requetes excessives
+     - Prévention des requêtes excessives
      - Protection du moteur de recherche contre la surcharge
-   * - Unite de limite
+   * - Unité de limite
      - Par adresse IP
-     - Ensemble du systeme
-   * - Reponse
+     - Ensemble du système
+   * - Réponse
      - HTTP 429
      - HTTP 429
-   * - Portee
-     - Toutes les requetes HTTP
-     - Requetes web / Requetes API (panneau d'administration etc. exclu)
+   * - Portée
+     - Toutes les requêtes HTTP
+     - Requêtes web / Requêtes API (panneau d'administration etc. exclu)
 
-La combinaison des deux fonctionnalites permet une protection systeme plus robuste.
+La combinaison des deux fonctionnalités permet une protection système plus robuste.
 
-Controle de charge adaptatif
+Contrôle de charge adaptatif
 ============================
 
-Le controle de charge adaptatif ajuste automatiquement la vitesse de traitement des taches
-en arriere-plan en fonction de l'utilisation CPU systeme du serveur Fess.
+Le contrôle de charge adaptatif ajuste automatiquement la vitesse de traitement des tâches
+en arrière-plan en fonction de l'utilisation CPU système du serveur Fess.
 
 Configuration
 -------------
@@ -204,58 +204,58 @@ Configuration
 Comportement
 ------------
 
-- Surveille l'utilisation CPU systeme du serveur ou Fess s'execute
-- Lorsque l'utilisation CPU atteint ou depasse le seuil, les threads de traitement concernes attendent que l'utilisation CPU descende en dessous du seuil
+- Surveille l'utilisation CPU système du serveur où Fess s'exécute
+- Lorsque l'utilisation CPU atteint ou dépasse le seuil, les threads de traitement concernés attendent que l'utilisation CPU descende en dessous du seuil
 - Lorsque l'utilisation CPU descend en dessous du seuil, le traitement reprend automatiquement
 
-**Taches en arriere-plan concernees :**
+**Tâches en arrière-plan concernées :**
 
-- Crawling (Web / Systeme de fichiers)
+- Crawling (Web / Système de fichiers)
 - Indexation (enregistrement de documents)
-- Traitement du magasin de donnees
-- Mises a jour des suggestions
-- Generation de vignettes
+- Traitement du magasin de données
+- Mises à jour des suggestions
+- Génération de vignettes
 - Sauvegarde et restauration
 
 .. note::
-   Le controle de charge adaptatif est active par defaut (seuil=50).
-   Il fonctionne independamment du controle de charge des requetes HTTP (``web.load.control`` / ``api.load.control``).
+   Le contrôle de charge adaptatif est activé par défaut (seuil=50).
+   Il fonctionne indépendamment du contrôle de charge des requêtes HTTP (``web.load.control`` / ``api.load.control``).
 
 .. list-table::
    :header-rows: 1
    :widths: 20 40 40
 
    * - Aspect
-     - Controle de charge des requetes HTTP
-     - Controle de charge adaptatif
+     - Contrôle de charge des requêtes HTTP
+     - Contrôle de charge adaptatif
    * - Cible de surveillance
      - Utilisation CPU d'OpenSearch
-     - Utilisation CPU systeme du serveur Fess
-   * - Cible de controle
-     - Requetes HTTP (Web / API)
-     - Taches en arriere-plan
-   * - Methode de controle
-     - Rejette les requetes en retournant HTTP 429
+     - Utilisation CPU système du serveur Fess
+   * - Cible de contrôle
+     - Requêtes HTTP (Web / API)
+     - Tâches en arrière-plan
+   * - Méthode de contrôle
+     - Rejette les requêtes en retournant HTTP 429
      - Met en pause temporairement les threads de traitement
-   * - Defaut
-     - Desactive (seuil=100)
-     - Active (seuil=50)
+   * - Défaut
+     - Désactivé (seuil=100)
+     - Activé (seuil=50)
 
-Depannage
+Dépannage
 =========
 
-Le controle de charge ne s'active pas
+Le contrôle de charge ne s'active pas
 --------------------------------------
 
-**Cause** : La configuration n'est pas correctement appliquee
+**Cause** : La configuration n'est pas correctement appliquée
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si ``web.load.control`` ou ``api.load.control`` est defini en dessous de 100
-2. Verifier si le fichier de configuration est correctement lu
-3. Verifier si |Fess| a ete redemarre
+1. Vérifier si ``web.load.control`` ou ``api.load.control`` est défini en dessous de 100
+2. Vérifier si le fichier de configuration est correctement lu
+3. Vérifier si |Fess| a été redémarré
 
-Les requetes legitimes sont rejetees
+Les requêtes légitimes sont rejetées
 --------------------------------------
 
 **Cause** : Les seuils sont trop bas
@@ -263,30 +263,30 @@ Les requetes legitimes sont rejetees
 **Solution** :
 
 1. Augmenter les valeurs de ``web.load.control`` ou ``api.load.control``
-2. Ajuster ``load.control.monitor.interval`` pour modifier la frequence de surveillance
+2. Ajuster ``load.control.monitor.interval`` pour modifier la fréquence de surveillance
 3. Augmenter les ressources du cluster OpenSearch
 
 .. warning::
-   Definir des seuils trop bas peut entrainer le rejet de requetes meme sous charge normale.
-   Verifiez l'utilisation CPU normale de votre cluster OpenSearch avant de definir des seuils appropries.
+   Définir des seuils trop bas peut entraîner le rejet de requêtes même sous charge normale.
+   Vérifiez l'utilisation CPU normale de votre cluster OpenSearch avant de définir des seuils appropriés.
 
 Le crawling est lent
 --------------------
 
-**Cause** : Les threads sont en etat d'attente en raison du controle de charge adaptatif
+**Cause** : Les threads sont en état d'attente en raison du contrôle de charge adaptatif
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si ``Cpu Load XX% is greater than YY%`` apparait dans les logs
-2. Verifier si le seuil ``adaptive.load.control`` est trop bas
+1. Vérifier si ``Cpu Load XX% is greater than YY%`` apparaît dans les logs
+2. Vérifier si le seuil ``adaptive.load.control`` est trop bas
 
 **Solution** :
 
 1. Augmenter la valeur de ``adaptive.load.control`` (ex : 70)
 2. Augmenter les ressources CPU du serveur Fess
-3. Definir a 0 pour desactiver le controle de charge adaptatif (non recommande)
+3. Définir à 0 pour désactiver le contrôle de charge adaptatif (non recommandé)
 
-Informations de reference
+Informations de référence
 =========================
 
-- :doc:`rate-limiting` - Configuration de la limitation de debit
+- :doc:`rate-limiting` - Configuration de la limitation de débit

--- a/fr/15.7/config/rag-chat.rst
+++ b/fr/15.7/config/rag-chat.rst
@@ -2,54 +2,54 @@
 Configuration du mode de recherche IA
 ==========================
 
-Apercu
+Aperçu
 ====
 
-Le mode de recherche IA (RAG: Retrieval-Augmented Generation) est une fonctionnalite qui enrichit les resultats de recherche de |Fess|
-avec un LLM (grand modele de langage) pour fournir des informations sous forme de dialogue.
-Les utilisateurs peuvent poser des questions en langage naturel et obtenir des reponses detaillees basees sur les resultats de recherche.
+Le mode de recherche IA (RAG: Retrieval-Augmented Generation) est une fonctionnalité qui enrichit les résultats de recherche de |Fess|
+avec un LLM (grand modèle de langage) pour fournir des informations sous forme de dialogue.
+Les utilisateurs peuvent poser des questions en langage naturel et obtenir des réponses détaillées basées sur les résultats de recherche.
 
-Dans |Fess| 15.7, la fonctionnalite LLM a ete separee en plugins ``fess-llm-*``.
-La configuration principale et la configuration specifique au fournisseur LLM s'effectuent dans ``fess_config.properties``,
-et la selection du fournisseur LLM (``rag.llm.name``) s'effectue dans ``system.properties`` ou via l'administration.
+Dans |Fess| 15.7, la fonctionnalité LLM a été séparée en plugins ``fess-llm-*``.
+La configuration principale et la configuration spécifique au fournisseur LLM s'effectuent dans ``fess_config.properties``,
+et la sélection du fournisseur LLM (``rag.llm.name``) s'effectue dans ``system.properties`` ou via l'administration.
 
 Pipeline de recherche
 ======================
 
-Le mode de recherche IA recupere ses documents source via le pipeline de recherche standard de |Fess| (rank fusion), avec le controle d'acces habituel de |Fess| par role et par etiquette (label). Par defaut, il s'agit d'une recherche par mots-cles (BM25) ; le LLM ne recherche, ne classe ni n'effectue lui-meme d'embedding des documents.
+Le mode de recherche IA récupère ses documents source via le pipeline de recherche standard de |Fess| (rank fusion), avec le contrôle d'accès habituel de |Fess| par rôle et par étiquette (label). Par défaut, il s'agit d'une recherche par mots-clés (BM25) ; le LLM ne recherche, ne classe ni n'effectue lui-même d'embedding des documents.
 
-Deux types de requetes executent des pipelines legerement differents :
+Deux types de requêtes exécutent des pipelines légèrement différents :
 
-- ``POST /api/v2/chat/stream`` (utilise par l'interface Web) execute le flux complet : **analyse d'intention -> recherche -> evaluation de pertinence par le LLM -> recuperation du contenu -> generation de reponse** (en streaming).
-- ``POST /api/v2/chat`` (non-streaming) execute un flux plus court : **analyse d'intention -> recherche -> generation de reponse** (sans phase d'evaluation de pertinence ni phase distincte de recuperation du contenu).
+- ``POST /api/v2/chat/stream`` (utilisé par l'interface Web) exécute le flux complet : **analyse d'intention -> recherche -> évaluation de pertinence par le LLM -> récupération du contenu -> génération de réponse** (en streaming).
+- ``POST /api/v2/chat`` (non-streaming) exécute un flux plus court : **analyse d'intention -> recherche -> génération de réponse** (sans phase d'évaluation de pertinence ni phase distincte de récupération du contenu).
 
-Dans le flux en streaming, un appel LLM supplementaire **evalue les resultats de recherche** et ne conserve que les documents juges pertinents avant que la reponse ne soit generee.
+Dans le flux en streaming, un appel LLM supplémentaire **évalue les résultats de recherche** et ne conserve que les documents jugés pertinents avant que la réponse ne soit générée.
 
 Fonctionnement du mode de recherche IA
 ================
 
-Le mode de recherche IA fonctionne selon un flux en plusieurs etapes.
+Le mode de recherche IA fonctionne selon un flux en plusieurs étapes.
 
-1. **Phase d'analyse d'intention** : Analyse la question de l'utilisateur et extrait les mots-cles optimaux pour la recherche
-2. **Phase de recherche** : Recherche des documents avec les mots-cles extraits en utilisant le moteur de recherche |Fess|
-3. **Fallback de regeneration de requete** : Lorsqu'aucun resultat n'est trouve, le LLM regenere la requete et reessaie
-4. **Phase d'evaluation** : Evalue la pertinence des resultats de recherche et selectionne les documents les plus appropries
-5. **Phase de generation** : Le LLM genere une reponse basee sur les documents selectionnes
-6. **Phase de sortie** : Retourne la reponse et les informations sources a l'utilisateur (avec rendu Markdown)
+1. **Phase d'analyse d'intention** : Analyse la question de l'utilisateur et extrait les mots-clés optimaux pour la recherche
+2. **Phase de recherche** : Recherche des documents avec les mots-clés extraits en utilisant le moteur de recherche |Fess|
+3. **Fallback de régénération de requête** : Lorsqu'aucun résultat n'est trouvé, le LLM régénère la requête et réessaie
+4. **Phase d'évaluation** : Évalue la pertinence des résultats de recherche et sélectionne les documents les plus appropriés
+5. **Phase de génération** : Le LLM génère une réponse basée sur les documents sélectionnés
+6. **Phase de sortie** : Retourne la réponse et les informations sources à l'utilisateur (avec rendu Markdown)
 
-Ce flux permet des reponses de haute qualite comprenant le contexte, superieur a la simple recherche par mots-cles.
-La regeneration de requete ameliore la couverture des reponses lorsque la requete initiale n'est pas optimale.
+Ce flux permet des réponses de haute qualité comprenant le contexte, supérieur à la simple recherche par mots-clés.
+La régénération de requête améliore la couverture des réponses lorsque la requête initiale n'est pas optimale.
 
 Configuration de base
 ========
 
-La configuration de la fonctionnalite de mode de recherche IA est divisee en configuration principale et en configuration du fournisseur.
+La configuration de la fonctionnalité de mode de recherche IA est divisée en configuration principale et en configuration du fournisseur.
 
 Configuration principale (fess_config.properties)
 ----------------------------------
 
-Configuration de base pour activer la fonctionnalite de mode de recherche IA.
-A configurer dans ``app/WEB-INF/conf/fess_config.properties``.
+Configuration de base pour activer la fonctionnalité de mode de recherche IA.
+À configurer dans ``app/WEB-INF/conf/fess_config.properties``.
 
 ::
 
@@ -59,11 +59,11 @@ A configurer dans ``app/WEB-INF/conf/fess_config.properties``.
 Configuration du fournisseur (system.properties / administration)
 -------------------------------------------------
 
-La selection du fournisseur LLM s'effectue via l'administration ou les proprietes systeme.
+La sélection du fournisseur LLM s'effectue via l'administration ou les propriétés système.
 
 **Via l'administration** :
 
-Depuis l'ecran de configuration Administration > Systeme > General, selectionnez le fournisseur LLM a utiliser.
+Depuis l'écran de configuration Administration > Système > Général, sélectionnez le fournisseur LLM à utiliser.
 
 **Via system.properties** :
 
@@ -72,24 +72,24 @@ Depuis l'ecran de configuration Administration > Systeme > General, selectionnez
     # Selectionner le fournisseur LLM (ollama, openai, gemini)
     rag.llm.name=ollama
 
-Pour la configuration detaillee des fournisseurs LLM, consultez :
+Pour la configuration détaillée des fournisseurs LLM, consultez :
 
 - :doc:`llm-ollama` - Configuration Ollama
 - :doc:`llm-openai` - Configuration OpenAI
 - :doc:`llm-gemini` - Configuration Google Gemini
 
-Reference rapide des chemins de configuration
+Référence rapide des chemins de configuration
 =============================================
 
-Dans |Fess| 15.7, les parametres sont separes en deux familles : la famille FessConfig
+Dans |Fess| 15.7, les paramètres sont séparés en deux familles : la famille FessConfig
 (``fess_config.properties``) et la famille SystemProperty (``system.properties``,
-persistee dans OpenSearch). Les chemins de configuration different ; ne pas les confondre.
+persistée dans OpenSearch). Les chemins de configuration diffèrent ; ne pas les confondre.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 18 32 15
 
-   * - Propriete
+   * - Propriété
      - Famille
      - Passage via Docker / options JVM
      - UI Admin
@@ -99,8 +99,8 @@ persistee dans OpenSearch). Les chemins de configuration different ; ne pas les 
      - Non
    * - ``rag.llm.name``
      - SystemProperty
-     - ``-Dfess.system.rag.llm.name=gemini`` (defaut initial uniquement)
-     - Oui (parametres generaux)
+     - ``-Dfess.system.rag.llm.name=gemini`` (défaut initial uniquement)
+     - Oui (paramètres généraux)
    * - ``rag.llm.gemini.api.key``
      - FessConfig
      - ``-Dfess.config.rag.llm.gemini.api.key=...``
@@ -124,8 +124,8 @@ persistee dans OpenSearch). Les chemins de configuration different ; ne pas les 
 
 .. note::
 
-   ``rag.llm.type`` est l'ancien nom de propriete dans |Fess| 15.5 et anterieur.
-   Dans 15.7 et superieur il est renomme en ``rag.llm.name`` ; les valeurs ecrites
+   ``rag.llm.type`` est l'ancien nom de propriété dans |Fess| 15.5 et antérieur.
+   Dans 15.7 et supérieur il est renommé en ``rag.llm.name`` ; les valeurs écrites
    sous ``rag.llm.type`` ne sont pas lues.
 
 Liste des configurations principales
@@ -137,29 +137,29 @@ Liste des configurations principales disponibles dans ``fess_config.properties``
    :header-rows: 1
    :widths: 40 40 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rag.chat.enabled``
-     - Activer la fonctionnalite de mode de recherche IA
+     - Activer la fonctionnalité de mode de recherche IA
      - ``false``
    * - ``rag.chat.context.max.documents``
-     - Nombre maximum de documents a inclure dans le contexte
+     - Nombre maximum de documents à inclure dans le contexte
      - ``5``
    * - ``rag.chat.session.timeout.minutes``
-     - Delai d'expiration de la session (minutes)
+     - Délai d'expiration de la session (minutes)
      - ``30``
    * - ``rag.chat.session.max.size``
-     - Nombre maximum de sessions pouvant etre maintenues simultanement
+     - Nombre maximum de sessions pouvant être maintenues simultanément
      - ``10000``
    * - ``rag.chat.history.max.messages``
      - Nombre maximum de messages dans l'historique de conversation
      - ``30``
    * - ``rag.chat.content.fields``
-     - Champs a recuperer des documents
+     - Champs à récupérer des documents
      - ``title,url,content,doc_id,content_title,content_description``
    * - ``rag.chat.message.max.length``
-     - Nombre maximum de caracteres du message utilisateur. Cette valeur est lue en tant que System Property ; l'entree dans ``fess_config.properties`` n'est pas utilisee. Definissez-la via les System Properties ou ``-Dfess.system.rag.chat.message.max.length``.
+     - Nombre maximum de caractères du message utilisateur. Cette valeur est lue en tant que System Property ; l'entrée dans ``fess_config.properties`` n'est pas utilisée. Définissez-la via les System Properties ou ``-Dfess.system.rag.chat.message.max.length``.
      - ``4000``
    * - ``rag.chat.highlight.fragment.size``
      - Taille du fragment pour le surlignage de recherche
@@ -168,38 +168,38 @@ Liste des configurations principales disponibles dans ``fess_config.properties``
      - Nombre de fragments pour le surlignage de recherche
      - ``3``
    * - ``rag.chat.content.fulltext.max.length``
-     - Seuil de ``content_length`` au-dela duquel les documents utilisent des extraits en surbrillance plutot que le texte integral dans le contexte de reponse
+     - Seuil de ``content_length`` au-delà duquel les documents utilisent des extraits en surbrillance plutôt que le texte intégral dans le contexte de réponse
      - ``3000``
    * - ``rag.chat.answer.highlight.fragment.size``
-     - Taille du fragment de surlignage lors de l'extraction d'extraits de grands documents pour le contexte de reponse
+     - Taille du fragment de surlignage lors de l'extraction d'extraits de grands documents pour le contexte de réponse
      - ``1000``
    * - ``rag.chat.answer.highlight.number.of.fragments``
-     - Nombre de fragments de surlignage lors de l'extraction d'extraits de grands documents pour le contexte de reponse
+     - Nombre de fragments de surlignage lors de l'extraction d'extraits de grands documents pour le contexte de réponse
      - ``5``
    * - ``rag.chat.history.assistant.content``
-     - Type de contenu a inclure dans l'historique de l'assistant ( ``full`` / ``smart_summary`` / ``source_titles`` / ``source_titles_and_urls`` / ``truncated`` / ``none`` )
+     - Type de contenu à inclure dans l'historique de l'assistant ( ``full`` / ``smart_summary`` / ``source_titles`` / ``source_titles_and_urls`` / ``truncated`` / ``none`` )
      - ``smart_summary``
    * - ``rag.chat.history.titles.max.count``
-     - Nombre maximum de titres de documents references conserves par tour en mode ``smart_summary``
+     - Nombre maximum de titres de documents référencés conservés par tour en mode ``smart_summary``
      - ``5``
 
-Parametres de generation
+Paramètres de génération
 ================
 
-Dans |Fess| 15.7, les parametres de generation (nombre maximum de tokens, temperature, etc.) se configurent par fournisseur
-et par type de prompt. Ces configurations sont gerees comme parametres de chaque plugin ``fess-llm-*``
+Dans |Fess| 15.7, les paramètres de génération (nombre maximum de tokens, température, etc.) se configurent par fournisseur
+et par type de prompt. Ces configurations sont gérées comme paramètres de chaque plugin ``fess-llm-*``
 et non comme configurations principales.
 
-Pour les details, consultez la documentation de chaque fournisseur :
+Pour les détails, consultez la documentation de chaque fournisseur :
 
-- :doc:`llm-ollama` - Parametres de generation Ollama
-- :doc:`llm-openai` - Parametres de generation OpenAI
-- :doc:`llm-gemini` - Parametres de generation Google Gemini
+- :doc:`llm-ollama` - Paramètres de génération Ollama
+- :doc:`llm-openai` - Paramètres de génération OpenAI
+- :doc:`llm-gemini` - Paramètres de génération Google Gemini
 
 Configuration du contexte
 ================
 
-Configuration du contexte passe au LLM depuis les resultats de recherche.
+Configuration du contexte passé au LLM depuis les résultats de recherche.
 
 Configuration principale
 --------
@@ -210,35 +210,35 @@ Les configurations suivantes s'effectuent dans ``fess_config.properties``.
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rag.chat.context.max.documents``
-     - Nombre maximum de documents a inclure dans le contexte
+     - Nombre maximum de documents à inclure dans le contexte
      - ``5``
    * - ``rag.chat.content.fields``
-     - Champs a recuperer des documents
+     - Champs à récupérer des documents
      - ``title,url,content,doc_id,content_title,content_description``
 
-Configuration specifique au fournisseur
+Configuration spécifique au fournisseur
 -----------------------
 
 Les configurations suivantes s'effectuent dans ``fess_config.properties`` pour chaque fournisseur.
 
-- ``rag.llm.{provider}.{promptType}.context.max.chars`` - Nombre maximum de caracteres du contexte
-- ``rag.llm.{provider}.chat.evaluation.max.relevant.docs`` - Nombre maximum de documents pertinents a selectionner lors de la phase d'evaluation
+- ``rag.llm.{provider}.{promptType}.context.max.chars`` - Nombre maximum de caractères du contexte
+- ``rag.llm.{provider}.chat.evaluation.max.relevant.docs`` - Nombre maximum de documents pertinents à sélectionner lors de la phase d'évaluation
 
 ``{provider}`` contient le nom du fournisseur tel que ``ollama``, ``openai``, ``gemini``, etc.
 ``{promptType}`` contient le type de prompt tel que ``intent``, ``evaluation``, ``answer``, ``summary``, ``faq``, ``queryregeneration``,
 ``unclear``, ``noresults``, ``docnotfound``, ``direct``, etc.
-La liste des types de prompt pris en charge est definie dans l'implementation ``*LlmClient`` de chaque plugin.
+La liste des types de prompt pris en charge est définie dans l'implémentation ``*LlmClient`` de chaque plugin.
 
-Pour les details, consultez la documentation de chaque fournisseur.
+Pour les détails, consultez la documentation de chaque fournisseur.
 
 Champs de contenu
 --------------------
 
-Champs specifiables dans ``rag.chat.content.fields`` :
+Champs spécifiables dans ``rag.chat.content.fields`` :
 
 - ``title`` - Titre du document
 - ``url`` - URL du document
@@ -247,25 +247,25 @@ Champs specifiables dans ``rag.chat.content.fields`` :
 - ``content_title`` - Titre du contenu
 - ``content_description`` - Description du contenu
 
-Prompt systeme
+Prompt système
 ==================
 
-Dans |Fess| 15.7, les prompts systeme sont definis dans le DI XML (``fess_llm++.xml``) de chaque plugin ``fess-llm-*``
-et non dans les fichiers de proprietes.
+Dans |Fess| 15.7, les prompts système sont définis dans le DI XML (``fess_llm++.xml``) de chaque plugin ``fess-llm-*``
+et non dans les fichiers de propriétés.
 
 Personnalisation des prompts
 -------------------------
 
-Pour personnaliser les prompts systeme, surchargez le fichier ``fess_llm++.xml`` dans le JAR du plugin.
+Pour personnaliser les prompts système, surchargez le fichier ``fess_llm++.xml`` dans le JAR du plugin.
 
-1. Recuperez ``fess_llm++.xml`` dans le fichier JAR du plugin utilise
-2. Apportez les modifications necessaires
-3. Placez-le dans l'emplacement approprie sous ``app/WEB-INF/`` pour le surcharger
+1. Récupérez ``fess_llm++.xml`` dans le fichier JAR du plugin utilisé
+2. Apportez les modifications nécessaires
+3. Placez-le dans l'emplacement approprié sous ``app/WEB-INF/`` pour le surcharger
 
-Des prompts systeme differents sont definis pour chaque type de prompt (analyse d'intention, evaluation, generation),
-avec une optimisation adaptee a chaque usage.
+Des prompts système différents sont définis pour chaque type de prompt (analyse d'intention, évaluation, génération),
+avec une optimisation adaptée à chaque usage.
 
-Pour les details, consultez la documentation de chaque fournisseur :
+Pour les détails, consultez la documentation de chaque fournisseur :
 
 - :doc:`llm-ollama` - Configuration des prompts Ollama
 - :doc:`llm-openai` - Configuration des prompts OpenAI
@@ -280,14 +280,14 @@ Configuration de la gestion des sessions de chat.
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rag.chat.session.timeout.minutes``
-     - Delai d'expiration de la session (minutes)
+     - Délai d'expiration de la session (minutes)
      - ``30``
    * - ``rag.chat.session.max.size``
-     - Nombre maximum de sessions pouvant etre maintenues simultanement
+     - Nombre maximum de sessions pouvant être maintenues simultanément
      - ``10000``
    * - ``rag.chat.history.max.messages``
      - Nombre maximum de messages dans l'historique de conversation
@@ -296,15 +296,15 @@ Configuration de la gestion des sessions de chat.
 Comportement des sessions
 ----------------
 
-- Lorsqu'un utilisateur commence un nouveau chat, une nouvelle session est creee
-- L'historique de conversation est sauvegarde dans la session, permettant un dialogue contextuel
-- Les sessions sont automatiquement supprimees apres expiration du delai
-- Lorsque l'historique depasse le nombre maximum de messages, les anciens messages sont supprimes
+- Lorsqu'un utilisateur commence un nouveau chat, une nouvelle session est créée
+- L'historique de conversation est sauvegardé dans la session, permettant un dialogue contextuel
+- Les sessions sont automatiquement supprimées après expiration du délai
+- Lorsque l'historique dépasse le nombre maximum de messages, les anciens messages sont supprimés
 
-Controle de la concurrence
+Contrôle de la concurrence
 ============
 
-Le nombre de requetes simultanees vers le LLM est controle par fournisseur dans ``fess_config.properties``.
+Le nombre de requêtes simultanées vers le LLM est contrôlé par fournisseur dans ``fess_config.properties``.
 
 ::
 
@@ -316,18 +316,18 @@ Le nombre de requetes simultanees vers le LLM est controle par fournisseur dans 
     # Timeout d'attente pour l'obtention d'un permis de concurrence (millisecondes, defaut : 30000)
     rag.llm.ollama.concurrency.wait.timeout=30000
 
-Considerations sur le controle de la concurrence
+Considérations sur le contrôle de la concurrence
 -----------------------
 
-- Tenez compte egalement des limitations de debit cote fournisseur LLM
-- Dans les environnements a forte charge, il est recommande de configurer des valeurs plus petites
-- Lorsque la limite de concurrence est atteinte, les requetes entrent dans une file d'attente et sont traitees sequentiellement
-- Si l'attente d'un permis depasse ``concurrency.wait.timeout``, la requete echoue avec une erreur de timeout
+- Tenez compte également des limitations de débit côté fournisseur LLM
+- Dans les environnements à forte charge, il est recommandé de configurer des valeurs plus petites
+- Lorsque la limite de concurrence est atteinte, les requêtes entrent dans une file d'attente et sont traitées séquentiellement
+- Si l'attente d'un permis dépasse ``concurrency.wait.timeout``, la requête échoue avec une erreur de timeout
 
 Mode d'historique de conversation
 =================================
 
-``rag.chat.history.assistant.content`` controle la maniere dont les reponses de l'assistant sont stockees dans l'historique de conversation.
+``rag.chat.history.assistant.content`` contrôle la manière dont les réponses de l'assistant sont stockées dans l'historique de conversation.
 
 .. list-table::
    :header-rows: 1
@@ -336,50 +336,50 @@ Mode d'historique de conversation
    * - Mode
      - Description
    * - ``smart_summary``
-     - (Par defaut) Le corps de la reponse de l'assistant est omis de l'historique ; seuls la requete de recherche passee et les titres des documents references (au maximum ``rag.chat.history.titles.max.count`` elements) sont conserves par tour
+     - (Par défaut) Le corps de la réponse de l'assistant est omis de l'historique ; seuls la requête de recherche passée et les titres des documents référencés (au maximum ``rag.chat.history.titles.max.count`` éléments) sont conservés par tour
    * - ``full``
-     - Preserve la reponse entiere telle quelle
+     - Préserve la réponse entière telle quelle
    * - ``source_titles``
-     - Preserve uniquement les titres des sources
+     - Préserve uniquement les titres des sources
    * - ``source_titles_and_urls``
-     - Preserve les titres et URLs des sources
+     - Préserve les titres et URLs des sources
    * - ``truncated``
-     - Tronque la reponse a la limite maximale de caracteres
+     - Tronque la réponse à la limite maximale de caractères
    * - ``none``
-     - Ne preserve pas l'historique
+     - Ne préserve pas l'historique
 
 .. note::
 
-   En mode ``smart_summary``, le corps de la reponse est remplace par la requete de recherche et les titres references, ce qui preserve le contexte efficacement tout en reduisant l'utilisation des tokens.
-   Les paires de messages utilisateur et assistant sont groupees en tours et empaquetees de maniere optimale dans un budget de caracteres.
-   Les limites maximales de caracteres pour l'historique et le resume sont controlees par l'implementation ``LlmClient`` de chaque plugin ``fess-llm-*``.
+   En mode ``smart_summary``, le corps de la réponse est remplacé par la requête de recherche et les titres référencés, ce qui préserve le contexte efficacement tout en réduisant l'utilisation des tokens.
+   Les paires de messages utilisateur et assistant sont groupées en tours et empaquetées de manière optimale dans un budget de caractères.
+   Les limites maximales de caractères pour l'historique et le résumé sont contrôlées par l'implémentation ``LlmClient`` de chaque plugin ``fess-llm-*``.
 
-Regeneration de requete
+Régénération de requête
 =======================
 
-Lorsqu'aucun resultat de recherche n'est trouve ou qu'aucun resultat pertinent n'est identifie, le LLM regenere automatiquement la requete et relance la recherche.
+Lorsqu'aucun résultat de recherche n'est trouvé ou qu'aucun résultat pertinent n'est identifié, le LLM régénère automatiquement la requête et relance la recherche.
 
-- Avec zero resultats de recherche : Regeneration de requete avec raison ``no_results``
-- Lorsqu'aucun document pertinent n'est trouve : Regeneration de requete avec raison ``no_relevant_results``
-- Retombe sur la requete originale si la regeneration echoue
+- Avec zéro résultats de recherche : Régénération de requête avec raison ``no_results``
+- Lorsqu'aucun document pertinent n'est trouvé : Régénération de requête avec raison ``no_relevant_results``
+- Retombe sur la requête originale si la régénération échoue
 
-Cette fonctionnalite est activee par defaut et integree dans les flux RAG synchrones et en streaming.
-Les prompts de regeneration de requete sont definis dans chaque plugin ``fess-llm-*``.
+Cette fonctionnalité est activée par défaut et intégrée dans les flux RAG synchrones et en streaming.
+Les prompts de régénération de requête sont définis dans chaque plugin ``fess-llm-*``.
 
 Rendu Markdown
 ==============
 
-Les reponses du mode de recherche IA sont rendues au format Markdown.
+Les réponses du mode de recherche IA sont rendues au format Markdown.
 
-- Les reponses du LLM sont analysees en Markdown et converties en HTML
-- Le HTML converti est assaini, n'autorisant que les balises et attributs surs
+- Les réponses du LLM sont analysées en Markdown et converties en HTML
+- Le HTML converti est assaini, n'autorisant que les balises et attributs sûrs
 - Prend en charge les titres, listes, blocs de code, tableaux, liens et autres syntaxes Markdown
-- Cote client, ``marked.js`` et ``DOMPurify`` sont utilises ; cote serveur, le sanitizer OWASP
+- Côté client, ``marked.js`` et ``DOMPurify`` sont utilisés ; côté serveur, le sanitizer OWASP
 
 Utilisation de l'API
 =========
 
-La fonctionnalite de mode de recherche IA est accessible via API REST (API v2).
+La fonctionnalité de mode de recherche IA est accessible via API REST (API v2).
 L'URL de base est ``http://<nom du serveur>/api/v2/``.
 
 La Chat API fournit les trois points de terminaison suivants.
@@ -391,19 +391,19 @@ La Chat API fournit les trois points de terminaison suivants.
    * - Point de terminaison
      - Description
    * - ``POST /api/v2/chat``
-     - Completion RAG groupee (non-streaming)
+     - Completion RAG groupée (non-streaming)
    * - ``POST /api/v2/chat/stream``
      - Completion RAG en streaming (Server-Sent Events)
    * - ``DELETE /api/v2/chat/sessions/{session_id}``
      - Effacer l'historique de conversation d'une session
 
-Les requetes sont envoyees avec un corps JSON de type ``Content-Type: application/json``.
-Les requetes modifiant l'etat (``POST`` / ``DELETE``) necessitent un jeton CSRF (en-tete ``X-Fess-CSRF-Token``).
-Les reponses sont encapsulees dans l'enveloppe commune ``response``.
+Les requêtes sont envoyées avec un corps JSON de type ``Content-Type: application/json``.
+Les requêtes modifiant l'état (``POST`` / ``DELETE``) nécessitent un jeton CSRF (en-tête ``X-Fess-CSRF-Token``).
+Les réponses sont encapsulées dans l'enveloppe commune ``response``.
 
 .. note::
 
-   Les points de terminaison ``/api/v1/chat`` au format parametres de formulaire disponibles dans |Fess| 15.5 et anterieur ont ete supprimes.
+   Les points de terminaison ``/api/v1/chat`` au format paramètres de formulaire disponibles dans |Fess| 15.5 et antérieur ont été supprimés.
    Dans 15.7, utilisez l'API JSON sous ``/api/v2/``.
 
 API non-streaming
@@ -411,7 +411,7 @@ API non-streaming
 
 Point de terminaison : ``POST /api/v2/chat``
 
-Corps de la requete (JSON) :
+Corps de la requête (JSON) :
 
 .. list-table::
    :header-rows: 1
@@ -425,18 +425,18 @@ Corps de la requete (JSON) :
      - Message de l'utilisateur
    * - ``session_id``
      - Non
-     - ID de session (pour continuer la conversation). Si omis, le serveur le cree et le retourne dans la reponse
+     - ID de session (pour continuer la conversation). Si omis, le serveur le crée et le retourne dans la réponse
    * - ``fields``
      - Non
-     - Champs de filtre optionnels pour l'etape de recuperation (objet)
+     - Champs de filtre optionnels pour l'étape de récupération (objet)
    * - ``fields.label``
      - Non
-     - Filtre de recherche par etiquette
+     - Filtre de recherche par étiquette
    * - ``extra_queries``
      - Non
-     - Expressions de requete supplementaires pour les filtres de facettes
+     - Expressions de requête supplémentaires pour les filtres de facettes
 
-Exemple de requete :
+Exemple de requête :
 
 .. code-block:: bash
 
@@ -445,7 +445,7 @@ Exemple de requete :
          -H "X-Fess-CSRF-Token: <token>" \
          -d '{"message":"Comment installer Fess ?"}'
 
-Exemple de reponse :
+Exemple de réponse :
 
 .. code-block:: json
 
@@ -471,10 +471,10 @@ API streaming
 
 Point de terminaison : ``POST /api/v2/chat/stream``
 
-Le corps de la requete est identique a ``POST /api/v2/chat`` (JSON).
-Les reponses sont streamees au format Server-Sent Events (SSE).
+Le corps de la requête est identique à ``POST /api/v2/chat`` (JSON).
+Les réponses sont streamées au format Server-Sent Events (SSE).
 
-Exemple de requete :
+Exemple de requête :
 
 .. code-block:: bash
 
@@ -485,161 +485,161 @@ Exemple de requete :
          --no-buffer \
          -d '{"message":"Quelles sont les caracteristiques de Fess ?"}'
 
-Evenements SSE :
+Événements SSE :
 
 .. list-table::
    :header-rows: 1
    :widths: 20 80
 
-   * - Evenement
+   * - Événement
      - Description (charge utile)
    * - ``phase``
      - Transition de phase du pipeline (``intent``, ``search``, ``evaluate``, ``fetch``, ``answer``). ``{ phase, status, message?, keywords?, hit_count?, ... }``
    * - ``chunk``
-     - Fragment de texte genere (``{ content }``)
+     - Fragment de texte généré (``{ content }``)
    * - ``retry``
-     - Notifie lorsqu'une requete LLM est reessayee (``{ phase, operation, attempt, max_attempts, sleep_ms, cause? }``)
+     - Notifie lorsqu'une requête LLM est réessayée (``{ phase, operation, attempt, max_attempts, sleep_ms, cause? }``)
    * - ``waiting``
      - Progression d'une phase longue telle que l'attente d'un permis de concurrence (``{ phase, reason, elapsed_ms, timeout_ms }``)
    * - ``fallback``
-     - Notifie lorsque la requete est regeneree suite a l'absence de resultats ou de resultats pertinents (``{ phase, reason, original_query?, new_query? }``, raison : ``no_results`` ou ``no_relevant_results``)
+     - Notifie lorsque la requête est régénérée suite à l'absence de résultats ou de résultats pertinents (``{ phase, reason, original_query?, new_query? }``, raison : ``no_results`` ou ``no_relevant_results``)
    * - ``warning``
-     - Notifie lors d'un avertissement recuperable (``{ phase, code, detail? }``, ex. epuisement des tokens d'un modele de raisonnement)
+     - Notifie lors d'un avertissement récupérable (``{ phase, code, detail? }``, ex. épuisement des tokens d'un modèle de raisonnement)
    * - ``sources``
      - Informations sur les documents sources (``{ sources: [...] }``)
    * - ``done``
-     - Traitement termine (``{ session_id, html_content? }``). ``html_content`` contient la chaine HTML rendue depuis Markdown
+     - Traitement terminé (``{ session_id, html_content? }``). ``html_content`` contient la chaîne HTML rendue depuis Markdown
    * - ``error``
-     - Echec terminal en cours de stream (``{ phase?, message, error_code }``). Timeout, depassement de la longueur de contexte, modele introuvable, reponse invalide, erreur de connexion, etc.
+     - Échec terminal en cours de stream (``{ phase?, message, error_code }``). Timeout, dépassement de la longueur de contexte, modèle introuvable, réponse invalide, erreur de connexion, etc.
 
 Effacer une session
 --------------------
 
 Point de terminaison : ``DELETE /api/v2/chat/sessions/{session_id}``
 
-Efface l'historique de conversation de la session specifiee. En cas de succes, ``cleared: true`` est retourne.
+Efface l'historique de conversation de la session spécifiée. En cas de succès, ``cleared: true`` est retourné.
 
-Pour la documentation API complete (authentification, CSRF, limites de debit, codes HTTP), consultez :doc:`../api/api-chat`.
+Pour la documentation API complète (authentification, CSRF, limites de débit, codes HTTP), consultez :doc:`../api/api-chat`.
 
 Interface Web
 ===================
 
-La fonctionnalite de mode de recherche IA est accessible depuis l'ecran de recherche de l'interface Web |Fess|.
+La fonctionnalité de mode de recherche IA est accessible depuis l'écran de recherche de l'interface Web |Fess|.
 
-Demarrer un chat
+Démarrer un chat
 --------------
 
-1. Accedez a l'ecran de recherche |Fess|
-2. Cliquez sur l'icone de chat
+1. Accédez à l'écran de recherche |Fess|
+2. Cliquez sur l'icône de chat
 3. Le panneau de chat s'affiche
 
 Utiliser le chat
 --------------
 
 1. Entrez votre question dans la zone de texte
-2. Cliquez sur le bouton d'envoi ou appuyez sur Entree
-3. La reponse de l'assistant IA s'affiche
-4. La reponse inclut des liens vers les sources
+2. Cliquez sur le bouton d'envoi ou appuyez sur Entrée
+3. La réponse de l'assistant IA s'affiche
+4. La réponse inclut des liens vers les sources
 
 Continuer la conversation
 ----------
 
-- Vous pouvez continuer la conversation dans la meme session de chat
-- Les reponses tiennent compte du contexte des questions precedentes
-- Cliquez sur "Nouveau chat" pour reinitialiser la session
+- Vous pouvez continuer la conversation dans la même session de chat
+- Les réponses tiennent compte du contexte des questions précédentes
+- Cliquez sur "Nouveau chat" pour réinitialiser la session
 
-Depannage
+Dépannage
 ======================
 
-Le bouton mode IA n'apparait pas sur l'ecran de recherche
+Le bouton mode IA n'apparaît pas sur l'écran de recherche
 ---------------------------------------------------------
 
-**Symptome** : Le bouton mode IA ne s'affiche pas dans l'en-tete des resultats
-de recherche, et acceder a ``/chat`` redirige vers la page d'accueil.
+**Symptôme** : Le bouton mode IA ne s'affiche pas dans l'en-tête des résultats
+de recherche, et accéder à ``/chat`` redirige vers la page d'accueil.
 
-**Liste de verifications** : verifier les points suivants dans l'ordre.
+**Liste de vérifications** : vérifier les points suivants dans l'ordre.
 
-1. ``rag.chat.enabled=true`` est-il defini ?
+1. ``rag.chat.enabled=true`` est-il défini ?
 
    - Docker : ``-Dfess.config.rag.chat.enabled=true`` est-il inclus dans ``FESS_JAVA_OPTS`` ?
-   - Installation par paquet : est-il ecrit dans ``app/WEB-INF/conf/fess_config.properties`` ?
+   - Installation par paquet : est-il écrit dans ``app/WEB-INF/conf/fess_config.properties`` ?
 
-2. Le plugin ``fess-llm-*`` correspondant est-il installe ?
+2. Le plugin ``fess-llm-*`` correspondant est-il installé ?
 
-   - Docker : ``FESS_PLUGINS=fess-llm-gemini:15.7.0`` (ou ``fess-llm-openai`` / ``fess-llm-ollama``) doit etre defini
-   - Installation par paquet : le JAR doit etre place dans ``app/WEB-INF/plugin/``
-   - Le journal de demarrage doit inclure ``Installing fess-llm-XXX-15.7.0.jar``
+   - Docker : ``FESS_PLUGINS=fess-llm-gemini:15.7.0`` (ou ``fess-llm-openai`` / ``fess-llm-ollama``) doit être défini
+   - Installation par paquet : le JAR doit être placé dans ``app/WEB-INF/plugin/``
+   - Le journal de démarrage doit inclure ``Installing fess-llm-XXX-15.7.0.jar``
 
-3. ``rag.llm.name`` correspond-il a un plugin installe ?
+3. ``rag.llm.name`` correspond-il à un plugin installé ?
 
-   - La valeur par defaut est ``ollama``. Si seul le plugin Gemini est installe, vous devez explicitement le definir a ``gemini`` (de meme ``openai`` pour le plugin OpenAI)
-   - Methode (a) : modifier ``rag.llm.name`` depuis Administration > Systeme > General (section RAG) et enregistrer
-   - Methode (b) : inclure ``-Dfess.system.rag.llm.name=gemini`` dans ``FESS_JAVA_OPTS`` au demarrage. N'agit que comme valeur par defaut initiale avant qu'une valeur ne soit persistee dans OpenSearch
+   - La valeur par défaut est ``ollama``. Si seul le plugin Gemini est installé, vous devez explicitement le définir à ``gemini`` (de même ``openai`` pour le plugin OpenAI)
+   - Méthode (a) : modifier ``rag.llm.name`` depuis Administration > Système > Général (section RAG) et enregistrer
+   - Méthode (b) : inclure ``-Dfess.system.rag.llm.name=gemini`` dans ``FESS_JAVA_OPTS`` au démarrage. N'agit que comme valeur par défaut initiale avant qu'une valeur ne soit persistée dans OpenSearch
 
-4. Un WARN comme ``[LLM] LlmClient not found. componentName=ollamaLlmClient`` se repete-t-il dans le journal ?
+4. Un WARN comme ``[LLM] LlmClient not found. componentName=ollamaLlmClient`` se répète-t-il dans le journal ?
 
-   - Symptome typique quand ``rag.llm.name`` est encore ``ollama`` mais que le plugin Ollama n'est pas installe
-   - Definir ``rag.llm.name`` au fournisseur reellement utilise resout le probleme
-   - De meme, ``componentName=geminiLlmClient`` indique que ``rag.llm.name=gemini`` est defini mais que le plugin ``fess-llm-gemini`` n'est pas installe
+   - Symptôme typique quand ``rag.llm.name`` est encore ``ollama`` mais que le plugin Ollama n'est pas installé
+   - Définir ``rag.llm.name`` au fournisseur réellement utilisé résout le problème
+   - De même, ``componentName=geminiLlmClient`` indique que ``rag.llm.name=gemini`` est défini mais que le plugin ``fess-llm-gemini`` n'est pas installé
 
-5. La cle d'API specifique au fournisseur est-elle configuree ?
+5. La clé d'API spécifique au fournisseur est-elle configurée ?
 
-   - Quand ``rag.llm.gemini.api.key`` / ``rag.llm.openai.api.key`` est vide, ``checkAvailabilityNow`` retourne ``false`` et le mode IA est desactive
-   - Activer DEBUG sur ``org.codelibs.fess.llm.gemini`` dans ``log4j2.xml`` fait apparaitre des messages comme ``[LLM:GEMINI] Gemini is not available. apiKey is blank``
+   - Quand ``rag.llm.gemini.api.key`` / ``rag.llm.openai.api.key`` est vide, ``checkAvailabilityNow`` retourne ``false`` et le mode IA est désactivé
+   - Activer DEBUG sur ``org.codelibs.fess.llm.gemini`` dans ``log4j2.xml`` fait apparaître des messages comme ``[LLM:GEMINI] Gemini is not available. apiKey is blank``
 
-6. L'hote Fess peut-il atteindre le fournisseur LLM ?
+6. L'hôte Fess peut-il atteindre le fournisseur LLM ?
 
-   - Pour les API cloud (Gemini / OpenAI), le conteneur doit avoir un acces sortant a Internet
-   - En cas de proxy, definissez ``http.proxy.host`` / ``http.proxy.port`` (et au besoin ``http.proxy.username`` / ``http.proxy.password``) dans ``fess_config.properties``. Dans un environnement Docker, ajoutez ``-Dfess.config.http.proxy.host=... -Dfess.config.http.proxy.port=...`` a ``FESS_JAVA_OPTS`` (depuis |Fess| 15.7, les clients LLM partagent la configuration de proxy commune a |Fess|)
+   - Pour les API cloud (Gemini / OpenAI), le conteneur doit avoir un accès sortant à Internet
+   - En cas de proxy, définissez ``http.proxy.host`` / ``http.proxy.port`` (et au besoin ``http.proxy.username`` / ``http.proxy.password``) dans ``fess_config.properties``. Dans un environnement Docker, ajoutez ``-Dfess.config.http.proxy.host=... -Dfess.config.http.proxy.port=...`` à ``FESS_JAVA_OPTS`` (depuis |Fess| 15.7, les clients LLM partagent la configuration de proxy commune à |Fess|)
 
 .. note::
 
-   La page "General" n'expose pas de case a cocher pour ``rag.chat.enabled`` (par conception).
-   Cette propriete de la famille FessConfig ne peut etre definie qu'a travers
+   La page "Général" n'expose pas de case à cocher pour ``rag.chat.enabled`` (par conception).
+   Cette propriété de la famille FessConfig ne peut être définie qu'à travers
    ``fess_config.properties`` ou ``-Dfess.config.rag.chat.enabled=true``.
 
 Le mode de recherche IA ne s'active pas
 ------------------------
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si ``rag.chat.enabled=true`` est configure
-2. Verifier si le fournisseur LLM est correctement configure dans ``rag.llm.name``
-3. Verifier si le plugin ``fess-llm-*`` correspondant est installe
-4. Verifier si la connexion au fournisseur LLM est possible
+1. Vérifier si ``rag.chat.enabled=true`` est configuré
+2. Vérifier si le fournisseur LLM est correctement configuré dans ``rag.llm.name``
+3. Vérifier si le plugin ``fess-llm-*`` correspondant est installé
+4. Vérifier si la connexion au fournisseur LLM est possible
 
-Qualite des reponses insuffisante
+Qualité des réponses insuffisante
 ----------------
 
-**Ameliorations** :
+**Améliorations** :
 
-1. Utiliser un modele LLM plus performant
+1. Utiliser un modèle LLM plus performant
 2. Augmenter ``rag.chat.context.max.documents``
-3. Personnaliser le prompt systeme dans le DI XML
-4. Ajuster les parametres de temperature specifiques au fournisseur (consultez la documentation de chaque plugin ``fess-llm-*``)
+3. Personnaliser le prompt système dans le DI XML
+4. Ajuster les paramètres de température spécifiques au fournisseur (consultez la documentation de chaque plugin ``fess-llm-*``)
 
-Reponses lentes
+Réponses lentes
 ----------------
 
-**Ameliorations** :
+**Améliorations** :
 
-1. Utiliser un modele LLM plus rapide (ex : Gemini Flash)
-2. Reduire les parametres max.tokens specifiques au fournisseur (consultez la documentation de chaque plugin ``fess-llm-*``)
-3. Reduire ``rag.chat.context.max.documents``
+1. Utiliser un modèle LLM plus rapide (ex : Gemini Flash)
+2. Réduire les paramètres max.tokens spécifiques au fournisseur (consultez la documentation de chaque plugin ``fess-llm-*``)
+3. Réduire ``rag.chat.context.max.documents``
 
 Sessions non maintenues
 ------------------------
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si le ``session_id`` est correctement envoye cote client
-2. Verifier le parametre ``rag.chat.session.timeout.minutes``
-3. Verifier la capacite de stockage des sessions
+1. Vérifier si le ``session_id`` est correctement envoyé côté client
+2. Vérifier le paramètre ``rag.chat.session.timeout.minutes``
+3. Vérifier la capacité de stockage des sessions
 
-Configuration de debogage
+Configuration de débogage
 ------------
 
-Pour investiguer les problemes, ajustez le niveau de log pour afficher des logs detailles.
+Pour investiguer les problèmes, ajustez le niveau de log pour afficher des logs détaillés.
 
 ``app/WEB-INF/classes/log4j2.xml`` :
 
@@ -649,20 +649,20 @@ Pour investiguer les problemes, ajustez le niveau de log pour afficher des logs 
     <Logger name="org.codelibs.fess.api.v2.handlers" level="DEBUG"/>
     <Logger name="org.codelibs.fess.chat" level="DEBUG"/>
 
-Les messages de log utilisent le prefixe ``[RAG]``, avec des sous-prefixes tels que ``[RAG:INTENT]``, ``[RAG:EVAL]`` et ``[RAG:ANSWER]`` pour chaque phase.
-Au niveau INFO, les logs de fin de chat (duree, nombre de sources) sont emis. Au niveau DEBUG, les details d'utilisation des tokens, de controle de concurrence et d'empaquetage de l'historique sont emis.
+Les messages de log utilisent le préfixe ``[RAG]``, avec des sous-préfixes tels que ``[RAG:INTENT]``, ``[RAG:EVAL]`` et ``[RAG:ANSWER]`` pour chaque phase.
+Au niveau INFO, les logs de fin de chat (durée, nombre de sources) sont émis. Au niveau DEBUG, les détails d'utilisation des tokens, de contrôle de concurrence et d'empaquetage de l'historique sont émis.
 
-Journal de recherche et type d'acces
+Journal de recherche et type d'accès
 -------------------------------------
 
-Les recherches via le mode de recherche IA sont enregistrees avec le nom du fournisseur LLM (par ex. ``ollama``, ``openai``, ``gemini``) comme type d'acces dans les journaux de recherche. Cela permet de distinguer les recherches du mode IA des recherches web ou API regulieres dans les analyses.
+Les recherches via le mode de recherche IA sont enregistrées avec le nom du fournisseur LLM (par ex. ``ollama``, ``openai``, ``gemini``) comme type d'accès dans les journaux de recherche. Cela permet de distinguer les recherches du mode IA des recherches web ou API régulières dans les analyses.
 
-Informations de reference
+Informations de référence
 ========
 
-- :doc:`llm-overview` - Apercu de l'integration LLM
+- :doc:`llm-overview` - Aperçu de l'intégration LLM
 - :doc:`llm-ollama` - Configuration Ollama
 - :doc:`llm-openai` - Configuration OpenAI
 - :doc:`llm-gemini` - Configuration Google Gemini
-- :doc:`../api/api-chat` - Reference API Chat
+- :doc:`../api/api-chat` - Référence API Chat
 - :doc:`../user/chat-search` - Guide de recherche par chat pour les utilisateurs

--- a/fr/15.7/config/rate-limiting.rst
+++ b/fr/15.7/config/rate-limiting.rst
@@ -1,23 +1,23 @@
 ==================================
-Configuration de la limitation de debit
+Configuration de la limitation de débit
 ==================================
 
-Apercu
+Aperçu
 ====
 
-|Fess| dispose d'une fonctionnalite de limitation de debit pour maintenir la stabilite et les performances du systeme.
-Cette fonctionnalite protege le systeme contre les requetes excessives et permet une allocation equitable des ressources.
+|Fess| dispose d'une fonctionnalité de limitation de débit pour maintenir la stabilité et les performances du système.
+Cette fonctionnalité protège le système contre les requêtes excessives et permet une allocation équitable des ressources.
 
-La limitation de debit s'applique dans les situations suivantes :
+La limitation de débit s'applique dans les situations suivantes :
 
-- Toutes les requetes HTTP, y compris l'API de recherche, l'API de mode de recherche IA et les pages d'administration (``RateLimitFilter``)
-- Requetes du crawler (controlees par la configuration du crawl)
+- Toutes les requêtes HTTP, y compris l'API de recherche, l'API de mode de recherche IA et les pages d'administration (``RateLimitFilter``)
+- Requêtes du crawler (contrôlées par la configuration du crawl)
 
-Limitation de debit des requetes HTTP
+Limitation de débit des requêtes HTTP
 ======================================
 
-Vous pouvez limiter le nombre de requetes HTTP vers |Fess| par adresse IP.
-Cette limitation s'applique a toutes les requetes HTTP, y compris l'API de recherche, l'API de mode de recherche IA, les pages d'administration, etc.
+Vous pouvez limiter le nombre de requêtes HTTP vers |Fess| par adresse IP.
+Cette limitation s'applique à toutes les requêtes HTTP, y compris l'API de recherche, l'API de mode de recherche IA, les pages d'administration, etc.
 
 Configuration
 ----
@@ -38,38 +38,38 @@ Configuration
 Comportement
 ----
 
-- Les requetes depassant la limite de debit retournent HTTP 429 (Too Many Requests)
-- Les requetes provenant d'IP figurant dans la liste de blocage retournent HTTP 403 (Forbidden)
-- Les limites sont appliquees par adresse IP
-- Pour chaque IP, la fenetre commence au premier requete et le compteur est reinitialise apres l'expiration de la periode de la fenetre (methode de fenetre fixe)
-- Le depassement de la limite entraine le blocage de l'IP pendant la duree ``rate.limit.block.duration.ms``
+- Les requêtes dépassant la limite de débit retournent HTTP 429 (Too Many Requests)
+- Les requêtes provenant d'IP figurant dans la liste de blocage retournent HTTP 403 (Forbidden)
+- Les limites sont appliquées par adresse IP
+- Pour chaque IP, la fenêtre commence au premier requête et le compteur est réinitialisé après l'expiration de la période de la fenêtre (méthode de fenêtre fixe)
+- Le dépassement de la limite entraîne le blocage de l'IP pendant la durée ``rate.limit.block.duration.ms``
 
-Limitation de debit du mode de recherche IA
+Limitation de débit du mode de recherche IA
 ====================
 
-La fonctionnalite de mode de recherche IA dispose d'une limitation de debit pour controler les couts de l'API LLM et la consommation de ressources.
-Le mode de recherche IA est soumis a la limitation de debit des requetes HTTP decrite ci-dessus, et dispose egalement de parametres de limitation de debit specifiques au mode de recherche IA.
+La fonctionnalité de mode de recherche IA dispose d'une limitation de débit pour contrôler les coûts de l'API LLM et la consommation de ressources.
+Le mode de recherche IA est soumis à la limitation de débit des requêtes HTTP décrite ci-dessus, et dispose également de paramètres de limitation de débit spécifiques au mode de recherche IA.
 
-Pour la configuration specifique de la limitation de debit du mode de recherche IA, consultez :doc:`rag-chat`.
+Pour la configuration spécifique de la limitation de débit du mode de recherche IA, consultez :doc:`rag-chat`.
 
 .. note::
-   La limitation de debit du mode de recherche IA s'applique separement de la limitation de debit cote fournisseur LLM.
+   La limitation de débit du mode de recherche IA s'applique séparément de la limitation de débit côté fournisseur LLM.
    Configurez en tenant compte des deux limites.
 
-Limitation de debit du crawler
+Limitation de débit du crawler
 ======================
 
-Vous pouvez configurer l'intervalle entre les requetes pour eviter que le crawler ne surcharge les sites cibles.
+Vous pouvez configurer l'intervalle entre les requêtes pour éviter que le crawler ne surcharge les sites cibles.
 
 Configuration du crawl Web
 ---------------
 
-Configurez les elements suivants dans l'ecran d'administration "Crawler" -> "Web" :
+Configurez les éléments suivants dans l'écran d'administration "Crawler" -> "Web" :
 
-- **Intervalle de requetes** : Temps d'attente entre les requetes (millisecondes)
-- **Nombre de threads** : Nombre de threads de crawl paralleles
+- **Intervalle de requêtes** : Temps d'attente entre les requêtes (millisecondes)
+- **Nombre de threads** : Nombre de threads de crawl parallèles
 
-Configuration recommandee :
+Configuration recommandée :
 
 ::
 
@@ -84,7 +84,7 @@ Configuration recommandee :
 Respect de robots.txt
 ----------------
 
-|Fess| respecte par defaut la directive Crawl-delay de robots.txt.
+|Fess| respecte par défaut la directive Crawl-delay de robots.txt.
 
 ::
 
@@ -92,70 +92,70 @@ Respect de robots.txt
     User-agent: *
     Crawl-delay: 10
 
-Le traitement de robots.txt est controle par ``crawler.ignore.robots.txt`` dans
-``app/WEB-INF/classes/fess_config.properties`` (defaut : ``false``).
-En le definissant sur ``true``, le traitement de robots.txt, y compris Crawl-delay, est desactive.
+Le traitement de robots.txt est contrôlé par ``crawler.ignore.robots.txt`` dans
+``app/WEB-INF/classes/fess_config.properties`` (défaut : ``false``).
+En le définissant sur ``true``, le traitement de robots.txt, y compris Crawl-delay, est désactivé.
 
 ::
 
     # Ignorer robots.txt (defaut : false)
     crawler.ignore.robots.txt=false
 
-Liste complete des proprietes de limitation de debit
+Liste complète des propriétés de limitation de débit
 ======================
 
-Toutes les proprietes configurables dans ``app/WEB-INF/classes/fess_config.properties``.
+Toutes les propriétés configurables dans ``app/WEB-INF/classes/fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rate.limit.enabled``
-     - Activer la limitation de debit
+     - Activer la limitation de débit
      - ``false``
    * - ``rate.limit.requests.per.window``
-     - Nombre maximum de requetes par fenetre
+     - Nombre maximum de requêtes par fenêtre
      - ``100``
    * - ``rate.limit.window.ms``
-     - Taille de la fenetre (millisecondes)
+     - Taille de la fenêtre (millisecondes)
      - ``60000``
    * - ``rate.limit.block.duration.ms``
-     - Duree de blocage de l'IP en cas de depassement (millisecondes)
+     - Durée de blocage de l'IP en cas de dépassement (millisecondes)
      - ``300000``
    * - ``rate.limit.retry.after.seconds``
-     - Valeur de l'en-tete Retry-After (secondes)
+     - Valeur de l'en-tête Retry-After (secondes)
      - ``60``
    * - ``rate.limit.whitelist.ips``
-     - Adresses IP exclues de la limitation de debit (separees par des virgules)
+     - Adresses IP exclues de la limitation de débit (séparées par des virgules)
      - ``127.0.0.1,::1``
    * - ``rate.limit.blocked.ips``
-     - Adresses IP a bloquer (separees par des virgules)
+     - Adresses IP à bloquer (séparées par des virgules)
      - (vide)
    * - ``rate.limit.trusted.proxies``
      - IP de proxies de confiance (pour obtenir l'IP client via X-Forwarded-For/X-Real-IP)
      - ``127.0.0.1,::1``
    * - ``rate.limit.cleanup.interval``
-     - Intervalle de nettoyage (nombre de requetes, reserve)
+     - Intervalle de nettoyage (nombre de requêtes, réservé)
      - ``1000``
 
 .. note::
-   ``rate.limit.cleanup.interval`` est un parametre reserve pour une utilisation future.
-   Dans l'implementation actuelle, les compteurs de requetes et les informations sur les IP bloquees
-   sont nettoyes automatiquement en fonction de l'expiration du cache interne
+   ``rate.limit.cleanup.interval`` est un paramètre réservé pour une utilisation future.
+   Dans l'implémentation actuelle, les compteurs de requêtes et les informations sur les IP bloquées
+   sont nettoyés automatiquement en fonction de l'expiration du cache interne
    (``rate.limit.window.ms`` et ``rate.limit.block.duration.ms``),
-   de sorte que cette valeur n'est pas utilisee.
+   de sorte que cette valeur n'est pas utilisée.
 
-Configuration avancee de limitation de debit
+Configuration avancée de limitation de débit
 ====================
 
-Limitation de debit personnalisee
+Limitation de débit personnalisée
 ------------------
 
-Pour appliquer des limites differentes selon des conditions specifiques,
-une implementation de composant personnalise est necessaire.
+Pour appliquer des limites différentes selon des conditions spécifiques,
+une implémentation de composant personnalisé est nécessaire.
 
 ::
 
@@ -170,7 +170,7 @@ une implementation de composant personnalise est necessaire.
 Configuration d'exclusion
 ========
 
-Vous pouvez exclure certaines adresses IP de la limitation de debit ou les bloquer.
+Vous pouvez exclure certaines adresses IP de la limitation de débit ou les bloquer.
 
 ::
 
@@ -185,27 +185,27 @@ Vous pouvez exclure certaines adresses IP de la limitation de debit ou les bloqu
 
 .. note::
    Si vous utilisez un reverse proxy, configurez l'adresse IP du proxy dans ``rate.limit.trusted.proxies``.
-   Seules les requetes provenant de proxies de confiance permettent d'obtenir l'IP client
-   via les en-tetes X-Forwarded-For et X-Real-IP.
+   Seules les requêtes provenant de proxies de confiance permettent d'obtenir l'IP client
+   via les en-têtes X-Forwarded-For et X-Real-IP.
 
 Surveillance et alertes
 ==============
 
-Configuration pour surveiller l'etat de la limitation de debit :
+Configuration pour surveiller l'état de la limitation de débit :
 
 Sortie de logs
 --------
 
-Lorsque la limitation de debit est appliquee, elle est enregistree dans les logs :
+Lorsque la limitation de débit est appliquée, elle est enregistrée dans les logs :
 
 ::
 
     <Logger name="org.codelibs.fess.helper.RateLimitHelper" level="INFO"/>
 
-Depannage
+Dépannage
 ======================
 
-Les requetes legitimes sont bloquees
+Les requêtes légitimes sont bloquées
 --------------------------------
 
 **Cause** : Les valeurs limites sont trop strictes
@@ -213,31 +213,31 @@ Les requetes legitimes sont bloquees
 **Solution** :
 
 1. Augmenter ``rate.limit.requests.per.window``
-2. Ajouter des IP specifiques a la liste blanche (``rate.limit.whitelist.ips``)
-3. Ajuster la taille de la fenetre (``rate.limit.window.ms``)
+2. Ajouter des IP spécifiques à la liste blanche (``rate.limit.whitelist.ips``)
+3. Ajuster la taille de la fenêtre (``rate.limit.window.ms``)
 
-La limitation de debit ne fonctionne pas
+La limitation de débit ne fonctionne pas
 --------------------
 
-**Cause** : La configuration n'est pas correctement appliquee
+**Cause** : La configuration n'est pas correctement appliquée
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si ``rate.limit.enabled=true`` est configure
-2. Verifier si le fichier de configuration est correctement lu
-3. Verifier si |Fess| a ete redemarre
+1. Vérifier si ``rate.limit.enabled=true`` est configuré
+2. Vérifier si le fichier de configuration est correctement lu
+3. Vérifier si |Fess| a été redémarré
 
 Impact sur les performances
 ----------------------
 
-Si la verification de la limitation de debit affecte les performances :
+Si la vérification de la limitation de débit affecte les performances :
 
-1. Utiliser la liste blanche pour ignorer les verifications sur les IP de confiance
-2. Desactiver la limitation de debit (``rate.limit.enabled=false``)
+1. Utiliser la liste blanche pour ignorer les vérifications sur les IP de confiance
+2. Désactiver la limitation de débit (``rate.limit.enabled=false``)
 
-Informations de reference
+Informations de référence
 ========
 
-- :doc:`rag-chat` - Configuration de la fonctionnalite de mode de recherche IA
+- :doc:`rag-chat` - Configuration de la fonctionnalité de mode de recherche IA
 - :doc:`../admin/webconfig-guide` - Guide de configuration du crawl Web
-- :doc:`../api/api-overview` - Apercu des API
+- :doc:`../api/api-overview` - Aperçu des API

--- a/fr/15.7/config/scripting-groovy.rst
+++ b/fr/15.7/config/scripting-groovy.rst
@@ -2,17 +2,17 @@
 Guide de script Groovy
 ==================================
 
-Apercu
+Aperçu
 ====
 
-Groovy est le langage de script par defaut de |Fess|.
-Il fonctionne sur la machine virtuelle Java (JVM) et, tout en etant hautement compatible avec Java,
-permet d'ecrire des scripts avec une syntaxe plus concise.
+Groovy est le langage de script par défaut de |Fess|.
+Il fonctionne sur la machine virtuelle Java (JVM) et, tout en étant hautement compatible avec Java,
+permet d'écrire des scripts avec une syntaxe plus concise.
 
 Syntaxe de base
 ========
 
-Declaration de variables
+Déclaration de variables
 --------
 
 ::
@@ -25,7 +25,7 @@ Declaration de variables
     String title = "Document Title"
     int pageNum = 1
 
-Manipulation de chaines
+Manipulation de chaînes
 ----------
 
 ::
@@ -52,7 +52,7 @@ Manipulation de chaines
     title.toUpperCase()
     title.toLowerCase()
 
-Operations sur les collections
+Opérations sur les collections
 ----------------
 
 ::
@@ -113,10 +113,10 @@ Scripts de Data Store
 Exemples de scripts pour la configuration Data Store.
 
 .. note::
-   Dans les scripts de data store, chaque ligne ``champ=expression`` est evaluee independamment en tant qu'expression unique.
-   Par consequent, les instructions ``import``, les declarations ``def`` multi-lignes et les structures de controle multi-lignes qui definissent plusieurs champs a la fois (comme les blocs ``if``) ne peuvent pas etre utilisees.
-   Lorsque vous utilisez des classes Java, ecrivez-les en tant qu'expression unique avec le nom de classe complet (FQCN), et utilisez un operateur ternaire par champ pour les valeurs conditionnelles (par exemple, ``url=data.published ? data.url : null`` ).
-   Par ailleurs, le nom de variable ``data`` utilise ici n'est qu'un exemple ; le nom de variable reel depend du connecteur de data store utilise. Consultez :doc:`../admin/dataconfig-guide` pour plus de details.
+   Dans les scripts de data store, chaque ligne ``champ=expression`` est évaluée indépendamment en tant qu'expression unique.
+   Par conséquent, les instructions ``import``, les déclarations ``def`` multi-lignes et les structures de contrôle multi-lignes qui définissent plusieurs champs à la fois (comme les blocs ``if``) ne peuvent pas être utilisées.
+   Lorsque vous utilisez des classes Java, écrivez-les en tant qu'expression unique avec le nom de classe complet (FQCN), et utilisez un opérateur ternaire par champ pour les valeurs conditionnelles (par exemple, ``url=data.published ? data.url : null`` ).
+   Par ailleurs, le nom de variable ``data`` utilisé ici n'est qu'un exemple ; le nom de variable réel dépend du connecteur de data store utilisé. Consultez :doc:`../admin/dataconfig-guide` pour plus de détails.
 
 Mapping de base
 ------------------
@@ -128,7 +128,7 @@ Mapping de base
     content=data.content
     lastModified=data.updated_at
 
-Generation d'URL
+Génération d'URL
 ---------
 
 ::
@@ -170,7 +170,7 @@ Traitement des dates
 Objets disponibles
 ==================
 
-Les objets disponibles dans les scripts varient en fonction du contexte d'execution.
+Les objets disponibles dans les scripts varient en fonction du contexte d'exécution.
 
 .. list-table::
    :header-rows: 1
@@ -181,33 +181,33 @@ Les objets disponibles dans les scripts varient en fonction du contexte d'execut
      - Description
    * - Tous les contextes
      - ``container``
-     - Conteneur DI. Utilise pour acceder aux composants via ``container.getComponent("...")``
-   * - Taches planifiees
+     - Conteneur DI. Utilisé pour accéder aux composants via ``container.getComponent("...")``
+   * - Tâches planifiées
      - ``executor``
-     - Controle d'execution des jobs ( ``JobExecutor`` ). Necessaire pour le support de l'arret des jobs
+     - Contrôle d'exécution des jobs ( ``JobExecutor`` ). Nécessaire pour le support de l'arrêt des jobs
    * - Data Store
-     - (specifique au connecteur)
-     - Variables d'enregistrement de donnees fournies par chaque data store. Le nom de la variable depend du connecteur
+     - (spécifique au connecteur)
+     - Variables d'enregistrement de données fournies par chaque data store. Le nom de la variable dépend du connecteur
    * - Mappage de chemins
      - ``url`` , ``matcher``
-     - La chaine URL a convertir et le resultat de la correspondance par expression reguliere ( ``Matcher`` ). Disponible dans les parametres de remplacement avec le prefixe ``groovy:``
+     - La chaîne URL à convertir et le résultat de la correspondance par expression régulière ( ``Matcher`` ). Disponible dans les paramètres de remplacement avec le préfixe ``groovy:``
    * - Boost de document
      - (champs du document)
-     - Chaque champ du document cible est disponible en tant que variable (utilise dans les expressions de condition et de valeur de boost)
+     - Chaque champ du document cible est disponible en tant que variable (utilisé dans les expressions de condition et de valeur de boost)
 
-Scripts de taches planifiees
+Scripts de tâches planifiées
 ============================
 
-Exemples de scripts Groovy pour les taches planifiees.
-Dans les taches planifiees, ``container`` et ``executor`` sont disponibles.
-Passer ``executor`` a la methode ``execute()`` du job active le controle d'arret du job.
+Exemples de scripts Groovy pour les tâches planifiées.
+Dans les tâches planifiées, ``container`` et ``executor`` sont disponibles.
+Passer ``executor`` à la méthode ``execute()`` du job active le contrôle d'arrêt du job.
 
 .. note::
-   Un script de tache planifiee est evalue en tant que script Groovy unique et complet.
-   Par consequent, contrairement aux scripts de data store, vous pouvez utiliser des instructions ``import``, des declarations ``def`` multi-lignes et des structures de controle multi-lignes.
-   Les exemples ci-dessous « Utilisation des classes Java », « Acces aux composants Fess », « Gestion des erreurs » et « Debogage et journalisation » supposent egalement ce contexte de script complet.
+   Un script de tâche planifiée est évalué en tant que script Groovy unique et complet.
+   Par conséquent, contrairement aux scripts de data store, vous pouvez utiliser des instructions ``import``, des déclarations ``def`` multi-lignes et des structures de contrôle multi-lignes.
+   Les exemples ci-dessous « Utilisation des classes Java », « Accès aux composants Fess », « Gestion des erreurs » et « Débogage et journalisation » supposent également ce contexte de script complet.
 
-Execution d'un job de crawl
+Exécution d'un job de crawl
 --------------------
 
 ::
@@ -230,7 +230,7 @@ Crawl conditionnel
     }
     return "Skipped during business hours"
 
-Execution sequentielle de plusieurs jobs
+Exécution séquentielle de plusieurs jobs
 ------------------------
 
 ::
@@ -248,7 +248,7 @@ Execution sequentielle de plusieurs jobs
 Utilisation des classes Java
 ================
 
-Dans les scripts Groovy, vous pouvez utiliser les bibliotheques standard Java et les classes Fess.
+Dans les scripts Groovy, vous pouvez utiliser les bibliothèques standard Java et les classes Fess.
 
 Date et heure
 ----------
@@ -261,7 +261,7 @@ Date et heure
     def now = LocalDateTime.now()
     def formatted = now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
-Operations sur les fichiers
+Opérations sur les fichiers
 ------------
 
 ::
@@ -282,13 +282,13 @@ Communication HTTP
     def response = url.text
 
 .. warning::
-   L'acces aux ressources externes affecte les performances,
-   utilisez-le au minimum necessaire.
+   L'accès aux ressources externes affecte les performances,
+   utilisez-le au minimum nécessaire.
 
-Acces aux composants Fess
+Accès aux composants Fess
 ==============================
 
-Utilisez ``container`` pour acceder aux composants Fess.
+Utilisez ``container`` pour accéder aux composants Fess.
 
 System Helper
 ----------------
@@ -298,7 +298,7 @@ System Helper
     def systemHelper = container.getComponent("systemHelper")
     def currentTime = systemHelper.getCurrentTimeAsLong()
 
-Recuperation des valeurs de configuration
+Récupération des valeurs de configuration
 ------------
 
 ::
@@ -306,7 +306,7 @@ Recuperation des valeurs de configuration
     def fessConfig = container.getComponent("fessConfig")
     def indexName = fessConfig.getIndexDocumentUpdateIndex()
 
-Execution de recherche
+Exécution de recherche
 ----------
 
 ::
@@ -317,8 +317,8 @@ Execution de recherche
 Gestion des erreurs
 ==================
 
-Les instructions ``import`` doivent etre placees en haut du script (elles ne peuvent pas etre placees dans des blocs tels que ``try-catch`` ).
-Vous pouvez intercepter les exceptions avec ``try-catch`` pour controler les erreurs de job.
+Les instructions ``import`` doivent être placées en haut du script (elles ne peuvent pas être placées dans des blocs tels que ``try-catch`` ).
+Vous pouvez intercepter les exceptions avec ``try-catch`` pour contrôler les erreurs de job.
 
 ::
 
@@ -333,7 +333,7 @@ Vous pouvez intercepter les exceptions avec ``try-catch`` pour controler les err
         return "Error: " + e.message
     }
 
-Debogage et journalisation
+Débogage et journalisation
 ==================
 
 Sortie de logs
@@ -350,7 +350,7 @@ Sortie de logs
     logger.warn("Warning: {}", message)
     logger.error("Error: {}", e.message, e)
 
-Sortie de debogage
+Sortie de débogage
 ----------------
 
 ::
@@ -362,16 +362,16 @@ Sortie de debogage
 Bonnes pratiques
 ==================
 
-1. **Garder la simplicite** : Eviter les logiques complexes, privilegier un code lisible
-2. **Verification de null** : Utiliser les operateurs ``?.`` et ``?:``
-3. **Gestion des exceptions** : Gerer les erreurs inattendues avec try-catch approprie
-4. **Sortie de logs** : Afficher des logs pour faciliter le debogage
-5. **Performance** : Minimiser les acces aux ressources externes
+1. **Garder la simplicité** : Éviter les logiques complexes, privilégier un code lisible
+2. **Vérification de null** : Utiliser les opérateurs ``?.`` et ``?:``
+3. **Gestion des exceptions** : Gérer les erreurs inattendues avec try-catch approprié
+4. **Sortie de logs** : Afficher des logs pour faciliter le débogage
+5. **Performance** : Minimiser les accès aux ressources externes
 
-Informations de reference
+Informations de référence
 ========
 
 - `Documentation officielle Groovy <https://groovy-lang.org/documentation.html>`__
-- :doc:`scripting-overview` - Apercu du scripting
+- :doc:`scripting-overview` - Aperçu du scripting
 - :doc:`../admin/dataconfig-guide` - Guide de configuration Data Store
 - :doc:`../admin/scheduler-guide` - Guide de configuration du planificateur

--- a/fr/15.7/dev/datastore-plugin.rst
+++ b/fr/15.7/dev/datastore-plugin.rst
@@ -1,19 +1,19 @@
 ==================================
-Developpement de plugins DataStore
+Développement de plugins DataStore
 ==================================
 
 Vue d'ensemble
 ==============
 
-En developpant un plugin DataStore, vous pouvez ajouter a |Fess| la capacite
-de recuperer du contenu depuis de nouvelles sources de donnees.
+En développant un plugin DataStore, vous pouvez ajouter à |Fess| la capacité
+de récupérer du contenu depuis de nouvelles sources de données.
 
 Structure de base
 =================
 
-Un plugin DataStore herite de ``AbstractDataStore``.
+Un plugin DataStore hérite de ``AbstractDataStore``.
 
-Implementation minimale
+Implémentation minimale
 -----------------------
 
 .. code-block:: java
@@ -48,34 +48,34 @@ Implementation minimale
 AbstractDataStore
 =================
 
-Methodes principales
+Méthodes principales
 --------------------
 
 .. list-table::
    :header-rows: 1
    :widths: 30 70
 
-   * - Methode
+   * - Méthode
      - Description
    * - ``getName()``
      - Retourne le nom du DataStore (obligatoire)
    * - ``storeData()``
-     - Effectue la recuperation et l'enregistrement dans l'index (obligatoire)
+     - Effectue la récupération et l'enregistrement dans l'index (obligatoire)
    * - ``register()``
      - Enregistre le plugin
 
-Parametres
+Paramètres
 ----------
 
-Parametres passes a la methode ``storeData()``:
+Paramètres passés à la méthode ``storeData()``:
 
 - ``dataConfig``: Configuration du DataStore
-- ``callback``: Callback pour la mise a jour de l'index
-- ``paramMap``: Parametres configures dans l'interface d'administration
+- ``callback``: Callback pour la mise à jour de l'index
+- ``paramMap``: Paramètres configurés dans l'interface d'administration
 - ``scriptMap``: Configuration des scripts
-- ``defaultDataMap``: Map de donnees par defaut
+- ``defaultDataMap``: Map de données par défaut
 
-Exemple d'implementation
+Exemple d'implémentation
 ========================
 
 DataStore simple
@@ -151,7 +151,7 @@ Gestion de la pagination
         }
     }
 
-Implementation de l'authentification
+Implémentation de l'authentification
 ====================================
 
 OAuth 2.0
@@ -181,7 +181,7 @@ OAuth 2.0
         }
     }
 
-Authentification par cle API
+Authentification par clé API
 ----------------------------
 
 .. code-block:: java
@@ -250,7 +250,7 @@ Exemple de configuration
 
 Exemple de configuration dans l'interface d'administration:
 
-Parametres
+Paramètres
 ----------
 
 ::
@@ -271,9 +271,9 @@ Script
     lastModified=data.updated_at
     mimetype=data.content_type
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`plugin-architecture` - Architecture des plugins
 - :doc:`../config/datastore/ds-overview` - Vue d'ensemble des connecteurs DataStore
-- `GitHub: fess-ds-* <https://github.com/codelibs?q=fess-ds>`__ - Exemples de plugins publies
+- `GitHub: fess-ds-* <https://github.com/codelibs?q=fess-ds>`__ - Exemples de plugins publiés

--- a/fr/15.7/dev/ingest-plugin.rst
+++ b/fr/15.7/dev/ingest-plugin.rst
@@ -5,21 +5,21 @@ Plugin Ingest
 Vue d'ensemble
 ==============
 
-Les plugins Ingest fournissent des fonctionnalites de traitement et de transformation
-des donnees avant leur enregistrement dans l'index.
+Les plugins Ingest fournissent des fonctionnalités de traitement et de transformation
+des données avant leur enregistrement dans l'index.
 
 Cas d'utilisation
 =================
 
 - Normalisation du texte (conversion pleine largeur/demi-largeur, etc.)
-- Ajout de metadonnees
+- Ajout de métadonnées
 - Masquage d'informations sensibles
-- Ajout de champs personnalises
+- Ajout de champs personnalisés
 
-Implementation de base
+Implémentation de base
 ======================
 
-Implementez l'interface ``IngestHandler``:
+Implémentez l'interface ``IngestHandler``:
 
 .. code-block:: java
 
@@ -72,7 +72,7 @@ Configuration
 
     ingest.handler.example.enabled=true
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`plugin-architecture` - Architecture des plugins

--- a/fr/15.7/dev/overview.rst
+++ b/fr/15.7/dev/overview.rst
@@ -1,43 +1,43 @@
 ==================================
-Vue d'ensemble developpeur
+Vue d'ensemble développeur
 ==================================
 
 Vue d'ensemble
 ==============
 
-Cette section decrit le developpement d'extensions pour |Fess|.
-Elle fournit des informations sur le developpement de plugins, la creation de connecteurs personnalises,
-la personnalisation de themes, etc.
+Cette section décrit le développement d'extensions pour |Fess|.
+Elle fournit des informations sur le développement de plugins, la création de connecteurs personnalisés,
+la personnalisation de thèmes, etc.
 
 Public cible
 ============
 
-- Developpeurs souhaitant creer des fonctionnalites personnalisees pour |Fess|
-- Developpeurs souhaitant creer des plugins
-- Developpeurs souhaitant comprendre le code source de |Fess|
+- Développeurs souhaitant créer des fonctionnalités personnalisées pour |Fess|
+- Développeurs souhaitant créer des plugins
+- Développeurs souhaitant comprendre le code source de |Fess|
 
-Connaissances prealables
+Connaissances préalables
 ------------------------
 
 - Connaissances de base de Java 21
-- Bases de Maven (systeme de build)
-- Experience en developpement d'applications web
+- Bases de Maven (système de build)
+- Expérience en développement d'applications web
 
-Environnement de developpement
+Environnement de développement
 ==============================
 
-Environnement recommande
+Environnement recommandé
 ------------------------
 
-- **JDK**: OpenJDK 21 ou superieur
+- **JDK**: OpenJDK 21 ou supérieur
 - **IDE**: IntelliJ IDEA / Eclipse / VS Code
-- **Outil de build**: Maven 3.9 ou superieur
+- **Outil de build**: Maven 3.9 ou supérieur
 - **Git**: Gestion de versions
 
 Configuration
 -------------
 
-1. Recuperation du code source:
+1. Récupération du code source:
 
 ::
 
@@ -50,16 +50,16 @@ Configuration
 
     mvn package -DskipTests
 
-3. Demarrage du serveur de developpement:
+3. Démarrage du serveur de développement:
 
 ::
 
     ./bin/fess
 
-Apercu de l'architecture
+Aperçu de l'architecture
 ========================
 
-|Fess| est compose des composants principaux suivants:
+|Fess| est composé des composants principaux suivants:
 
 Structure des composants
 ------------------------
@@ -71,13 +71,13 @@ Structure des composants
    * - Composant
      - Description
    * - Couche Web
-     - Implementation MVC avec le framework LastaFlute
+     - Implémentation MVC avec le framework LastaFlute
    * - Couche Service
-     - Logique metier
-   * - Couche d'acces aux donnees
-     - Integration OpenSearch via DBFlute
+     - Logique métier
+   * - Couche d'accès aux données
+     - Intégration OpenSearch via DBFlute
    * - Crawler
-     - Collecte de contenu via la bibliotheque fess-crawler
+     - Collecte de contenu via la bibliothèque fess-crawler
    * - Moteur de recherche
      - Recherche plein texte avec OpenSearch
 
@@ -85,10 +85,10 @@ Frameworks principaux
 ---------------------
 
 - **LastaFlute**: Framework web (actions, formulaires, validation)
-- **DBFlute**: Framework d'acces aux donnees (integration OpenSearch)
-- **Lasta Di**: Conteneur d'injection de dependances
+- **DBFlute**: Framework d'accès aux données (intégration OpenSearch)
+- **Lasta Di**: Conteneur d'injection de dépendances
 
-Structure des repertoires
+Structure des répertoires
 =========================
 
 ::
@@ -119,44 +119,44 @@ Points d'extension
 Plugins
 -------
 
-Vous pouvez ajouter des fonctionnalites via des plugins.
+Vous pouvez ajouter des fonctionnalités via des plugins.
 
-- **Plugins DataStore**: Crawl depuis de nouvelles sources de donnees
+- **Plugins DataStore**: Crawl depuis de nouvelles sources de données
 - **Plugins Script Engine**: Support de nouveaux langages de script
 - **Plugins WebApp**: Extension de l'interface web
-- **Plugins Ingest**: Traitement des donnees lors de l'indexation
+- **Plugins Ingest**: Traitement des données lors de l'indexation
 
-Details: :doc:`plugin-architecture`
+Détails: :doc:`plugin-architecture`
 
-Themes
+Thèmes
 ------
 
-Vous pouvez personnaliser le design de l'ecran de recherche.
+Vous pouvez personnaliser le design de l'écran de recherche.
 
-Details: :doc:`theme-development`
+Détails: :doc:`theme-development`
 
 Configuration
 -------------
 
-De nombreux comportements peuvent etre personnalises via ``fess_config.properties``.
+De nombreux comportements peuvent être personnalisés via ``fess_config.properties``.
 
-Details: :doc:`../config/intro`
+Détails: :doc:`../config/intro`
 
-Developpement de plugins
+Développement de plugins
 ========================
 
-Pour plus de details sur le developpement de plugins, consultez:
+Pour plus de détails sur le développement de plugins, consultez:
 
 - :doc:`plugin-architecture` - Architecture des plugins
-- :doc:`datastore-plugin` - Developpement de plugins DataStore
+- :doc:`datastore-plugin` - Développement de plugins DataStore
 - :doc:`script-engine-plugin` - Plugins Script Engine
 - :doc:`webapp-plugin` - Plugins WebApp
 - :doc:`ingest-plugin` - Plugins Ingest
 
-Developpement de themes
+Développement de thèmes
 =======================
 
-- :doc:`theme-development` - Personnalisation des themes
+- :doc:`theme-development` - Personnalisation des thèmes
 
 Bonnes pratiques
 ================
@@ -166,13 +166,13 @@ Conventions de codage
 
 - Suivre le style de code existant de |Fess|
 - Formater le code avec ``mvn formatter:format``
-- Ajouter les en-tetes de licence avec ``mvn license:format``
+- Ajouter les en-têtes de licence avec ``mvn license:format``
 
 Tests
 -----
 
-- Ecrire des tests unitaires (``*Test.java``)
-- Les tests d'integration sont ``*Tests.java``
+- Écrire des tests unitaires (``*Test.java``)
+- Les tests d'intégration sont ``*Tests.java``
 
 Journalisation
 --------------

--- a/fr/15.7/dev/plugin-architecture.rst
+++ b/fr/15.7/dev/plugin-architecture.rst
@@ -5,8 +5,8 @@ Architecture des plugins
 Vue d'ensemble
 ==============
 
-Le systeme de plugins de |Fess| permet d'etendre les fonctionnalites de base.
-Les plugins sont distribues sous forme de fichiers JAR et charges dynamiquement.
+Le système de plugins de |Fess| permet d'étendre les fonctionnalités de base.
+Les plugins sont distribués sous forme de fichiers JAR et chargés dynamiquement.
 
 Types de plugins
 ================
@@ -20,13 +20,13 @@ Types de plugins
    * - Type
      - Description
    * - DataStore
-     - Recuperation de contenu depuis de nouvelles sources de donnees (Box, Slack, etc.)
+     - Récupération de contenu depuis de nouvelles sources de données (Box, Slack, etc.)
    * - Script Engine
      - Support de nouveaux langages de script
    * - WebApp
      - Extension de l'interface web
    * - Ingest
-     - Traitement des donnees lors de l'indexation
+     - Traitement des données lors de l'indexation
 
 Structure d'un plugin
 =====================
@@ -83,7 +83,7 @@ Enregistrement du plugin
 Enregistrement dans le conteneur DI
 -----------------------------------
 
-Les plugins sont enregistres dans des fichiers de configuration comme ``fess_ds.xml``:
+Les plugins sont enregistrés dans des fichiers de configuration comme ``fess_ds.xml``:
 
 .. code-block:: xml
 
@@ -109,21 +109,21 @@ Cycle de vie du plugin
 Initialisation
 --------------
 
-1. Le fichier JAR est charge
+1. Le fichier JAR est chargé
 2. Le conteneur DI initialise les composants
-3. Les methodes ``@PostConstruct`` sont appelees
-4. Le plugin est enregistre dans le gestionnaire
+3. Les méthodes ``@PostConstruct`` sont appelées
+4. Le plugin est enregistré dans le gestionnaire
 
 Terminaison
 -----------
 
-1. Les methodes ``@PreDestroy`` sont appelees (si definies)
+1. Les méthodes ``@PreDestroy`` sont appelées (si définies)
 2. Nettoyage des ressources
 
-Dependances
+Dépendances
 ===========
 
-Dependance avec Fess
+Dépendance avec Fess
 --------------------
 
 .. code-block:: xml
@@ -135,10 +135,10 @@ Dependance avec Fess
         <scope>provided</scope>
     </dependency>
 
-Bibliotheques externes
+Bibliothèques externes
 ----------------------
 
-Les plugins peuvent inclure leurs propres dependances:
+Les plugins peuvent inclure leurs propres dépendances:
 
 .. code-block:: xml
 
@@ -148,13 +148,13 @@ Les plugins peuvent inclure leurs propres dependances:
         <version>1.0.0</version>
     </dependency>
 
-Les bibliotheques dependantes peuvent etre distribuees avec le JAR du plugin,
-ou vous pouvez creer un fat JAR avec Maven Shade Plugin.
+Les bibliothèques dépendantes peuvent être distribuées avec le JAR du plugin,
+ou vous pouvez créer un fat JAR avec Maven Shade Plugin.
 
-Recuperation de la configuration
+Récupération de la configuration
 ================================
 
-Recuperation depuis FessConfig
+Récupération depuis FessConfig
 ------------------------------
 
 .. code-block:: java
@@ -195,7 +195,7 @@ Installation
 
 1. **Depuis l'interface d'administration**:
 
-   - "Systeme" -> "Plugins" -> "Installer"
+   - "Système" -> "Plugins" -> "Installer"
    - Entrer le nom du plugin et installer
 
 2. **Ligne de commande**:
@@ -206,10 +206,10 @@ Installation
 
 3. **Manuellement**:
 
-   - Copier le fichier JAR dans le repertoire ``plugins/``
-   - Redemarrer |Fess|
+   - Copier le fichier JAR dans le répertoire ``plugins/``
+   - Redémarrer |Fess|
 
-Debogage
+Débogage
 ========
 
 Sortie de logs
@@ -224,19 +224,19 @@ Sortie de logs
         logger.info("Info message");
     }
 
-Mode developpement
+Mode développement
 ------------------
 
-En developpement, vous pouvez lancer |Fess| depuis l'IDE pour deboguer:
+En développement, vous pouvez lancer |Fess| depuis l'IDE pour déboguer:
 
-1. Executer la classe ``FessBoot`` en mode debug
+1. Exécuter la classe ``FessBoot`` en mode debug
 2. Inclure les sources du plugin dans le projet
-3. Definir des points d'arret
+3. Définir des points d'arrêt
 
-Liste des plugins publies
+Liste des plugins publiés
 =========================
 
-Principaux plugins publies par le projet |Fess|:
+Principaux plugins publiés par le projet |Fess|:
 
 .. list-table::
    :header-rows: 1
@@ -253,16 +253,16 @@ Principaux plugins publies par le projet |Fess|:
    * - fess-ds-atlassian
      - Connecteur Confluence/Jira
    * - fess-ds-git
-     - Connecteur de depot Git
+     - Connecteur de dépôt Git
    * - fess-theme-\*
-     - Themes personnalises
+     - Thèmes personnalisés
 
-Ces plugins sont publies sur `GitHub <https://github.com/codelibs>`__ comme reference de developpement.
+Ces plugins sont publiés sur `GitHub <https://github.com/codelibs>`__ comme référence de développement.
 
-Informations complementaires
+Informations complémentaires
 ============================
 
-- :doc:`datastore-plugin` - Developpement de plugins DataStore
+- :doc:`datastore-plugin` - Développement de plugins DataStore
 - :doc:`script-engine-plugin` - Plugins Script Engine
 - :doc:`webapp-plugin` - Plugins WebApp
 - :doc:`ingest-plugin` - Plugins Ingest

--- a/fr/15.7/dev/script-engine-plugin.rst
+++ b/fr/15.7/dev/script-engine-plugin.rst
@@ -5,13 +5,13 @@ Plugin Script Engine
 Vue d'ensemble
 ==============
 
-En developpant un plugin Script Engine, vous pouvez ajouter le support de nouveaux
-langages de script a |Fess|.
+En développant un plugin Script Engine, vous pouvez ajouter le support de nouveaux
+langages de script à |Fess|.
 
-Implementation de base
+Implémentation de base
 ======================
 
-Implementez l'interface ``ScriptEngine``:
+Implémentez l'interface ``ScriptEngine``:
 
 .. code-block:: java
 
@@ -47,14 +47,14 @@ Enregistrement
 Exemple d'utilisation
 =====================
 
-Selection du type de script dans l'interface d'administration:
+Sélection du type de script dans l'interface d'administration:
 
 ::
 
     scriptType=example
     scriptData=your script here
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`plugin-architecture` - Architecture des plugins

--- a/fr/15.7/dev/theme-development.rst
+++ b/fr/15.7/dev/theme-development.rst
@@ -1,14 +1,14 @@
 ==================================
-Guide de developpement de themes
+Guide de développement de thèmes
 ==================================
 
 Vue d'ensemble
 ==============
 
-Le systeme de themes de |Fess| permet de personnaliser le design de l'ecran de recherche.
-Les themes peuvent etre distribues sous forme de plugins et vous pouvez basculer entre plusieurs themes.
+Le système de thèmes de |Fess| permet de personnaliser le design de l'écran de recherche.
+Les thèmes peuvent être distribués sous forme de plugins et vous pouvez basculer entre plusieurs thèmes.
 
-Structure d'un theme
+Structure d'un thème
 ====================
 
 ::
@@ -27,7 +27,7 @@ Structure d'un theme
             └── templates/
                 └── search.html
 
-Creation d'un theme de base
+Création d'un thème de base
 ===========================
 
 Personnalisation CSS
@@ -57,8 +57,8 @@ Personnalisation CSS
 Changement du logo
 ------------------
 
-1. Placer le logo personnalise dans ``images/logo.png``
-2. Referencer le logo dans le CSS:
+1. Placer le logo personnalisé dans ``images/logo.png``
+2. Référencer le logo dans le CSS:
 
 .. code-block:: css
 
@@ -81,7 +81,7 @@ Les templates sont au format JSP.
         <p>Rechercher dans les documents internes</p>
     </div>
 
-Enregistrement du theme
+Enregistrement du thème
 =======================
 
 pom.xml
@@ -112,19 +112,19 @@ Installation
 
     ./bin/fess-plugin install fess-theme-example
 
-Selection du theme depuis l'interface d'administration:
+Sélection du thème depuis l'interface d'administration:
 
-1. "Systeme" -> "Design"
-2. Selectionner le theme
+1. "Système" -> "Design"
+2. Sélectionner le thème
 3. Sauvegarder et appliquer
 
-Exemples de themes existants
+Exemples de thèmes existants
 ============================
 
 - `fess-theme-simple <https://github.com/codelibs/fess-theme-simple>`__
 - `fess-theme-minimal <https://github.com/codelibs/fess-theme-minimal>`__
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`plugin-architecture` - Architecture des plugins

--- a/fr/15.7/dev/webapp-plugin.rst
+++ b/fr/15.7/dev/webapp-plugin.rst
@@ -5,7 +5,7 @@ Plugin WebApp
 Vue d'ensemble
 ==============
 
-Les plugins WebApp permettent d'etendre l'interface web de Fess.
+Les plugins WebApp permettent d'étendre l'interface web de Fess.
 Vous pouvez ajouter de nouvelles pages, personnaliser l'interface d'administration, etc.
 
 Structure de base
@@ -21,7 +21,7 @@ Structure de base
         └── webapp/WEB-INF/view/example/
             └── index.jsp
 
-Implementation de l'Action
+Implémentation de l'Action
 ==========================
 
 .. code-block:: java
@@ -74,8 +74,8 @@ Extension API
         }
     }
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`plugin-architecture` - Architecture des plugins
-- :doc:`overview` - Vue d'ensemble developpeur
+- :doc:`overview` - Vue d'ensemble développeur

--- a/fr/15.7/user/chat-search.rst
+++ b/fr/15.7/user/chat-search.rst
@@ -2,202 +2,202 @@
 Mode de recherche IA
 ==============================
 
-Apercu
+Aperçu
 ====
 
-La fonctionnalite de mode de recherche IA de |Fess| vous permet de rechercher des informations
-sous forme de conversation naturelle, en complement de la recherche par mots-cles traditionnelle.
-Lorsque vous posez une question, l'assistant IA analyse les resultats de recherche
-et genere une reponse comprehensible.
+La fonctionnalité de mode de recherche IA de |Fess| vous permet de rechercher des informations
+sous forme de conversation naturelle, en complément de la recherche par mots-clés traditionnelle.
+Lorsque vous posez une question, l'assistant IA analyse les résultats de recherche
+et génère une réponse compréhensible.
 
-Caracteristiques du mode de recherche IA
+Caractéristiques du mode de recherche IA
 ====================
 
 Recherche sous forme de dialogue
 ----------------
 
-Au lieu de reflechir a des mots-cles, vous pouvez poser des questions comme dans une conversation normale.
+Au lieu de réfléchir à des mots-clés, vous pouvez poser des questions comme dans une conversation normale.
 
 Exemples :
 
 - "Comment installer Fess ?"
 - "Comment crawler des fichiers ?"
-- "Que faire si les resultats de recherche ne s'affichent pas ?"
+- "Que faire si les résultats de recherche ne s'affichent pas ?"
 
-Reponses comprenant le contexte
+Réponses comprenant le contexte
 ------------------
 
-L'assistant IA comprend l'intention de votre question et synthetise les informations pertinentes dans sa reponse.
-Il extrait les informations necessaires de plusieurs resultats de recherche et les presente de maniere organisee.
+L'assistant IA comprend l'intention de votre question et synthétise les informations pertinentes dans sa réponse.
+Il extrait les informations nécessaires de plusieurs résultats de recherche et les présente de manière organisée.
 
 Citation des sources
 ----------
 
-Les reponses de l'IA mentionnent les sources (documents de reference).
-Si vous souhaitez verifier l'exactitude de la reponse, vous pouvez consulter directement le document original.
+Les réponses de l'IA mentionnent les sources (documents de référence).
+Si vous souhaitez vérifier l'exactitude de la réponse, vous pouvez consulter directement le document original.
 
 Continuation de la conversation
 ----------
 
 Il ne s'agit pas d'une seule question, vous pouvez continuer la conversation.
-Vous pouvez poser des questions supplementaires en tenant compte du contexte des questions et reponses precedentes.
+Vous pouvez poser des questions supplémentaires en tenant compte du contexte des questions et réponses précédentes.
 
 Comment utiliser la recherche par chat
 ====================
 
-Demarrer un chat
+Démarrer un chat
 ------------------
 
-1. Accedez a l'ecran de recherche de |Fess|
-2. Cliquez sur l'icone de chat en bas a droite de l'ecran
+1. Accédez à l'écran de recherche de |Fess|
+2. Cliquez sur l'icône de chat en bas à droite de l'écran
 3. Le panneau de chat s'affiche
 
 Saisir une question
 --------------
 
 1. Entrez votre question dans la zone de texte
-2. Cliquez sur le bouton d'envoi ou appuyez sur Entree
-3. L'assistant IA genere une reponse
+2. Cliquez sur le bouton d'envoi ou appuyez sur Entrée
+3. L'assistant IA génère une réponse
 
 .. note::
-   La generation de la reponse peut prendre quelques secondes.
+   La génération de la réponse peut prendre quelques secondes.
    Pendant le traitement, la phase actuelle (recherche en cours, analyse en cours, etc.) s'affiche.
 
-Verifier la reponse
+Vérifier la réponse
 --------------
 
-La reponse de l'assistant IA s'affiche. La reponse comprend les informations suivantes :
+La réponse de l'assistant IA s'affiche. La réponse comprend les informations suivantes :
 
-- **Corps de la reponse** : Reponse detaillee a votre question
-- **Sources** : Liens vers les documents sur lesquels la reponse est basee (sous forme [1], [2], etc.)
+- **Corps de la réponse** : Réponse détaillée à votre question
+- **Sources** : Liens vers les documents sur lesquels la réponse est basée (sous forme [1], [2], etc.)
 
 Cliquez sur les liens des sources pour consulter le document original.
 
 Continuer la conversation
 ------------
 
-Si vous avez des questions supplementaires, vous pouvez continuer a poser des questions :
+Si vous avez des questions supplémentaires, vous pouvez continuer à poser des questions :
 
 - "Pouvez-vous m'en dire plus ?"
-- "Y a-t-il d'autres methodes ?"
-- "Plus de details sur XXX"
+- "Y a-t-il d'autres méthodes ?"
+- "Plus de détails sur XXX"
 
-L'assistant IA repond en tenant compte du contexte de la conversation precedente.
+L'assistant IA répond en tenant compte du contexte de la conversation précédente.
 
 Commencer une nouvelle conversation
 ------------------
 
 Si vous souhaitez poser une question sur un autre sujet, cliquez sur le bouton "Nouveau chat".
-Cela efface l'historique de conversation et demarre une nouvelle conversation.
+Cela efface l'historique de conversation et démarre une nouvelle conversation.
 
 Conseils pour poser des questions efficaces
 ==================
 
-Poser des questions specifiques
+Poser des questions spécifiques
 ----------------
 
-Les questions specifiques obtiennent de meilleures reponses que les questions vagues.
+Les questions spécifiques obtiennent de meilleures réponses que les questions vagues.
 
 .. list-table::
    :header-rows: 1
    :widths: 50 50
 
    * - Question vague
-     - Question specifique
+     - Question spécifique
    * - Comment configurer ?
-     - Comment modifier les parametres memoire de Fess ?
+     - Comment modifier les paramètres mémoire de Fess ?
    * - Il y a une erreur
-     - J'obtiens une erreur "index non trouve" lors de la recherche
-   * - A propos du crawl
+     - J'obtiens une erreur "index non trouvé" lors de la recherche
+   * - À propos du crawl
      - Comment configurer les exclusions lors du crawl d'un site web ?
 
 Inclure le contexte
 ----------------
 
-Inclure la situation ou l'objectif permet d'obtenir des reponses plus appropriees.
+Inclure la situation ou l'objectif permet d'obtenir des réponses plus appropriées.
 
 Bons exemples :
 
 - "J'utilise Fess dans un environnement Docker. Comment changer l'emplacement de sauvegarde des logs ?"
-- "C'est ma premiere utilisation de Fess. Par quoi dois-je commencer ?"
+- "C'est ma première utilisation de Fess. Par quoi dois-je commencer ?"
 
-Poser des questions par etapes
+Poser des questions par étapes
 ----------------
 
-Les problemes complexes deviennent plus faciles a comprendre en posant des questions par etapes.
+Les problèmes complexes deviennent plus faciles à comprendre en posant des questions par étapes.
 
 1. "Puis-je crawler des partages de fichiers avec Fess ?"
 2. "Comment me connecter via le protocole SMB ?"
-3. "Que faire pour les dossiers partages necessitant une authentification ?"
+3. "Que faire pour les dossiers partagés nécessitant une authentification ?"
 
-Questions frequentes
+Questions fréquentes
 ============
 
-Q: La fonctionnalite de chat ne s'affiche pas
+Q: La fonctionnalité de chat ne s'affiche pas
 -------------------------------
 
-R: La fonctionnalite de chat peut ne pas etre activee.
-Verifiez aupres de l'administrateur systeme si la fonctionnalite de mode de recherche IA est activee.
+R: La fonctionnalité de chat peut ne pas être activée.
+Vérifiez auprès de l'administrateur système si la fonctionnalité de mode de recherche IA est activée.
 
-Q: La reponse met du temps a s'afficher
+Q: La réponse met du temps à s'afficher
 ---------------------------------------
 
-R: L'IA analyse les resultats de recherche et genere une reponse, ce qui peut prendre de quelques secondes a une dizaine de secondes.
-Pendant le traitement, la phase actuelle ("Recherche en cours", "Analyse en cours", "Generation de la reponse", etc.) s'affiche.
+R: L'IA analyse les résultats de recherche et génère une réponse, ce qui peut prendre de quelques secondes à une dizaine de secondes.
+Pendant le traitement, la phase actuelle ("Recherche en cours", "Analyse en cours", "Génération de la réponse", etc.) s'affiche.
 
-Q: La source de la reponse semble incorrecte
+Q: La source de la réponse semble incorrecte
 -----------------------------------------
 
-R: Cliquez sur le lien de la source pour verifier le document original.
-L'IA genere des reponses basees sur les resultats de recherche, mais peut parfois mal interpreter les informations.
-Pour les informations importantes, nous vous recommandons de toujours verifier le document original.
+R: Cliquez sur le lien de la source pour vérifier le document original.
+L'IA génère des réponses basées sur les résultats de recherche, mais peut parfois mal interpréter les informations.
+Pour les informations importantes, nous vous recommandons de toujours vérifier le document original.
 
-Q: La conversation precedente semble avoir ete oubliee
+Q: La conversation précédente semble avoir été oubliée
 -----------------------------------
 
-R: La session a peut-etre expire.
-Apres une certaine periode d'inactivite, l'historique de conversation est efface.
-Veuillez demarrer une nouvelle conversation.
+R: La session a peut-être expiré.
+Après une certaine période d'inactivité, l'historique de conversation est effacé.
+Veuillez démarrer une nouvelle conversation.
 
-Q: Je n'obtiens pas de reponse a certaines questions
+Q: Je n'obtiens pas de réponse à certaines questions
 ---------------------------------------
 
-R: Les possibilites suivantes sont a considerer :
+R: Les possibilités suivantes sont à considérer :
 
 - Les documents de recherche ne contiennent pas d'informations pertinentes
-- La question est trop vague pour effectuer une recherche appropriee
-- La limite de debit a ete atteinte
+- La question est trop vague pour effectuer une recherche appropriée
+- La limite de débit a été atteinte
 
-Essayez de reformuler votre question ou attendez un moment avant de reessayer.
+Essayez de reformuler votre question ou attendez un moment avant de réessayer.
 
-Q: Puis-je poser des questions dans une autre langue que le francais ?
+Q: Puis-je poser des questions dans une autre langue que le français ?
 -------------------------------
 
-R: Oui, selon la configuration, vous pouvez generalement poser des questions en anglais ou dans d'autres langues.
-L'IA reconnait la langue de la question et tente de repondre dans la meme langue.
+R: Oui, selon la configuration, vous pouvez généralement poser des questions en anglais ou dans d'autres langues.
+L'IA reconnaît la langue de la question et tente de répondre dans la même langue.
 
 Notes importantes
 ========
 
-Concernant les reponses de l'IA
+Concernant les réponses de l'IA
 ----------------
 
-- Les reponses de l'IA sont generees en fonction des resultats de recherche
-- L'exactitude des reponses n'est pas garantie
-- Pour les decisions importantes, verifiez toujours le document original
-- Pour les informations les plus recentes, consultez la documentation officielle
+- Les réponses de l'IA sont générées en fonction des résultats de recherche
+- L'exactitude des réponses n'est pas garantie
+- Pour les décisions importantes, vérifiez toujours le document original
+- Pour les informations les plus récentes, consultez la documentation officielle
 
-Concernant la confidentialite
+Concernant la confidentialité
 --------------------
 
-- Les questions saisies sont utilisees pour la recherche et le traitement par l'IA
-- L'historique de conversation est supprime apres la fin de la session
-- Selon la configuration du systeme, des logs peuvent etre enregistres
+- Les questions saisies sont utilisées pour la recherche et le traitement par l'IA
+- L'historique de conversation est supprimé après la fin de la session
+- Selon la configuration du système, des logs peuvent être enregistrés
 
-Informations de reference
+Informations de référence
 ========
 
 - :doc:`search-and` - Comment utiliser la recherche AND
 - :doc:`search-not` - Comment utiliser la recherche NOT
 - :doc:`search-field` - Comment utiliser la recherche par champ
-- :doc:`advanced-search` - Fonctionnalites de recherche avancee
+- :doc:`advanced-search` - Fonctionnalités de recherche avancée

--- a/fr/15.8/api/admin/api-admin-accesstoken.rst
+++ b/fr/15.8/api/admin/api-admin-accesstoken.rst
@@ -5,18 +5,18 @@ AccessToken API
 Vue d'ensemble
 ==============
 
-L'API AccessToken est une API permettant de gerer les jetons d'acces API de |Fess|.
-Il est possible de creer, recuperer, mettre a jour et supprimer des jetons.
+L'API AccessToken est une API permettant de gérer les jetons d'accès API de |Fess|.
+Il est possible de créer, récupérer, mettre à jour et supprimer des jetons.
 
-Les jetons d'acces sont utilises pour l'authentification lors d'appels programmatiques a l'API de recherche ou a l'API Admin de |Fess|.
-Pour les specifications communes de l'API Admin incluant cette API (methode d'authentification, format des reponses, valeurs de ``status``, reponses d'erreur,
+Les jetons d'accès sont utilisés pour l'authentification lors d'appels programmatiques à l'API de recherche ou à l'API Admin de |Fess|.
+Pour les spécifications communes de l'API Admin incluant cette API (méthode d'authentification, format des réponses, valeurs de ``status``, réponses d'erreur,
 codes de statut HTTP), consultez :doc:`api-admin-overview`.
 
 .. note::
 
-   Pour acceder a cette API, le jeton d'acces utilise dans la requete doit disposer d'une permission
-   correspondant a ``api.admin.access.permissions``
-   (valeur par defaut : ``{role}admin-api``).
+   Pour accéder à cette API, le jeton d'accès utilisé dans la requête doit disposer d'une permission
+   correspondant à ``api.admin.access.permissions``
+   (valeur par défaut : ``{role}admin-api``).
 
 URL de base
 ===========
@@ -32,60 +32,60 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /settings
-     - Obtention de la liste des jetons d'acces
+     - Obtention de la liste des jetons d'accès
    * - GET
      - /setting/{id}
-     - Obtention d'un jeton d'acces
+     - Obtention d'un jeton d'accès
    * - POST
      - /setting
-     - Creation d'un jeton d'acces
+     - Création d'un jeton d'accès
    * - PUT
      - /setting
-     - Mise a jour d'un jeton d'acces
+     - Mise à jour d'un jeton d'accès
    * - DELETE
      - /setting/{id}
-     - Suppression d'un jeton d'acces
+     - Suppression d'un jeton d'accès
 
-Obtention de la liste des jetons d'acces
+Obtention de la liste des jetons d'accès
 ========================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/accesstoken/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 25 ; modifiable via ``paging.page.size``)
+     - Nombre d'éléments par page (par défaut : 25 ; modifiable via ``paging.page.size``)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1 ; par defaut : 1)
+     - Numéro de page (commence à 1 ; par défaut : 1)
    * - ``id``
      - String
      - Non
-     - Filtre permettant de recuperer uniquement le jeton ayant l'ID specifie
+     - Filtre permettant de récupérer uniquement le jeton ayant l'ID spécifié
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -115,24 +115,24 @@ Reponse
 
 .. note::
 
-   Chaque objet jeton contient egalement des informations d'audit et de version telles que
+   Chaque objet jeton contient également des informations d'audit et de version telles que
    ``createdBy``, ``createdTime``, ``updatedBy``,
    ``updatedTime`` et ``versionNo``.
-   ``createdTime`` et ``updatedTime`` sont exprimes en millisecondes depuis l'epoch (valeur numerique).
-   Les champs dont la valeur est ``null`` sont exclus de la reponse.
-   ``permissions`` est retourne sous forme de chaine separee par des sauts de ligne (``\n``).
+   ``createdTime`` et ``updatedTime`` sont exprimés en millisecondes depuis l'epoch (valeur numérique).
+   Les champs dont la valeur est ``null`` sont exclus de la réponse.
+   ``permissions`` est retourné sous forme de chaîne séparée par des sauts de ligne (``\n``).
 
-Obtention d'un jeton d'acces
+Obtention d'un jeton d'accès
 ============================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/accesstoken/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -156,10 +156,10 @@ Reponse
       }
     }
 
-Creation d'un jeton d'acces
+Création d'un jeton d'accès
 ============================
 
-Requete
+Requête
 -------
 
 ::
@@ -167,7 +167,7 @@ Requete
     POST /api/admin/accesstoken/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -190,24 +190,24 @@ Description des champs
      - Description
    * - ``name``
      - Oui
-     - Nom du jeton (1000 caracteres maximum)
+     - Nom du jeton (1000 caractères maximum)
    * - ``permissions``
      - Non
-     - Permissions accordees a ce jeton. Plusieurs permissions peuvent etre specifiees en les separant par des sauts de ligne (``\n``) (exemple : ``{role}admin-api``). Pour les jetons appelant l'API Admin, une permission correspondant a ``api.admin.access.permissions`` (valeur par defaut : ``{role}admin-api``) est requise.
+     - Permissions accordées à ce jeton. Plusieurs permissions peuvent être spécifiées en les séparant par des sauts de ligne (``\n``) (exemple : ``{role}admin-api``). Pour les jetons appelant l'API Admin, une permission correspondant à ``api.admin.access.permissions`` (valeur par défaut : ``{role}admin-api``) est requise.
    * - ``parameterName``
      - Non
-     - Nom du parametre de requete permettant de transmettre des permissions supplementaires. Si une requete authentifiee par ce jeton contient un parametre portant ce nom, sa valeur est ajoutee aux ``permissions``. Si omis, aucun parametre n'est configure.
+     - Nom du paramètre de requête permettant de transmettre des permissions supplémentaires. Si une requête authentifiée par ce jeton contient un paramètre portant ce nom, sa valeur est ajoutée aux ``permissions``. Si omis, aucun paramètre n'est configuré.
    * - ``expires``
      - Non
-     - Date d'expiration, specifiee sous forme de chaine au format ``YYYY-MM-DDTHH:MM:SS`` (exemple : ``2026-01-01T00:00:00``). Si omis, le jeton n'expire pas.
+     - Date d'expiration, spécifiée sous forme de chaîne au format ``YYYY-MM-DDTHH:MM:SS`` (exemple : ``2026-01-01T00:00:00``). Si omis, le jeton n'expire pas.
 
 .. note::
 
-   La chaine du jeton (``token``) est generee automatiquement cote serveur. Si ``token``
-   est specifie dans le corps de la requete, il est ignore. La reponse de creation ne contient pas la chaine du jeton ;
-   pour recuperer la chaine de jeton generee, utilisez "Obtention d'un jeton d'acces" (``GET /setting/{id}``).
+   La chaîne du jeton (``token``) est générée automatiquement côté serveur. Si ``token``
+   est spécifié dans le corps de la requête, il est ignoré. La réponse de création ne contient pas la chaîne du jeton ;
+   pour récupérer la chaîne de jeton générée, utilisez "Obtention d'un jeton d'accès" (``GET /setting/{id}``).
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -220,10 +220,10 @@ Reponse
       }
     }
 
-Mise a jour d'un jeton d'acces
+Mise à jour d'un jeton d'accès
 ==============================
 
-Requete
+Requête
 -------
 
 ::
@@ -231,7 +231,7 @@ Requete
     PUT /api/admin/accesstoken/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -247,7 +247,7 @@ Corps de la requete
 Description des champs
 ~~~~~~~~~~~~~~~~~~~~~~
 
-En plus des champs utilises lors de la creation, les champs suivants sont employes lors de la mise a jour.
+En plus des champs utilisés lors de la création, les champs suivants sont employés lors de la mise à jour.
 
 .. list-table::
    :header-rows: 1
@@ -258,17 +258,17 @@ En plus des champs utilises lors de la creation, les champs suivants sont employ
      - Description
    * - ``id``
      - Oui
-     - ID du jeton a mettre a jour
+     - ID du jeton à mettre à jour
    * - ``versionNo``
      - Oui
-     - Numero de version pour le verrouillage optimiste. Specifiez le ``versionNo`` du jeton obtenu au prealable.
+     - Numéro de version pour le verrouillage optimiste. Spécifiez le ``versionNo`` du jeton obtenu au préalable.
 
 .. note::
 
-   La chaine du jeton (``token``) ne peut pas etre mise a jour. Si ``token`` est specifie dans le corps de la requete,
-   il est ignore et la valeur existante est conservee.
+   La chaîne du jeton (``token``) ne peut pas être mise à jour. Si ``token`` est spécifié dans le corps de la requête,
+   il est ignoré et la valeur existante est conservée.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -281,17 +281,17 @@ Reponse
       }
     }
 
-Suppression d'un jeton d'acces
+Suppression d'un jeton d'accès
 ==============================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/accesstoken/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -305,7 +305,7 @@ Reponse
 Exemples d'utilisation
 ======================
 
-Creation d'un jeton API
+Création d'un jeton API
 -----------------------
 
 .. code-block:: bash
@@ -321,7 +321,7 @@ Creation d'un jeton API
 Appel API utilisant un jeton
 ----------------------------
 
-Le jeton cree est utilise pour l'authentification lors d'appels a l'API de recherche ou a d'autres APIs.
+Le jeton créé est utilisé pour l'authentification lors d'appels à l'API de recherche ou à d'autres APIs.
 
 .. code-block:: bash
 
@@ -332,9 +332,9 @@ Le jeton cree est utilise pour l'authentification lors d'appels a l'API de reche
     # Utiliser le jeton comme parametre de requete (necessite la configuration de api.access.token.request.parameter)
     curl "http://localhost:8080/api/v2/search?q=test&token=your_token_here"
 
-Informations complementaires
+Informations complémentaires
 ============================
 
-- :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin (authentification, format des reponses, erreurs)
+- :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin (authentification, format des réponses, erreurs)
 - :doc:`../api-search` - API de recherche
-- :doc:`../../admin/accesstoken-guide` - Guide de gestion des jetons d'acces
+- :doc:`../../admin/accesstoken-guide` - Guide de gestion des jetons d'accès

--- a/fr/15.8/api/admin/api-admin-badword.rst
+++ b/fr/15.8/api/admin/api-admin-badword.rst
@@ -5,8 +5,8 @@ API BadWord
 Vue d'ensemble
 ==============
 
-L'API BadWord permet de gerer les mots interdits (exclusion de mots inappropries des suggestions) dans |Fess|.
-Vous pouvez configurer les mots-cles que vous ne souhaitez pas afficher dans la fonction de suggestion.
+L'API BadWord permet de gérer les mots interdits (exclusion de mots inappropriés des suggestions) dans |Fess|.
+Vous pouvez configurer les mots-clés que vous ne souhaitez pas afficher dans la fonction de suggestion.
 
 URL de base
 ===========
@@ -22,7 +22,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
@@ -33,55 +33,55 @@ Liste des endpoints
      - Obtention d'un mot interdit
    * - POST
      - /setting
-     - Creation d'un mot interdit
+     - Création d'un mot interdit
    * - PUT
      - /setting
-     - Mise a jour d'un mot interdit
+     - Mise à jour d'un mot interdit
    * - DELETE
      - /setting/{id}
      - Suppression d'un mot interdit
    * - PUT
      - /upload
-     - Televersement CSV des mots interdits
+     - Téléversement CSV des mots interdits
    * - GET
      - /download
-     - Telechargement CSV des mots interdits
+     - Téléchargement CSV des mots interdits
 
 Obtention de la liste des mots interdits
 ========================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/badword/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 20)
+     - Nombre d'éléments par page (par défaut : 20)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1, par defaut : 1)
+     - Numéro de page (commence à 1, par défaut : 1)
    * - ``id``
      - String
      - Non
-     - Filtrer uniquement sur le mot interdit ayant l'ID specifie
+     - Filtrer uniquement sur le mot interdit ayant l'ID spécifié
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -102,14 +102,14 @@ Reponse
 Obtention d'un mot interdit
 ===========================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/badword/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -124,10 +124,10 @@ Reponse
       }
     }
 
-Creation d'un mot interdit
+Création d'un mot interdit
 ==========================
 
-Requete
+Requête
 -------
 
 ::
@@ -135,7 +135,7 @@ Requete
     POST /api/admin/badword/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -156,9 +156,9 @@ Description des champs
      - Description
    * - ``suggestWord``
      - Oui
-     - Mot-cle a exclure (ne peut pas contenir d'espaces)
+     - Mot-clé à exclure (ne peut pas contenir d'espaces)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -171,10 +171,10 @@ Reponse
       }
     }
 
-Mise a jour d'un mot interdit
+Mise à jour d'un mot interdit
 =============================
 
-Requete
+Requête
 -------
 
 ::
@@ -182,7 +182,7 @@ Requete
     PUT /api/admin/badword/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -193,7 +193,7 @@ Corps de la requete
       "versionNo": 1
     }
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -209,14 +209,14 @@ Reponse
 Suppression d'un mot interdit
 =============================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/badword/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -229,12 +229,12 @@ Reponse
       }
     }
 
-Televersement CSV des mots interdits
+Téléversement CSV des mots interdits
 ====================================
 
-Enregistre en masse des mots interdits depuis un fichier CSV. Le fichier est envoye en ``multipart/form-data``. L'import est execute de maniere asynchrone cote serveur.
+Enregistre en masse des mots interdits depuis un fichier CSV. Le fichier est envoyé en ``multipart/form-data``. L'import est exécuté de manière asynchrone côté serveur.
 
-Requete
+Requête
 -------
 
 ::
@@ -242,35 +242,35 @@ Requete
     PUT /api/admin/badword/upload
     Content-Type: multipart/form-data
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``badWordFile``
      - Oui
-     - Fichier CSV des mots interdits a televerser
+     - Fichier CSV des mots interdits à téléverser
 
 Format CSV
 ~~~~~~~~~~
 
-- La premiere ligne est ignoree en tant que ligne d'en-tete (le nom de colonne est arbitraire ; ``BadWord`` est ecrit lors du telechargement).
-- A partir de la deuxieme ligne, ecrivez un mot interdit par ligne en tant que ``suggestWord``.
-- Les lignes dont la valeur est vide sont ignorees.
-- Prefixez un mot par ``--`` pour le supprimer (par exemple, ``--spam`` supprime ``spam``).
-- Specifier un mot deja enregistre est traite comme une mise a jour (l'auteur et la date de mise a jour sont reinitialises).
+- La première ligne est ignorée en tant que ligne d'en-tête (le nom de colonne est arbitraire ; ``BadWord`` est écrit lors du téléchargement).
+- À partir de la deuxième ligne, écrivez un mot interdit par ligne en tant que ``suggestWord``.
+- Les lignes dont la valeur est vide sont ignorées.
+- Préfixez un mot par ``--`` pour le supprimer (par exemple, ``--spam`` supprime ``spam``).
+- Spécifier un mot déjà enregistré est traité comme une mise à jour (l'auteur et la date de mise à jour sont réinitialisés).
 
 .. note::
 
-   Comme l'import s'execute de maniere asynchrone cote serveur, une reponse ``status: 0``
-   indique que la requete a ete acceptee, et non que l'import est termine.
+   Comme l'import s'exécute de manière asynchrone côté serveur, une réponse ``status: 0``
+   indique que la requête a été acceptée, et non que l'import est terminé.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -281,13 +281,13 @@ Reponse
       }
     }
 
-Telechargement CSV des mots interdits
+Téléchargement CSV des mots interdits
 =====================================
 
-Telecharge les mots interdits enregistres sous forme de fichier CSV (``badword.csv``). La reponse est un flux ``application/octet-stream``.
-Le CSV comporte une ligne d'en-tete ``BadWord`` sur la premiere ligne, suivie d'un mot interdit enregistre par ligne.
+Télécharge les mots interdits enregistrés sous forme de fichier CSV (``badword.csv``). La réponse est un flux ``application/octet-stream``.
+Le CSV comporte une ligne d'en-tête ``BadWord`` sur la première ligne, suivie d'un mot interdit enregistré par ligne.
 
-Requete
+Requête
 -------
 
 ::
@@ -297,7 +297,7 @@ Requete
 Exemples d'utilisation
 ======================
 
-Exclusion d'un mot-cle spam
+Exclusion d'un mot-clé spam
 ---------------------------
 
 .. code-block:: bash
@@ -309,7 +309,7 @@ Exclusion d'un mot-cle spam
            "suggestWord": "spam"
          }'
 
-Televersement d'un fichier CSV
+Téléversement d'un fichier CSV
 ------------------------------
 
 .. code-block:: bash
@@ -318,7 +318,7 @@ Televersement d'un fichier CSV
          -H "Authorization: Bearer YOUR_TOKEN" \
          -F "badWordFile=@badword.csv"
 
-Telechargement d'un fichier CSV
+Téléchargement d'un fichier CSV
 -------------------------------
 
 .. code-block:: bash
@@ -327,7 +327,7 @@ Telechargement d'un fichier CSV
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o badword.csv
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.8/api/admin/api-admin-crawlinginfo.rst
+++ b/fr/15.8/api/admin/api-admin-crawlinginfo.rst
@@ -5,7 +5,7 @@ API CrawlingInfo
 Vue d'ensemble
 ==============
 
-L'API CrawlingInfo permet de consulter et de gerer les informations de crawl (sessions de crawl) de |Fess|.
+L'API CrawlingInfo permet de consulter et de gérer les informations de crawl (sessions de crawl) de |Fess|.
 Vous pouvez obtenir la liste des sessions de crawl, les consulter individuellement, les supprimer, etc.
 
 URL de base
@@ -22,7 +22,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
@@ -36,43 +36,43 @@ Liste des endpoints
      - Suppression d'une information de crawl
    * - DELETE
      - /all
-     - Suppression groupee des sessions de crawl (hors sessions en cours)
+     - Suppression groupée des sessions de crawl (hors sessions en cours)
 
 Obtention de la liste des informations de crawl
 ===============================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/crawlinginfo/logs
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (defaut : 20)
+     - Nombre d'éléments par page (défaut : 20)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (base 1, defaut : 1)
+     - Numéro de page (base 1, défaut : 1)
    * - ``sessionId``
      - String
      - Non
      - Filtre par ID de session (correspondance partielle)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -100,7 +100,7 @@ Reponse
       }
     }
 
-Champs de la reponse
+Champs de la réponse
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -116,27 +116,27 @@ Champs de la reponse
    * - ``name``
      - Nom de la session
    * - ``expiredTime``
-     - Date d'expiration (millisecondes epoch ; retournee sous forme de chaine)
+     - Date d'expiration (millisecondes epoch ; retournée sous forme de chaîne)
    * - ``createdTime``
-     - Heure de creation (millisecondes epoch ; retournee sous forme de nombre)
+     - Heure de création (millisecondes epoch ; retournée sous forme de nombre)
 
 .. note::
 
-   Chaque objet de journal dans la reponse inclut egalement un champ interne ``crudMode``
-   (un entier indiquant le mode d'operation CRUD, toujours ``0`` pour les operations de lecture).
-   Les clients peuvent l'ignorer en toute securite.
+   Chaque objet de journal dans la réponse inclut également un champ interne ``crudMode``
+   (un entier indiquant le mode d'opération CRUD, toujours ``0`` pour les opérations de lecture).
+   Les clients peuvent l'ignorer en toute sécurité.
 
 Obtention d'une information de crawl
 ====================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/crawlinginfo/log/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -157,14 +157,14 @@ Reponse
 Suppression d'une information de crawl
 ======================================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/crawlinginfo/log/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -175,19 +175,19 @@ Reponse
       }
     }
 
-Suppression groupee des sessions de crawl
+Suppression groupée des sessions de crawl
 ==========================================
 
-Supprime toutes les sessions de crawl (ainsi que leurs donnees de parametres), a l'exception de celles qui sont actuellement en cours d'execution. Il n'y a pas de seuil d'age ou de duree ; toute session qui n'est pas en cours d'execution est supprimee.
+Supprime toutes les sessions de crawl (ainsi que leurs données de paramètres), à l'exception de celles qui sont actuellement en cours d'exécution. Il n'y a pas de seuil d'âge ou de durée ; toute session qui n'est pas en cours d'exécution est supprimée.
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/crawlinginfo/all
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -209,7 +209,7 @@ Obtention de la liste des informations de crawl
     curl -X GET "http://localhost:8080/api/admin/crawlinginfo/logs?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Filtrage par session specifique
+Filtrage par session spécifique
 -------------------------------
 
 .. code-block:: bash
@@ -233,7 +233,7 @@ Suppression d'une information de crawl
     curl -X DELETE "http://localhost:8080/api/admin/crawlinginfo/log/crawling_info_id_1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Suppression groupee des sessions
+Suppression groupée des sessions
 --------------------------------
 
 .. code-block:: bash
@@ -241,10 +241,10 @@ Suppression groupee des sessions
     curl -X DELETE "http://localhost:8080/api/admin/crawlinginfo/all" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
-- :doc:`api-admin-failureurl` - API des URLs en echec
-- :doc:`api-admin-joblog` - API des journaux de taches
+- :doc:`api-admin-failureurl` - API des URLs en échec
+- :doc:`api-admin-joblog` - API des journaux de tâches
 - :doc:`../../admin/crawlinginfo-guide` - Guide des informations de crawl

--- a/fr/15.8/api/admin/api-admin-dataconfig.rst
+++ b/fr/15.8/api/admin/api-admin-dataconfig.rst
@@ -5,8 +5,8 @@ API DataConfig
 Vue d'ensemble
 ==============
 
-L'API DataConfig permet de gerer les configurations de datastore de |Fess|.
-Vous pouvez manipuler les configurations de crawl pour les bases de donnees, les fichiers CSV, JSON et autres sources de donnees.
+L'API DataConfig permet de gérer les configurations de datastore de |Fess|.
+Vous pouvez manipuler les configurations de crawl pour les bases de données, les fichiers CSV, JSON et autres sources de données.
 
 URL de base
 ===========
@@ -22,7 +22,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
@@ -33,10 +33,10 @@ Liste des endpoints
      - Obtention d'une configuration datastore
    * - POST
      - /setting
-     - Creation d'une configuration datastore
+     - Création d'une configuration datastore
    * - PUT
      - /setting
-     - Mise a jour d'une configuration datastore
+     - Mise à jour d'une configuration datastore
    * - DELETE
      - /setting/{id}
      - Suppression d'une configuration datastore
@@ -44,32 +44,32 @@ Liste des endpoints
 Obtention de la liste des configurations datastore
 ==================================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/dataconfig/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 25)
+     - Nombre d'éléments par page (par défaut : 25)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1, par defaut : 1)
+     - Numéro de page (commence à 1, par défaut : 1)
    * - ``name``
      - String
      - Non
@@ -83,7 +83,7 @@ Parametres
      - Non
      - Filtrer par description
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -95,7 +95,7 @@ Reponse
           {
             "id": "dataconfig_id_1",
             "name": "Database Crawler",
-            "description": "Crawler de base de donnees",
+            "description": "Crawler de base de données",
             "handlerName": "DatabaseDataStore",
             "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/mydb",
             "handlerScript": "...",
@@ -113,14 +113,14 @@ Reponse
 Obtention d'une configuration datastore
 =======================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/dataconfig/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -131,7 +131,7 @@ Reponse
         "setting": {
           "id": "dataconfig_id_1",
           "name": "Database Crawler",
-          "description": "Crawler de base de donnees",
+          "description": "Crawler de base de données",
           "handlerName": "DatabaseDataStore",
           "handlerParameter": "driver=org.postgresql.Driver\nurl=jdbc:postgresql://localhost/mydb\nusername=dbuser\npassword=dbpass",
           "handlerScript": "...",
@@ -144,10 +144,10 @@ Reponse
       }
     }
 
-Creation d'une configuration datastore
+Création d'une configuration datastore
 ======================================
 
-Requete
+Requête
 -------
 
 ::
@@ -155,7 +155,7 @@ Requete
     POST /api/admin/dataconfig/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -192,27 +192,27 @@ Description des champs
      - Nom du gestionnaire de datastore
    * - ``handlerParameter``
      - Non
-     - Parametres du gestionnaire (informations de connexion, etc.)
+     - Paramètres du gestionnaire (informations de connexion, etc.)
    * - ``handlerScript``
      - Non
-     - Script de transformation des donnees
+     - Script de transformation des données
    * - ``boost``
      - Oui
-     - Valeur de boost des resultats de recherche
+     - Valeur de boost des résultats de recherche
    * - ``available``
      - Oui
-     - Active/Desactive (chaine ``"true"`` / ``"false"``)
+     - Activé/Désactivé (chaîne ``"true"`` / ``"false"``)
    * - ``sortOrder``
      - Oui
      - Ordre d'affichage
    * - ``permissions``
      - Non
-     - Roles autorises (separes par des sauts de ligne si plusieurs)
+     - Rôles autorisés (séparés par des sauts de ligne si plusieurs)
    * - ``virtualHosts``
      - Non
-     - Hotes virtuels (separes par des sauts de ligne si plusieurs)
+     - Hôtes virtuels (séparés par des sauts de ligne si plusieurs)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -225,10 +225,10 @@ Reponse
       }
     }
 
-Mise a jour d'une configuration datastore
+Mise à jour d'une configuration datastore
 =========================================
 
-Requete
+Requête
 -------
 
 ::
@@ -236,7 +236,7 @@ Requete
     PUT /api/admin/dataconfig/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -253,7 +253,7 @@ Corps de la requete
       "versionNo": 1
     }
 
-Les requetes de mise a jour necessitent les memes champs obligatoires que la creation (``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``), ainsi que les champs suivants :
+Les requêtes de mise a jour nécessitent les mêmes champs obligatoires que la création (``name``, ``handlerName``, ``boost``, ``available``, ``sortOrder``), ainsi que les champs suivants :
 
 .. list-table::
    :header-rows: 1
@@ -264,12 +264,12 @@ Les requetes de mise a jour necessitent les memes champs obligatoires que la cre
      - Description
    * - ``id``
      - Oui
-     - ID de la configuration a mettre a jour
+     - ID de la configuration à mettre à jour
    * - ``versionNo``
      - Oui
-     - Numero de version pour le verrouillage optimiste (indiquer la valeur obtenue lors de la recuperation du parametre)
+     - Numéro de version pour le verrouillage optimiste (indiquer la valeur obtenue lors de la récupération du paramètre)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -285,14 +285,14 @@ Reponse
 Suppression d'une configuration datastore
 =========================================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/dataconfig/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -313,24 +313,24 @@ Types de gestionnaires
    * - Nom du gestionnaire
      - Description
    * - ``DatabaseDataStore``
-     - Connexion a une base de donnees via JDBC
+     - Connexion à une base de données via JDBC
    * - ``CsvDataStore``
-     - Lecture des donnees depuis un fichier CSV (traitement de chaque ligne comme un document)
+     - Lecture des données depuis un fichier CSV (traitement de chaque ligne comme un document)
    * - ``CsvListDataStore``
-     - Lecture des fichiers CSV avec suppression automatique des fichiers traites (extension de ``CsvDataStore`` avec filtrage par horodatage)
+     - Lecture des fichiers CSV avec suppression automatique des fichiers traités (extension de ``CsvDataStore`` avec filtrage par horodatage)
    * - ``JsonDataStore``
-     - Lecture des donnees depuis un fichier JSON ou une API JSON
+     - Lecture des données depuis un fichier JSON ou une API JSON
 
 .. note::
 
-   Les types de gestionnaires disponibles dependent des plugins de datastore installes.
-   Les gestionnaires ci-dessus sont inclus par defaut. L'installation de plugins de datastore
+   Les types de gestionnaires disponibles dépendent des plugins de datastore installés.
+   Les gestionnaires ci-dessus sont inclus par défaut. L'installation de plugins de datastore
    tels que SharePoint, Slack ou Salesforce rend disponibles leurs noms de gestionnaire respectifs.
 
 Exemples d'utilisation
 ======================
 
-Configuration de crawl de base de donnees
+Configuration de crawl de base de données
 -----------------------------------------
 
 .. code-block:: bash
@@ -348,7 +348,7 @@ Configuration de crawl de base de donnees
            "sortOrder": 0
          }'
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.8/api/admin/api-admin-dict.rst
+++ b/fr/15.8/api/admin/api-admin-dict.rst
@@ -5,9 +5,9 @@ API Dict
 Vue d'ensemble
 ==============
 
-L'API Dict est une API permettant de gerer les dictionnaires de |Fess|.
+L'API Dict est une API permettant de gérer les dictionnaires de |Fess|.
 L'endpoint racine permet d'obtenir la liste des dictionnaires disponibles.
-La consultation, la creation, la mise a jour et la suppression des entrees de dictionnaire individuelles, ainsi que le televersement et le telechargement des fichiers de dictionnaire, s'effectuent via les sous-endpoints propres a chaque type de dictionnaire (synonym, kuromoji, mapping, protwords, stopwords, stemmeroverride).
+La consultation, la création, la mise à jour et la suppression des entrées de dictionnaire individuelles, ainsi que le téléversement et le téléchargement des fichiers de dictionnaire, s'effectuent via les sous-endpoints propres à chaque type de dictionnaire (synonym, kuromoji, mapping, protwords, stopwords, stemmeroverride).
 
 URL de base
 ===========
@@ -33,11 +33,11 @@ Racine des dictionnaires
      - /
      - Obtention de la liste des dictionnaires
 
-Endpoints propres a chaque type de dictionnaire
+Endpoints propres à chaque type de dictionnaire
 -----------------------------------------------
 
-``{type}`` doit etre l'une des valeurs suivantes : ``synonym`` , ``kuromoji`` , ``mapping`` , ``protwords`` , ``stopwords`` , ``stemmeroverride`` .
-Ces valeurs correspondent a la valeur du champ ``type`` inclus dans la reponse de la liste des dictionnaires.
+``{type}`` doit être l'une des valeurs suivantes : ``synonym`` , ``kuromoji`` , ``mapping`` , ``protwords`` , ``stopwords`` , ``stemmeroverride`` .
+Ces valeurs correspondent à la valeur du champ ``type`` inclus dans la réponse de la liste des dictionnaires.
 ``{dictId}`` est l'ID du dictionnaire obtenu via l'obtention de la liste des dictionnaires.
 
 .. list-table::
@@ -49,39 +49,39 @@ Ces valeurs correspondent a la valeur du champ ``type`` inclus dans la reponse d
      - Description
    * - GET
      - /{type}/settings/{dictId}
-     - Obtention de la liste des entrees de dictionnaire
+     - Obtention de la liste des entrées de dictionnaire
    * - GET
      - /{type}/setting/{dictId}/{id}
-     - Obtention d'une entree de dictionnaire
+     - Obtention d'une entrée de dictionnaire
    * - POST
      - /{type}/setting/{dictId}
-     - Creation d'une entree de dictionnaire
+     - Création d'une entrée de dictionnaire
    * - PUT
      - /{type}/setting/{dictId}
-     - Mise a jour d'une entree de dictionnaire
+     - Mise à jour d'une entrée de dictionnaire
    * - DELETE
      - /{type}/setting/{dictId}/{id}
-     - Suppression d'une entree de dictionnaire
+     - Suppression d'une entrée de dictionnaire
    * - PUT
      - /{type}/upload/{dictId}
-     - Televersement d'un fichier de dictionnaire
+     - Téléversement d'un fichier de dictionnaire
    * - GET
      - /{type}/download/{dictId}
-     - Telechargement d'un fichier de dictionnaire
+     - Téléchargement d'un fichier de dictionnaire
 
 Obtention de la liste des dictionnaires
 =======================================
 
 Obtient la liste des fichiers de dictionnaire disponibles.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/dict
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -108,7 +108,7 @@ Reponse
       }
     }
 
-Champs de la reponse
+Champs de la réponse
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -118,56 +118,56 @@ Champs de la reponse
    * - Champ
      - Description
    * - ``settings[].id``
-     - ID du dictionnaire (utilise comme ``{dictId}`` dans les operations sur les dictionnaires individuels)
+     - ID du dictionnaire (utilisé comme ``{dictId}`` dans les opérations sur les dictionnaires individuels)
    * - ``settings[].type``
      - Type de dictionnaire
    * - ``settings[].path``
      - Chemin du fichier de dictionnaire
    * - ``settings[].timestamp``
-     - Date et heure de mise a jour du fichier de dictionnaire
+     - Date et heure de mise à jour du fichier de dictionnaire
    * - ``total``
      - Nombre total de fichiers de dictionnaire
 
-Obtention de la liste des entrees de dictionnaire
+Obtention de la liste des entrées de dictionnaire
 =================================================
 
-Obtient la liste des entrees du dictionnaire specifie.
+Obtient la liste des entrées du dictionnaire spécifié.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/dict/{type}/settings/{dictId}
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``dictId``
      - String
      - Oui
-     - ID du dictionnaire (parametre de chemin)
+     - ID du dictionnaire (paramètre de chemin)
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (defaut : 25)
+     - Nombre d'éléments par page (défaut : 25)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1, defaut : 1)
+     - Numéro de page (commence à 1, défaut : 1)
 
-Reponse
+Réponse
 -------
 
-Les champs de chaque element du tableau ``settings`` de la reponse varient selon le type de dictionnaire (voir « Champs des entrees par type de dictionnaire » ci-dessous).
+Les champs de chaque élément du tableau ``settings`` de la réponse varient selon le type de dictionnaire (voir « Champs des entrées par type de dictionnaire » ci-dessous).
 
 .. code-block:: json
 
@@ -189,39 +189,39 @@ Les champs de chaque element du tableau ``settings`` de la reponse varient selon
 
 L'exemple ci-dessus correspond au dictionnaire ``synonym``.
 
-Obtention d'une entree de dictionnaire
+Obtention d'une entrée de dictionnaire
 ======================================
 
-Obtient une entree specifique du dictionnaire.
+Obtient une entrée spécifique du dictionnaire.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/dict/{type}/setting/{dictId}/{id}
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``dictId``
      - String
      - Oui
-     - ID du dictionnaire (parametre de chemin)
+     - ID du dictionnaire (paramètre de chemin)
    * - ``id``
      - Long
      - Oui
-     - ID de l'entree (parametre de chemin)
+     - ID de l'entrée (paramètre de chemin)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -239,12 +239,12 @@ Reponse
       }
     }
 
-Creation d'une entree de dictionnaire
+Création d'une entrée de dictionnaire
 =====================================
 
-Cree une nouvelle entree dans le dictionnaire.
+Crée une nouvelle entrée dans le dictionnaire.
 
-Requete
+Requête
 -------
 
 ::
@@ -252,7 +252,7 @@ Requete
     POST /api/admin/dict/{type}/setting/{dictId}
     Content-Type: application/json
 
-Corps de la requete (exemple synonym)
+Corps de la requête (exemple synonym)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -262,7 +262,7 @@ Corps de la requete (exemple synonym)
       "outputs": "検索,サーチ,リサーチ"
     }
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -276,12 +276,12 @@ Reponse
       }
     }
 
-Mise a jour d'une entree de dictionnaire
+Mise à jour d'une entrée de dictionnaire
 ========================================
 
-Met a jour une entree existante du dictionnaire.
+Met à jour une entrée existante du dictionnaire.
 
-Requete
+Requête
 -------
 
 ::
@@ -289,7 +289,7 @@ Requete
     PUT /api/admin/dict/{type}/setting/{dictId}
     Content-Type: application/json
 
-Corps de la requete (exemple synonym)
+Corps de la requête (exemple synonym)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -300,7 +300,7 @@ Corps de la requete (exemple synonym)
       "outputs": "検索,サーチ,リサーチ,search"
     }
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -314,39 +314,39 @@ Reponse
       }
     }
 
-Suppression d'une entree de dictionnaire
+Suppression d'une entrée de dictionnaire
 ========================================
 
-Supprime une entree du dictionnaire.
+Supprime une entrée du dictionnaire.
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/dict/{type}/setting/{dictId}/{id}
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``dictId``
      - String
      - Oui
-     - ID du dictionnaire (parametre de chemin)
+     - ID du dictionnaire (paramètre de chemin)
    * - ``id``
      - Long
      - Oui
-     - ID de l'entree (parametre de chemin)
+     - ID de l'entrée (paramètre de chemin)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -360,12 +360,12 @@ Reponse
       }
     }
 
-Televersement d'un fichier de dictionnaire
+Téléversement d'un fichier de dictionnaire
 ==========================================
 
-Televerse et remplace l'integralite du fichier de dictionnaire.
+Téléverse et remplace l'intégralité du fichier de dictionnaire.
 
-Requete
+Requête
 -------
 
 ::
@@ -373,9 +373,9 @@ Requete
     PUT /api/admin/dict/{type}/upload/{dictId}
     Content-Type: multipart/form-data
 
-Le nom du champ de fichier varie selon le type de dictionnaire (voir « Champs des entrees par type de dictionnaire » ci-dessous).
+Le nom du champ de fichier varie selon le type de dictionnaire (voir « Champs des entrées par type de dictionnaire » ci-dessous).
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -387,33 +387,33 @@ Reponse
       }
     }
 
-Telechargement d'un fichier de dictionnaire
+Téléchargement d'un fichier de dictionnaire
 ===========================================
 
-Telecharge le fichier de dictionnaire.
+Télécharge le fichier de dictionnaire.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/dict/{type}/download/{dictId}
 
-La reponse est le binaire du fichier de dictionnaire ( ``application/octet-stream`` ).
+La réponse est le binaire du fichier de dictionnaire ( ``application/octet-stream`` ).
 
-Champs des entrees par type de dictionnaire
+Champs des entrées par type de dictionnaire
 ===========================================
 
-Les champs du corps de requete de creation/mise a jour d'une entree de dictionnaire ainsi que ceux de la reponse varient selon le type de dictionnaire.
-``id`` (ID de l'entree) et ``dictId`` (ID du dictionnaire) sont inclus de maniere commune dans la reponse.
+Les champs du corps de requête de création/mise à jour d'une entrée de dictionnaire ainsi que ceux de la réponse varient selon le type de dictionnaire.
+``id`` (ID de l'entrée) et ``dictId`` (ID du dictionnaire) sont inclus de manière commune dans la réponse.
 
 .. list-table::
    :header-rows: 1
    :widths: 18 42 40
 
    * - Type
-     - Champs de l'entree
-     - Champ du fichier televerse
+     - Champs de l'entrée
+     - Champ du fichier téléversé
    * - ``synonym``
      - ``inputs`` (requis), ``outputs`` (requis)
      - ``synonymFile``
@@ -444,7 +444,7 @@ Obtention de la liste des dictionnaires
     curl -X GET "http://localhost:8080/api/admin/dict" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Obtention de la liste des entrees du dictionnaire de synonymes
+Obtention de la liste des entrées du dictionnaire de synonymes
 --------------------------------------------------------------
 
 .. code-block:: bash
@@ -452,7 +452,7 @@ Obtention de la liste des entrees du dictionnaire de synonymes
     curl -X GET "http://localhost:8080/api/admin/dict/synonym/settings/{dictId}" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Ajout d'une entree au dictionnaire de synonymes
+Ajout d'une entrée au dictionnaire de synonymes
 -----------------------------------------------
 
 .. code-block:: bash
@@ -465,7 +465,7 @@ Ajout d'une entree au dictionnaire de synonymes
            "outputs": "検索,サーチ,リサーチ"
          }'
 
-Televersement du fichier de dictionnaire de synonymes
+Téléversement du fichier de dictionnaire de synonymes
 -----------------------------------------------------
 
 .. code-block:: bash
@@ -474,7 +474,7 @@ Televersement du fichier de dictionnaire de synonymes
          -H "Authorization: Bearer YOUR_TOKEN" \
          -F "synonymFile=@synonym.txt"
 
-Telechargement du fichier de dictionnaire de synonymes
+Téléchargement du fichier de dictionnaire de synonymes
 ------------------------------------------------------
 
 .. code-block:: bash
@@ -483,7 +483,7 @@ Telechargement du fichier de dictionnaire de synonymes
          -H "Authorization: Bearer YOUR_TOKEN" \
          -o synonym.txt
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.8/api/admin/api-admin-failureurl.rst
+++ b/fr/15.8/api/admin/api-admin-failureurl.rst
@@ -5,8 +5,8 @@ API FailureUrl
 Vue d'ensemble
 ==============
 
-L'API FailureUrl permet de gerer les URLs en echec lors du crawl de |Fess|.
-Vous pouvez obtenir la liste des URLs ayant provoque une erreur pendant le crawl, les consulter individuellement, les supprimer, etc.
+L'API FailureUrl permet de gérer les URLs en échec lors du crawl de |Fess|.
+Vous pouvez obtenir la liste des URLs ayant provoqué une erreur pendant le crawl, les consulter individuellement, les supprimer, etc.
 
 URL de base
 ===========
@@ -22,69 +22,69 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /logs
-     - Obtention de la liste des URLs en echec
+     - Obtention de la liste des URLs en échec
    * - GET
      - /log/{id}
-     - Obtention d'une URL en echec
+     - Obtention d'une URL en échec
    * - DELETE
      - /log/{id}
-     - Suppression d'une URL en echec
+     - Suppression d'une URL en échec
    * - DELETE
      - /all
-     - Suppression de toutes les URLs en echec
+     - Suppression de toutes les URLs en échec
 
-Obtention de la liste des URLs en echec
+Obtention de la liste des URLs en échec
 =======================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/failureurl/logs
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (defaut : 20)
+     - Nombre d'éléments par page (défaut : 20)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1, defaut : 1)
+     - Numéro de page (commence à 1, défaut : 1)
    * - ``url``
      - String
      - Non
-     - Filtre par URL (les caracteres generiques ``*`` ``?`` sont supportes)
+     - Filtre par URL (les caractères génériques ``*`` ``?`` sont supportés)
    * - ``errorCountMin``
      - Integer
      - Non
-     - Borne inferieure du nombre d'erreurs (superieur ou egal a la valeur specifiee)
+     - Borne inférieure du nombre d'erreurs (supérieur ou égal à la valeur spécifiée)
    * - ``errorCountMax``
      - Integer
      - Non
-     - Borne superieure du nombre d'erreurs (inferieur ou egal a la valeur specifiee)
+     - Borne supérieure du nombre d'erreurs (inférieur ou égal à la valeur spécifiée)
    * - ``errorName``
      - String
      - Non
-     - Filtre par nom d'erreur (correspondance avec caracteres generiques sur le nom de classe complet stocke ; ``*`` ``?`` supportes)
+     - Filtre par nom d'erreur (correspondance avec caractères génériques sur le nom de classe complet stocké ; ``*`` ``?`` supportés)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -118,7 +118,7 @@ Reponse
       }
     }
 
-Champs de la reponse
+Champs de la réponse
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -128,9 +128,9 @@ Champs de la reponse
    * - Champ
      - Description
    * - ``id``
-     - ID de l'URL en echec
+     - ID de l'URL en échec
    * - ``url``
-     - URL en echec
+     - URL en échec
    * - ``threadName``
      - Nom du thread
    * - ``errorName``
@@ -138,27 +138,27 @@ Champs de la reponse
    * - ``errorLog``
      - Journal d'erreur (message de l'exception ou trace de la pile)
    * - ``errorCount``
-     - Nombre d'occurrences de l'erreur (valeur numerique sous forme de chaine)
+     - Nombre d'occurrences de l'erreur (valeur numérique sous forme de chaîne)
    * - ``lastAccessTime``
-     - Heure du dernier acces (millisecondes epoch sous forme de chaine)
+     - Heure du dernier accès (millisecondes epoch sous forme de chaîne)
    * - ``configId``
      - ID de la configuration de crawl
 
 .. note::
 
-   Tous les champs de la reponse sont retournes sous forme de chaines (JSON string). ``errorCount`` est une valeur numerique representee sous forme de chaine, et ``lastAccessTime`` est le nombre de millisecondes epoch represente sous forme de chaine.
+   Tous les champs de la réponse sont retournés sous forme de chaînes (JSON string). ``errorCount`` est une valeur numérique représentée sous forme de chaîne, et ``lastAccessTime`` est le nombre de millisecondes epoch représenté sous forme de chaîne.
 
-Obtention d'une URL en echec
+Obtention d'une URL en échec
 ============================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/failureurl/log/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -179,17 +179,17 @@ Reponse
       }
     }
 
-Suppression d'une URL en echec
+Suppression d'une URL en échec
 ==============================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/failureurl/log/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -200,19 +200,19 @@ Reponse
       }
     }
 
-Suppression de toutes les URLs en echec
+Suppression de toutes les URLs en échec
 =======================================
 
-Supprime toutes les URLs en echec. Cette operation ne prend aucun parametre.
+Supprime toutes les URLs en échec. Cette opération ne prend aucun paramètre.
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/failureurl/all
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -226,7 +226,7 @@ Reponse
 Types d'erreurs
 ===============
 
-``errorName`` contient le nom de classe complet de l'exception survenue pendant le crawl, tel qu'il a ete capture. Il ne s'agit pas d'une enumeration fixe ; tout nom de classe peut apparaitre selon l'exception levee. Voici quelques exemples representatifs.
+``errorName`` contient le nom de classe complet de l'exception survenue pendant le crawl, tel qu'il a été capturé. Il ne s'agit pas d'une énumération fixe ; tout nom de classe peut apparaître selon l'exception levée. Voici quelques exemples représentatifs.
 
 .. list-table::
    :header-rows: 1
@@ -235,24 +235,24 @@ Types d'erreurs
    * - Nom de l'erreur (exemple)
      - Description
    * - ``java.net.ConnectException``
-     - Connexion refusee (impossible de se connecter au serveur)
+     - Connexion refusée (impossible de se connecter au serveur)
    * - ``java.net.UnknownHostException``
-     - Nom d'hote impossible a resoudre (erreur DNS)
+     - Nom d'hôte impossible à résoudre (erreur DNS)
    * - ``java.net.SocketTimeoutException``
-     - Delai de connexion ou de lecture depasse
+     - Délai de connexion ou de lecture dépassé
    * - ``javax.net.ssl.SSLException``
-     - Erreur de negociation SSL/TLS ou de certificat
+     - Erreur de négociation SSL/TLS ou de certificat
    * - ``java.io.IOException``
-     - Erreur d'entree/sortie
+     - Erreur d'entrée/sortie
    * - ``org.codelibs.fess.exception.ContentNotFoundException``
-     - URL ayant retourne un code de statut HTTP configure dans ``crawler.failure.url.status.codes`` (defaut : 403, 404, 410)
+     - URL ayant retourné un code de statut HTTP configuré dans ``crawler.failure.url.status.codes`` (défaut : 403, 404, 410)
    * - ``org.codelibs.fess.crawler.exception.MaxLengthExceededException``
-     - Le contenu a depasse la longueur maximale autorisee
+     - Le contenu a dépassé la longueur maximale autorisée
 
 Exemples d'utilisation
 ======================
 
-Obtention de la liste des URLs en echec
+Obtention de la liste des URLs en échec
 ---------------------------------------
 
 .. code-block:: bash
@@ -278,7 +278,7 @@ Filtrage par nom d'erreur
     curl -X GET "http://localhost:8080/api/admin/failureurl/logs?errorName=*ConnectException" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Obtention d'une URL en echec
+Obtention d'une URL en échec
 ----------------------------
 
 .. code-block:: bash
@@ -286,7 +286,7 @@ Obtention d'une URL en echec
     curl -X GET "http://localhost:8080/api/admin/failureurl/log/failure_id_1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Suppression d'une URL en echec
+Suppression d'une URL en échec
 ------------------------------
 
 .. code-block:: bash
@@ -294,7 +294,7 @@ Suppression d'une URL en echec
     curl -X DELETE "http://localhost:8080/api/admin/failureurl/log/failure_id_1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Suppression de toutes les URLs en echec
+Suppression de toutes les URLs en échec
 ---------------------------------------
 
 .. code-block:: bash
@@ -302,7 +302,7 @@ Suppression de toutes les URLs en echec
     curl -X DELETE "http://localhost:8080/api/admin/failureurl/all" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Agregation par type d'erreur
+Agrégation par type d'erreur
 ----------------------------
 
 .. code-block:: bash
@@ -312,10 +312,10 @@ Agregation par type d'erreur
          -H "Authorization: Bearer YOUR_TOKEN" | \
          jq '[.response.logs[].errorName] | group_by(.) | map({error: .[0], count: length})'
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
 - :doc:`api-admin-crawlinginfo` - API des informations de crawl
-- :doc:`api-admin-joblog` - API des journaux de taches
-- :doc:`../../admin/failureurl-guide` - Guide de gestion des URLs en echec
+- :doc:`api-admin-joblog` - API des journaux de tâches
+- :doc:`../../admin/failureurl-guide` - Guide de gestion des URLs en échec

--- a/fr/15.8/api/admin/api-admin-group.rst
+++ b/fr/15.8/api/admin/api-admin-group.rst
@@ -5,8 +5,8 @@ API Group
 Vue d'ensemble
 ==============
 
-L'API Group permet de gerer les groupes de |Fess|.
-Vous pouvez creer, mettre a jour et supprimer des groupes.
+L'API Group permet de gérer les groupes de |Fess|.
+Vous pouvez créer, mettre à jour et supprimer des groupes.
 
 URL de base
 ===========
@@ -22,7 +22,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
@@ -33,10 +33,10 @@ Liste des endpoints
      - Obtention d'un groupe
    * - POST
      - /setting
-     - Creation d'un groupe
+     - Création d'un groupe
    * - PUT
      - /setting
-     - Mise a jour d'un groupe
+     - Mise à jour d'un groupe
    * - DELETE
      - /setting/{id}
      - Suppression d'un groupe
@@ -44,38 +44,38 @@ Liste des endpoints
 Obtention de la liste des groupes
 =================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/group/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 25)
+     - Nombre d'éléments par page (par défaut : 25)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1, par defaut : 1)
+     - Numéro de page (commence à 1, par défaut : 1)
    * - ``id``
      - String
      - Non
-     - Filtre par correspondance exacte sur l'ID de groupe specifie
+     - Filtre par correspondance exacte sur l'ID de groupe spécifié
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -108,14 +108,14 @@ Reponse
 Obtention d'un groupe
 =====================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/group/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -134,10 +134,10 @@ Reponse
       }
     }
 
-Creation d'un groupe
+Création d'un groupe
 ====================
 
-Requete
+Requête
 -------
 
 ::
@@ -145,7 +145,7 @@ Requete
     POST /api/admin/group/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -169,12 +169,12 @@ Description des champs
      - Description
    * - ``name``
      - Oui
-     - Nom du groupe (maximum 100 caracteres)
+     - Nom du groupe (maximum 100 caractères)
    * - ``attributes``
      - Non
-     - Map d'attributs (contenant des attributs LDAP comme ``gidNumber``). Les valeurs sont specifiees sous forme de chaines de caracteres
+     - Map d'attributs (contenant des attributs LDAP comme ``gidNumber``). Les valeurs sont spécifiées sous forme de chaînes de caractères
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -187,10 +187,10 @@ Reponse
       }
     }
 
-Mise a jour d'un groupe
+Mise à jour d'un groupe
 =======================
 
-Requete
+Requête
 -------
 
 ::
@@ -198,7 +198,7 @@ Requete
     PUT /api/admin/group/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -224,18 +224,18 @@ Description des champs
      - Description
    * - ``id``
      - Oui
-     - ID du groupe a mettre a jour
+     - ID du groupe à mettre à jour
    * - ``name``
      - Oui
-     - Nom du groupe (maximum 100 caracteres)
+     - Nom du groupe (maximum 100 caractères)
    * - ``attributes``
      - Non
-     - Map d'attributs (contenant des attributs LDAP comme ``gidNumber``). Les valeurs sont specifiees sous forme de chaines de caracteres
+     - Map d'attributs (contenant des attributs LDAP comme ``gidNumber``). Les valeurs sont spécifiées sous forme de chaînes de caractères
    * - ``versionNo``
      - Oui
-     - Numero de version pour le verrouillage optimiste. Specifiez la valeur de ``versionNo`` obtenue lors de l'obtention du groupe
+     - Numéro de version pour le verrouillage optimiste. Spécifiez la valeur de ``versionNo`` obtenue lors de l'obtention du groupe
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -251,14 +251,14 @@ Reponse
 Suppression d'un groupe
 =======================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/group/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -274,7 +274,7 @@ Reponse
 Exemples d'utilisation
 ======================
 
-Creation d'un nouveau groupe
+Création d'un nouveau groupe
 ----------------------------
 
 .. code-block:: bash
@@ -297,10 +297,10 @@ Obtention de la liste des groupes
     curl -X GET "http://localhost:8080/api/admin/group/settings" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
 - :doc:`api-admin-user` - API de gestion des utilisateurs
-- :doc:`api-admin-role` - API de gestion des roles
+- :doc:`api-admin-role` - API de gestion des rôles
 - :doc:`../../admin/group-guide` - Guide de gestion des groupes

--- a/fr/15.8/api/admin/api-admin-joblog.rst
+++ b/fr/15.8/api/admin/api-admin-joblog.rst
@@ -5,8 +5,8 @@ API JobLog
 Vue d'ensemble
 ==============
 
-L'API JobLog permet de consulter et de gerer les journaux d'execution des taches de |Fess|.
-Vous pouvez obtenir l'historique d'execution des taches planifiees et des taches de crawl, les resultats d'execution, les informations d'erreur, et les supprimer.
+L'API JobLog permet de consulter et de gérer les journaux d'exécution des tâches de |Fess|.
+Vous pouvez obtenir l'historique d'exécution des tâches planifiées et des tâches de crawl, les résultats d'exécution, les informations d'erreur, et les supprimer.
 
 URL de base
 ===========
@@ -22,54 +22,54 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /logs
-     - Obtention de la liste des journaux de taches
+     - Obtention de la liste des journaux de tâches
    * - GET
      - /log/{id}
-     - Obtention d'un journal de tache
+     - Obtention d'un journal de tâche
    * - DELETE
      - /log/{id}
-     - Suppression d'un journal de tache
+     - Suppression d'un journal de tâche
 
-Obtention de la liste des journaux de taches
+Obtention de la liste des journaux de tâches
 ============================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/joblog/logs
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (defaut : 20)
+     - Nombre d'éléments par page (défaut : 20)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (base 1, defaut : 1)
+     - Numéro de page (base 1, défaut : 1)
    * - ``id``
      - String
      - Non
-     - Filtre par ID de journal de tache (correspondance exacte)
+     - Filtre par ID de journal de tâche (correspondance exacte)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -105,7 +105,7 @@ Reponse
       }
     }
 
-Champs de la reponse
+Champs de la réponse
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -115,41 +115,41 @@ Champs de la reponse
    * - Champ
      - Description
    * - ``id``
-     - ID du journal de tache
+     - ID du journal de tâche
    * - ``jobName``
-     - Nom de la tache
+     - Nom de la tâche
    * - ``jobStatus``
-     - Statut de la tache (``ok`` : succes, ``fail`` : echec, ``running`` : en cours d'execution)
+     - Statut de la tâche (``ok`` : succès, ``fail`` : échec, ``running`` : en cours d'exécution)
    * - ``target``
-     - Cible d'execution (nom de la cible du planificateur ; valeur par defaut : ``all``)
+     - Cible d'exécution (nom de la cible du planificateur ; valeur par défaut : ``all``)
    * - ``scriptType``
      - Type de script (ex. : ``groovy``)
    * - ``scriptData``
-     - Script execute
+     - Script exécuté
    * - ``scriptResult``
-     - Resultat d'execution
+     - Résultat d'exécution
    * - ``startTime``
-     - Heure de debut (millisecondes epoch ; retournee sous forme de chaine)
+     - Heure de début (millisecondes epoch ; retournée sous forme de chaîne)
    * - ``endTime``
-     - Heure de fin (millisecondes epoch ; retournee sous forme de chaine). Non retournee pour les taches en cours d'execution.
+     - Heure de fin (millisecondes epoch ; retournée sous forme de chaîne). Non retournée pour les tâches en cours d'exécution.
 
 .. note::
 
-   Chaque objet de journal dans la reponse inclut egalement un champ interne ``crudMode``
-   (un entier indiquant le mode d'operation CRUD, toujours ``0`` pour les operations de lecture).
-   Les clients peuvent l'ignorer en toute securite.
+   Chaque objet de journal dans la réponse inclut également un champ interne ``crudMode``
+   (un entier indiquant le mode d'opération CRUD, toujours ``0`` pour les opérations de lecture).
+   Les clients peuvent l'ignorer en toute sécurité.
 
-Obtention d'un journal de tache
+Obtention d'un journal de tâche
 ================================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/joblog/log/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -171,20 +171,20 @@ Reponse
       }
     }
 
-Si le journal de tache correspondant a l'ID specifie n'existe pas, une reponse d'erreur
-est retournee avec une valeur differente de 0 dans ``status``.
+Si le journal de tâche correspondant à l'ID spécifié n'existe pas, une réponse d'erreur
+est retournée avec une valeur différente de 0 dans ``status``.
 
-Suppression d'un journal de tache
+Suppression d'un journal de tâche
 ==================================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/joblog/log/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -195,13 +195,13 @@ Reponse
       }
     }
 
-Si le journal de tache correspondant a l'ID specifie n'existe pas, une reponse d'erreur
-est retournee avec une valeur differente de 0 dans ``status``.
+Si le journal de tâche correspondant à l'ID spécifié n'existe pas, une réponse d'erreur
+est retournée avec une valeur différente de 0 dans ``status``.
 
 Exemples d'utilisation
 ======================
 
-Obtention de la liste des journaux de taches
+Obtention de la liste des journaux de tâches
 --------------------------------------------
 
 .. code-block:: bash
@@ -209,7 +209,7 @@ Obtention de la liste des journaux de taches
     curl -X GET "http://localhost:8080/api/admin/joblog/logs?size=50&page=1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Extraction des taches en echec uniquement
+Extraction des tâches en échec uniquement
 -----------------------------------------
 
 .. code-block:: bash
@@ -219,7 +219,7 @@ Extraction des taches en echec uniquement
          -H "Authorization: Bearer YOUR_TOKEN" | \
          jq '.response.logs[] | select(.jobStatus=="fail")'
 
-Obtention d'un journal de tache
+Obtention d'un journal de tâche
 --------------------------------
 
 .. code-block:: bash
@@ -227,7 +227,7 @@ Obtention d'un journal de tache
     curl -X GET "http://localhost:8080/api/admin/joblog/log/joblog_id_1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Suppression d'un journal de tache
+Suppression d'un journal de tâche
 ----------------------------------
 
 .. code-block:: bash
@@ -235,7 +235,7 @@ Suppression d'un journal de tache
     curl -X DELETE "http://localhost:8080/api/admin/joblog/log/joblog_id_1" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Calcul du taux de reussite des taches
+Calcul du taux de réussite des tâches
 --------------------------------------
 
 .. code-block:: bash
@@ -244,10 +244,10 @@ Calcul du taux de reussite des taches
          -H "Authorization: Bearer YOUR_TOKEN" | \
          jq '.response.logs | {total: length, ok: [.[] | select(.jobStatus=="ok")] | length, fail: [.[] | select(.jobStatus=="fail")] | length}'
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
 - :doc:`api-admin-scheduler` - API du planificateur
 - :doc:`api-admin-crawlinginfo` - API des informations de crawl
-- :doc:`../../admin/joblog-guide` - Guide de gestion des journaux de taches
+- :doc:`../../admin/joblog-guide` - Guide de gestion des journaux de tâches

--- a/fr/15.8/api/admin/api-admin-relatedcontent.rst
+++ b/fr/15.8/api/admin/api-admin-relatedcontent.rst
@@ -5,8 +5,8 @@ RelatedContent API
 Vue d'ensemble
 ==============
 
-L'API RelatedContent est une API permettant de gerer les contenus associes dans |Fess|.
-Vous pouvez afficher des contenus personnalises associes a des mots-cles specifiques.
+L'API RelatedContent est une API permettant de gérer les contenus associés dans |Fess|.
+Vous pouvez afficher des contenus personnalisés associés à des mots-clés spécifiques.
 
 URL de base
 ===========
@@ -22,64 +22,64 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET
      - /settings
-     - Lister les contenus associes
+     - Lister les contenus associés
    * - GET
      - /setting/{id}
-     - Obtenir un contenu associe
+     - Obtenir un contenu associé
    * - POST
      - /setting
-     - Creer un contenu associe
+     - Creer un contenu associé
    * - PUT
      - /setting
-     - Mettre a jour un contenu associe
+     - Mettre à jour un contenu associé
    * - DELETE
      - /setting/{id}
-     - Supprimer un contenu associe
+     - Supprimer un contenu associé
 
-Lister les contenus associes
+Lister les contenus associés
 ============================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/relatedcontent/settings
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements par page (par defaut : 25 ; modifiable via ``paging.page.size`` du fichier ``fess_config.properties``)
+     - Nombre d'éléments par page (par défaut : 25 ; modifiable via ``paging.page.size`` du fichier ``fess_config.properties``)
    * - ``page``
      - Integer
      - Non
-     - Numero de page (commence a 1 ; par defaut : 1 ; une valeur inferieure ou egale a 0 est traitee comme 1)
+     - Numéro de page (commence à 1 ; par défaut : 1 ; une valeur inférieure ou égale à 0 est traitée comme 1)
    * - ``term``
      - String
      - Non
-     - Filtrer par mot-cle de recherche (recherche avec caracteres generiques)
+     - Filtrer par mot-clé de recherche (recherche avec caractères génériques)
    * - ``content``
      - String
      - Non
-     - Filtrer par contenu (recherche avec caracteres generiques)
+     - Filtrer par contenu (recherche avec caractères génériques)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -108,27 +108,27 @@ Reponse
 
 .. note::
 
-   Chaque element de ``settings`` ainsi que l'objet ``setting`` retourne par
-   l'endpoint d'obtention contiennent les champs de l'entite stockee tels quels.
+   Chaque élément de ``settings`` ainsi que l'objet ``setting`` retourné par
+   l'endpoint d'obtention contiennent les champs de l'entité stockée tels quels.
    En plus de ``term``, ``content``, ``sortOrder`` et ``virtualHost``, les champs
    d'audit ``createdBy``, ``createdTime``, ``updatedBy``, ``updatedTime`` ainsi que
-   le champ de verrouillage optimiste ``versionNo`` sont egalement retournes.
-   ``createdTime`` et ``updatedTime`` sont exprimes en millisecondes depuis l'epoque
-   (nombres). Les champs non renseignes (null) sont omis de la reponse. De plus,
-   l'objet ``response`` de toutes les reponses contient toujours ``version``, qui
-   indique la version du produit (voir :doc:`api-admin-overview` pour les details).
+   le champ de verrouillage optimiste ``versionNo`` sont également retournés.
+   ``createdTime`` et ``updatedTime`` sont exprimés en millisecondes depuis l'époque
+   (nombres). Les champs non renseignés (null) sont omis de la réponse. De plus,
+   l'objet ``response`` de toutes les réponses contient toujours ``version``, qui
+   indique la version du produit (voir :doc:`api-admin-overview` pour les détails).
 
-Obtenir un contenu associe
+Obtenir un contenu associé
 ==========================
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/relatedcontent/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -154,13 +154,13 @@ Reponse
 
 .. note::
 
-   La valeur de ``versionNo`` requise lors d'une mise a jour (PUT) est celle
-   incluse dans cette reponse d'obtention.
+   La valeur de ``versionNo`` requise lors d'une mise à jour (PUT) est celle
+   incluse dans cette réponse d'obtention.
 
-Creer un contenu associe
+Creer un contenu associé
 ========================
 
-Requete
+Requête
 -------
 
 ::
@@ -168,7 +168,7 @@ Requete
     POST /api/admin/relatedcontent/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -192,18 +192,18 @@ Description des champs
      - Description
    * - ``term``
      - **Oui**
-     - Mot-cle de recherche (maximum 10000 caracteres)
+     - Mot-clé de recherche (maximum 10000 caractères)
    * - ``content``
      - **Oui**
-     - Contenu HTML a afficher (maximum 10000 caracteres)
+     - Contenu HTML à afficher (maximum 10000 caractères)
    * - ``sortOrder``
      - **Non**
      - Ordre d'affichage (entier compris entre 0 et 2147483647)
    * - ``virtualHost``
      - **Non**
-     - Hote virtuel (maximum 1000 caracteres)
+     - Hôte virtuel (maximum 1000 caractères)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -217,10 +217,10 @@ Reponse
       }
     }
 
-Mettre a jour un contenu associe
+Mettre à jour un contenu associé
 =================================
 
-Requete
+Requête
 -------
 
 ::
@@ -228,7 +228,7 @@ Requete
     PUT /api/admin/relatedcontent/setting
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -254,24 +254,24 @@ Description des champs
      - Description
    * - ``id``
      - **Oui**
-     - Identifiant du contenu associe a mettre a jour (maximum 1000 caracteres)
+     - Identifiant du contenu associé à mettre à jour (maximum 1000 caractères)
    * - ``term``
      - **Oui**
-     - Mot-cle de recherche (maximum 10000 caracteres)
+     - Mot-clé de recherche (maximum 10000 caractères)
    * - ``content``
      - **Oui**
-     - Contenu HTML a afficher (maximum 10000 caracteres)
+     - Contenu HTML à afficher (maximum 10000 caractères)
    * - ``sortOrder``
      - **Non**
      - Ordre d'affichage (entier compris entre 0 et 2147483647)
    * - ``virtualHost``
      - **Non**
-     - Hote virtuel (maximum 1000 caracteres)
+     - Hôte virtuel (maximum 1000 caractères)
    * - ``versionNo``
      - **Oui**
-     - Numero de version pour le verrouillage optimiste. Specifier la valeur incluse dans la reponse de ``setting/{id}``.
+     - Numéro de version pour le verrouillage optimiste. Specifier la valeur incluse dans la réponse de ``setting/{id}``.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -288,21 +288,21 @@ Reponse
 .. note::
 
    Les champs d'audit tels que ``createdBy``, ``createdTime``, ``updatedBy``,
-   ``updatedTime`` et ``crudMode`` sont ignores meme s'ils sont inclus dans le
-   corps de la requete, car ils sont definis automatiquement cote serveur. Il
-   n'est pas necessaire de les specifier lors de la creation ou de la mise a jour.
+   ``updatedTime`` et ``crudMode`` sont ignorés même s'ils sont inclus dans le
+   corps de la requête, car ils sont définis automatiquement côté serveur. Il
+   n'est pas nécessaire de les spécifier lors de la création ou de la mise à jour.
 
-Supprimer un contenu associe
+Supprimer un contenu associé
 ============================
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/relatedcontent/setting/{id}
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -317,7 +317,7 @@ Reponse
 Exemples d'utilisation
 ======================
 
-Contenu associe pour les informations produit
+Contenu associé pour les informations produit
 ---------------------------------------------
 
 .. code-block:: bash
@@ -331,7 +331,7 @@ Contenu associe pour les informations produit
            "sortOrder": 0
          }'
 
-Contenu associe pour les informations de support
+Contenu associé pour les informations de support
 ------------------------------------------------
 
 .. code-block:: bash
@@ -345,9 +345,9 @@ Contenu associe pour les informations de support
            "sortOrder": 0
          }'
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin
-- :doc:`api-admin-relatedquery` - API des requetes associees
-- :doc:`../../admin/relatedcontent-guide` - Guide de gestion des contenus associes
+- :doc:`api-admin-relatedquery` - API des requetes associées
+- :doc:`../../admin/relatedcontent-guide` - Guide de gestion des contenus associés

--- a/fr/15.8/api/admin/api-admin-searchlist.rst
+++ b/fr/15.8/api/admin/api-admin-searchlist.rst
@@ -5,10 +5,10 @@ SearchList API
 Vue d'ensemble
 ==============
 
-L'API SearchList est une API d'administration de |Fess| permettant de rechercher et de gerer les documents dans l'index.
-Elle permet de rechercher, obtenir, creer, mettre a jour et supprimer des documents.
+L'API SearchList est une API d'administration de |Fess| permettant de rechercher et de gérer les documents dans l'index.
+Elle permet de rechercher, obtenir, créer, mettre à jour et supprimer des documents.
 
-Tous les noms de champs dans la reponse sont en ``snake_case``. Les champs dont la valeur est ``null`` sont omis de la reponse.
+Tous les noms de champs dans la réponse sont en ``snake_case``. Les champs dont la valeur est ``null`` sont omis de la réponse.
 
 URL de base
 ===========
@@ -20,9 +20,9 @@ URL de base
 Authentification
 ================
 
-Pour appeler cette API, une authentification par jeton d'acces est requise, comme explique dans :doc:`api-admin-overview`.
-Le jeton doit disposer des permissions d'acces a l'API d'administration (par defaut ``Radmin-api``).
-Cette permission peut etre modifiee via la cle de configuration ``api.admin.access.permissions``.
+Pour appeler cette API, une authentification par jeton d'accès est requise, comme expliqué dans :doc:`api-admin-overview`.
+Le jeton doit disposer des permissions d'accès à l'API d'administration (par défaut ``Radmin-api``).
+Cette permission peut être modifiée via la clé de configuration ``api.admin.access.permissions``.
 
 Liste des endpoints
 ===================
@@ -31,7 +31,7 @@ Liste des endpoints
    :header-rows: 1
    :widths: 15 35 50
 
-   * - Methode
+   * - Méthode
      - Chemin
      - Description
    * - GET / PUT
@@ -42,23 +42,23 @@ Liste des endpoints
      - Obtention d'un document
    * - POST
      - /doc
-     - Creation d'un document
+     - Création d'un document
    * - PUT
      - /doc
-     - Mise a jour d'un document
+     - Mise à jour d'un document
    * - DELETE
      - /doc/{id}
      - Suppression d'un document (par ID)
    * - DELETE
      - /query
-     - Suppression de documents (par requete)
+     - Suppression de documents (par requête)
 
 Recherche de documents
 ======================
 
-Recherche les documents correspondant aux criteres de recherche.
+Recherche les documents correspondant aux critères de recherche.
 
-Requete
+Requête
 -------
 
 ::
@@ -66,21 +66,21 @@ Requete
     GET /api/admin/searchlist/docs
     PUT /api/admin/searchlist/docs
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``q``
      - String
      - Non
-     - Requete de recherche (1000 caracteres maximum). Si elle n'est pas specifiee, tous les documents sont concernes.
+     - Requête de recherche (1000 caractères maximum). Si elle n'est pas spécifiée, tous les documents sont concernés.
    * - ``sort``
      - String
      - Non
@@ -88,39 +88,39 @@ Parametres
    * - ``start``
      - Integer
      - Non
-     - Position de depart a base zero (par defaut ``0``).
+     - Position de départ à base zéro (par défaut ``0``).
    * - ``offset``
      - Integer
      - Non
-     - Decalage depuis ``start`` (par defaut ``0``).
+     - Décalage depuis ``start`` (par défaut ``0``).
    * - ``pn``
      - Integer
      - Non
-     - Numero de page.
+     - Numéro de page.
    * - ``num``
      - Integer
      - Non
-     - Nombre d'elements a obtenir (par defaut ``10``). Les valeurs depassant le maximum configure (par defaut ``100``) ou les valeurs inferieures ou egales a ``0`` sont ramenees au maximum.
+     - Nombre d'éléments à obtenir (par défaut ``10``). Les valeurs dépassant le maximum configuré (par défaut ``100``) ou les valeurs inférieures ou égales à ``0`` sont ramenées au maximum.
    * - ``size``
      - Integer
      - Non
-     - Nombre d'elements a obtenir (alias de ``num``, fourni pour compatibilite avec les autres API d'administration).
+     - Nombre d'éléments à obtenir (alias de ``num``, fourni pour compatibilité avec les autres API d'administration).
    * - ``lang``
      - String[]
      - Non
-     - Langue de recherche. Peut etre specifie plusieurs fois (tableau). Ex. ``en``.
+     - Langue de recherche. Peut être spécifié plusieurs fois (tableau). Ex. ``en``.
    * - ``ex_q``
      - String[]
      - Non
-     - Expressions de requete supplementaires. Peut etre specifie plusieurs fois (tableau).
+     - Expressions de requête supplémentaires. Peut être spécifié plusieurs fois (tableau).
    * - ``fields.<name>``
      - String[]
      - Non
-     - Filtre par valeur de champ. Le cas le plus courant est ``fields.label`` (filtre par nom d'etiquette) ; tout ``fields.<name>`` restreint les resultats aux documents dont le champ ``<name>`` correspond a la valeur donnee. Peut etre specifie plusieurs fois.
+     - Filtre par valeur de champ. Le cas le plus courant est ``fields.label`` (filtre par nom d'étiquette) ; tout ``fields.<name>`` restreint les résultats aux documents dont le champ ``<name>`` correspond à la valeur donnée. Peut être spécifié plusieurs fois.
    * - ``as.<name>``
      - String[]
      - Non
-     - Conditions de recherche avancee. Tout ``as.<name>`` (ex. ``as.q``) est transmis au generateur de conditions de recherche avancee. Peut etre specifie plusieurs fois par nom.
+     - Conditions de recherche avancée. Tout ``as.<name>`` (ex. ``as.q``) est transmis au générateur de conditions de recherche avancée. Peut être spécifié plusieurs fois par nom.
    * - ``sdh``
      - String
      - Non
@@ -128,9 +128,9 @@ Parametres
 
 .. note::
 
-   Cet endpoint ne prend pas en charge les facettes, la mise en evidence ou la recherche geographique. Ces parametres sont ignores s'ils sont specifies.
+   Cet endpoint ne prend pas en charge les facettes, la mise en évidence ou la recherche géographique. Ces paramètres sont ignorés s'ils sont spécifiés.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -166,7 +166,7 @@ Reponse
       }
     }
 
-Champs de la reponse
+Champs de la réponse
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -176,75 +176,75 @@ Champs de la reponse
    * - Champ
      - Description
    * - ``version``
-     - Version de |Fess| en cours d'execution (la valeur d'exemple est indicative).
+     - Version de |Fess| en cours d'exécution (la valeur d'exemple est indicative).
    * - ``status``
-     - Code de statut (``0`` en cas de succes ; voir "Codes de statut").
+     - Code de statut (``0`` en cas de succès ; voir "Codes de statut").
    * - ``query_id``
-     - ID de la requete de recherche.
+     - ID de la requête de recherche.
    * - ``docs``
-     - Tableau des documents resultats de la recherche. Chaque document est une carte de noms de champs et de valeurs, utilisant les noms de champs de l'index tels quels (``doc_id``, ``url``, ``title``, ``content_description``, etc.).
+     - Tableau des documents résultats de la recherche. Chaque document est une carte de noms de champs et de valeurs, utilisant les noms de champs de l'index tels quels (``doc_id``, ``url``, ``title``, ``content_description``, etc.).
    * - ``exec_time``
-     - Temps d'execution de la recherche (secondes, chaine de caracteres).
+     - Temps d'exécution de la recherche (secondes, chaîne de caractères).
    * - ``query_time``
-     - Temps de requete du moteur de recherche (millisecondes).
+     - Temps de requête du moteur de recherche (millisecondes).
    * - ``page_size``
-     - Nombre d'elements par page.
+     - Nombre d'éléments par page.
    * - ``page_number``
-     - Numero de la page courante.
+     - Numéro de la page courante.
    * - ``record_count``
-     - Nombre d'elements correspondants.
+     - Nombre d'éléments correspondants.
    * - ``record_count_relation``
-     - Relation du nombre d'elements correspondants. ``eq`` indique un comptage exact, ``gte`` indique que seule la borne inferieure est connue.
+     - Relation du nombre d'éléments correspondants. ``eq`` indique un comptage exact, ``gte`` indique que seule la borne inférieure est connue.
    * - ``page_count``
      - Nombre total de pages.
    * - ``next_page``
      - Indique s'il existe une page suivante (bool).
    * - ``prev_page``
-     - Indique s'il existe une page precedente (bool).
+     - Indique s'il existe une page précédente (bool).
    * - ``start_record_number``
-     - Numero du premier enregistrement de cette page.
+     - Numéro du premier enregistrement de cette page.
    * - ``end_record_number``
-     - Numero du dernier enregistrement de cette page.
+     - Numéro du dernier enregistrement de cette page.
    * - ``page_numbers``
-     - Tableau des numeros de page a afficher dans le paginateur (chaines de caracteres).
+     - Tableau des numéros de page à afficher dans le paginateur (chaînes de caractères).
    * - ``partial``
-     - Indique si les resultats sont partiels (bool).
+     - Indique si les résultats sont partiels (bool).
    * - ``search_query``
-     - Requete de recherche reellement executee.
+     - Requête de recherche réellement exécutée.
    * - ``requested_time``
-     - Horodatage de la requete (epoch en millisecondes).
+     - Horodatage de la requête (epoch en millisecondes).
    * - ``highlight_params``
-     - Chaine de parametres de requete pour la mise en evidence (generalement vide pour cette API d'administration).
+     - Chaîne de paramètres de requête pour la mise en évidence (généralement vide pour cette API d'administration).
 
 Obtention d'un document
 =======================
 
-Obtient un seul document en specifiant son ID de document.
+Obtient un seul document en spécifiant son ID de document.
 
-Requete
+Requête
 -------
 
 ::
 
     GET /api/admin/searchlist/doc/{id}
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``id``
      - String
      - Oui
-     - ID du document (valeur de ``doc_id``, parametre de chemin).
+     - ID du document (valeur de ``doc_id``, paramètre de chemin).
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -261,14 +261,14 @@ Reponse
       }
     }
 
-Si aucun document n'existe pour l'ID specifie, une reponse d'erreur (``status`` = ``1``) est retournee.
+Si aucun document n'existe pour l'ID spécifié, une réponse d'erreur (``status`` = ``1``) est retournée.
 
-Creation d'un document
+Création d'un document
 ======================
 
-Cree un nouveau document dans l'index.
+Crée un nouveau document dans l'index.
 
-Requete
+Requête
 -------
 
 ::
@@ -276,7 +276,7 @@ Requete
     POST /api/admin/searchlist/doc
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -303,20 +303,20 @@ Description des champs
      - Description
    * - ``doc``
      - Oui
-     - Document a enregistrer. Specifie sous forme de carte de noms de champs d'index et de valeurs.
+     - Document à enregistrer. Spécifié sous forme de carte de noms de champs d'index et de valeurs.
 
-Parmi les champs specifies dans ``doc``, tous les champs obligatoires configures dans ``index.admin.required.fields`` (par defaut ``url,title,role,boost``) doivent etre fournis.
-Contrairement a l'API :doc:`Documents API <api-admin-documents>` par lot, cet endpoint ne complete pas automatiquement les valeurs par defaut telles que ``role`` ou ``boost``, de sorte que les champs obligatoires doivent etre specifies explicitement dans la requete.
-``doc_id`` est genere automatiquement cote serveur et n'est pas specifie lors de la creation.
+Parmi les champs spécifiés dans ``doc``, tous les champs obligatoires configurés dans ``index.admin.required.fields`` (par défaut ``url,title,role,boost``) doivent être fournis.
+Contrairement à l'API :doc:`Documents API <api-admin-documents>` par lot, cet endpoint ne complète pas automatiquement les valeurs par défaut telles que ``role`` ou ``boost``, de sorte que les champs obligatoires doivent être spécifiés explicitement dans la requête.
+``doc_id`` est généré automatiquement côté serveur et n'est pas spécifié lors de la création.
 
-La valeur de chaque champ est validee en fonction de la configuration du type de champ. Si le type ne correspond pas, une erreur (``status`` = ``1``) est retournee.
+La valeur de chaque champ est validée en fonction de la configuration du type de champ. Si le type ne correspond pas, une erreur (``status`` = ``1``) est retournée.
 
 .. list-table::
    :header-rows: 1
    :widths: 40 60
 
-   * - Cle de configuration
-     - Valeur par defaut
+   * - Clé de configuration
+     - Valeur par défaut
    * - ``index.admin.array.fields``
      - ``lang,role,label,anchor,virtual_host``
    * - ``index.admin.date.fields``
@@ -330,7 +330,7 @@ La valeur de chaque champ est validee en fonction de la configuration du type de
    * - ``index.admin.double.fields``
      - (vide)
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -351,16 +351,16 @@ Reponse
    * - Champ
      - Description
    * - ``id``
-     - Le ``doc_id`` du document enregistre.
+     - Le ``doc_id`` du document enregistré.
    * - ``created``
-     - ``true`` lors de la creation.
+     - ``true`` lors de la création.
 
-Mise a jour d'un document
+Mise à jour d'un document
 =========================
 
-Met a jour un document existant.
+Met à jour un document existant.
 
-Requete
+Requête
 -------
 
 ::
@@ -368,7 +368,7 @@ Requete
     PUT /api/admin/searchlist/doc
     Content-Type: application/json
 
-Corps de la requete
+Corps de la requête
 ~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: json
@@ -396,12 +396,12 @@ Description des champs
      - Description
    * - ``doc``
      - Oui
-     - Document a mettre a jour. Specifie sous forme de carte de noms de champs d'index et de valeurs.
+     - Document à mettre à jour. Spécifié sous forme de carte de noms de champs d'index et de valeurs.
 
-Le document a mettre a jour est identifie par ``doc_id`` dans ``doc``. Si ``doc_id`` n'est pas specifie, ou si aucun document correspondant n'existe, une erreur (``status`` = ``1``) est retournee.
-Comme pour la creation, tous les champs obligatoires configures dans ``index.admin.required.fields`` (par defaut ``url,title,role,boost``) doivent etre fournis, et la valeur de chaque champ est validee en fonction de la configuration du type.
+Le document à mettre à jour est identifié par ``doc_id`` dans ``doc``. Si ``doc_id`` n'est pas spécifié, ou si aucun document correspondant n'existe, une erreur (``status`` = ``1``) est retournée.
+Comme pour la création, tous les champs obligatoires configurés dans ``index.admin.required.fields`` (par défaut ``url,title,role,boost``) doivent être fournis, et la valeur de chaque champ est validée en fonction de la configuration du type.
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -422,39 +422,39 @@ Reponse
    * - Champ
      - Description
    * - ``id``
-     - Le ``doc_id`` du document mis a jour.
+     - Le ``doc_id`` du document mis à jour.
    * - ``created``
-     - ``false`` lors de la mise a jour.
+     - ``false`` lors de la mise à jour.
 
 Suppression d'un document (par ID)
 ===================================
 
-Supprime un document en specifiant son ID de document.
+Supprime un document en spécifiant son ID de document.
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/searchlist/doc/{id}
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``id``
      - String
      - Oui
-     - ID du document (valeur de ``doc_id``, parametre de chemin).
+     - ID du document (valeur de ``doc_id``, paramètre de chemin).
 
-Reponse
+Réponse
 -------
 
 .. code-block:: json
@@ -466,40 +466,40 @@ Reponse
       }
     }
 
-Suppression de documents (par requete)
+Suppression de documents (par requête)
 =======================================
 
-Supprime en masse les documents correspondant a une requete de recherche.
+Supprime en masse les documents correspondant à une requête de recherche.
 
-Requete
+Requête
 -------
 
 ::
 
     DELETE /api/admin/searchlist/query
 
-Parametres
+Paramètres
 ~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 15 50
 
-   * - Parametre
+   * - Paramètre
      - Type
      - Requis
      - Description
    * - ``q``
      - String
      - Oui
-     - Requete de recherche des documents a supprimer.
+     - Requête de recherche des documents à supprimer.
 
-La cible de suppression est construite avec la meme requete que "Recherche de documents", de sorte que les parametres de filtrage tels que ``fields.<name>`` et ``ex_q`` peuvent etre utilises conjointement. Si ``q`` n'est pas specifie, une erreur (``status`` = ``1``) est retournee.
+La cible de suppression est construite avec la même requête que "Recherche de documents", de sorte que les paramètres de filtrage tels que ``fields.<name>`` et ``ex_q`` peuvent être utilisés conjointement. Si ``q`` n'est pas spécifié, une erreur (``status`` = ``1``) est retournée.
 
-Reponse
+Réponse
 -------
 
-Retourne le nombre de documents supprimes dans ``count``.
+Retourne le nombre de documents supprimés dans ``count``.
 
 .. code-block:: json
 
@@ -514,7 +514,7 @@ Retourne le nombre de documents supprimes dans ``count``.
 Codes de statut
 ===============
 
-Le champ ``status`` dans la reponse prend l'une des valeurs suivantes.
+Le champ ``status`` dans la réponse prend l'une des valeurs suivantes.
 
 .. list-table::
    :header-rows: 1
@@ -525,19 +525,19 @@ Le champ ``status`` dans la reponse prend l'une des valeurs suivantes.
      - Description
    * - ``0``
      - OK
-     - Succes.
+     - Succès.
    * - ``1``
      - BAD_REQUEST
-     - La requete est invalide (champ obligatoire manquant, type incorrect, document cible introuvable, requete invalide, etc.).
+     - La requête est invalide (champ obligatoire manquant, type incorrect, document cible introuvable, requête invalide, etc.).
    * - ``2``
      - SYSTEM_ERROR
-     - Erreur systeme.
+     - Erreur système.
    * - ``3``
      - UNAUTHORIZED
      - Erreur d'authentification.
    * - ``9``
      - FAILED
-     - Le traitement a echoue.
+     - Le traitement a échoué.
 
 Exemples d'utilisation
 ======================
@@ -558,7 +558,7 @@ Obtention d'un document
     curl -X GET "http://localhost:8080/api/admin/searchlist/doc/abcdef0123456789" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Creation d'un document
+Création d'un document
 ----------------------
 
 .. code-block:: bash
@@ -576,7 +576,7 @@ Creation d'un document
            }
          }'
 
-Suppression de documents par requete
+Suppression de documents par requête
 -------------------------------------
 
 .. code-block:: bash
@@ -584,7 +584,7 @@ Suppression de documents par requete
     curl -X DELETE "http://localhost:8080/api/admin/searchlist/query?q=url:example.com" \
          -H "Authorization: Bearer YOUR_TOKEN"
 
-Informations complementaires
+Informations complémentaires
 =============================
 
 - :doc:`api-admin-overview` - Vue d'ensemble de l'API Admin

--- a/fr/15.8/api/admin/index.rst
+++ b/fr/15.8/api/admin/index.rst
@@ -1,8 +1,8 @@
 ==================================
-Reference de l'API d'administration
+Référence de l'API d'administration
 ==================================
 
-L'API d'administration |Fess| est une API RESTful permettant d'acceder aux fonctions d'administration par programmation.
+L'API d'administration |Fess| est une API RESTful permettant d'accéder aux fonctions d'administration par programmation.
 
 .. toctree::
    :maxdepth: 2
@@ -58,7 +58,7 @@ L'API d'administration |Fess| est une API RESTful permettant d'acceder aux fonct
 
 .. toctree::
    :maxdepth: 2
-   :caption: Systeme
+   :caption: Système
 
    api-admin-general
    api-admin-systeminfo

--- a/fr/15.8/config/datastore/ds-atlassian.rst
+++ b/fr/15.8/config/datastore/ds-atlassian.rst
@@ -2,12 +2,12 @@
 Connecteur Atlassian
 ==================================
 
-Apercu
+Aperçu
 ======
 
-Le connecteur Atlassian fournit une fonctionnalite pour recuperer des donnees depuis les produits Atlassian (Jira, Confluence) et les enregistrer dans l'index de |Fess|.
+Le connecteur Atlassian fournit une fonctionnalité pour récupérer des données depuis les produits Atlassian (Jira, Confluence) et les enregistrer dans l'index de |Fess|.
 
-Cette fonctionnalite necessite le plugin ``fess-ds-atlassian``.
+Cette fonctionnalité nécessite le plugin ``fess-ds-atlassian``.
 
 Produits pris en charge
 =======================
@@ -15,23 +15,23 @@ Produits pris en charge
 - Jira (Cloud / Server / Data Center)
 - Confluence (Cloud / Server / Data Center)
 
-Prerequis
+Prérequis
 =========
 
 1. L'installation du plugin est requise
-2. Les informations d'authentification appropriees pour les produits Atlassian sont necessaires
+2. Les informations d'authentification appropriées pour les produits Atlassian sont nécessaires
 3. Pour la version Cloud, OAuth 2.0 est disponible ; pour la version Server, OAuth 1.0a ou l'authentification basique sont disponibles
 
 Installation du plugin
 ----------------------
 
-Installez depuis l'interface d'administration sous "Systeme" -> "Plugins" :
+Installez depuis l'interface d'administration sous "Système" -> "Plugins" :
 
-1. Telechargez ``fess-ds-atlassian-X.X.X.jar`` depuis Maven Central
+1. Téléchargez ``fess-ds-atlassian-X.X.X.jar`` depuis Maven Central
 2. Uploadez et installez depuis l'interface de gestion des plugins
-3. Redemarrez |Fess|
+3. Redémarrez |Fess|
 
-Methode de configuration
+Méthode de configuration
 ========================
 
 Configurez depuis l'interface d'administration : "Crawler" -> "DataStore" -> "Nouveau".
@@ -43,7 +43,7 @@ Configuration de base
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
+   * - Élément
      - Exemple de configuration
    * - Nom
      - Company Jira/Confluence
@@ -52,7 +52,7 @@ Configuration de base
    * - Actif
      - Oui
 
-Configuration des parametres
+Configuration des paramètres
 ----------------------------
 
 Exemple version Cloud (OAuth 2.0) :
@@ -89,14 +89,14 @@ Exemple version Server (OAuth 1.0a) :
     oauth.secret=verification_code
     oauth.access_token=your_access_token
 
-Liste des parametres
+Liste des paramètres
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``home``
@@ -104,22 +104,22 @@ Liste des parametres
      - URL de l'instance Atlassian
    * - ``is_cloud``
      - Non
-     - ``true`` pour la version Cloud, ``false`` pour la version Server (defaut : ``true``). Utilise uniquement pour la selection du point de terminaison lors de l'authentification OAuth 2.0 ; ignore pour les authentifications basique et OAuth 1.0a.
+     - ``true`` pour la version Cloud, ``false`` pour la version Server (défaut : ``true``). Utilisé uniquement pour la sélection du point de terminaison lors de l'authentification OAuth 2.0 ; ignoré pour les authentifications basique et OAuth 1.0a.
    * - ``auth_type``
      - Oui
      - Type d'authentification : ``oauth``, ``oauth2``, ``basic``
    * - ``oauth.consumer_key``
      - Pour OAuth 1.0a
-     - Cle consommateur (generalement ``OauthKey``)
+     - Clé consommateur (généralement ``OauthKey``)
    * - ``oauth.private_key``
      - Pour OAuth 1.0a
-     - Cle privee RSA (format PEM)
+     - Clé privée RSA (format PEM)
    * - ``oauth.secret``
      - Pour OAuth 1.0a
-     - Code de verification
+     - Code de vérification
    * - ``oauth.access_token``
      - Pour OAuth 1.0a
-     - Token d'acces
+     - Token d'accès
    * - ``oauth2.client_id``
      - Pour OAuth 2.0
      - ID client
@@ -128,13 +128,13 @@ Liste des parametres
      - Secret client
    * - ``oauth2.access_token``
      - Pour OAuth 2.0
-     - Token d'acces
+     - Token d'accès
    * - ``oauth2.refresh_token``
      - Non
-     - Token de rafraichissement (OAuth 2.0)
+     - Token de rafraîchissement (OAuth 2.0)
    * - ``oauth2.token_url``
      - Non
-     - URL du token (OAuth 2.0, defaut : ``https://auth.atlassian.com/oauth/token``)
+     - URL du token (OAuth 2.0, défaut : ``https://auth.atlassian.com/oauth/token``)
    * - ``basic.username``
      - Pour auth basique
      - Nom d'utilisateur
@@ -143,40 +143,40 @@ Liste des parametres
      - Mot de passe
    * - ``issue.jql``
      - Non
-     - JQL (Jira uniquement, conditions de recherche avancees). Si non specifie, tous les tickets (``created is not empty``) sont cibles.
+     - JQL (Jira uniquement, conditions de recherche avancées). Si non spécifié, tous les tickets (``created is not empty``) sont ciblés.
    * - ``issue_max_results``
      - Non
-     - Nombre maximum de resultats par requete API Jira (defaut : ``50``, Jira uniquement)
+     - Nombre maximum de résultats par requête API Jira (défaut : ``50``, Jira uniquement)
    * - ``content_limit``
      - Non
-     - Nombre maximum d'elements par requete API Confluence (defaut : ``25``, Confluence uniquement)
+     - Nombre maximum d'éléments par requête API Confluence (défaut : ``25``, Confluence uniquement)
    * - ``ignore_error``
      - Non
-     - Continuer le traitement en cas d'erreur (defaut : ``true``)
+     - Continuer le traitement en cas d'erreur (défaut : ``true``)
    * - ``include_pattern``
      - Non
-     - Modele d'inclusion d'URL (regex)
+     - Modèle d'inclusion d'URL (regex)
    * - ``exclude_pattern``
      - Non
-     - Modele d'exclusion d'URL (regex)
+     - Modèle d'exclusion d'URL (regex)
    * - ``number_of_threads``
      - Non
-     - Nombre de threads pour le traitement parallele (defaut : ``1``)
+     - Nombre de threads pour le traitement parallèle (défaut : ``1``)
    * - ``proxy_host``
      - Non
-     - Nom d'hote du proxy HTTP
+     - Nom d'hôte du proxy HTTP
    * - ``proxy_port``
      - Non
-     - Numero de port du proxy HTTP
+     - Numéro de port du proxy HTTP
    * - ``connection_timeout``
      - Non
-     - Delai de connexion HTTP (millisecondes)
+     - Délai de connexion HTTP (millisecondes)
    * - ``read_timeout``
      - Non
-     - Delai de lecture HTTP (millisecondes)
+     - Délai de lecture HTTP (millisecondes)
    * - ``readInterval``
      - Non
-     - Intervalle entre le traitement de chaque document (en millisecondes, defaut : ``0``)
+     - Intervalle entre le traitement de chaque document (en millisecondes, défaut : ``0``)
 
 Configuration du script
 -----------------------
@@ -194,10 +194,10 @@ Pour Jira
 Champs disponibles :
 
 - ``issue.view_url`` - URL du ticket
-- ``issue.summary`` - Resume du ticket
+- ``issue.summary`` - Résumé du ticket
 - ``issue.description`` - Description du ticket
 - ``issue.comments`` - Commentaires du ticket
-- ``issue.last_modified`` - Date de derniere modification
+- ``issue.last_modified`` - Date de dernière modification
 
 Pour Confluence
 ~~~~~~~~~~~~~~~
@@ -215,25 +215,25 @@ Champs disponibles :
 - ``content.title`` - Titre de la page
 - ``content.body`` - Corps de la page
 - ``content.comments`` - Commentaires de la page
-- ``content.last_modified`` - Date de derniere modification
+- ``content.last_modified`` - Date de dernière modification
 
 .. note::
-   Le connecteur Confluence recupere a la fois les pages normales (page) et les articles de blog (blogpost).
+   Le connecteur Confluence récupère à la fois les pages normales (page) et les articles de blog (blogpost).
 
 Configuration de l'authentification OAuth 2.0
 =============================================
 
-Pour la version Cloud (recommande)
+Pour la version Cloud (recommandé)
 ----------------------------------
 
-1. Creez une application dans Atlassian Developer Console
+1. Créez une application dans Atlassian Developer Console
 2. Obtenez les informations d'authentification OAuth 2.0
-3. Configurez les scopes necessaires :
+3. Configurez les scopes nécessaires :
 
    - Jira : ``read:jira-work``, ``read:jira-user``
    - Confluence : ``read:confluence-content.all``, ``read:confluence-user``
 
-4. Obtenez le token d'acces et le token de rafraichissement
+4. Obtenez le token d'accès et le token de rafraîchissement
 
 Configuration de l'authentification OAuth 1.0a
 ==============================================
@@ -241,16 +241,16 @@ Configuration de l'authentification OAuth 1.0a
 Pour la version Server
 ----------------------
 
-1. Creez un Application Link dans Jira ou Confluence
-2. Generez une paire de cles RSA :
+1. Créez un Application Link dans Jira ou Confluence
+2. Générez une paire de clés RSA :
 
    ::
 
        openssl genrsa -out private_key.pem 2048
        openssl rsa -in private_key.pem -pubout -out public_key.pem
 
-3. Enregistrez la cle publique dans l'Application Link
-4. Configurez la cle privee dans les parametres
+3. Enregistrez la clé publique dans l'Application Link
+4. Configurez la clé privée dans les paramètres
 
 Configuration de l'authentification basique
 ===========================================
@@ -259,21 +259,21 @@ Configuration simple pour la version Server
 -------------------------------------------
 
 .. warning::
-   L'authentification basique n'est pas recommandee pour des raisons de securite. Utilisez l'authentification OAuth autant que possible.
+   L'authentification basique n'est pas recommandée pour des raisons de sécurité. Utilisez l'authentification OAuth autant que possible.
 
 Pour utiliser l'authentification basique :
 
-1. Preparez un compte utilisateur avec des privileges d'administration
-2. Configurez le nom d'utilisateur et le mot de passe dans les parametres
-3. Utilisez HTTPS pour assurer une connexion securisee
+1. Préparez un compte utilisateur avec des privilèges d'administration
+2. Configurez le nom d'utilisateur et le mot de passe dans les paramètres
+3. Utilisez HTTPS pour assurer une connexion sécurisée
 
-Recherche avancee avec JQL
+Recherche avancée avec JQL
 ==========================
 
 Filtrer les tickets Jira avec JQL
 ---------------------------------
 
-Explorer uniquement les tickets correspondant a des conditions specifiques :
+Explorer uniquement les tickets correspondant à des conditions spécifiques :
 
 ::
 
@@ -289,7 +289,7 @@ Explorer uniquement les tickets correspondant a des conditions specifiques :
     # Combinaison de conditions multiples
     issue.jql=project IN ("PROJ1", "PROJ2") AND updated >= -90d AND status != "Done"
 
-Pour plus de details sur JQL, consultez la `documentation JQL Atlassian <https://confluence.atlassian.com/jirasoftwarecloud/advanced-searching-764478330.html>`_.
+Pour plus de détails sur JQL, consultez la `documentation JQL Atlassian <https://confluence.atlassian.com/jirasoftwarecloud/advanced-searching-764478330.html>`_.
 
 Exemples d'utilisation
 ======================
@@ -297,7 +297,7 @@ Exemples d'utilisation
 Exploration de Jira Cloud
 -------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -322,7 +322,7 @@ Script :
 Exploration de Confluence Server
 --------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -342,64 +342,64 @@ Script :
     last_modified=content.last_modified
     digest=content.title
 
-Depannage
+Dépannage
 =========
 
 Erreur d'authentification
 -------------------------
 
-**Symptome** : ``401 Unauthorized`` ou ``403 Forbidden``
+**Symptôme** : ``401 Unauthorized`` ou ``403 Forbidden``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifiez que les informations d'authentification sont correctes
-2. Pour la version Cloud, verifiez que les scopes appropries sont configures
-3. Pour la version Server, verifiez que l'utilisateur dispose des autorisations appropriees
-4. Pour OAuth 2.0, verifiez la date d'expiration du token
+1. Vérifiez que les informations d'authentification sont correctes
+2. Pour la version Cloud, vérifiez que les scopes appropriés sont configurés
+3. Pour la version Server, vérifiez que l'utilisateur dispose des autorisations appropriées
+4. Pour OAuth 2.0, vérifiez la date d'expiration du token
 
 Erreur de connexion
 -------------------
 
-**Symptome** : ``Connection refused`` ou timeout de connexion
+**Symptôme** : ``Connection refused`` ou timeout de connexion
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifiez que l'URL ``home`` est correcte
-2. Verifiez les parametres du pare-feu
-3. Verifiez que l'instance Atlassian est en cours d'execution
-4. Verifiez que le parametre ``is_cloud`` est correctement configure
+1. Vérifiez que l'URL ``home`` est correcte
+2. Vérifiez les paramètres du pare-feu
+3. Vérifiez que l'instance Atlassian est en cours d'exécution
+4. Vérifiez que le paramètre ``is_cloud`` est correctement configuré
 
-Impossible de recuperer les donnees
+Impossible de récupérer les données
 -----------------------------------
 
-**Symptome** : L'exploration reussit mais 0 document
+**Symptôme** : L'exploration réussit mais 0 document
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifiez que le JQL n'est pas trop restrictif
-2. Verifiez que l'utilisateur a des droits de lecture sur les projets/espaces
-3. Verifiez la configuration du script
-4. Verifiez les erreurs dans les logs
+1. Vérifiez que le JQL n'est pas trop restrictif
+2. Vérifiez que l'utilisateur a des droits de lecture sur les projets/espaces
+3. Vérifiez la configuration du script
+4. Vérifiez les erreurs dans les logs
 
-Rafraichissement du token OAuth 2.0
+Rafraîchissement du token OAuth 2.0
 -----------------------------------
 
-**Symptome** : Des erreurs d'authentification se produisent apres un certain temps
+**Symptôme** : Des erreurs d'authentification se produisent après un certain temps
 
 **Solution** :
 
-Les tokens d'acces OAuth 2.0 ont une date d'expiration. Configurez le token de rafraichissement pour permettre le renouvellement automatique :
+Les tokens d'accès OAuth 2.0 ont une date d'expiration. Configurez le token de rafraîchissement pour permettre le renouvellement automatique :
 
 ::
 
     oauth2.refresh_token=your_refresh_token
 
-Lors du renouvellement des tokens, le nouveau token d'acces et le nouveau token de rafraichissement sont automatiquement enregistres dans la configuration du data store, de sorte que les explorations suivantes utilisent les tokens mis a jour (aucune mise a jour manuelle n'est necessaire).
+Lors du renouvellement des tokens, le nouveau token d'accès et le nouveau token de rafraîchissement sont automatiquement enregistrés dans la configuration du data store, de sorte que les explorations suivantes utilisent les tokens mis à jour (aucune mise à jour manuelle n'est nécessaire).
 
-Informations de reference
+Informations de référence
 =========================
 
-- :doc:`ds-overview` - Apercu des connecteurs DataStore
-- :doc:`ds-database` - Connecteur base de donnees
+- :doc:`ds-overview` - Aperçu des connecteurs DataStore
+- :doc:`ds-database` - Connecteur base de données
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration DataStore
 - `Atlassian Developer <https://developer.atlassian.com/>`_

--- a/fr/15.8/config/datastore/ds-elasticsearch.rst
+++ b/fr/15.8/config/datastore/ds-elasticsearch.rst
@@ -2,13 +2,13 @@
 Connecteur Elasticsearch/OpenSearch
 =====================================
 
-Apercu
+Aperçu
 ======
 
-Le connecteur Elasticsearch/OpenSearch fournit la fonctionnalite permettant de recuperer des donnees
-a partir d'un cluster Elasticsearch ou OpenSearch et de les enregistrer dans l'index |Fess|.
+Le connecteur Elasticsearch/OpenSearch fournit la fonctionnalité permettant de récupérer des données
+à partir d'un cluster Elasticsearch ou OpenSearch et de les enregistrer dans l'index |Fess|.
 
-Cette fonctionnalite necessite le plugin ``fess-ds-elasticsearch``.
+Cette fonctionnalité nécessite le plugin ``fess-ds-elasticsearch``.
 
 Versions prises en charge
 =========================
@@ -16,17 +16,17 @@ Versions prises en charge
 - Elasticsearch 7.x / 8.x
 - OpenSearch 1.x / 2.x
 
-Prerequis
+Prérequis
 =========
 
 1. L'installation du plugin est requise
-2. L'acces en lecture au cluster Elasticsearch/OpenSearch est necessaire
-3. Les droits d'execution de requetes sont necessaires
+2. L'accès en lecture au cluster Elasticsearch/OpenSearch est nécessaire
+3. Les droits d'exécution de requêtes sont nécessaires
 
 Installation du plugin
 ----------------------
 
-Methode 1 : Placement direct du fichier JAR
+Méthode 1 : Placement direct du fichier JAR
 
 ::
 
@@ -38,11 +38,11 @@ Methode 1 : Placement direct du fichier JAR
     # ou
     cp fess-ds-elasticsearch-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Methode 2 : Installation depuis l'interface d'administration
+Méthode 2 : Installation depuis l'interface d'administration
 
-1. Ouvrir "Systeme" -> "Plugins"
-2. Telecharger le fichier JAR
-3. Redemarrer |Fess|
+1. Ouvrir "Système" -> "Plugins"
+2. Télécharger le fichier JAR
+3. Redémarrer |Fess|
 
 Configuration
 =============
@@ -56,7 +56,7 @@ Configuration de base
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
+   * - Élément
      - Exemple
    * - Nom
      - External Elasticsearch
@@ -66,10 +66,10 @@ Configuration de base
      - Oui
 
 .. note::
-   ``ElasticsearchListDataStore`` est un gestionnaire qui etend ``ElasticsearchDataStore``. Il traite les donnees recuperees sous forme de liste de fichiers et prend en charge l'indexation multi-thread.
-   Le nombre de threads peut etre specifie avec le parametre ``numOfThreads`` (par defaut : 1).
+   ``ElasticsearchListDataStore`` est un gestionnaire qui étend ``ElasticsearchDataStore``. Il traite les données récupérées sous forme de liste de fichiers et prend en charge l'indexation multi-thread.
+   Le nombre de threads peut être spécifié avec le paramètre ``numOfThreads`` (par défaut : 1).
 
-Configuration des parametres
+Configuration des paramètres
 -----------------------------
 
 Connexion de base :
@@ -92,19 +92,19 @@ Connexion avec authentification :
     size=100
     scroll=1m
 
-Liste des parametres
+Liste des paramètres
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``settings.http.hosts``
      - Non
-     - URL des hotes Elasticsearch/OpenSearch. Plusieurs hotes peuvent etre specifies en les separant par des virgules (ex : ``http://host1:9200,http://host2:9200``). Une erreur de connexion se produit si non specifie
+     - URL des hôtes Elasticsearch/OpenSearch. Plusieurs hôtes peuvent être spécifiés en les séparant par des virgules (ex : ``http://host1:9200,http://host2:9200``). Une erreur de connexion se produit si non spécifié
    * - ``settings.fesen.username``
      - Non
      - Nom d'utilisateur pour l'authentification
@@ -113,59 +113,59 @@ Liste des parametres
      - Mot de passe pour l'authentification
    * - ``index``
      - Non
-     - Nom de l'index cible (par defaut : ``_all``). Plusieurs index peuvent etre specifies en les separant par des virgules
+     - Nom de l'index cible (par défaut : ``_all``). Plusieurs index peuvent être spécifiés en les séparant par des virgules
    * - ``size``
      - Non
-     - Nombre d'elements recuperes lors du scroll (si non specifie, la valeur par defaut du serveur Elasticsearch/OpenSearch est utilisee)
+     - Nombre d'éléments récupérés lors du scroll (si non spécifié, la valeur par défaut du serveur Elasticsearch/OpenSearch est utilisée)
    * - ``scroll``
      - Non
-     - Timeout du scroll (par defaut : 1m)
+     - Timeout du scroll (par défaut : 1m)
    * - ``timeout``
      - Non
-     - Timeout de la requete (par defaut : 1m)
+     - Timeout de la requête (par défaut : 1m)
    * - ``query``
      - Non
-     - JSON de requete (par defaut : match_all). Specifier uniquement le corps de la requete (le wrapper externe ``{"query":...}`` n'est pas necessaire)
+     - JSON de requête (par défaut : match_all). Spécifier uniquement le corps de la requête (le wrapper externe ``{"query":...}`` n'est pas nécessaire)
    * - ``fields``
      - Non
-     - Champs a recuperer (separes par des virgules)
+     - Champs à récupérer (séparés par des virgules)
    * - ``preference``
      - Non
-     - Preference de replique de shard pour l'execution de la recherche (par defaut : ``_local``)
+     - Préférence de réplique de shard pour l'exécution de la recherche (par défaut : ``_local``)
    * - ``delete.processed.doc``
      - Non
-     - Supprimer les documents traites de l'index source (par defaut : false)
+     - Supprimer les documents traités de l'index source (par défaut : false)
    * - ``readInterval``
      - Non
-     - Temps d'attente entre le traitement de chaque document en millisecondes (par defaut : 0)
+     - Temps d'attente entre le traitement de chaque document en millisecondes (par défaut : 0)
    * - ``numOfThreads``
      - Non
-     - Nombre de threads pour l'indexation (valide uniquement pour ``ElasticsearchListDataStore``, par defaut : 1)
+     - Nombre de threads pour l'indexation (valide uniquement pour ``ElasticsearchListDataStore``, par défaut : 1)
 
-Parametres de connexion supplementaires
+Paramètres de connexion supplémentaires
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Les parametres prefixes par ``settings.`` sont transmis comme configuration du client HTTP Elasticsearch/OpenSearch interne (client HTTP fesen).
-Les principaux parametres supplementaires sont les suivants.
+Les paramètres préfixés par ``settings.`` sont transmis comme configuration du client HTTP Elasticsearch/OpenSearch interne (client HTTP fesen).
+Les principaux paramètres supplémentaires sont les suivants.
 
 .. list-table::
    :header-rows: 1
    :widths: 40 60
 
-   * - Parametre
+   * - Paramètre
      - Description
    * - ``settings.http.ssl.certificate_authorities``
      - Chemin du fichier de certificat CA de confiance (format X.509) pour les connexions HTTPS
    * - ``settings.http.compression``
-     - Activer la compression HTTP (par defaut : true)
+     - Activer la compression HTTP (par défaut : true)
    * - ``settings.http.proxy_host``
-     - Nom d'hote du serveur proxy (``settings.https.proxy_host`` est egalement accepte)
+     - Nom d'hôte du serveur proxy (``settings.https.proxy_host`` est également accepté)
    * - ``settings.http.proxy_port``
-     - Numero de port du serveur proxy (``settings.https.proxy_port`` est egalement accepte)
+     - Numéro de port du serveur proxy (``settings.https.proxy_port`` est également accepté)
    * - ``settings.http.proxy_username``
-     - Nom d'utilisateur pour l'authentification proxy (``settings.https.proxy_username`` est egalement accepte)
+     - Nom d'utilisateur pour l'authentification proxy (``settings.https.proxy_username`` est également accepté)
    * - ``settings.http.proxy_password``
-     - Mot de passe pour l'authentification proxy (``settings.https.proxy_password`` est egalement accepte)
+     - Mot de passe pour l'authentification proxy (``settings.https.proxy_password`` est également accepté)
 
 Configuration du script
 -----------------------
@@ -179,7 +179,7 @@ Mapping de base :
     content=source.content
     last_modified=source.timestamp
 
-Acces aux champs imbriques :
+Accès aux champs imbriqués :
 
 ::
 
@@ -198,28 +198,28 @@ Champs disponibles
 - ``index`` - Nom de l'index
 - ``score`` - Score de recherche
 - ``version`` - Version du document
-- ``seqNo`` - Numero de sequence
+- ``seqNo`` - Numéro de séquence
 - ``primaryTerm`` - Terme primaire
 - ``clusterAlias`` - Alias du cluster (pour la recherche inter-clusters)
-- ``hit`` - Objet SearchHit (utilisation avancee)
+- ``hit`` - Objet SearchHit (utilisation avancée)
 
-Configuration des requetes
+Configuration des requêtes
 ==========================
 
-Recuperation de tous les documents
+Récupération de tous les documents
 ------------------------------------
 
-Par defaut, tous les documents sont recuperes.
-Si le parametre ``query`` n'est pas specifie, ``match_all`` est utilise.
+Par défaut, tous les documents sont récupérés.
+Si le paramètre ``query`` n'est pas spécifié, ``match_all`` est utilisé.
 
-Filtrage par conditions specifiques
+Filtrage par conditions spécifiques
 ------------------------------------
 
 ::
 
     query={"term":{"status":"published"}}
 
-Specification de plage :
+Spécification de plage :
 
 ::
 
@@ -232,13 +232,13 @@ Conditions multiples :
     query={"bool":{"must":[{"term":{"category":"news"}},{"range":{"views":{"gte":100}}}]}}
 
 .. note::
-   Le parametre ``query`` n'accepte que le corps de la requete. Le wrapper externe ``{"query":...}`` n'est pas necessaire.
-   Les options de niveau recherche telles que le tri ne peuvent pas etre specifiees dans ce parametre.
+   Le paramètre ``query`` n'accepte que le corps de la requête. Le wrapper externe ``{"query":...}`` n'est pas nécessaire.
+   Les options de niveau recherche telles que le tri ne peuvent pas être spécifiées dans ce paramètre.
 
-Recuperation de champs specifiques uniquement
+Récupération de champs spécifiques uniquement
 =============================================
 
-Limitation des champs avec le parametre fields
+Limitation des champs avec le paramètre fields
 -----------------------------------------------
 
 ::
@@ -248,7 +248,7 @@ Limitation des champs avec le parametre fields
     fields=title,content,url,timestamp
     size=100
 
-Pour recuperer tous les champs, ne specifiez pas ``fields`` ou laissez-le vide.
+Pour récupérer tous les champs, ne spécifiez pas ``fields`` ou laissez-le vide.
 
 Exemples d'utilisation
 ======================
@@ -256,7 +256,7 @@ Exemples d'utilisation
 Crawl d'un index de base
 -------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -278,7 +278,7 @@ Script :
 Crawl d'un cluster avec authentification
 -----------------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -302,7 +302,7 @@ Script :
 Crawl de plusieurs index
 --------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -324,7 +324,7 @@ Script :
 Crawl d'un cluster OpenSearch
 -------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -347,7 +347,7 @@ Script :
 Crawl avec limitation de champs
 ---------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -365,12 +365,12 @@ Script :
     content=source.content
     last_modified=source.timestamp
 
-Repartition de charge multi-hotes
+Répartition de charge multi-hôtes
 -----------------------------------
 
-En specifiant plusieurs hotes separes par des virgules dans ``settings.http.hosts``, les requetes sont distribuees entre chaque hote.
+En spécifiant plusieurs hôtes séparés par des virgules dans ``settings.http.hosts``, les requêtes sont distribuées entre chaque hôte.
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -388,63 +388,63 @@ Script :
     content=source.content
     last_modified=source.timestamp
 
-Depannage
+Dépannage
 =========
 
 Erreur de connexion
 --------------------
 
-**Symptome** : ``Connection refused`` ou ``No route to host``
+**Symptôme** : ``Connection refused`` ou ``No route to host``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si l'URL de l'hote est correcte (protocole, nom d'hote, port)
-2. Verifier si Elasticsearch/OpenSearch est en cours d'execution
-3. Verifier les parametres du pare-feu
-4. Pour HTTPS, verifier si le certificat est valide
+1. Vérifier si l'URL de l'hôte est correcte (protocole, nom d'hôte, port)
+2. Vérifier si Elasticsearch/OpenSearch est en cours d'exécution
+3. Vérifier les paramètres du pare-feu
+4. Pour HTTPS, vérifier si le certificat est valide
 
 Erreur d'authentification
 --------------------------
 
-**Symptome** : ``401 Unauthorized`` ou ``403 Forbidden``
+**Symptôme** : ``401 Unauthorized`` ou ``403 Forbidden``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si le nom d'utilisateur et le mot de passe sont corrects
-2. Verifier si l'utilisateur a les droits appropries :
+1. Vérifier si le nom d'utilisateur et le mot de passe sont corrects
+2. Vérifier si l'utilisateur a les droits appropriés :
 
    - Droits de lecture sur l'index
    - Droits d'utilisation de l'API scroll
 
-3. Si Elasticsearch Security (X-Pack) est active, verifier si la configuration est correcte
+3. Si Elasticsearch Security (X-Pack) est activé, vérifier si la configuration est correcte
 
 Index introuvable
 ------------------
 
-**Symptome** : ``index_not_found_exception``
+**Symptôme** : ``index_not_found_exception``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si le nom de l'index est correct (incluant la casse)
-2. Verifier si l'index existe :
+1. Vérifier si le nom de l'index est correct (incluant la casse)
+2. Vérifier si l'index existe :
 
    ::
 
        GET /_cat/indices
 
-3. Verifier si le pattern wildcard est correct (ex : ``logs-*``)
+3. Vérifier si le pattern wildcard est correct (ex : ``logs-*``)
 
-Erreur de requete
+Erreur de requête
 ------------------
 
-**Symptome** : ``parsing_exception`` ou ``search_phase_execution_exception``
+**Symptôme** : ``parsing_exception`` ou ``search_phase_execution_exception``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si le JSON de la requete est correct
-2. Verifier si la requete est compatible avec la version d'Elasticsearch/OpenSearch
-3. Verifier si les noms de champs sont corrects
-4. Tester la requete directement sur Elasticsearch/OpenSearch :
+1. Vérifier si le JSON de la requête est correct
+2. Vérifier si la requête est compatible avec la version d'Elasticsearch/OpenSearch
+3. Vérifier si les noms de champs sont corrects
+4. Tester la requête directement sur Elasticsearch/OpenSearch :
 
    ::
 
@@ -456,7 +456,7 @@ Erreur de requete
 Timeout du scroll
 ------------------
 
-**Symptome** : ``No search context found`` ou ``Scroll timeout``
+**Symptôme** : ``No search context found`` ou ``Scroll timeout``
 
 **Solution** :
 
@@ -466,18 +466,18 @@ Timeout du scroll
 
        scroll=10m
 
-2. Reduire ``size`` :
+2. Réduire ``size`` :
 
    ::
 
        size=50
 
-3. Verifier les ressources du cluster
+3. Vérifier les ressources du cluster
 
-Crawl de donnees volumineuses
+Crawl de données volumineuses
 ------------------------------
 
-**Symptome** : Le crawl est lent ou expire
+**Symptôme** : Le crawl est lent ou expire
 
 **Solution** :
 
@@ -488,34 +488,34 @@ Crawl de donnees volumineuses
        size=100
        size=500  # Plus grand
 
-2. Limiter les champs recuperes avec ``fields``
-3. Filtrer les documents necessaires avec ``query``
-4. Diviser en plusieurs data stores (par index, par periode, etc.)
+2. Limiter les champs récupérés avec ``fields``
+3. Filtrer les documents nécessaires avec ``query``
+4. Diviser en plusieurs data stores (par index, par période, etc.)
 
-Memoire insuffisante
+Mémoire insuffisante
 ---------------------
 
-**Symptome** : OutOfMemoryError
+**Symptôme** : OutOfMemoryError
 
 **Solution** :
 
-1. Reduire ``size``
-2. Limiter les champs recuperes avec ``fields``
+1. Réduire ``size``
+2. Limiter les champs récupérés avec ``fields``
 3. Augmenter la taille du tas de |Fess|
-4. Exclure les champs volumineux (donnees binaires, etc.)
+4. Exclure les champs volumineux (données binaires, etc.)
 
 Connexion SSL/TLS
 =================
 
-Cas de certificat auto-signe
+Cas de certificat auto-signé
 ------------------------------
 
 .. warning::
-   Utilisez des certificats signes de maniere appropriee en environnement de production.
+   Utilisez des certificats signés de manière appropriée en environnement de production.
 
-Methode 1 : Specifier le certificat CA avec le parametre ``settings.http.ssl.certificate_authorities`` (recommande)
+Méthode 1 : Spécifier le certificat CA avec le paramètre ``settings.http.ssl.certificate_authorities`` (recommandé)
 
-Indiquez le chemin du fichier de certificat CA de confiance (format X.509). Cette methode n'affecte pas le keystore global de |Fess|.
+Indiquez le chemin du fichier de certificat CA de confiance (format X.509). Cette méthode n'affecte pas le keystore global de |Fess|.
 
 ::
 
@@ -523,9 +523,9 @@ Indiquez le chemin du fichier de certificat CA de confiance (format X.509). Cett
     settings.http.ssl.certificate_authorities=/path/to/es-cert.crt
     index=myindex
 
-Methode 2 : Ajouter le certificat au keystore Java
+Méthode 2 : Ajouter le certificat au keystore Java
 
-Ajoutez le certificat au trust store de la JVM qui demarre |Fess|.
+Ajoutez le certificat au trust store de la JVM qui démarre |Fess|.
 
 ::
 
@@ -534,7 +534,7 @@ Ajoutez le certificat au trust store de la JVM qui demarre |Fess|.
 Connexion via un proxy
 -----------------------
 
-Pour se connecter via un serveur proxy, specifiez ``settings.http.proxy_host`` et ``settings.http.proxy_port``.
+Pour se connecter via un serveur proxy, spécifiez ``settings.http.proxy_host`` et ``settings.http.proxy_port``.
 
 ::
 
@@ -543,29 +543,29 @@ Pour se connecter via un serveur proxy, specifiez ``settings.http.proxy_host`` e
     settings.http.proxy_port=8080
     index=myindex
 
-Exemples de requetes avancees
+Exemples de requêtes avancées
 ==============================
 
-Requete avec agregation
+Requête avec agrégation
 ------------------------
 
 .. note::
-   Le parametre ``query`` n'accepte que le corps de la requete. Les agregations (aggs), le tri et autres
-   options de niveau recherche ne peuvent pas etre specifies. Seuls les documents sont recuperes.
+   Le paramètre ``query`` n'accepte que le corps de la requête. Les agrégations (aggs), le tri et autres
+   options de niveau recherche ne peuvent pas être spécifiés. Seuls les documents sont récupérés.
 
 Champs de script
 -----------------
 
 .. note::
    Les champs de script Elasticsearch/OpenSearch ne sont pas inclus dans ``_source`` et ne peuvent donc pas
-   etre accedes via le prefixe ``source.*``. Pour utiliser les champs de script, accedez-y via l'objet
+   être accédés via le préfixe ``source.*``. Pour utiliser les champs de script, accédez-y via l'objet
    ``hit`` en utilisant ``hit.getFields()``.
 
-Informations de reference
+Informations de référence
 ==========================
 
-- :doc:`ds-overview` - Apercu des connecteurs Data Store
-- :doc:`ds-database` - Connecteur de base de donnees
+- :doc:`ds-overview` - Aperçu des connecteurs Data Store
+- :doc:`ds-database` - Connecteur de base de données
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration Data Store
 - `Elasticsearch Documentation <https://www.elastic.co/guide/>`_
 - `OpenSearch Documentation <https://opensearch.org/docs/>`_

--- a/fr/15.8/config/datastore/ds-gsuite.rst
+++ b/fr/15.8/config/datastore/ds-gsuite.rst
@@ -2,32 +2,32 @@
 Connecteur Google Workspace
 ==================================
 
-Apercu
+Aperçu
 ====
 
-Le connecteur Google Workspace fournit la fonctionnalite permettant de recuperer les fichiers
+Le connecteur Google Workspace fournit la fonctionnalité permettant de récupérer les fichiers
 depuis Google Drive (anciennement G Suite) et de les enregistrer dans l'index |Fess|.
 
-Cette fonctionnalite necessite le plugin ``fess-ds-gsuite``.
+Cette fonctionnalité nécessite le plugin ``fess-ds-gsuite``.
 
 Services pris en charge
 ============
 
-- Google Drive (Mon Drive, Drive partages)
+- Google Drive (Mon Drive, Drive partagés)
 - Google Docs, Sheets, Slides, Forms, etc.
 
-Prerequis
+Prérequis
 ========
 
 1. L'installation du plugin est requise
-2. La creation d'un projet Google Cloud Platform est necessaire
-3. La creation d'un compte de service et l'obtention des identifiants sont necessaires
-4. La configuration de la delegation a l'echelle du domaine Google Workspace est necessaire
+2. La création d'un projet Google Cloud Platform est nécessaire
+3. La création d'un compte de service et l'obtention des identifiants sont nécessaires
+4. La configuration de la délégation à l'échelle du domaine Google Workspace est nécessaire
 
 Installation du plugin
 ------------------------
 
-Methode 1 : Placement direct du fichier JAR
+Méthode 1 : Placement direct du fichier JAR
 
 ::
 
@@ -39,11 +39,11 @@ Methode 1 : Placement direct du fichier JAR
     # ou
     cp fess-ds-gsuite-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
 
-Methode 2 : Installation depuis l'interface d'administration
+Méthode 2 : Installation depuis l'interface d'administration
 
-1. Ouvrir "Systeme" -> "Plugins"
-2. Telecharger le fichier JAR
-3. Redemarrer |Fess|
+1. Ouvrir "Système" -> "Plugins"
+2. Télécharger le fichier JAR
+3. Redémarrer |Fess|
 
 Configuration
 ========
@@ -57,7 +57,7 @@ Configuration de base
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
+   * - Élément
      - Exemple
    * - Nom
      - Company Google Drive
@@ -66,7 +66,7 @@ Configuration de base
    * - Active
      - Oui
 
-Configuration des parametres
+Configuration des paramètres
 ----------------
 
 ::
@@ -75,79 +75,79 @@ Configuration des parametres
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project.iam.gserviceaccount.com
 
-Liste des parametres
+Liste des paramètres
 ~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``private_key``
      - Oui
-     - Cle privee du compte de service (format PEM, sauts de ligne en ``\n``)
+     - Clé privée du compte de service (format PEM, sauts de ligne en ``\n``)
    * - ``private_key_id``
      - Oui
-     - ID de la cle privee
+     - ID de la clé privée
    * - ``client_email``
      - Oui
      - Adresse email du compte de service
    * - ``max_size``
      - Non
-     - Taille maximale des fichiers a indexer (en octets). Par defaut : ``10000000`` (environ 10 Mo)
+     - Taille maximale des fichiers à indexer (en octets). Par défaut : ``10000000`` (environ 10 Mo)
    * - ``ignore_folder``
      - Non
-     - Ignorer les dossiers ou non. Par defaut : ``true``
+     - Ignorer les dossiers ou non. Par défaut : ``true``
    * - ``ignore_error``
      - Non
-     - Continuer le traitement en cas d'erreur. Par defaut : ``true``
+     - Continuer le traitement en cas d'erreur. Par défaut : ``true``
    * - ``supported_mimetypes``
      - Non
-     - Types MIME a indexer (expression reguliere, separes par des virgules). Par defaut : ``.*`` (tous les types)
+     - Types MIME à indexer (expression régulière, séparés par des virgules). Par défaut : ``.*`` (tous les types)
    * - ``include_pattern``
      - Non
-     - Expression reguliere des URL a inclure dans l'indexation
+     - Expression régulière des URL à inclure dans l'indexation
    * - ``exclude_pattern``
      - Non
-     - Expression reguliere des URL a exclure de l'indexation
+     - Expression régulière des URL à exclure de l'indexation
    * - ``default_permissions``
      - Non
-     - Permissions par defaut (separees par des virgules, ex : ``{role}drive-users``)
+     - Permissions par défaut (séparées par des virgules, ex : ``{role}drive-users``)
    * - ``number_of_threads``
      - Non
-     - Nombre de threads de traitement parallele. Par defaut : ``1``
+     - Nombre de threads de traitement parallèle. Par défaut : ``1``
    * - ``query``
      - Non
-     - Chaine de requete de recherche de l'API Google Drive
+     - Chaîne de requête de recherche de l'API Google Drive
    * - ``corpora``
      - Non
-     - Corpus a rechercher. Par defaut : ``allDrives``
+     - Corpus à rechercher. Par défaut : ``allDrives``
    * - ``spaces``
      - Non
-     - Espaces a rechercher (parametre ``spaces`` de l'API Google Drive, par ex. ``drive``, ``appDataFolder``). Par defaut : non defini (valeur par defaut de l'API).
+     - Espaces à rechercher (paramètre ``spaces`` de l'API Google Drive, par ex. ``drive``, ``appDataFolder``). Par défaut : non défini (valeur par défaut de l'API).
    * - ``fields``
      - Non
-     - Champs de fichier a demander a l'API Google Drive. Par defaut : ``*`` (tous les champs).
+     - Champs de fichier à demander à l'API Google Drive. Par défaut : ``*`` (tous les champs).
    * - ``read_timeout``
      - Non
-     - Delai de lecture HTTP (en millisecondes). Par defaut : ``20000``
+     - Délai de lecture HTTP (en millisecondes). Par défaut : ``20000``
    * - ``connect_timeout``
      - Non
-     - Delai de connexion HTTP (en millisecondes). Par defaut : ``20000``
+     - Délai de connexion HTTP (en millisecondes). Par défaut : ``20000``
    * - ``refresh_token_interval``
      - Non
-     - Intervalle (en secondes) pour renouveler le jeton d'acces OAuth. Par defaut : ``3540`` (59 minutes).
+     - Intervalle (en secondes) pour renouveler le jeton d'accès OAuth. Par défaut : ``3540`` (59 minutes).
    * - ``max_cached_content_size``
      - Non
-     - Taille maximale (en octets) du contenu conserve en memoire ; un contenu plus volumineux est decharge dans un fichier temporaire. Par defaut : ``1048576`` (1 Mo).
+     - Taille maximale (en octets) du contenu conservé en mémoire ; un contenu plus volumineux est déchargé dans un fichier temporaire. Par défaut : ``1048576`` (1 Mo).
    * - ``proxy_host``
      - Non
-     - Nom d'hote du serveur proxy
+     - Nom d'hôte du serveur proxy
    * - ``proxy_port``
      - Non
-     - Numero de port du serveur proxy
+     - Numéro de port du serveur proxy
 
 Configuration du script
 --------------
@@ -186,9 +186,9 @@ Champs disponibles
    * - ``file.filetype``
      - Type de fichier
    * - ``file.created_time``
-     - Date de creation
+     - Date de création
    * - ``file.modified_time``
-     - Date de derniere modification
+     - Date de dernière modification
    * - ``file.web_view_link``
      - Lien pour ouvrir dans le navigateur
    * - ``file.url``
@@ -198,68 +198,68 @@ Champs disponibles
    * - ``file.size``
      - Taille du fichier (octets)
    * - ``file.roles``
-     - Permissions d'acces
+     - Permissions d'accès
 
-Pour plus de details, consultez `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_.
+Pour plus de détails, consultez `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_.
 
 Configuration Google Cloud Platform
 =========================
 
-1. Creation du projet
+1. Création du projet
 ---------------------
 
-Accedez a https://console.cloud.google.com/ :
+Accédez à https://console.cloud.google.com/ :
 
-1. Creez un nouveau projet
+1. Créez un nouveau projet
 2. Entrez le nom du projet
-3. Selectionnez l'organisation et l'emplacement
+3. Sélectionnez l'organisation et l'emplacement
 
 2. Activation de l'API Google Drive
 ---------------------------
 
-Dans "APIs et services" -> "Bibliotheque" :
+Dans "APIs et services" -> "Bibliothèque" :
 
 1. Recherchez "Google Drive API"
 2. Cliquez sur "Activer"
 
-3. Creation du compte de service
+3. Création du compte de service
 ---------------------------
 
 Dans "APIs et services" -> "Identifiants" :
 
-1. Selectionnez "Creer des identifiants" -> "Compte de service"
+1. Sélectionnez "Créer des identifiants" -> "Compte de service"
 2. Entrez le nom du compte de service (ex: fess-crawler)
-3. Cliquez sur "Creer et continuer"
-4. Les roles ne sont pas necessaires (ignorez)
+3. Cliquez sur "Créer et continuer"
+4. Les rôles ne sont pas nécessaires (ignorez)
 5. Cliquez sur "Terminer"
 
-4. Creation de la cle du compte de service
+4. Création de la clé du compte de service
 -------------------------------
 
-Pour le compte de service cree :
+Pour le compte de service créé :
 
 1. Cliquez sur le compte de service
-2. Ouvrez l'onglet "Cles"
-3. "Ajouter une cle" -> "Creer une nouvelle cle"
-4. Selectionnez le format JSON
-5. Enregistrez le fichier JSON telecharge
+2. Ouvrez l'onglet "Clés"
+3. "Ajouter une clé" -> "Créer une nouvelle clé"
+4. Sélectionnez le format JSON
+5. Enregistrez le fichier JSON téléchargé
 
-5. Activation de la delegation a l'echelle du domaine
+5. Activation de la délégation à l'échelle du domaine
 -----------------------------
 
-Dans les parametres du compte de service :
+Dans les paramètres du compte de service :
 
-1. Cochez "Activer la delegation a l'echelle du domaine"
+1. Cochez "Activer la délégation à l'échelle du domaine"
 2. Cliquez sur "Enregistrer"
 3. Copiez "l'ID client OAuth 2"
 
 6. Autorisation dans la console d'administration Google Workspace
 ---------------------------------------
 
-Accedez a https://admin.google.com/ :
+Accédez à https://admin.google.com/ :
 
-1. Ouvrez "Securite" -> "Acces et controle des donnees" -> "Controles d'API"
-2. Selectionnez "Delegation a l'echelle du domaine"
+1. Ouvrez "Sécurité" -> "Accès et contrôle des données" -> "Contrôles d'API"
+2. Sélectionnez "Délégation à l'échelle du domaine"
 3. Cliquez sur "Ajouter nouveau"
 4. Entrez l'ID client
 5. Entrez les scopes OAuth :
@@ -276,7 +276,7 @@ Configuration des identifiants
 Obtention des informations depuis le fichier JSON
 --------------------------
 
-Fichier JSON telecharge :
+Fichier JSON téléchargé :
 
 ::
 
@@ -293,13 +293,13 @@ Fichier JSON telecharge :
       "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/..."
     }
 
-Configurez les informations suivantes dans les parametres :
+Configurez les informations suivantes dans les paramètres :
 
 - ``private_key_id`` -> ``private_key_id``
 - ``private_key`` -> ``private_key`` (conservez les sauts de ligne en ``\n``)
 - ``client_email`` -> ``client_email``
 
-Format de la cle privee
+Format de la clé privée
 ~~~~~~~~~~~~
 
 ``private_key`` conserve les sauts de ligne en ``\n`` :
@@ -314,7 +314,7 @@ Exemples d'utilisation
 Crawl de l'ensemble de Google Drive
 --------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -340,7 +340,7 @@ Script :
 Crawl avec permissions
 ----------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -378,72 +378,72 @@ Google Docs uniquement :
         url=file.web_view_link
     }
 
-Depannage
+Dépannage
 ======================
 
 Erreur d'authentification
 ----------
 
-**Symptome** : ``401 Unauthorized`` ou ``403 Forbidden``
+**Symptôme** : ``401 Unauthorized`` ou ``403 Forbidden``
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si les identifiants du compte de service sont corrects :
+1. Vérifier si les identifiants du compte de service sont corrects :
 
    - Les sauts de ligne de ``private_key`` sont-ils en ``\n`` ?
    - ``private_key_id`` est-il correct ?
    - ``client_email`` est-il correct ?
 
-2. Verifier si l'API Google Drive est activee
-3. Verifier si la delegation a l'echelle du domaine est configuree
-4. Verifier si l'autorisation a ete accordee dans la console d'administration Google Workspace
-5. Verifier si le scope OAuth est correct (``https://www.googleapis.com/auth/drive``)
+2. Vérifier si l'API Google Drive est activée
+3. Vérifier si la délégation à l'échelle du domaine est configurée
+4. Vérifier si l'autorisation a été accordée dans la console d'administration Google Workspace
+5. Vérifier si le scope OAuth est correct (``https://www.googleapis.com/auth/drive``)
 
-Erreur de delegation a l'echelle du domaine
+Erreur de délégation à l'échelle du domaine
 ------------------------
 
-**Symptome** : ``Not Authorized to access this resource/api``
+**Symptôme** : ``Not Authorized to access this resource/api``
 
 **Solution** :
 
-1. Verifier l'autorisation dans la console d'administration Google Workspace :
+1. Vérifier l'autorisation dans la console d'administration Google Workspace :
 
-   - L'ID client est-il correctement enregistre ?
+   - L'ID client est-il correctement enregistré ?
    - Le scope OAuth est-il correct ? (``https://www.googleapis.com/auth/drive``)
 
-2. Verifier si la delegation a l'echelle du domaine est activee sur le compte de service
+2. Vérifier si la délégation à l'échelle du domaine est activée sur le compte de service
 
-Impossible de recuperer les fichiers
+Impossible de récupérer les fichiers
 ----------------------
 
-**Symptome** : Le crawl reussit mais 0 fichiers
+**Symptôme** : Le crawl réussit mais 0 fichiers
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si des fichiers existent dans Google Drive
-2. Verifier si le compte de service a les droits de lecture
-3. Verifier si la delegation a l'echelle du domaine est correctement configuree
-4. Verifier si le Drive de l'utilisateur cible est accessible
+1. Vérifier si des fichiers existent dans Google Drive
+2. Vérifier si le compte de service a les droits de lecture
+3. Vérifier si la délégation à l'échelle du domaine est correctement configurée
+4. Vérifier si le Drive de l'utilisateur cible est accessible
 
 Erreur de quota API
 -----------------
 
-**Symptome** : ``403 Rate Limit Exceeded`` ou ``429 Too Many Requests``
+**Symptôme** : ``403 Rate Limit Exceeded`` ou ``429 Too Many Requests``
 
 **Solution** :
 
-1. Verifier le quota dans Google Cloud Platform
+1. Vérifier le quota dans Google Cloud Platform
 2. Augmenter l'intervalle de crawl
-3. Demander une augmentation de quota si necessaire
+3. Demander une augmentation de quota si nécessaire
 
-Erreur de format de cle privee
+Erreur de format de clé privée
 --------------------------
 
-**Symptome** : ``Invalid private key format``
+**Symptôme** : ``Invalid private key format``
 
 **Solution** :
 
-Verifier si les sauts de ligne sont correctement en ``\n`` :
+Vérifier si les sauts de ligne sont correctement en ``\n`` :
 
 ::
 
@@ -455,39 +455,39 @@ Verifier si les sauts de ligne sont correctement en ``\n`` :
     MIIEvgIBADANBgkqhkiG9w0BAQE...
     -----END PRIVATE KEY-----
 
-Crawl des Drive partages
+Crawl des Drive partagés
 ----------------------
 
 .. note::
-   Pour crawler les Drive partages avec un compte de service,
-   vous devez ajouter le compte de service comme membre du Drive partage.
+   Pour crawler les Drive partagés avec un compte de service,
+   vous devez ajouter le compte de service comme membre du Drive partagé.
 
-1. Ouvrez le Drive partage dans Google Drive
-2. Cliquez sur "Gerer les membres"
+1. Ouvrez le Drive partagé dans Google Drive
+2. Cliquez sur "Gérer les membres"
 3. Ajoutez l'adresse email du compte de service
-4. Definissez le niveau de permission sur "Lecteur"
+4. Définissez le niveau de permission sur "Lecteur"
 
 Cas de nombreux fichiers
 ------------------------
 
-**Symptome** : Le crawl prend du temps ou expire
+**Symptôme** : Le crawl prend du temps ou expire
 
 **Solution** :
 
 1. Diviser en plusieurs data stores
-2. Repartir la charge avec les parametres de planification
+2. Répartir la charge avec les paramètres de planification
 3. Ajuster l'intervalle de crawl
-4. Crawler uniquement des dossiers specifiques
+4. Crawler uniquement des dossiers spécifiques
 
-Permissions et controle d'acces
+Permissions et contrôle d'accès
 ==================
 
 Reflet des permissions de partage Google Drive
 ----------------------------
 
-Reflet des parametres de partage Google Drive dans les permissions Fess :
+Reflet des paramètres de partage Google Drive dans les permissions Fess :
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -510,10 +510,10 @@ Script :
 
 ``file.roles`` contient les informations de partage Google Drive.
 
-Informations de reference
+Informations de référence
 ========
 
-- :doc:`ds-overview` - Apercu des connecteurs Data Store
+- :doc:`ds-overview` - Aperçu des connecteurs Data Store
 - :doc:`ds-microsoft365` - Connecteur Microsoft 365
 - :doc:`ds-box` - Connecteur Box
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration Data Store

--- a/fr/15.8/config/datastore/ds-overview.rst
+++ b/fr/15.8/config/datastore/ds-overview.rst
@@ -1,25 +1,25 @@
 ==================================
-Apercu des connecteurs DataStore
+Aperçu des connecteurs DataStore
 ==================================
 
-Apercu
+Aperçu
 ======
 
-Les connecteurs DataStore de |Fess| fournissent une fonctionnalite permettant de recuperer
-et d'indexer du contenu depuis des sources de donnees autres que les sites web ou les systemes de fichiers.
+Les connecteurs DataStore de |Fess| fournissent une fonctionnalité permettant de récupérer
+et d'indexer du contenu depuis des sources de données autres que les sites web ou les systèmes de fichiers.
 
-En utilisant les connecteurs DataStore, vous pouvez rendre recherchables les donnees provenant des sources suivantes :
+En utilisant les connecteurs DataStore, vous pouvez rendre recherchables les données provenant des sources suivantes :
 
 - Stockage cloud (Box, Dropbox, Google Drive, OneDrive)
 - Outils de collaboration (Confluence, Jira, Slack)
-- Bases de donnees (MySQL, PostgreSQL, Oracle, etc.)
-- Autres systemes (Git, Salesforce, Elasticsearch, etc.)
+- Bases de données (MySQL, PostgreSQL, Oracle, etc.)
+- Autres systèmes (Git, Salesforce, Elasticsearch, etc.)
 
 Connecteurs disponibles
 =======================
 
-|Fess| fournit des connecteurs pour diverses sources de donnees.
-La plupart des connecteurs sont fournis sous forme de plugins et peuvent etre installes selon les besoins.
+|Fess| fournit des connecteurs pour diverses sources de données.
+La plupart des connecteurs sont fournis sous forme de plugins et peuvent être installés selon les besoins.
 
 Stockage cloud
 --------------
@@ -61,7 +61,7 @@ Outils de collaboration
      - fess-ds-slack
      - Exploration des messages et fichiers Slack
 
-Outils de developpement et operations
+Outils de développement et opérations
 -------------------------------------
 
 .. list-table::
@@ -73,15 +73,15 @@ Outils de developpement et operations
      - Description
    * - :doc:`ds-git`
      - fess-ds-git
-     - Exploration du code source des depots Git
+     - Exploration du code source des dépôts Git
    * - :doc:`ds-elasticsearch`
      - fess-ds-elasticsearch
-     - Recuperation de donnees depuis Elasticsearch/OpenSearch
+     - Récupération de données depuis Elasticsearch/OpenSearch
    * - :doc:`ds-salesforce`
      - fess-ds-salesforce
      - Exploration des objets Salesforce
 
-Bases de donnees et fichiers
+Bases de données et fichiers
 ----------------------------
 
 .. list-table::
@@ -93,13 +93,13 @@ Bases de donnees et fichiers
      - Description
    * - :doc:`ds-database`
      - fess-ds-db
-     - Recuperation de donnees depuis les bases de donnees compatibles JDBC
+     - Récupération de données depuis les bases de données compatibles JDBC
    * - :doc:`ds-csv`
      - fess-ds-csv
-     - Recuperation de donnees depuis les fichiers CSV
+     - Récupération de données depuis les fichiers CSV
    * - :doc:`ds-json`
      - fess-ds-json
-     - Recuperation de donnees depuis les fichiers JSON
+     - Récupération de données depuis les fichiers JSON
 
 Installation des connecteurs
 ============================
@@ -107,59 +107,59 @@ Installation des connecteurs
 Installation des plugins
 ------------------------
 
-Les plugins de connecteurs DataStore peuvent etre installes depuis l'interface d'administration.
+Les plugins de connecteurs DataStore peuvent être installés depuis l'interface d'administration.
 
 Depuis l'interface d'administration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Connectez-vous a l'interface d'administration
-2. Naviguez vers "Systeme" -> "Plugin"
+1. Connectez-vous à l'interface d'administration
+2. Naviguez vers "Système" -> "Plugin"
 3. Cliquez sur le bouton "Installer"
-4. Selectionnez le plugin dans l'onglet "Distant" (ou telechargez un fichier JAR depuis l'onglet "Local")
+4. Sélectionnez le plugin dans l'onglet "Distant" (ou téléchargez un fichier JAR depuis l'onglet "Local")
 5. Cliquez sur "Installer"
-6. Redemarrez |Fess|
+6. Redémarrez |Fess|
 
 Configuration de base des DataStores
 ====================================
 
 La configuration des connecteurs DataStore s'effectue dans l'interface d'administration sous "Crawler" -> "DataStore".
 
-Elements de configuration communs
+Éléments de configuration communs
 ---------------------------------
 
-Elements de configuration communs a tous les connecteurs DataStore :
+Éléments de configuration communs à tous les connecteurs DataStore :
 
 .. list-table::
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
+   * - Élément
      - Description
    * - Nom
      - Nom d'identification de la configuration
    * - Description
      - Description de la configuration
    * - Nom du handler
-     - Nom du handler du connecteur a utiliser (ex: ``CsvDataStore``)
-   * - Parametres
-     - Parametres de configuration specifiques au connecteur (format key=value)
+     - Nom du handler du connecteur à utiliser (ex: ``CsvDataStore``)
+   * - Paramètres
+     - Paramètres de configuration spécifiques au connecteur (format key=value)
    * - Script
      - Script de mapping des champs d'index
    * - Boost
-     - Priorite dans les resultats de recherche
+     - Priorité dans les résultats de recherche
    * - Autorisations
-     - Autorisations d'acces aux documents recuperes par ce connecteur
-   * - Hotes virtuels
-     - Hote virtuel auquel cette configuration s'applique
+     - Autorisations d'accès aux documents récupérés par ce connecteur
+   * - Hôtes virtuels
+     - Hôte virtuel auquel cette configuration s'applique
    * - Ordre d'affichage
      - Ordre d'affichage dans la liste des configurations
    * - Actif
      - Activer ou non cette configuration
 
-Configuration des parametres
+Configuration des paramètres
 ----------------------------
 
-Les parametres sont specifies au format ``key=value`` separes par des retours a la ligne :
+Les paramètres sont spécifiés au format ``key=value`` séparés par des retours à la ligne :
 
 ::
 
@@ -170,10 +170,10 @@ Les parametres sont specifies au format ``key=value`` separes par des retours a 
 Configuration du script
 -----------------------
 
-Le script permet de mapper les donnees recuperees vers les champs d'index de |Fess|.
+Le script permet de mapper les données récupérées vers les champs d'index de |Fess|.
 Chaque ligne du script associe un champ d'index |Fess| (membre gauche) au champ fourni par le connecteur (membre droit).
 
-Voici un exemple pour le connecteur CSV avec les colonnes d'en-tete ``link``, ``subject`` et ``body`` :
+Voici un exemple pour le connecteur CSV avec les colonnes d'en-tête ``link``, ``subject`` et ``body`` :
 
 ::
 
@@ -184,72 +184,72 @@ Voici un exemple pour le connecteur CSV avec les colonnes d'en-tete ``link``, ``
 .. note::
 
    Les noms de champs utilisables dans le script varient selon le connecteur.
-   Box/Dropbox/Google Drive/OneDrive referencent l'objet recupere avec le prefixe ``file.*`` ; Slack utilise ``message.*`` ; Jira utilise ``issue.*``.
-   En revanche, les connecteurs CSV, JSON et Base de donnees n'utilisent aucun prefixe ; les champs sont references directement :
+   Box/Dropbox/Google Drive/OneDrive référencent l'objet récupéré avec le préfixe ``file.*`` ; Slack utilise ``message.*`` ; Jira utilise ``issue.*``.
+   En revanche, les connecteurs CSV, JSON et Base de données n'utilisent aucun préfixe ; les champs sont référencés directement :
 
-   - CSV : noms des colonnes d'en-tete (si ``has_header_line=true``), ou ``cell1``, ``cell2``, ... (index base 1) ; ainsi que ``csvfile`` et ``csvfilename``.
+   - CSV : noms des colonnes d'en-tête (si ``has_header_line=true``), ou ``cell1``, ``cell2``, ... (index base 1) ; ainsi que ``csvfile`` et ``csvfilename``.
    - JSON : noms des champs de l'objet JSON.
-   - Base de donnees : noms des colonnes (alias) du resultat SELECT.
+   - Base de données : noms des colonnes (alias) du résultat SELECT.
 
-   Consultez la documentation individuelle de chaque connecteur pour plus de details.
+   Consultez la documentation individuelle de chaque connecteur pour plus de détails.
 
 Configuration de l'authentification
 ===================================
 
-La plupart des connecteurs DataStore necessitent une authentification (OAuth 2.0, cle API, compte de service, etc.).
+La plupart des connecteurs DataStore nécessitent une authentification (OAuth 2.0, clé API, compte de service, etc.).
 
-Les parametres d'authentification varient selon le connecteur.
-Consultez la documentation de chaque connecteur pour les details de configuration de l'authentification.
+Les paramètres d'authentification varient selon le connecteur.
+Consultez la documentation de chaque connecteur pour les détails de configuration de l'authentification.
 
-Parametres communs
+Paramètres communs
 ==================
 
-Parametres communs a tous les connecteurs DataStore :
+Paramètres communs à tous les connecteurs DataStore :
 
 .. list-table::
    :header-rows: 1
    :widths: 20 15 65
 
-   * - Parametre
-     - Defaut
+   * - Paramètre
+     - Défaut
      - Description
    * - ``readInterval``
      - ``0``
-     - Delai d'attente entre le traitement de chaque enregistrement (en millisecondes). Utilisez ce parametre pour reduire la charge du serveur lors du traitement de grandes quantites de donnees.
+     - Délai d'attente entre le traitement de chaque enregistrement (en millisecondes). Utilisez ce paramètre pour réduire la charge du serveur lors du traitement de grandes quantités de données.
    * - ``script_type``
      - ``groovy``
-     - Type de moteur de script utilise pour le mappage des champs d'index. Par defaut, seul ``groovy`` est disponible.
+     - Type de moteur de script utilisé pour le mappage des champs d'index. Par défaut, seul ``groovy`` est disponible.
 
-Depannage
+Dépannage
 =========
 
-Le connecteur n'apparait pas
+Le connecteur n'apparaît pas
 ----------------------------
 
-1. Verifiez que le plugin est correctement installe
-2. Redemarrez |Fess|
-3. Verifiez les erreurs dans les logs
+1. Vérifiez que le plugin est correctement installé
+2. Redémarrez |Fess|
+3. Vérifiez les erreurs dans les logs
 
 Erreur d'authentification
 -------------------------
 
-1. Verifiez que les informations d'authentification sont correctes
-2. Verifiez la date d'expiration du token
-3. Verifiez que les autorisations necessaires sont accordees
-4. Verifiez que l'acces API est autorise cote service
+1. Vérifiez que les informations d'authentification sont correctes
+2. Vérifiez la date d'expiration du token
+3. Vérifiez que les autorisations nécessaires sont accordées
+4. Vérifiez que l'accès API est autorisé côté service
 
-Impossible de recuperer les donnees
+Impossible de récupérer les données
 -----------------------------------
 
-1. Verifiez le format des parametres
-2. Verifiez les droits d'acces aux dossiers/fichiers cibles
-3. Verifiez les parametres de filtre
-4. Verifiez les messages d'erreur detailles dans les logs
+1. Vérifiez le format des paramètres
+2. Vérifiez les droits d'accès aux dossiers/fichiers cibles
+3. Vérifiez les paramètres de filtre
+4. Vérifiez les messages d'erreur détaillés dans les logs
 
-Configuration de debogage
+Configuration de débogage
 -------------------------
 
-Pour investiguer les problemes, ajustez le niveau de log. Le crawling des datastores s'execute dans le processus crawler ; c'est donc le fichier de configuration des logs du crawler qu'il faut modifier :
+Pour investiguer les problèmes, ajustez le niveau de log. Le crawling des datastores s'exécute dans le processus crawler ; c'est donc le fichier de configuration des logs du crawler qu'il faut modifier :
 
 ``app/WEB-INF/env/crawler/resources/log4j2.xml`` :
 
@@ -257,7 +257,7 @@ Pour investiguer les problemes, ajustez le niveau de log. Le crawling des datast
 
     <Logger name="org.codelibs.fess.ds" level="DEBUG"/>
 
-Informations de reference
+Informations de référence
 =========================
 
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration DataStore

--- a/fr/15.8/config/datastore/ds-salesforce.rst
+++ b/fr/15.8/config/datastore/ds-salesforce.rst
@@ -2,28 +2,28 @@
 Connecteur Salesforce
 ==================================
 
-Apercu
+Aperçu
 ====
 
-Le connecteur Salesforce fournit la fonctionnalite permettant de recuperer des donnees
-depuis les objets Salesforce (objets standard, objets personnalises) et de les enregistrer dans l'index |Fess|.
+Le connecteur Salesforce fournit la fonctionnalité permettant de récupérer des données
+depuis les objets Salesforce (objets standard, objets personnalisés) et de les enregistrer dans l'index |Fess|.
 
-Cette fonctionnalite necessite le plugin ``fess-ds-salesforce``.
+Cette fonctionnalité nécessite le plugin ``fess-ds-salesforce``.
 
 Objets pris en charge
 ================
 
-- **Objets standard** : objets standard predefinis (Account, Contact, Lead, Opportunity, Case, Solution, etc.). L'ensemble des objets standard est fixe et la totalite d'entre eux est recuperee a chaque crawl.
-- **Objets personnalises** : objets definis par l'utilisateur, specifies via le parametre ``custom`` (objets dont le nom API se termine par ``__c``).
+- **Objets standard** : objets standard prédéfinis (Account, Contact, Lead, Opportunity, Case, Solution, etc.). L'ensemble des objets standard est fixe et la totalité d'entre eux est récupérée à chaque crawl.
+- **Objets personnalisés** : objets définis par l'utilisateur, spécifiés via le paramètre ``custom`` (objets dont le nom API se termine par ``__c``).
 
 .. note::
 
-   Les objets standard sont toujours crawles integralement (il n'est pas possible de selectionner individuellement les objets standard a crawler). Pour exclure des objets indesirables, utilisez le filtrage par URL via ``include_pattern`` / ``exclude_pattern``.
+   Les objets standard sont toujours crawlés intégralement (il n'est pas possible de sélectionner individuellement les objets standard à crawler). Pour exclure des objets indésirables, utilisez le filtrage par URL via ``include_pattern`` / ``exclude_pattern``.
 
 Liste des objets standard
 -------------------------
 
-Les objets standard suivants sont crawles. La colonne "Nom de l'objet" est l'identifiant utilise dans le mapping des champs (par exemple ``<NomObjet>.title``) ; ``object.type`` est la valeur du type d'objet que vous pouvez referencer dans les scripts.
+Les objets standard suivants sont crawlés. La colonne "Nom de l'objet" est l'identifiant utilisé dans le mapping des champs (par exemple ``<NomObjet>.title``) ; ``object.type`` est la valeur du type d'objet que vous pouvez référencer dans les scripts.
 
 .. list-table::
    :header-rows: 1
@@ -102,20 +102,20 @@ Les objets standard suivants sont crawles. La colonne "Nom de l'objet" est l'ide
      - ``DandBCompany``
      - D&B Company
 
-Prerequis
+Prérequis
 ========
 
 1. L'installation du plugin est requise
-2. La creation d'une application connectee (Connected App) Salesforce est necessaire
-3. La configuration de l'authentification OAuth est necessaire
-4. L'acces en lecture aux objets est requis
+2. La création d'une application connectée (Connected App) Salesforce est nécessaire
+3. La configuration de l'authentification OAuth est nécessaire
+4. L'accès en lecture aux objets est requis
 
 Installation du plugin
 ------------------------
 
-Installez depuis l'interface d'administration via "Systeme" -> "Plugins".
+Installez depuis l'interface d'administration via "Système" -> "Plugins".
 
-Ou consultez :doc:`../../admin/plugin-guide` pour plus de details.
+Ou consultez :doc:`../../admin/plugin-guide` pour plus de détails.
 
 Configuration
 ========
@@ -129,7 +129,7 @@ Configuration de base
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
+   * - Élément
      - Exemple
    * - Nom
      - Salesforce CRM
@@ -138,10 +138,10 @@ Configuration de base
    * - Active
      - Oui
 
-Configuration des parametres
+Configuration des paramètres
 ----------------
 
-Authentification OAuth Token (recommandee) :
+Authentification OAuth Token (recommandée) :
 
 ::
 
@@ -172,19 +172,19 @@ Authentification OAuth Password :
     number_of_threads=1
     ignore_error=true
 
-Liste des parametres
+Liste des paramètres
 ~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametre
+   * - Paramètre
      - Requis
      - Description
    * - ``base_url``
      - Non
-     - URL Salesforce (par defaut : ``https://login.salesforce.com``, Sandbox : ``https://test.salesforce.com``)
+     - URL Salesforce (par défaut : ``https://login.salesforce.com``, Sandbox : ``https://test.salesforce.com``)
    * - ``auth_type``
      - Oui
      - Type d'authentification (``oauth_token`` ou ``oauth_password``)
@@ -196,52 +196,52 @@ Liste des parametres
      - Mot de passe Salesforce
    * - ``client_id``
      - Oui
-     - Consumer Key de l'application connectee
+     - Consumer Key de l'application connectée
    * - ``private_key``
      - Pour oauth_token
-     - Cle privee (format PEM, sauts de ligne en ``\n``)
+     - Clé privée (format PEM, sauts de ligne en ``\n``)
    * - ``client_secret``
      - Pour oauth_password
-     - Consumer Secret de l'application connectee
+     - Consumer Secret de l'application connectée
    * - ``security_token``
      - Pour oauth_password
-     - Token de securite de l'utilisateur
+     - Token de sécurité de l'utilisateur
    * - ``number_of_threads``
      - Non
-     - Nombre de threads de traitement parallele (par defaut : 1)
+     - Nombre de threads de traitement parallèle (par défaut : 1)
    * - ``ignore_error``
      - Non
-     - Continuer le traitement en cas d'erreur (par defaut : true)
+     - Continuer le traitement en cas d'erreur (par défaut : true)
    * - ``custom``
      - Non
-     - Noms des objets personnalises (separes par des virgules)
+     - Noms des objets personnalisés (séparés par des virgules)
    * - ``<objet>.title``
      - Non
-     - Nom du champ a utiliser pour le titre
+     - Nom du champ à utiliser pour le titre
    * - ``<objet>.contents``
      - Non
-     - Noms des champs a utiliser pour le contenu (separes par des virgules)
+     - Noms des champs à utiliser pour le contenu (séparés par des virgules)
    * - ``<objet>.descriptions``
      - Non
-     - Noms de champs pour la description (separes par des virgules)
+     - Noms de champs pour la description (séparés par des virgules)
    * - ``<objet>.thumbnail``
      - Non
      - Nom du champ pour la miniature
    * - ``include_pattern``
      - Non
-     - Modele d'inclusion du filtre URL (regex)
+     - Modèle d'inclusion du filtre URL (regex)
    * - ``exclude_pattern``
      - Non
-     - Modele d'exclusion du filtre URL (regex)
+     - Modèle d'exclusion du filtre URL (regex)
    * - ``refresh_token_interval``
      - Non
-     - Intervalle d'actualisation du jeton en secondes (par defaut : 3540)
+     - Intervalle d'actualisation du jeton en secondes (par défaut : 3540)
    * - ``proxy_host``
      - Non
-     - Nom d'hote du proxy HTTP
+     - Nom d'hôte du proxy HTTP
    * - ``proxy_port``
-     - Si proxy_host est defini
-     - Numero de port du proxy HTTP
+     - Si proxy_host est défini
+     - Numéro de port du proxy HTTP
 
 Configuration du script
 --------------
@@ -277,40 +277,40 @@ Champs disponibles
    * - ``object.content_length``
      - Longueur du contenu
    * - ``object.created``
-     - Date de creation
+     - Date de création
    * - ``object.last_modified``
-     - Date de derniere modification
+     - Date de dernière modification
    * - ``object.url``
      - URL de l'objet
    * - ``object.thumbnail``
      - URL de la miniature
 
-Configuration de l'application connectee Salesforce
+Configuration de l'application connectée Salesforce
 ====================================
 
-1. Creation de l'application connectee
+1. Création de l'application connectée
 -----------------------------
 
 Dans Salesforce Setup :
 
 1. Ouvrez "Gestionnaire d'applications"
-2. Cliquez sur "Nouvelle application connectee"
+2. Cliquez sur "Nouvelle application connectée"
 3. Entrez les informations de base :
 
-   - Nom de l'application connectee : Fess Crawler
+   - Nom de l'application connectée : Fess Crawler
    - Nom de l'API : Fess_Crawler
    - Email de contact : your-email@example.com
 
-4. Cochez "Activer les parametres OAuth (Activer OAuth)"
+4. Cochez "Activer les paramètres OAuth (Activer OAuth)"
 
-2. Configuration de l'authentification OAuth Token (recommandee)
+2. Configuration de l'authentification OAuth Token (recommandée)
 --------------------------------
 
-Dans les parametres OAuth :
+Dans les paramètres OAuth :
 
-1. Cochez "Utiliser les signatures numeriques"
-2. Telechargez un certificat (cree selon les etapes ci-dessous)
-3. Scopes OAuth selectionnes :
+1. Cochez "Utiliser les signatures numériques"
+2. Téléchargez un certificat (créé selon les étapes ci-dessous)
+3. Scopes OAuth sélectionnés :
 
    - Full access (full)
    - Perform requests on your behalf at any time (refresh_token, offline_access)
@@ -318,7 +318,7 @@ Dans les parametres OAuth :
 4. Cliquez sur "Enregistrer"
 5. Copiez la Consumer Key
 
-Creation du certificat :
+Création du certificat :
 
 ::
 
@@ -331,16 +331,16 @@ Creation du certificat :
     # Verification de la cle privee
     cat private_key.pem
 
-Telechargez le certificat (certificate.crt) sur Salesforce et
-configurez le contenu de la cle privee (private_key.pem) dans les parametres.
+Téléchargez le certificat (certificate.crt) sur Salesforce et
+configurez le contenu de la clé privée (private_key.pem) dans les paramètres.
 
 3. Configuration de l'authentification OAuth Password
 ---------------------------
 
-Dans les parametres OAuth :
+Dans les paramètres OAuth :
 
-1. URL de callback : ``https://localhost`` (non utilisee mais requise)
-2. Scopes OAuth selectionnes :
+1. URL de callback : ``https://localhost`` (non utilisée mais requise)
+2. Scopes OAuth sélectionnés :
 
    - Full access (full)
    - Perform requests on your behalf at any time (refresh_token, offline_access)
@@ -348,29 +348,29 @@ Dans les parametres OAuth :
 3. Cliquez sur "Enregistrer"
 4. Copiez la Consumer Key et le Consumer Secret
 
-Obtention du token de securite :
+Obtention du token de sécurité :
 
-1. Ouvrez les parametres personnels dans Salesforce
-2. Cliquez sur "Reinitialiser mon token de securite"
-3. Copiez le token envoye par email
+1. Ouvrez les paramètres personnels dans Salesforce
+2. Cliquez sur "Réinitialiser mon token de sécurité"
+3. Copiez le token envoyé par email
 
-4. Autorisation de l'application connectee
+4. Autorisation de l'application connectée
 -----------------------------
 
-Dans "Administration" -> "Gerer les applications connectees" :
+Dans "Administration" -> "Gérer les applications connectées" :
 
-1. Selectionnez l'application connectee creee
+1. Sélectionnez l'application connectée créée
 2. Cliquez sur "Modifier"
-3. Changez "Utilisateurs autorises" en "Les utilisateurs approuves par l'administrateur sont preautorises"
+3. Changez "Utilisateurs autorisés" en "Les utilisateurs approuvés par l'administrateur sont préautorisés"
 4. Attribuez des profils ou des ensembles de permissions
 
-Configuration des objets personnalises
+Configuration des objets personnalisés
 ==========================
 
-Crawl des objets personnalises
+Crawl des objets personnalisés
 ------------------------------
 
-Specifiez les noms des objets personnalises avec le parametre ``custom`` :
+Spécifiez les noms des objets personnalisés avec le paramètre ``custom`` :
 
 ::
 
@@ -389,20 +389,20 @@ Mapping des champs pour chaque objet :
     ProjectTask.title=Task_Name__c
     ProjectTask.contents=Task_Name__c,Task_Description__c
 
-Regles de mapping des champs
+Règles de mapping des champs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``<nom_objet>.title`` - Champ a utiliser pour le titre (champ unique)
-- ``<nom_objet>.contents`` - Champs a utiliser pour le contenu (plusieurs separes par des virgules)
-- ``<nom_objet>.descriptions`` - Champs a utiliser pour la description (plusieurs separes par des virgules)
-- ``<nom_objet>.thumbnail`` - Champ a utiliser pour la miniature (champ unique)
+- ``<nom_objet>.title`` - Champ à utiliser pour le titre (champ unique)
+- ``<nom_objet>.contents`` - Champs à utiliser pour le contenu (plusieurs séparés par des virgules)
+- ``<nom_objet>.descriptions`` - Champs à utiliser pour la description (plusieurs séparés par des virgules)
+- ``<nom_objet>.thumbnail`` - Champ à utiliser pour la miniature (champ unique)
 
 .. note::
 
    Pour le mapping des champs des objets standard, le nom de l'objet utilise la notation UPPER_SNAKE_CASE
    (la valeur de la colonne "Nom de l'objet" dans la section `Liste des objets standard`_)
    (ex. : ``ACCOUNT.title=Name``, ``DAND_B_COMPANY.title=Name``).
-   Pour les objets personnalises, le nom de reference API est utilise tel quel (ex. : ``Product__c.title=Name``).
+   Pour les objets personnalisés, le nom de référence API est utilisé tel quel (ex. : ``Product__c.title=Name``).
 
 Exemples d'utilisation
 ======
@@ -410,7 +410,7 @@ Exemples d'utilisation
 Crawl des objets standard
 --------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -433,10 +433,10 @@ Script :
     timestamp=object.last_modified
     url=object.url
 
-Crawl des objets personnalises
+Crawl des objets personnalisés
 ------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -466,7 +466,7 @@ Script :
 Crawl d'un environnement Sandbox
 ---------------------
 
-Parametres :
+Paramètres :
 
 ::
 
@@ -489,106 +489,106 @@ Script :
     timestamp=object.last_modified
     url=object.url
 
-Depannage
+Dépannage
 ======================
 
 Erreur d'authentification
 ----------
 
-**Symptome** : ``Authentication failed`` ou ``invalid_grant``
+**Symptôme** : ``Authentication failed`` ou ``invalid_grant``
 
-**Points a verifier** :
+**Points à vérifier** :
 
 1. Pour l'authentification OAuth Token :
 
-   - Verifier si la Consumer Key est correcte
-   - Verifier si la cle privee est correctement copiee (sauts de ligne en ``\n``)
-   - Verifier si le certificat a ete telecharge sur Salesforce
-   - Verifier si le nom d'utilisateur est correct
+   - Vérifier si la Consumer Key est correcte
+   - Vérifier si la clé privée est correctement copiée (sauts de ligne en ``\n``)
+   - Vérifier si le certificat a été téléchargé sur Salesforce
+   - Vérifier si le nom d'utilisateur est correct
 
 2. Pour l'authentification OAuth Password :
 
-   - Verifier si la Consumer Key et le Consumer Secret sont corrects
-   - Verifier si le token de securite est correct
-   - Verifier que le mot de passe et le token de securite ne sont pas concatenes (configurer separement)
+   - Vérifier si la Consumer Key et le Consumer Secret sont corrects
+   - Vérifier si le token de sécurité est correct
+   - Vérifier que le mot de passe et le token de sécurité ne sont pas concaténés (configurer séparément)
 
 3. Commun :
 
-   - Verifier si base_url est correct (environnement de production ou Sandbox)
-   - Verifier si l'application connectee est autorisee
+   - Vérifier si base_url est correct (environnement de production ou Sandbox)
+   - Vérifier si l'application connectée est autorisée
 
-Impossible de recuperer les objets
+Impossible de récupérer les objets
 --------------------------
 
-**Symptome** : Le crawl reussit mais 0 objets
+**Symptôme** : Le crawl réussit mais 0 objets
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si l'utilisateur a les droits de lecture sur l'objet
-2. Pour les objets personnalises, verifier si le nom de l'objet est correct (nom de reference API)
-3. Verifier si le mapping des champs est correct
-4. Verifier les messages d'erreur dans les logs
+1. Vérifier si l'utilisateur a les droits de lecture sur l'objet
+2. Pour les objets personnalisés, vérifier si le nom de l'objet est correct (nom de référence API)
+3. Vérifier si le mapping des champs est correct
+4. Vérifier les messages d'erreur dans les logs
 
-Nom des objets personnalises
+Nom des objets personnalisés
 --------------------------
 
-Verifier le nom de reference API de l'objet personnalise :
+Vérifier le nom de référence API de l'objet personnalisé :
 
 1. Ouvrez "Gestionnaire d'objets" dans Salesforce Setup
-2. Selectionnez l'objet personnalise
-3. Copiez le "Nom de l'API" (se termine generalement par ``__c``)
+2. Sélectionnez l'objet personnalisé
+3. Copiez le "Nom de l'API" (se termine généralement par ``__c``)
 
 Exemple :
 
 - Label d'affichage : Product
 - Nom de l'API : Product__c (utilisez celui-ci)
 
-Verification des noms de champs
+Vérification des noms de champs
 ------------------
 
-Verifier le nom de reference API des champs personnalises :
+Vérifier le nom de référence API des champs personnalisés :
 
 1. Ouvrez "Champs et relations" de l'objet
-2. Selectionnez le champ personnalise
-3. Copiez le "Nom du champ" (se termine generalement par ``__c``)
+2. Sélectionnez le champ personnalisé
+3. Copiez le "Nom du champ" (se termine généralement par ``__c``)
 
 Exemple :
 
 - Label d'affichage du champ : Product Description
 - Nom du champ : Product_Description__c (utilisez celui-ci)
 
-Limitation de debit API
+Limitation de débit API
 -------------
 
-**Symptome** : ``REQUEST_LIMIT_EXCEEDED``
+**Symptôme** : ``REQUEST_LIMIT_EXCEEDED``
 
 **Solution** :
 
-1. Reduire ``number_of_threads`` (definir a 1)
+1. Réduire ``number_of_threads`` (définir à 1)
 2. Augmenter l'intervalle de crawl
-3. Verifier l'utilisation de l'API Salesforce
-4. Acheter des limites API supplementaires si necessaire
+3. Vérifier l'utilisation de l'API Salesforce
+4. Acheter des limites API supplémentaires si nécessaire
 
-Cas de nombreuses donnees
+Cas de nombreuses données
 ----------------------
 
-**Symptome** : Le crawl prend du temps ou expire
+**Symptôme** : Le crawl prend du temps ou expire
 
 **Solution** :
 
 1. Diviser les objets en plusieurs data stores
 2. Ajuster ``number_of_threads`` (environ 2-4)
-3. Repartir le calendrier de crawl
-4. Mapper uniquement les champs necessaires
+3. Répartir le calendrier de crawl
+4. Mapper uniquement les champs nécessaires
 
-Erreur de format de cle privee
+Erreur de format de clé privée
 --------------------------
 
-**Symptome** : ``Invalid private key format``
+**Symptôme** : ``Invalid private key format``
 
 **Solution** :
 
-Verifier si les sauts de ligne de la cle privee sont correctement en ``\n`` :
+Vérifier si les sauts de ligne de la clé privée sont correctement en ``\n`` :
 
 ::
 
@@ -600,11 +600,11 @@ Verifier si les sauts de ligne de la cle privee sont correctement en ``\n`` :
     MIIEvgIBADANBgkqhkiG9w0BAQE...
     -----END PRIVATE KEY-----
 
-Informations de reference
+Informations de référence
 ========
 
-- :doc:`ds-overview` - Apercu des connecteurs Data Store
-- :doc:`ds-database` - Connecteur de base de donnees
+- :doc:`ds-overview` - Aperçu des connecteurs Data Store
+- :doc:`ds-database` - Connecteur de base de données
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration Data Store
 - `Salesforce REST API <https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/>`_
 - `Salesforce OAuth 2.0 JWT Bearer Flow <https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm>`_

--- a/fr/15.8/config/llm-gemini.rst
+++ b/fr/15.8/config/llm-gemini.rst
@@ -2,70 +2,70 @@
 Configuration Google Gemini
 ===========================
 
-Apercu
+Aperçu
 ======
 
-Google Gemini est un grand modele de langage (LLM) de pointe fourni par Google.
-|Fess| peut utiliser l'API Google AI (Generative Language API) pour realiser la fonctionnalite de mode de recherche IA avec les modeles Gemini.
+Google Gemini est un grand modèle de langage (LLM) de pointe fourni par Google.
+|Fess| peut utiliser l'API Google AI (Generative Language API) pour réaliser la fonctionnalité de mode de recherche IA avec les modèles Gemini.
 
-L'utilisation de Gemini permet de generer des reponses de haute qualite en tirant parti de la derniere technologie IA de Google.
+L'utilisation de Gemini permet de générer des réponses de haute qualité en tirant parti de la dernière technologie IA de Google.
 
-Caracteristiques principales
+Caractéristiques principales
 -----------------------------
 
 - **Prise en charge multimodale** : Peut traiter les images en plus du texte
-- **Long contexte** : Fenetre de contexte longue permettant de traiter de grandes quantites de documents a la fois
-- **Efficacite des couts** : Le modele Flash est rapide et peu couteux
-- **Integration Google** : Integration facile avec les services Google Cloud
+- **Long contexte** : Fenêtre de contexte longue permettant de traiter de grandes quantités de documents à la fois
+- **Efficacité des coûts** : Le modèle Flash est rapide et peu coûteux
+- **Intégration Google** : Intégration facile avec les services Google Cloud
 
-Modeles pris en charge
+Modèles pris en charge
 -----------------------
 
-Principaux modeles disponibles avec Gemini :
+Principaux modèles disponibles avec Gemini :
 
-- ``gemini-3.1-flash-lite-preview`` - Modele rapide leger et a faible cout (par defaut)
-- ``gemini-3-flash-preview`` - Modele Flash standard
-- ``gemini-3.1-pro`` / ``gemini-3-pro`` - Modeles de raisonnement avance
-- ``gemini-2.5-flash`` - Version stable du modele rapide
-- ``gemini-2.5-pro`` - Version stable du modele de raisonnement
+- ``gemini-3.1-flash-lite-preview`` - Modèle rapide léger et à faible coût (par défaut)
+- ``gemini-3-flash-preview`` - Modèle Flash standard
+- ``gemini-3.1-pro`` / ``gemini-3-pro`` - Modèles de raisonnement avancé
+- ``gemini-2.5-flash`` - Version stable du modèle rapide
+- ``gemini-2.5-pro`` - Version stable du modèle de raisonnement
 
 .. note::
-   Pour les derniers modeles disponibles, consultez `Google AI for Developers <https://ai.google.dev/models/gemini>`__.
+   Pour les derniers modèles disponibles, consultez `Google AI for Developers <https://ai.google.dev/models/gemini>`__.
 
-Prerequis
+Prérequis
 =========
 
-Avant d'utiliser Gemini, preparez les elements suivants.
+Avant d'utiliser Gemini, préparez les éléments suivants.
 
 1. **Compte Google** : Un compte Google est requis
-2. **Acces Google AI Studio** : Accedez a `https://aistudio.google.com/ <https://aistudio.google.com/>`__
-3. **Cle API** : Generez une cle API dans Google AI Studio
+2. **Accès Google AI Studio** : Accédez à `https://aistudio.google.com/ <https://aistudio.google.com/>`__
+3. **Clé API** : Générez une clé API dans Google AI Studio
 
-Obtention de la cle API
+Obtention de la clé API
 ------------------------
 
-1. Accedez a `Google AI Studio <https://aistudio.google.com/>`__
+1. Accédez à `Google AI Studio <https://aistudio.google.com/>`__
 2. Cliquez sur "Get API key"
-3. Selectionnez "Create API key"
-4. Selectionnez ou creez un projet
-5. Enregistrez la cle API generee en lieu sur
+3. Sélectionnez "Create API key"
+4. Sélectionnez ou créez un projet
+5. Enregistrez la clé API générée en lieu sûr
 
 .. warning::
-   La cle API est une information confidentielle. Faites attention aux points suivants :
+   La clé API est une information confidentielle. Faites attention aux points suivants :
 
-   - Ne pas la commiter dans un systeme de gestion de versions
+   - Ne pas la commiter dans un système de gestion de versions
    - Ne pas l'afficher dans les logs
-   - La gerer via des variables d'environnement ou des fichiers de configuration securises
+   - La gérer via des variables d'environnement ou des fichiers de configuration sécurisés
 
 Installation du plugin
 ======================
 
-La fonctionnalite d'integration Gemini est fournie sous forme de plugin ``fess-llm-gemini``.
-Pour utiliser Gemini, l'installation du plugin est necessaire.
+La fonctionnalité d'intégration Gemini est fournie sous forme de plugin ``fess-llm-gemini``.
+Pour utiliser Gemini, l'installation du plugin est nécessaire.
 
-1. Telechargez `fess-llm-gemini-15.8.0.jar`
-2. Placez-le dans le repertoire ``app/WEB-INF/plugin/`` de |Fess|
-3. Redemarrez |Fess|
+1. Téléchargez `fess-llm-gemini-15.8.0.jar`
+2. Placez-le dans le répertoire ``app/WEB-INF/plugin/`` de |Fess|
+3. Redémarrez |Fess|
 
 ::
 
@@ -73,17 +73,17 @@ Pour utiliser Gemini, l'installation du plugin est necessaire.
     cp fess-llm-gemini-15.8.0.jar /path/to/fess/app/WEB-INF/plugin/
 
 .. note::
-   La version du plugin doit correspondre a la version de |Fess|.
+   La version du plugin doit correspondre à la version de |Fess|.
 
 Configuration de base
 =====================
 
-La selection du fournisseur LLM ( ``rag.llm.name`` ) s'effectue via l'administration ou dans ``system.properties``, et l'activation de la fonctionnalite de mode de recherche IA ainsi que les parametres specifiques a Gemini s'effectuent dans ``fess_config.properties``.
+La sélection du fournisseur LLM ( ``rag.llm.name`` ) s'effectue via l'administration ou dans ``system.properties``, et l'activation de la fonctionnalité de mode de recherche IA ainsi que les paramètres spécifiques à Gemini s'effectuent dans ``fess_config.properties``.
 
 Configuration de fess_config.properties
 -----------------------------------------
 
-Ajoutez la configuration d'activation de la fonctionnalite de mode de recherche IA dans ``app/WEB-INF/conf/fess_config.properties``.
+Ajoutez la configuration d'activation de la fonctionnalité de mode de recherche IA dans ``app/WEB-INF/conf/fess_config.properties``.
 
 ::
 
@@ -93,12 +93,12 @@ Ajoutez la configuration d'activation de la fonctionnalite de mode de recherche 
 Configuration du fournisseur LLM
 ----------------------------------
 
-Le nom du fournisseur LLM ( ``rag.llm.name`` ) se configure via l'administration (Administration > Systeme > General) ou dans ``system.properties``. Les parametres specifiques a Gemini se decrivent dans ``fess_config.properties``.
+Le nom du fournisseur LLM ( ``rag.llm.name`` ) se configure via l'administration (Administration > Système > General) ou dans ``system.properties``. Les paramètres spécifiques à Gemini se décrivent dans ``fess_config.properties``.
 
 Configuration minimale
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-``system.properties`` (configurable egalement via Administration > Systeme > General) :
+``system.properties`` (configurable également via Administration > Système > General) :
 
 ::
 
@@ -118,10 +118,10 @@ Configuration minimale
     # Modele a utiliser
     rag.llm.gemini.model=gemini-3.1-flash-lite-preview
 
-Configuration recommandee (environnement de production)
+Configuration recommandée (environnement de production)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``system.properties`` (configurable egalement via Administration > Systeme > General) :
+``system.properties`` (configurable également via Administration > Système > General) :
 
 ::
 
@@ -147,91 +147,91 @@ Configuration recommandee (environnement de production)
     # Configuration du timeout
     rag.llm.gemini.timeout=60000
 
-Elements de configuration
+Éléments de configuration
 =========================
 
-Tous les elements de configuration disponibles pour le client Gemini. Tous sauf ``rag.llm.name`` se configurent dans ``fess_config.properties``.
+Tous les éléments de configuration disponibles pour le client Gemini. Tous sauf ``rag.llm.name`` se configurent dans ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rag.llm.gemini.api.key``
-     - Cle API Google AI (doit etre definie pour utiliser l'API Gemini)
+     - Clé API Google AI (doit être définie pour utiliser l'API Gemini)
      - ``""``
    * - ``rag.llm.gemini.model``
-     - Nom du modele a utiliser
+     - Nom du modèle à utiliser
      - ``gemini-3.1-flash-lite-preview``
    * - ``rag.llm.gemini.api.url``
      - URL de base de l'API
      - ``https://generativelanguage.googleapis.com/v1beta``
    * - ``rag.llm.gemini.timeout``
-     - Timeout de la requete (millisecondes)
+     - Timeout de la requête (millisecondes)
      - ``60000``
    * - ``rag.llm.gemini.availability.check.interval``
-     - Intervalle de verification de disponibilite (secondes)
+     - Intervalle de vérification de disponibilité (secondes)
      - ``60``
    * - ``rag.llm.gemini.max.concurrent.requests``
-     - Nombre maximum de requetes simultanees
+     - Nombre maximum de requêtes simultanées
      - ``5``
    * - ``rag.llm.gemini.chat.evaluation.max.relevant.docs``
-     - Nombre maximum de documents pertinents lors de l'evaluation
+     - Nombre maximum de documents pertinents lors de l'évaluation
      - ``3``
    * - ``rag.llm.gemini.chat.evaluation.description.max.chars``
-     - Nombre maximum de caracteres pour la description du document lors de l'evaluation
+     - Nombre maximum de caractères pour la description du document lors de l'évaluation
      - ``500``
    * - ``rag.llm.gemini.concurrency.wait.timeout``
-     - Delai d'attente des requetes simultanees (millisecondes)
+     - Délai d'attente des requêtes simultanées (millisecondes)
      - ``30000``
    * - ``rag.llm.gemini.history.max.chars``
-     - Nombre maximum de caracteres de l'historique de chat
+     - Nombre maximum de caractères de l'historique de chat
      - ``10000``
    * - ``rag.llm.gemini.intent.history.max.messages``
-     - Nombre maximum de messages d'historique pour la determination d'intention
+     - Nombre maximum de messages d'historique pour la détermination d'intention
      - ``10``
    * - ``rag.llm.gemini.intent.history.max.chars``
-     - Nombre maximum de caracteres d'historique pour la determination d'intention
+     - Nombre maximum de caractères d'historique pour la détermination d'intention
      - ``5000``
    * - ``rag.llm.gemini.history.assistant.max.chars``
-     - Nombre maximum de caracteres de l'historique de l'assistant
+     - Nombre maximum de caractères de l'historique de l'assistant
      - ``1000``
    * - ``rag.llm.gemini.history.assistant.summary.max.chars``
-     - Nombre maximum de caracteres du resume de l'historique de l'assistant
+     - Nombre maximum de caractères du résumé de l'historique de l'assistant
      - ``1000``
    * - ``rag.llm.gemini.retry.max``
      - Nombre maximum de tentatives HTTP (lors d'erreurs ``429`` et ``5xx``)
      - ``10``
    * - ``rag.llm.gemini.retry.base.delay.ms``
-     - Delai de base du backoff exponentiel (millisecondes)
+     - Délai de base du backoff exponentiel (millisecondes)
      - ``2000``
 
-Methode d'authentification
+Méthode d'authentification
 ===========================
 
-La cle API est transmise via l'en-tete HTTP ``x-goog-api-key`` (methode recommandee par Google).
-Elle n'est plus ajoutee a l'URL en tant que parametre de requete ``?key=...`` comme auparavant ; la cle API ne reste donc plus dans les journaux d'acces.
+La clé API est transmise via l'en-tête HTTP ``x-goog-api-key`` (méthode recommandée par Google).
+Elle n'est plus ajoutée à l'URL en tant que paramètre de requête ``?key=...`` comme auparavant ; la clé API ne reste donc plus dans les journaux d'accès.
 
-Comportement de reessai
+Comportement de réessai
 ========================
 
-Les requetes vers l'API Gemini sont automatiquement reessayees pour les codes de statut HTTP suivants :
+Les requêtes vers l'API Gemini sont automatiquement réessayées pour les codes de statut HTTP suivants :
 
-- ``429`` Resource Exhausted (depassement de quota / limitation de debit)
+- ``429`` Resource Exhausted (dépassement de quota / limitation de débit)
 - ``500`` Internal Server Error
 - ``503`` Service Unavailable
 - ``504`` Gateway Timeout
 
-Lors d'un reessai, |Fess| attend selon un backoff exponentiel (valeur de base ``rag.llm.gemini.retry.base.delay.ms`` millisecondes, jusqu'a ``rag.llm.gemini.retry.max`` tentatives, avec une gigue de +/-20%).
-Pour les requetes en streaming, seule la connexion initiale est sujette aux reessais ; les erreurs survenant apres le debut de la reception du corps de la reponse sont propagees immediatement.
+Lors d'un réessai, |Fess| attend selon un backoff exponentiel (valeur de base ``rag.llm.gemini.retry.base.delay.ms`` millisecondes, jusqu'à ``rag.llm.gemini.retry.max`` tentatives, avec une gigue de +/-20%).
+Pour les requêtes en streaming, seule la connexion initiale est sujette aux réessais ; les erreurs survenant après le début de la réception du corps de la réponse sont propagées immédiatement.
 
 Configuration par type de prompt
 ==================================
 
-Dans |Fess|, les parametres du LLM peuvent etre configures finement par type de prompt.
-La configuration par type de prompt s'ecrit dans ``fess_config.properties``.
+Dans |Fess|, les paramètres du LLM peuvent être configurés finement par type de prompt.
+La configuration par type de prompt s'écrit dans ``fess_config.properties``.
 
 Format de configuration
 ------------------------
@@ -253,30 +253,30 @@ Types de prompt disponibles
    * - Type de prompt
      - Description
    * - ``intent``
-     - Prompt pour determiner l'intention de l'utilisateur
+     - Prompt pour déterminer l'intention de l'utilisateur
    * - ``evaluation``
-     - Prompt pour evaluer la pertinence des documents
+     - Prompt pour évaluer la pertinence des documents
    * - ``unclear``
-     - Prompt pour le cas ou la question est peu claire
+     - Prompt pour le cas où la question est peu claire
    * - ``noresults``
-     - Prompt pour le cas ou il n'y a pas de resultats de recherche
+     - Prompt pour le cas où il n'y a pas de résultats de recherche
    * - ``docnotfound``
-     - Prompt pour le cas ou le document n'est pas trouve
+     - Prompt pour le cas où le document n'est pas trouvé
    * - ``answer``
-     - Prompt de generation de reponse
+     - Prompt de génération de réponse
    * - ``summary``
-     - Prompt de generation de resume
+     - Prompt de génération de résumé
    * - ``faq``
-     - Prompt de generation de FAQ
+     - Prompt de génération de FAQ
    * - ``direct``
-     - Prompt de reponse directe
+     - Prompt de réponse directe
    * - ``queryregeneration``
-     - Prompt de regeneration de requete
+     - Prompt de régénération de requête
 
-Valeurs par defaut par type de prompt
+Valeurs par défaut par type de prompt
 ---------------------------------------
 
-Valeurs par defaut pour chaque type de prompt. Ces valeurs sont utilisees lorsqu'aucune configuration explicite n'est definie.
+Valeurs par défaut pour chaque type de prompt. Ces valeurs sont utilisées lorsqu'aucune configuration explicite n'est définie.
 
 .. list-table::
    :header-rows: 1
@@ -348,16 +348,16 @@ Exemple de configuration
     rag.llm.gemini.faq.context.max.chars=10000
 
 .. note::
-   La valeur par defaut de ``context.max.chars`` varie selon le type de prompt.
-   ``answer`` et ``summary`` sont a 16000, ``faq`` est a 10000, et les autres types de prompt sont a 10000.
+   La valeur par défaut de ``context.max.chars`` varie selon le type de prompt.
+   ``answer`` et ``summary`` sont à 16000, ``faq`` est à 10000, et les autres types de prompt sont à 10000.
 
-Prise en charge des modeles de reflexion
+Prise en charge des modèles de réflexion
 ==========================================
 
-Gemini prend en charge les modeles de reflexion (Thinking Model).
-L'utilisation de modeles de reflexion permet au modele d'executer un processus de raisonnement interne avant de generer une reponse, produisant ainsi des reponses plus precises.
+Gemini prend en charge les modèles de réflexion (Thinking Model).
+L'utilisation de modèles de réflexion permet au modèle d'exécuter un processus de raisonnement interne avant de générer une réponse, produisant ainsi des réponses plus précises.
 
-Le budget de reflexion se configure par type de prompt dans ``fess_config.properties``. |Fess| convertit automatiquement la valeur entiere (nombre de tokens) de ``rag.llm.gemini.{promptType}.thinking.budget`` vers le champ d'API approprie en fonction de la generation du modele resolue lors de la requete.
+Le budget de réflexion se configure par type de prompt dans ``fess_config.properties``. |Fess| convertit automatiquement la valeur entière (nombre de tokens) de ``rag.llm.gemini.{promptType}.thinking.budget`` vers le champ d'API approprié en fonction de la génération du modèle résolue lors de la requête.
 
 ::
 
@@ -367,11 +367,11 @@ Le budget de reflexion se configure par type de prompt dans ``fess_config.proper
     # Budget de reflexion pour la generation de resume
     rag.llm.gemini.summary.thinking.budget=1024
 
-Mappage selon la generation du modele
+Mappage selon la génération du modèle
 ---------------------------------------
 
-- **Gemini 2.x** (par exemple ``gemini-2.5-flash``) : la valeur entiere configuree est envoyee telle quelle en tant que ``thinkingConfig.thinkingBudget``. Specifier ``0`` desactive completement la reflexion.
-- **Gemini 3.x** (par exemple ``gemini-3.1-flash-lite-preview``) : la valeur entiere est regroupee en compartiments et envoyee comme valeur enumeree de ``thinkingConfig.thinkingLevel`` (``MINIMAL`` / ``LOW`` / ``MEDIUM`` / ``HIGH``).
+- **Gemini 2.x** (par exemple ``gemini-2.5-flash``) : la valeur entière configurée est envoyée telle quelle en tant que ``thinkingConfig.thinkingBudget``. Spécifier ``0`` désactive complètement la réflexion.
+- **Gemini 3.x** (par exemple ``gemini-3.1-flash-lite-preview``) : la valeur entière est regroupée en compartiments et envoyée comme valeur énumérée de ``thinkingConfig.thinkingLevel`` (``MINIMAL`` / ``LOW`` / ``MEDIUM`` / ``HIGH``).
 
 Le mappage des compartiments pour Gemini 3.x est le suivant :
 
@@ -384,7 +384,7 @@ Le mappage des compartiments pour Gemini 3.x est le suivant :
      - Remarques
    * - ``<=0``
      - ``MINIMAL`` ou ``LOW``
-     - ``MINIMAL`` pour les modeles Flash / Flash-Lite ; ``LOW`` pour les modeles de la famille Pro qui ne prennent pas en charge ``MINIMAL`` (``gemini-3-pro`` / ``gemini-3.1-pro``)
+     - ``MINIMAL`` pour les modèles Flash / Flash-Lite ; ``LOW`` pour les modèles de la famille Pro qui ne prennent pas en charge ``MINIMAL`` (``gemini-3-pro`` / ``gemini-3.1-pro``)
    * - ``<=4096``
      - ``MEDIUM``
      -
@@ -393,32 +393,32 @@ Le mappage des compartiments pour Gemini 3.x est le suivant :
      -
 
 .. note::
-   Gemini 3.x consomme toujours un certain nombre de tokens de reflexion, quel que soit le compartiment (meme avec ``thinkingLevel=MINIMAL``, plusieurs centaines de tokens peuvent etre consommes).
-   Pour cette raison, lors de l'utilisation d'un modele Gemini 3.x, |Fess| ajoute automatiquement une marge supplementaire (1024 tokens) a la valeur ``maxOutputTokens`` par defaut, afin d'eviter une troncature de la reponse due a ``finishReason=MAX_TOKENS``.
-   Avec Gemini 2.x, ``thinkingBudget=0`` desactive la reflexion elle-meme, donc aucune marge supplementaire n'est ajoutee.
+   Gemini 3.x consomme toujours un certain nombre de tokens de réflexion, quel que soit le compartiment (même avec ``thinkingLevel=MINIMAL``, plusieurs centaines de tokens peuvent être consommés).
+   Pour cette raison, lors de l'utilisation d'un modèle Gemini 3.x, |Fess| ajoute automatiquement une marge supplémentaire (1024 tokens) à la valeur ``maxOutputTokens`` par défaut, afin d'éviter une troncature de la réponse due à ``finishReason=MAX_TOKENS``.
+   Avec Gemini 2.x, ``thinkingBudget=0`` désactive la réflexion elle-même, donc aucune marge supplémentaire n'est ajoutée.
 
 .. note::
-   Configurer un budget de reflexion eleve peut allonger le temps de reponse.
-   Configurez une valeur appropriee selon l'usage.
+   Configurer un budget de réflexion élevé peut allonger le temps de réponse.
+   Configurez une valeur appropriée selon l'usage.
 
 Configuration via options JVM
 ==============================
 
-Pour des raisons de securite, il est recommande de configurer la cle API via
-l'environnement d'execution (options JVM) plutot que via des fichiers de configuration.
+Pour des raisons de sécurité, il est recommandé de configurer la clé API via
+l'environnement d'exécution (options JVM) plutôt que via des fichiers de configuration.
 
 Environnement Docker
 ---------------------
 
-Le depot officiel `docker-fess <https://github.com/codelibs/docker-fess>`__
-inclut un overlay Gemini (``compose-gemini.yaml``). Etapes minimales :
+Le dépôt officiel `docker-fess <https://github.com/codelibs/docker-fess>`__
+inclut un overlay Gemini (``compose-gemini.yaml``). Étapes minimales :
 
 ::
 
     export GEMINI_API_KEY="AIzaSy..."
     docker compose -f compose.yaml -f compose-opensearch3.yaml -f compose-gemini.yaml up -d
 
-Contenu de ``compose-gemini.yaml`` (reference pour un setup equivalent) :
+Contenu de ``compose-gemini.yaml`` (référence pour un setup équivalent) :
 
 .. code-block:: yaml
 
@@ -428,19 +428,19 @@ Contenu de ``compose-gemini.yaml`` (reference pour un setup equivalent) :
           - "FESS_PLUGINS=fess-llm-gemini:15.8.0"
           - "FESS_JAVA_OPTS=-Dfess.config.rag.chat.enabled=true -Dfess.config.rag.llm.gemini.api.key=${GEMINI_API_KEY:-} -Dfess.config.rag.llm.gemini.model=${GEMINI_MODEL:-gemini-3.1-flash-lite-preview} -Dfess.system.rag.llm.name=gemini"
 
-Points cles :
+Points clés :
 
-- ``FESS_PLUGINS=fess-llm-gemini:15.8.0`` fait que ``run.sh`` telecharge automatiquement le plugin JAR et le place dans ``app/WEB-INF/plugin/``
+- ``FESS_PLUGINS=fess-llm-gemini:15.8.0`` fait que ``run.sh`` télécharge automatiquement le plugin JAR et le place dans ``app/WEB-INF/plugin/``
 - ``-Dfess.config.rag.chat.enabled=true`` active le mode de recherche IA
-- ``-Dfess.config.rag.llm.gemini.api.key=...`` definit la cle API, ``-Dfess.config.rag.llm.gemini.model=...`` choisit le modele
-- ``-Dfess.system.rag.llm.name=gemini`` n'agit que comme valeur par defaut initiale avant qu'une valeur ne soit persistee dans OpenSearch. Apres demarrage, le parametre peut aussi etre modifie sous Administration > Systeme > General (section RAG)
+- ``-Dfess.config.rag.llm.gemini.api.key=...`` définit la clé API, ``-Dfess.config.rag.llm.gemini.model=...`` choisit le modèle
+- ``-Dfess.system.rag.llm.name=gemini`` n'agit que comme valeur par défaut initiale avant qu'une valeur ne soit persistée dans OpenSearch. Après démarrage, le paramètre peut aussi être modifié sous Administration > Système > General (section RAG)
 
-Si l'acces Internet passe par un proxy, specifiez la configuration ``http.proxy.*`` de |Fess| via ``FESS_JAVA_OPTS`` (voir la section "Utilisation via un proxy HTTP" ci-dessous).
+Si l'accès Internet passe par un proxy, spécifiez la configuration ``http.proxy.*`` de |Fess| via ``FESS_JAVA_OPTS`` (voir la section "Utilisation via un proxy HTTP" ci-dessous).
 
 Environnement systemd
 ----------------------
 
-Ajouter a ``FESS_JAVA_OPTS`` dans ``/etc/sysconfig/fess`` (ou ``/etc/default/fess``) :
+Ajouter à ``FESS_JAVA_OPTS`` dans ``/etc/sysconfig/fess`` (ou ``/etc/default/fess``) :
 
 ::
 
@@ -449,108 +449,108 @@ Ajouter a ``FESS_JAVA_OPTS`` dans ``/etc/sysconfig/fess`` (ou ``/etc/default/fes
 Utilisation via un proxy HTTP
 ==============================
 
-Le client Gemini partage la configuration de proxy HTTP commune a |Fess|. Specifiez les proprietes suivantes dans ``fess_config.properties``.
+Le client Gemini partage la configuration de proxy HTTP commune à |Fess|. Spécifiez les propriétés suivantes dans ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``http.proxy.host``
-     - Nom d'hote du proxy (chaine vide pour ne pas utiliser de proxy)
+     - Nom d'hôte du proxy (chaîne vide pour ne pas utiliser de proxy)
      - ``""``
    * - ``http.proxy.port``
-     - Numero de port du proxy
+     - Numéro de port du proxy
      - ``8080``
    * - ``http.proxy.username``
-     - Nom d'utilisateur pour l'authentification du proxy (facultatif ; lorsqu'il est renseigne, l'authentification Basic est activee)
+     - Nom d'utilisateur pour l'authentification du proxy (facultatif ; lorsqu'il est renseigné, l'authentification Basic est activée)
      - ``""``
    * - ``http.proxy.password``
      - Mot de passe pour l'authentification du proxy
      - ``""``
 
-Dans un environnement Docker, specifiez ce qui suit dans ``FESS_JAVA_OPTS``::
+Dans un environnement Docker, spécifiez ce qui suit dans ``FESS_JAVA_OPTS``::
 
     -Dfess.config.http.proxy.host=proxy.example.com
     -Dfess.config.http.proxy.port=8080
 
 .. note::
-   Cette configuration s'applique egalement a tous les acces HTTP de |Fess|, notamment ceux du crawler.
-   Les proprietes systeme Java traditionnelles (``-Dhttps.proxyHost``, etc.) ne sont pas prises en compte par le client Gemini.
+   Cette configuration s'applique également à tous les accès HTTP de |Fess|, notamment ceux du crawler.
+   Les propriétés système Java traditionnelles (``-Dhttps.proxyHost``, etc.) ne sont pas prises en compte par le client Gemini.
 
 Utilisation via Vertex AI
 ==========================
 
-Si vous utilisez Google Cloud Platform, vous pouvez egalement utiliser Gemini via Vertex AI.
-Pour Vertex AI, le point de terminaison API et la methode d'authentification different.
+Si vous utilisez Google Cloud Platform, vous pouvez également utiliser Gemini via Vertex AI.
+Pour Vertex AI, le point de terminaison API et la méthode d'authentification diffèrent.
 
 .. note::
    |Fess| actuel utilise l'API Google AI (generativelanguage.googleapis.com).
-   Si l'utilisation via Vertex AI est necessaire, une implementation personnalisee peut etre requise.
+   Si l'utilisation via Vertex AI est nécessaire, une implémentation personnalisée peut être requise.
 
-Guide de selection des modeles
+Guide de sélection des modèles
 ================================
 
-Guide pour la selection du modele selon l'usage.
+Guide pour la sélection du modèle selon l'usage.
 
 .. list-table::
    :header-rows: 1
    :widths: 25 20 20 35
 
-   * - Modele
+   * - Modèle
      - Vitesse
-     - Qualite
+     - Qualité
      - Usage
    * - ``gemini-3.1-flash-lite-preview``
      - Rapide
-     - Elevee
-     - Leger et a faible cout (par defaut, prend en charge ``thinkingLevel=MINIMAL``)
+     - Élevée
+     - Léger et à faible coût (par défaut, prend en charge ``thinkingLevel=MINIMAL``)
    * - ``gemini-3-flash-preview``
      - Rapide
      - Maximale
-     - Usage general (prend en charge ``thinkingLevel=MINIMAL``)
+     - Usage général (prend en charge ``thinkingLevel=MINIMAL``)
    * - ``gemini-3.1-pro`` / ``gemini-3-pro``
      - Moyenne
      - Maximale
      - Raisonnement complexe (``MINIMAL`` non pris en charge ; au minimum ``LOW``)
    * - ``gemini-2.5-flash``
      - Rapide
-     - Elevee
-     - Version stable, priorite au cout
+     - Élevée
+     - Version stable, priorité au coût
    * - ``gemini-2.5-pro``
      - Moyenne
-     - Elevee
+     - Élevée
      - Version stable, long contexte
 
-Fenetre de contexte
+Fenêtre de contexte
 --------------------
 
-Les modeles Gemini prennent en charge des fenetres de contexte tres longues :
+Les modèles Gemini prennent en charge des fenêtres de contexte très longues :
 
 - **Gemini 3 Flash / 2.5 Flash** : Maximum 1 million de tokens
 - **Gemini 3.1 Pro / 2.5 Pro** : Maximum 1 million de tokens (3.1 Pro) / 2 millions de tokens (2.5 Pro)
 
-Cette caracteristique permet d'inclure davantage de resultats de recherche dans le contexte.
+Cette caractéristique permet d'inclure davantage de résultats de recherche dans le contexte.
 
 ::
 
     # Inclure davantage de documents dans le contexte (a configurer dans fess_config.properties)
     rag.llm.gemini.answer.context.max.chars=20000
 
-Estimation des couts
+Estimation des coûts
 ---------------------
 
-L'API Google AI est facturee a l'usage (avec une offre gratuite).
+L'API Google AI est facturée à l'usage (avec une offre gratuite).
 
 .. list-table::
    :header-rows: 1
    :widths: 30 35 35
 
-   * - Modele
-     - Entree (1M caracteres)
-     - Sortie (1M caracteres)
+   * - Modèle
+     - Entrée (1M caractères)
+     - Sortie (1M caractères)
    * - Gemini 3 Flash Preview
      - $0.50
      - $3.00
@@ -567,73 +567,73 @@ L'API Google AI est facturee a l'usage (avec une offre gratuite).
 .. note::
    Pour les derniers prix et informations sur l'offre gratuite, consultez `Google AI Pricing <https://ai.google.dev/pricing>`__.
 
-Controle des requetes simultanees
+Contrôle des requêtes simultanées
 ===================================
 
-Dans |Fess|, le nombre de requetes simultanees vers Gemini peut etre controle.
-Configurez la propriete suivante dans ``fess_config.properties``.
+Dans |Fess|, le nombre de requêtes simultanées vers Gemini peut être contrôlé.
+Configurez la propriété suivante dans ``fess_config.properties``.
 
 ::
 
     # Nombre maximum de requetes simultanees (par defaut : 5)
     rag.llm.gemini.max.concurrent.requests=5
 
-Cette configuration permet d'eviter les requetes excessives vers l'API Google AI et de prevenir les erreurs de limitation de debit.
+Cette configuration permet d'éviter les requêtes excessives vers l'API Google AI et de prévenir les erreurs de limitation de débit.
 
-Limites de l'offre gratuite (a titre indicatif)
+Limites de l'offre gratuite (à titre indicatif)
 -------------------------------------------------
 
 L'API Google AI dispose d'une offre gratuite avec les limites suivantes :
 
-- Requetes/minute : 15 RPM
+- Requêtes/minute : 15 RPM
 - Tokens/minute : 1 million TPM
-- Requetes/jour : 1,500 RPD
+- Requêtes/jour : 1,500 RPD
 
-Lors de l'utilisation de l'offre gratuite, il est recommande de configurer ``rag.llm.gemini.max.concurrent.requests`` a une valeur basse.
+Lors de l'utilisation de l'offre gratuite, il est recommandé de configurer ``rag.llm.gemini.max.concurrent.requests`` à une valeur basse.
 
-Depannage
+Dépannage
 ==========
 
 Erreur d'authentification
 --------------------------
 
-**Symptome** : Erreur liee a la cle API
+**Symptôme** : Erreur liée à la clé API
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si la cle API est correctement configuree
-2. Verifier si la cle API est valide dans Google AI Studio
-3. Verifier si la cle API a les permissions necessaires
-4. Verifier si l'API est activee dans le projet
+1. Vérifier si la clé API est correctement configurée
+2. Vérifier si la clé API est valide dans Google AI Studio
+3. Vérifier si la clé API a les permissions nécessaires
+4. Vérifier si l'API est activée dans le projet
 
-Erreur de limitation de debit
+Erreur de limitation de débit
 -------------------------------
 
-**Symptome** : Erreur "429 Resource has been exhausted"
+**Symptôme** : Erreur "429 Resource has been exhausted"
 
 **Solution** :
 
-1. Reduire le nombre de requetes simultanees dans ``fess_config.properties``::
+1. Réduire le nombre de requêtes simultanées dans ``fess_config.properties``::
 
     rag.llm.gemini.max.concurrent.requests=3
 
-2. Attendre quelques minutes avant de reessayer
-3. Demander une augmentation de quota si necessaire
+2. Attendre quelques minutes avant de réessayer
+3. Demander une augmentation de quota si nécessaire
 
-Restriction de region
+Restriction de région
 ----------------------
 
-**Symptome** : Erreur indiquant que le service n'est pas disponible
+**Symptôme** : Erreur indiquant que le service n'est pas disponible
 
-**Points a verifier** :
+**Points à vérifier** :
 
-L'API Google AI n'est disponible que dans certaines regions. Consultez la documentation Google
-pour les regions prises en charge.
+L'API Google AI n'est disponible que dans certaines régions. Consultez la documentation Google
+pour les régions prises en charge.
 
 Timeout
 --------
 
-**Symptome** : La requete expire
+**Symptôme** : La requête expire
 
 **Solution** :
 
@@ -641,12 +641,12 @@ Timeout
 
     rag.llm.gemini.timeout=120000
 
-2. Envisager l'utilisation du modele Flash (plus rapide)
+2. Envisager l'utilisation du modèle Flash (plus rapide)
 
-Configuration de debogage
+Configuration de débogage
 --------------------------
 
-Pour investiguer les problemes, ajustez le niveau de log de |Fess| pour afficher des logs detailles lies a Gemini.
+Pour investiguer les problèmes, ajustez le niveau de log de |Fess| pour afficher des logs détaillés liés à Gemini.
 
 ``app/WEB-INF/classes/log4j2.xml`` :
 
@@ -654,22 +654,22 @@ Pour investiguer les problemes, ajustez le niveau de log de |Fess| pour afficher
 
     <Logger name="org.codelibs.fess.llm.gemini" level="DEBUG"/>
 
-Notes de securite
+Notes de sécurité
 ==================
 
-Lors de l'utilisation de l'API Google AI, faites attention aux points de securite suivants.
+Lors de l'utilisation de l'API Google AI, faites attention aux points de sécurité suivants.
 
-1. **Confidentialite des donnees** : Le contenu des resultats de recherche est envoye aux serveurs Google
-2. **Gestion des cles API** : La fuite de cles peut entrainer une utilisation non autorisee
-3. **Conformite** : Si les donnees contiennent des informations confidentielles, verifiez les politiques de votre organisation
+1. **Confidentialité des données** : Le contenu des résultats de recherche est envoyé aux serveurs Google
+2. **Gestion des clés API** : La fuite de clés peut entraîner une utilisation non autorisée
+3. **Conformité** : Si les données contiennent des informations confidentielles, vérifiez les politiques de votre organisation
 4. **Conditions d'utilisation** : Respectez les conditions d'utilisation et la Politique d'utilisation acceptable de Google
 
-Informations de reference
+Informations de référence
 ==========================
 
 - `Google AI for Developers <https://ai.google.dev/>`__
 - `Google AI Studio <https://aistudio.google.com/>`__
 - `Gemini API Documentation <https://ai.google.dev/docs>`__
 - `Google AI Pricing <https://ai.google.dev/pricing>`__
-- :doc:`llm-overview` - Apercu de l'integration LLM
-- :doc:`rag-chat` - Details de la fonctionnalite de mode de recherche IA
+- :doc:`llm-overview` - Aperçu de l'intégration LLM
+- :doc:`rag-chat` - Détails de la fonctionnalité de mode de recherche IA

--- a/fr/15.8/config/load-control.rst
+++ b/fr/15.8/config/load-control.rst
@@ -1,31 +1,31 @@
 =====================================
-Configuration du controle de charge
+Configuration du contrôle de charge
 =====================================
 
-Apercu
+Aperçu
 ======
 
-|Fess| dispose de deux types de fonctionnalites de controle de charge qui protegent la stabilite du systeme en fonction de l'utilisation CPU.
+|Fess| dispose de deux types de fonctionnalités de contrôle de charge qui protègent la stabilité du système en fonction de l'utilisation CPU.
 
-**Controle de charge des requetes HTTP** (``web.load.control`` / ``api.load.control``) :
+**Contrôle de charge des requêtes HTTP** (``web.load.control`` / ``api.load.control``) :
 
-- Surveillance en temps reel de l'utilisation CPU du cluster OpenSearch
-- Seuils independants configurables pour les requetes web et les requetes API
-- Retourne HTTP 429 (Too Many Requests) lorsque les seuils sont depasses
-- Le panneau d'administration, la connexion et les ressources statiques sont exclus du controle
-- Desactive par defaut (seuil=100)
+- Surveillance en temps réel de l'utilisation CPU du cluster OpenSearch
+- Seuils indépendants configurables pour les requêtes web et les requêtes API
+- Retourne HTTP 429 (Too Many Requests) lorsque les seuils sont dépassés
+- Le panneau d'administration, la connexion et les ressources statiques sont exclus du contrôle
+- Désactivé par défaut (seuil=100)
 
-**Controle de charge adaptatif** (``adaptive.load.control``) :
+**Contrôle de charge adaptatif** (``adaptive.load.control``) :
 
-- Surveille l'utilisation CPU systeme du serveur Fess lui-meme
-- Ralentit automatiquement les taches en arriere-plan telles que le crawling, l'indexation, les mises a jour de suggestions et la generation de vignettes
-- Lorsque l'utilisation CPU atteint ou depasse le seuil, les threads de traitement sont mis en pause et reprennent lorsqu'elle descend en dessous du seuil
-- Active par defaut (seuil=50)
+- Surveille l'utilisation CPU système du serveur Fess lui-même
+- Ralentit automatiquement les tâches en arrière-plan telles que le crawling, l'indexation, les mises à jour de suggestions et la génération de vignettes
+- Lorsque l'utilisation CPU atteint ou dépasse le seuil, les threads de traitement sont mis en pause et reprennent lorsqu'elle descend en dessous du seuil
+- Activé par défaut (seuil=50)
 
-Configuration du controle de charge des requetes HTTP
+Configuration du contrôle de charge des requêtes HTTP
 =====================================================
 
-Definissez les proprietes suivantes dans ``fess_config.properties`` :
+Définissez les propriétés suivantes dans ``fess_config.properties`` :
 
 ::
 
@@ -45,57 +45,57 @@ Definissez les proprietes suivantes dans ``fess_config.properties`` :
     load.control.monitor.interval=1
 
 .. note::
-   Lorsque ``web.load.control`` et ``api.load.control`` sont tous deux definis a 100 (defaut),
-   la surveillance CPU d'OpenSearch ne demarre pas.
+   Lorsque ``web.load.control`` et ``api.load.control`` sont tous deux définis à 100 (défaut),
+   la surveillance CPU d'OpenSearch ne démarre pas.
 
 Fonctionnement
 ==============
 
-Mecanisme de surveillance
+Mécanisme de surveillance
 -------------------------
 
-Lorsque le controle de charge est active (l'un ou l'autre des seuils est inferieur a 100), LoadControlMonitorTarget surveille periodiquement l'utilisation CPU du cluster OpenSearch.
+Lorsque le contrôle de charge est activé (l'un ou l'autre des seuils est inférieur à 100), LoadControlMonitorTarget surveille périodiquement l'utilisation CPU du cluster OpenSearch.
 
-- Recupere les statistiques OS de tous les noeuds du cluster OpenSearch
-- Enregistre l'utilisation CPU la plus elevee parmi tous les noeuds
-- Surveille a l'intervalle specifie par ``load.control.monitor.interval`` (defaut : 1 seconde)
-- La surveillance demarre de maniere differee lors de la premiere requete
+- Récupère les statistiques OS de tous les noeuds du cluster OpenSearch
+- Enregistre l'utilisation CPU la plus élevée parmi tous les noeuds
+- Surveille à l'intervalle spécifié par ``load.control.monitor.interval`` (défaut : 1 seconde)
+- La surveillance démarre de manière différée lors de la première requête
 
 .. note::
-   Si la recuperation des informations de surveillance echoue, l'utilisation CPU est reinitialisee a 0.
-   Les trois premiers echecs consecutifs sont enregistres au niveau WARNING dans les logs ; a partir
-   du quatrieme echec, le niveau passe a DEBUG (afin d'eviter une inflation des logs en cas d'echecs
-   persistants). Le compteur d'echecs est reinitialise des qu'une surveillance reussit.
+   Si la récupération des informations de surveillance échoue, l'utilisation CPU est réinitialisée à 0.
+   Les trois premiers échecs consécutifs sont enregistrés au niveau WARNING dans les logs ; à partir
+   du quatrième échec, le niveau passe à DEBUG (afin d'éviter une inflation des logs en cas d'échecs
+   persistants). Le compteur d'échecs est réinitialisé dès qu'une surveillance réussit.
 
-Controle des requetes
+Contrôle des requêtes
 ---------------------
 
-Lorsqu'une requete arrive, LoadControlFilter la traite dans l'ordre suivant :
+Lorsqu'une requête arrive, LoadControlFilter la traite dans l'ordre suivant :
 
-1. Verifier si le chemin est exclu (si exclu, laisser passer)
-2. Determiner le type de requete (Web / API)
+1. Vérifier si le chemin est exclu (si exclu, laisser passer)
+2. Déterminer le type de requête (Web / API)
 3. Obtenir le seuil correspondant
-4. Si le seuil est de 100 ou plus, ne pas controler (laisser passer)
+4. Si le seuil est de 100 ou plus, ne pas contrôler (laisser passer)
 5. Comparer l'utilisation CPU actuelle avec le seuil
 6. Si l'utilisation CPU >= seuil, retourner HTTP 429
 
-**Requetes exclues :**
+**Requêtes exclues :**
 
-- Chemins commencant par ``/admin`` (panneau d'administration)
-- Chemins commencant par ``/error`` (pages d'erreur)
-- Chemins commencant par ``/login`` (pages de connexion)
+- Chemins commençant par ``/admin`` (panneau d'administration)
+- Chemins commençant par ``/error`` (pages d'erreur)
+- Chemins commençant par ``/login`` (pages de connexion)
 - Ressources statiques (``.css``, ``.js``, ``.png``, ``.jpg``, ``.gif``, ``.ico``, ``.svg``, ``.woff``, ``.woff2``, ``.ttf``, ``.eot``)
 
-**Pour les requetes web :**
+**Pour les requêtes web :**
 
 - Retourne le code de statut HTTP 429
 - Affiche la page d'erreur (``busy.jsp``)
 
-**Pour les requetes API :**
+**Pour les requêtes API :**
 
 - Retourne le code de statut HTTP 429
-- Ajoute l'en-tete de reponse HTTP ``Retry-After: 60``
-- Retourne une reponse JSON :
+- Ajoute l'en-tête de réponse HTTP ``Retry-After: 60``
+- Retourne une réponse JSON :
 
 ::
 
@@ -108,17 +108,17 @@ Lorsqu'une requete arrive, LoadControlFilter la traite dans l'ordre suivant :
     }
 
 .. note::
-   Lorsqu'une requete est rejetee, le message suivant est enregistre au niveau INFO dans les logs du serveur :
+   Lorsqu'une requête est rejetée, le message suivant est enregistré au niveau INFO dans les logs du serveur :
    ``Rejecting request due to high CPU load: path=..., cpu=...%, threshold=...%``
-   Cela permet de verifier quel chemin a ete rejete et pour quel seuil.
+   Cela permet de vérifier quel chemin a été rejeté et pour quel seuil.
 
 Exemples de configuration
 =========================
 
-Limiter uniquement les requetes web
+Limiter uniquement les requêtes web
 ------------------------------------
 
-Configuration qui limite uniquement les requetes de recherche web sans restreindre l'API :
+Configuration qui limite uniquement les requêtes de recherche web sans restreindre l'API :
 
 ::
 
@@ -131,10 +131,10 @@ Configuration qui limite uniquement les requetes de recherche web sans restreind
     # Intervalle de surveillance : 1 seconde
     load.control.monitor.interval=1
 
-Limiter a la fois le web et l'API
+Limiter à la fois le web et l'API
 ----------------------------------
 
-Exemple avec des seuils differents pour le web et l'API :
+Exemple avec des seuils différents pour le web et l'API :
 
 ::
 
@@ -148,46 +148,46 @@ Exemple avec des seuils differents pour le web et l'API :
     load.control.monitor.interval=2
 
 .. note::
-   En definissant le seuil API plus haut que le seuil web, vous pouvez realiser un controle progressif
-   ou les requetes web sont restreintes en premier lors d'une charge elevee, et les requetes API sont
-   egalement restreintes lorsque la charge augmente davantage.
+   En définissant le seuil API plus haut que le seuil web, vous pouvez réaliser un contrôle progressif
+   où les requêtes web sont restreintes en premier lors d'une charge élevée, et les requêtes API sont
+   également restreintes lorsque la charge augmente davantage.
 
-Difference avec la limitation de debit
+Différence avec la limitation de débit
 =======================================
 
-|Fess| dispose d'une fonctionnalite de :doc:`rate-limiting` separee du controle de charge.
-Ces deux mecanismes protegent le systeme avec des approches differentes.
+|Fess| dispose d'une fonctionnalité de :doc:`rate-limiting` séparée du contrôle de charge.
+Ces deux mécanismes protègent le système avec des approches différentes.
 
 .. list-table::
    :header-rows: 1
    :widths: 20 40 40
 
    * - Aspect
-     - Limitation de debit
-     - Controle de charge
-   * - Base de controle
-     - Nombre de requetes (par unite de temps)
+     - Limitation de débit
+     - Contrôle de charge
+   * - Base de contrôle
+     - Nombre de requêtes (par unité de temps)
      - Utilisation CPU d'OpenSearch
    * - Objectif
-     - Prevention des requetes excessives
+     - Prévention des requêtes excessives
      - Protection du moteur de recherche contre la surcharge
-   * - Unite de limite
+   * - Unité de limite
      - Par adresse IP
-     - Ensemble du systeme
-   * - Reponse
+     - Ensemble du système
+   * - Réponse
      - HTTP 429
      - HTTP 429
-   * - Portee
-     - Toutes les requetes HTTP
-     - Requetes web / Requetes API (panneau d'administration etc. exclu)
+   * - Portée
+     - Toutes les requêtes HTTP
+     - Requêtes web / Requêtes API (panneau d'administration etc. exclu)
 
-La combinaison des deux fonctionnalites permet une protection systeme plus robuste.
+La combinaison des deux fonctionnalités permet une protection système plus robuste.
 
-Controle de charge adaptatif
+Contrôle de charge adaptatif
 ============================
 
-Le controle de charge adaptatif ajuste automatiquement la vitesse de traitement des taches
-en arriere-plan en fonction de l'utilisation CPU systeme du serveur Fess.
+Le contrôle de charge adaptatif ajuste automatiquement la vitesse de traitement des tâches
+en arrière-plan en fonction de l'utilisation CPU système du serveur Fess.
 
 Configuration
 -------------
@@ -204,58 +204,58 @@ Configuration
 Comportement
 ------------
 
-- Surveille l'utilisation CPU systeme du serveur ou Fess s'execute
-- Lorsque l'utilisation CPU atteint ou depasse le seuil, les threads de traitement concernes attendent que l'utilisation CPU descende en dessous du seuil
+- Surveille l'utilisation CPU système du serveur où Fess s'exécute
+- Lorsque l'utilisation CPU atteint ou dépasse le seuil, les threads de traitement concernés attendent que l'utilisation CPU descende en dessous du seuil
 - Lorsque l'utilisation CPU descend en dessous du seuil, le traitement reprend automatiquement
 
-**Taches en arriere-plan concernees :**
+**Tâches en arrière-plan concernées :**
 
-- Crawling (Web / Systeme de fichiers)
+- Crawling (Web / Système de fichiers)
 - Indexation (enregistrement de documents)
-- Traitement du magasin de donnees
-- Mises a jour des suggestions
-- Generation de vignettes
+- Traitement du magasin de données
+- Mises à jour des suggestions
+- Génération de vignettes
 - Sauvegarde et restauration
 
 .. note::
-   Le controle de charge adaptatif est active par defaut (seuil=50).
-   Il fonctionne independamment du controle de charge des requetes HTTP (``web.load.control`` / ``api.load.control``).
+   Le contrôle de charge adaptatif est activé par défaut (seuil=50).
+   Il fonctionne indépendamment du contrôle de charge des requêtes HTTP (``web.load.control`` / ``api.load.control``).
 
 .. list-table::
    :header-rows: 1
    :widths: 20 40 40
 
    * - Aspect
-     - Controle de charge des requetes HTTP
-     - Controle de charge adaptatif
+     - Contrôle de charge des requêtes HTTP
+     - Contrôle de charge adaptatif
    * - Cible de surveillance
      - Utilisation CPU d'OpenSearch
-     - Utilisation CPU systeme du serveur Fess
-   * - Cible de controle
-     - Requetes HTTP (Web / API)
-     - Taches en arriere-plan
-   * - Methode de controle
-     - Rejette les requetes en retournant HTTP 429
+     - Utilisation CPU système du serveur Fess
+   * - Cible de contrôle
+     - Requêtes HTTP (Web / API)
+     - Tâches en arrière-plan
+   * - Méthode de contrôle
+     - Rejette les requêtes en retournant HTTP 429
      - Met en pause temporairement les threads de traitement
-   * - Defaut
-     - Desactive (seuil=100)
-     - Active (seuil=50)
+   * - Défaut
+     - Désactivé (seuil=100)
+     - Activé (seuil=50)
 
-Depannage
+Dépannage
 =========
 
-Le controle de charge ne s'active pas
+Le contrôle de charge ne s'active pas
 --------------------------------------
 
-**Cause** : La configuration n'est pas correctement appliquee
+**Cause** : La configuration n'est pas correctement appliquée
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si ``web.load.control`` ou ``api.load.control`` est defini en dessous de 100
-2. Verifier si le fichier de configuration est correctement lu
-3. Verifier si |Fess| a ete redemarre
+1. Vérifier si ``web.load.control`` ou ``api.load.control`` est défini en dessous de 100
+2. Vérifier si le fichier de configuration est correctement lu
+3. Vérifier si |Fess| a été redémarré
 
-Les requetes legitimes sont rejetees
+Les requêtes légitimes sont rejetées
 --------------------------------------
 
 **Cause** : Les seuils sont trop bas
@@ -263,30 +263,30 @@ Les requetes legitimes sont rejetees
 **Solution** :
 
 1. Augmenter les valeurs de ``web.load.control`` ou ``api.load.control``
-2. Ajuster ``load.control.monitor.interval`` pour modifier la frequence de surveillance
+2. Ajuster ``load.control.monitor.interval`` pour modifier la fréquence de surveillance
 3. Augmenter les ressources du cluster OpenSearch
 
 .. warning::
-   Definir des seuils trop bas peut entrainer le rejet de requetes meme sous charge normale.
-   Verifiez l'utilisation CPU normale de votre cluster OpenSearch avant de definir des seuils appropries.
+   Définir des seuils trop bas peut entraîner le rejet de requêtes même sous charge normale.
+   Vérifiez l'utilisation CPU normale de votre cluster OpenSearch avant de définir des seuils appropriés.
 
 Le crawling est lent
 --------------------
 
-**Cause** : Les threads sont en etat d'attente en raison du controle de charge adaptatif
+**Cause** : Les threads sont en état d'attente en raison du contrôle de charge adaptatif
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si ``Cpu Load XX% is greater than YY%`` apparait dans les logs
-2. Verifier si le seuil ``adaptive.load.control`` est trop bas
+1. Vérifier si ``Cpu Load XX% is greater than YY%`` apparaît dans les logs
+2. Vérifier si le seuil ``adaptive.load.control`` est trop bas
 
 **Solution** :
 
 1. Augmenter la valeur de ``adaptive.load.control`` (ex : 70)
 2. Augmenter les ressources CPU du serveur Fess
-3. Definir a 0 pour desactiver le controle de charge adaptatif (non recommande)
+3. Définir à 0 pour désactiver le contrôle de charge adaptatif (non recommandé)
 
-Informations de reference
+Informations de référence
 =========================
 
-- :doc:`rate-limiting` - Configuration de la limitation de debit
+- :doc:`rate-limiting` - Configuration de la limitation de débit

--- a/fr/15.8/config/rag-chat.rst
+++ b/fr/15.8/config/rag-chat.rst
@@ -2,54 +2,54 @@
 Configuration du mode de recherche IA
 ==========================
 
-Apercu
+Aperçu
 ====
 
-Le mode de recherche IA (RAG: Retrieval-Augmented Generation) est une fonctionnalite qui enrichit les resultats de recherche de |Fess|
-avec un LLM (grand modele de langage) pour fournir des informations sous forme de dialogue.
-Les utilisateurs peuvent poser des questions en langage naturel et obtenir des reponses detaillees basees sur les resultats de recherche.
+Le mode de recherche IA (RAG: Retrieval-Augmented Generation) est une fonctionnalité qui enrichit les résultats de recherche de |Fess|
+avec un LLM (grand modèle de langage) pour fournir des informations sous forme de dialogue.
+Les utilisateurs peuvent poser des questions en langage naturel et obtenir des réponses détaillées basées sur les résultats de recherche.
 
-Dans |Fess| 15.8, la fonctionnalite LLM a ete separee en plugins ``fess-llm-*``.
-La configuration principale et la configuration specifique au fournisseur LLM s'effectuent dans ``fess_config.properties``,
-et la selection du fournisseur LLM (``rag.llm.name``) s'effectue dans ``system.properties`` ou via l'administration.
+Dans |Fess| 15.8, la fonctionnalité LLM a été séparée en plugins ``fess-llm-*``.
+La configuration principale et la configuration spécifique au fournisseur LLM s'effectuent dans ``fess_config.properties``,
+et la sélection du fournisseur LLM (``rag.llm.name``) s'effectue dans ``system.properties`` ou via l'administration.
 
 Pipeline de recherche
 ======================
 
-Le mode de recherche IA recupere ses documents source via le pipeline de recherche standard de |Fess| (rank fusion), avec le controle d'acces habituel de |Fess| par role et par etiquette (label). Par defaut, il s'agit d'une recherche par mots-cles (BM25) ; le LLM ne recherche, ne classe ni n'effectue lui-meme d'embedding des documents.
+Le mode de recherche IA récupère ses documents source via le pipeline de recherche standard de |Fess| (rank fusion), avec le contrôle d'accès habituel de |Fess| par rôle et par étiquette (label). Par défaut, il s'agit d'une recherche par mots-clés (BM25) ; le LLM ne recherche, ne classe ni n'effectue lui-même d'embedding des documents.
 
-Deux types de requetes executent des pipelines legerement differents :
+Deux types de requêtes exécutent des pipelines légèrement différents :
 
-- ``POST /api/v2/chat/stream`` (utilise par l'interface Web) execute le flux complet : **analyse d'intention -> recherche -> evaluation de pertinence par le LLM -> recuperation du contenu -> generation de reponse** (en streaming).
-- ``POST /api/v2/chat`` (non-streaming) execute un flux plus court : **analyse d'intention -> recherche -> generation de reponse** (sans phase d'evaluation de pertinence ni phase distincte de recuperation du contenu).
+- ``POST /api/v2/chat/stream`` (utilisé par l'interface Web) exécute le flux complet : **analyse d'intention -> recherche -> évaluation de pertinence par le LLM -> récupération du contenu -> génération de réponse** (en streaming).
+- ``POST /api/v2/chat`` (non-streaming) exécute un flux plus court : **analyse d'intention -> recherche -> génération de réponse** (sans phase d'évaluation de pertinence ni phase distincte de récupération du contenu).
 
-Dans le flux en streaming, un appel LLM supplementaire **evalue les resultats de recherche** et ne conserve que les documents juges pertinents avant que la reponse ne soit generee.
+Dans le flux en streaming, un appel LLM supplémentaire **évalue les résultats de recherche** et ne conserve que les documents jugés pertinents avant que la réponse ne soit générée.
 
 Fonctionnement du mode de recherche IA
 ================
 
-Le mode de recherche IA fonctionne selon un flux en plusieurs etapes.
+Le mode de recherche IA fonctionne selon un flux en plusieurs étapes.
 
-1. **Phase d'analyse d'intention** : Analyse la question de l'utilisateur et extrait les mots-cles optimaux pour la recherche
-2. **Phase de recherche** : Recherche des documents avec les mots-cles extraits en utilisant le moteur de recherche |Fess|
-3. **Fallback de regeneration de requete** : Lorsqu'aucun resultat n'est trouve, le LLM regenere la requete et reessaie
-4. **Phase d'evaluation** : Evalue la pertinence des resultats de recherche et selectionne les documents les plus appropries
-5. **Phase de generation** : Le LLM genere une reponse basee sur les documents selectionnes
-6. **Phase de sortie** : Retourne la reponse et les informations sources a l'utilisateur (avec rendu Markdown)
+1. **Phase d'analyse d'intention** : Analyse la question de l'utilisateur et extrait les mots-clés optimaux pour la recherche
+2. **Phase de recherche** : Recherche des documents avec les mots-clés extraits en utilisant le moteur de recherche |Fess|
+3. **Fallback de régénération de requête** : Lorsqu'aucun résultat n'est trouvé, le LLM régénère la requête et réessaie
+4. **Phase d'évaluation** : Évalue la pertinence des résultats de recherche et sélectionne les documents les plus appropriés
+5. **Phase de génération** : Le LLM génère une réponse basée sur les documents sélectionnés
+6. **Phase de sortie** : Retourne la réponse et les informations sources à l'utilisateur (avec rendu Markdown)
 
-Ce flux permet des reponses de haute qualite comprenant le contexte, superieur a la simple recherche par mots-cles.
-La regeneration de requete ameliore la couverture des reponses lorsque la requete initiale n'est pas optimale.
+Ce flux permet des réponses de haute qualité comprenant le contexte, supérieur à la simple recherche par mots-clés.
+La régénération de requête améliore la couverture des réponses lorsque la requête initiale n'est pas optimale.
 
 Configuration de base
 ========
 
-La configuration de la fonctionnalite de mode de recherche IA est divisee en configuration principale et en configuration du fournisseur.
+La configuration de la fonctionnalité de mode de recherche IA est divisée en configuration principale et en configuration du fournisseur.
 
 Configuration principale (fess_config.properties)
 ----------------------------------
 
-Configuration de base pour activer la fonctionnalite de mode de recherche IA.
-A configurer dans ``app/WEB-INF/conf/fess_config.properties``.
+Configuration de base pour activer la fonctionnalité de mode de recherche IA.
+À configurer dans ``app/WEB-INF/conf/fess_config.properties``.
 
 ::
 
@@ -59,11 +59,11 @@ A configurer dans ``app/WEB-INF/conf/fess_config.properties``.
 Configuration du fournisseur (system.properties / administration)
 -------------------------------------------------
 
-La selection du fournisseur LLM s'effectue via l'administration ou les proprietes systeme.
+La sélection du fournisseur LLM s'effectue via l'administration ou les propriétés système.
 
 **Via l'administration** :
 
-Depuis l'ecran de configuration Administration > Systeme > General, selectionnez le fournisseur LLM a utiliser.
+Depuis l'écran de configuration Administration > Système > General, sélectionnez le fournisseur LLM à utiliser.
 
 **Via system.properties** :
 
@@ -72,24 +72,24 @@ Depuis l'ecran de configuration Administration > Systeme > General, selectionnez
     # Selectionner le fournisseur LLM (ollama, openai, gemini)
     rag.llm.name=ollama
 
-Pour la configuration detaillee des fournisseurs LLM, consultez :
+Pour la configuration détaillée des fournisseurs LLM, consultez :
 
 - :doc:`llm-ollama` - Configuration Ollama
 - :doc:`llm-openai` - Configuration OpenAI
 - :doc:`llm-gemini` - Configuration Google Gemini
 
-Reference rapide des chemins de configuration
+Référence rapide des chemins de configuration
 =============================================
 
-Dans |Fess| 15.8, les parametres sont separes en deux familles : la famille FessConfig
+Dans |Fess| 15.8, les paramètres sont séparés en deux familles : la famille FessConfig
 (``fess_config.properties``) et la famille SystemProperty (``system.properties``,
-persistee dans OpenSearch). Les chemins de configuration different ; ne pas les confondre.
+persistée dans OpenSearch). Les chemins de configuration diffèrent ; ne pas les confondre.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 18 32 15
 
-   * - Propriete
+   * - Propriété
      - Famille
      - Passage via Docker / options JVM
      - UI Admin
@@ -99,8 +99,8 @@ persistee dans OpenSearch). Les chemins de configuration different ; ne pas les 
      - Non
    * - ``rag.llm.name``
      - SystemProperty
-     - ``-Dfess.system.rag.llm.name=gemini`` (defaut initial uniquement)
-     - Oui (parametres generaux)
+     - ``-Dfess.system.rag.llm.name=gemini`` (défaut initial uniquement)
+     - Oui (paramètres généraux)
    * - ``rag.llm.gemini.api.key``
      - FessConfig
      - ``-Dfess.config.rag.llm.gemini.api.key=...``
@@ -124,8 +124,8 @@ persistee dans OpenSearch). Les chemins de configuration different ; ne pas les 
 
 .. note::
 
-   ``rag.llm.type`` est l'ancien nom de propriete dans |Fess| 15.5 et anterieur.
-   Dans 15.8 et superieur il est renomme en ``rag.llm.name`` ; les valeurs ecrites
+   ``rag.llm.type`` est l'ancien nom de propriété dans |Fess| 15.5 et antérieur.
+   Dans 15.8 et supérieur il est renommé en ``rag.llm.name`` ; les valeurs écrites
    sous ``rag.llm.type`` ne sont pas lues.
 
 Liste des configurations principales
@@ -137,29 +137,29 @@ Liste des configurations principales disponibles dans ``fess_config.properties``
    :header-rows: 1
    :widths: 40 40 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rag.chat.enabled``
-     - Activer la fonctionnalite de mode de recherche IA
+     - Activer la fonctionnalité de mode de recherche IA
      - ``false``
    * - ``rag.chat.context.max.documents``
-     - Nombre maximum de documents a inclure dans le contexte
+     - Nombre maximum de documents à inclure dans le contexte
      - ``5``
    * - ``rag.chat.session.timeout.minutes``
-     - Delai d'expiration de la session (minutes)
+     - Délai d'expiration de la session (minutes)
      - ``30``
    * - ``rag.chat.session.max.size``
-     - Nombre maximum de sessions pouvant etre maintenues simultanement
+     - Nombre maximum de sessions pouvant être maintenues simultanément
      - ``10000``
    * - ``rag.chat.history.max.messages``
      - Nombre maximum de messages dans l'historique de conversation
      - ``30``
    * - ``rag.chat.content.fields``
-     - Champs a recuperer des documents
+     - Champs à récupérer des documents
      - ``title,url,content,doc_id,content_title,content_description``
    * - ``rag.chat.message.max.length``
-     - Nombre maximum de caracteres du message utilisateur. Cette valeur est lue en tant que System Property ; l'entree dans ``fess_config.properties`` n'est pas utilisee. Definissez-la via les System Properties ou ``-Dfess.system.rag.chat.message.max.length``.
+     - Nombre maximum de caractères du message utilisateur. Cette valeur est lue en tant que System Property ; l'entrée dans ``fess_config.properties`` n'est pas utilisée. Définissez-la via les System Properties ou ``-Dfess.system.rag.chat.message.max.length``.
      - ``4000``
    * - ``rag.chat.highlight.fragment.size``
      - Taille du fragment pour le surlignage de recherche
@@ -168,38 +168,38 @@ Liste des configurations principales disponibles dans ``fess_config.properties``
      - Nombre de fragments pour le surlignage de recherche
      - ``3``
    * - ``rag.chat.content.fulltext.max.length``
-     - Seuil de ``content_length`` au-dela duquel les documents utilisent des extraits en surbrillance plutot que le texte integral dans le contexte de reponse
+     - Seuil de ``content_length`` au-delà duquel les documents utilisent des extraits en surbrillance plutôt que le texte intégral dans le contexte de réponse
      - ``3000``
    * - ``rag.chat.answer.highlight.fragment.size``
-     - Taille du fragment de surlignage lors de l'extraction d'extraits de grands documents pour le contexte de reponse
+     - Taille du fragment de surlignage lors de l'extraction d'extraits de grands documents pour le contexte de réponse
      - ``1000``
    * - ``rag.chat.answer.highlight.number.of.fragments``
-     - Nombre de fragments de surlignage lors de l'extraction d'extraits de grands documents pour le contexte de reponse
+     - Nombre de fragments de surlignage lors de l'extraction d'extraits de grands documents pour le contexte de réponse
      - ``5``
    * - ``rag.chat.history.assistant.content``
-     - Type de contenu a inclure dans l'historique de l'assistant ( ``full`` / ``smart_summary`` / ``source_titles`` / ``source_titles_and_urls`` / ``truncated`` / ``none`` )
+     - Type de contenu à inclure dans l'historique de l'assistant ( ``full`` / ``smart_summary`` / ``source_titles`` / ``source_titles_and_urls`` / ``truncated`` / ``none`` )
      - ``smart_summary``
    * - ``rag.chat.history.titles.max.count``
-     - Nombre maximum de titres de documents references conserves par tour en mode ``smart_summary``
+     - Nombre maximum de titres de documents référencés conservés par tour en mode ``smart_summary``
      - ``5``
 
-Parametres de generation
+Paramètres de génération
 ================
 
-Dans |Fess| 15.8, les parametres de generation (nombre maximum de tokens, temperature, etc.) se configurent par fournisseur
-et par type de prompt. Ces configurations sont gerees comme parametres de chaque plugin ``fess-llm-*``
+Dans |Fess| 15.8, les paramètres de génération (nombre maximum de tokens, température, etc.) se configurent par fournisseur
+et par type de prompt. Ces configurations sont gérées comme paramètres de chaque plugin ``fess-llm-*``
 et non comme configurations principales.
 
-Pour les details, consultez la documentation de chaque fournisseur :
+Pour les détails, consultez la documentation de chaque fournisseur :
 
-- :doc:`llm-ollama` - Parametres de generation Ollama
-- :doc:`llm-openai` - Parametres de generation OpenAI
-- :doc:`llm-gemini` - Parametres de generation Google Gemini
+- :doc:`llm-ollama` - Paramètres de génération Ollama
+- :doc:`llm-openai` - Paramètres de génération OpenAI
+- :doc:`llm-gemini` - Paramètres de génération Google Gemini
 
 Configuration du contexte
 ================
 
-Configuration du contexte passe au LLM depuis les resultats de recherche.
+Configuration du contexte passé au LLM depuis les résultats de recherche.
 
 Configuration principale
 --------
@@ -210,35 +210,35 @@ Les configurations suivantes s'effectuent dans ``fess_config.properties``.
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rag.chat.context.max.documents``
-     - Nombre maximum de documents a inclure dans le contexte
+     - Nombre maximum de documents à inclure dans le contexte
      - ``5``
    * - ``rag.chat.content.fields``
-     - Champs a recuperer des documents
+     - Champs à récupérer des documents
      - ``title,url,content,doc_id,content_title,content_description``
 
-Configuration specifique au fournisseur
+Configuration spécifique au fournisseur
 -----------------------
 
 Les configurations suivantes s'effectuent dans ``fess_config.properties`` pour chaque fournisseur.
 
-- ``rag.llm.{provider}.{promptType}.context.max.chars`` - Nombre maximum de caracteres du contexte
-- ``rag.llm.{provider}.chat.evaluation.max.relevant.docs`` - Nombre maximum de documents pertinents a selectionner lors de la phase d'evaluation
+- ``rag.llm.{provider}.{promptType}.context.max.chars`` - Nombre maximum de caractères du contexte
+- ``rag.llm.{provider}.chat.evaluation.max.relevant.docs`` - Nombre maximum de documents pertinents à sélectionner lors de la phase d'évaluation
 
 ``{provider}`` contient le nom du fournisseur tel que ``ollama``, ``openai``, ``gemini``, etc.
 ``{promptType}`` contient le type de prompt tel que ``intent``, ``evaluation``, ``answer``, ``summary``, ``faq``, ``queryregeneration``,
 ``unclear``, ``noresults``, ``docnotfound``, ``direct``, etc.
-La liste des types de prompt pris en charge est definie dans l'implementation ``*LlmClient`` de chaque plugin.
+La liste des types de prompt pris en charge est définie dans l'implémentation ``*LlmClient`` de chaque plugin.
 
-Pour les details, consultez la documentation de chaque fournisseur.
+Pour les détails, consultez la documentation de chaque fournisseur.
 
 Champs de contenu
 --------------------
 
-Champs specifiables dans ``rag.chat.content.fields`` :
+Champs spécifiables dans ``rag.chat.content.fields`` :
 
 - ``title`` - Titre du document
 - ``url`` - URL du document
@@ -247,25 +247,25 @@ Champs specifiables dans ``rag.chat.content.fields`` :
 - ``content_title`` - Titre du contenu
 - ``content_description`` - Description du contenu
 
-Prompt systeme
+Prompt système
 ==================
 
-Dans |Fess| 15.8, les prompts systeme sont definis dans le DI XML (``fess_llm++.xml``) de chaque plugin ``fess-llm-*``
-et non dans les fichiers de proprietes.
+Dans |Fess| 15.8, les prompts système sont définis dans le DI XML (``fess_llm++.xml``) de chaque plugin ``fess-llm-*``
+et non dans les fichiers de propriétés.
 
 Personnalisation des prompts
 -------------------------
 
-Pour personnaliser les prompts systeme, surchargez le fichier ``fess_llm++.xml`` dans le JAR du plugin.
+Pour personnaliser les prompts système, surchargez le fichier ``fess_llm++.xml`` dans le JAR du plugin.
 
-1. Recuperez ``fess_llm++.xml`` dans le fichier JAR du plugin utilise
-2. Apportez les modifications necessaires
-3. Placez-le dans l'emplacement approprie sous ``app/WEB-INF/`` pour le surcharger
+1. Récupérez ``fess_llm++.xml`` dans le fichier JAR du plugin utilisé
+2. Apportez les modifications nécessaires
+3. Placez-le dans l'emplacement approprié sous ``app/WEB-INF/`` pour le surcharger
 
-Des prompts systeme differents sont definis pour chaque type de prompt (analyse d'intention, evaluation, generation),
-avec une optimisation adaptee a chaque usage.
+Des prompts système différents sont définis pour chaque type de prompt (analyse d'intention, évaluation, génération),
+avec une optimisation adaptée à chaque usage.
 
-Pour les details, consultez la documentation de chaque fournisseur :
+Pour les détails, consultez la documentation de chaque fournisseur :
 
 - :doc:`llm-ollama` - Configuration des prompts Ollama
 - :doc:`llm-openai` - Configuration des prompts OpenAI
@@ -280,14 +280,14 @@ Configuration de la gestion des sessions de chat.
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rag.chat.session.timeout.minutes``
-     - Delai d'expiration de la session (minutes)
+     - Délai d'expiration de la session (minutes)
      - ``30``
    * - ``rag.chat.session.max.size``
-     - Nombre maximum de sessions pouvant etre maintenues simultanement
+     - Nombre maximum de sessions pouvant être maintenues simultanément
      - ``10000``
    * - ``rag.chat.history.max.messages``
      - Nombre maximum de messages dans l'historique de conversation
@@ -296,15 +296,15 @@ Configuration de la gestion des sessions de chat.
 Comportement des sessions
 ----------------
 
-- Lorsqu'un utilisateur commence un nouveau chat, une nouvelle session est creee
-- L'historique de conversation est sauvegarde dans la session, permettant un dialogue contextuel
-- Les sessions sont automatiquement supprimees apres expiration du delai
-- Lorsque l'historique depasse le nombre maximum de messages, les anciens messages sont supprimes
+- Lorsqu'un utilisateur commence un nouveau chat, une nouvelle session est créée
+- L'historique de conversation est sauvegardé dans la session, permettant un dialogue contextuel
+- Les sessions sont automatiquement supprimées après expiration du délai
+- Lorsque l'historique dépasse le nombre maximum de messages, les anciens messages sont supprimés
 
-Controle de la concurrence
+Contrôle de la concurrence
 ============
 
-Le nombre de requetes simultanees vers le LLM est controle par fournisseur dans ``fess_config.properties``.
+Le nombre de requêtes simultanées vers le LLM est contrôlé par fournisseur dans ``fess_config.properties``.
 
 ::
 
@@ -316,18 +316,18 @@ Le nombre de requetes simultanees vers le LLM est controle par fournisseur dans 
     # Timeout d'attente pour l'obtention d'un permis de concurrence (millisecondes, defaut : 30000)
     rag.llm.ollama.concurrency.wait.timeout=30000
 
-Considerations sur le controle de la concurrence
+Considérations sur le contrôle de la concurrence
 -----------------------
 
-- Tenez compte egalement des limitations de debit cote fournisseur LLM
-- Dans les environnements a forte charge, il est recommande de configurer des valeurs plus petites
-- Lorsque la limite de concurrence est atteinte, les requetes entrent dans une file d'attente et sont traitees sequentiellement
-- Si l'attente d'un permis depasse ``concurrency.wait.timeout``, la requete echoue avec une erreur de timeout
+- Tenez compte également des limitations de débit côté fournisseur LLM
+- Dans les environnements à forte charge, il est recommandé de configurer des valeurs plus petites
+- Lorsque la limite de concurrence est atteinte, les requêtes entrent dans une file d'attente et sont traitées séquentiellement
+- Si l'attente d'un permis dépasse ``concurrency.wait.timeout``, la requête échoue avec une erreur de timeout
 
 Mode d'historique de conversation
 =================================
 
-``rag.chat.history.assistant.content`` controle la maniere dont les reponses de l'assistant sont stockees dans l'historique de conversation.
+``rag.chat.history.assistant.content`` contrôle la manière dont les réponses de l'assistant sont stockées dans l'historique de conversation.
 
 .. list-table::
    :header-rows: 1
@@ -336,50 +336,50 @@ Mode d'historique de conversation
    * - Mode
      - Description
    * - ``smart_summary``
-     - (Par defaut) Le corps de la reponse de l'assistant est omis de l'historique ; seuls la requete de recherche passee et les titres des documents references (au maximum ``rag.chat.history.titles.max.count`` elements) sont conserves par tour
+     - (Par défaut) Le corps de la réponse de l'assistant est omis de l'historique ; seuls la requête de recherche passée et les titres des documents référencés (au maximum ``rag.chat.history.titles.max.count`` éléments) sont conservés par tour
    * - ``full``
-     - Preserve la reponse entiere telle quelle
+     - Préserve la réponse entière telle quelle
    * - ``source_titles``
-     - Preserve uniquement les titres des sources
+     - Préserve uniquement les titres des sources
    * - ``source_titles_and_urls``
-     - Preserve les titres et URLs des sources
+     - Préserve les titres et URLs des sources
    * - ``truncated``
-     - Tronque la reponse a la limite maximale de caracteres
+     - Tronque la réponse à la limite maximale de caractères
    * - ``none``
-     - Ne preserve pas l'historique
+     - Ne préserve pas l'historique
 
 .. note::
 
-   En mode ``smart_summary``, le corps de la reponse est remplace par la requete de recherche et les titres references, ce qui preserve le contexte efficacement tout en reduisant l'utilisation des tokens.
-   Les paires de messages utilisateur et assistant sont groupees en tours et empaquetees de maniere optimale dans un budget de caracteres.
-   Les limites maximales de caracteres pour l'historique et le resume sont controlees par l'implementation ``LlmClient`` de chaque plugin ``fess-llm-*``.
+   En mode ``smart_summary``, le corps de la réponse est remplacé par la requête de recherche et les titres référencés, ce qui préserve le contexte efficacement tout en réduisant l'utilisation des tokens.
+   Les paires de messages utilisateur et assistant sont groupées en tours et empaquetées de manière optimale dans un budget de caractères.
+   Les limites maximales de caractères pour l'historique et le résumé sont contrôlées par l'implémentation ``LlmClient`` de chaque plugin ``fess-llm-*``.
 
-Regeneration de requete
+Régénération de requête
 =======================
 
-Lorsqu'aucun resultat de recherche n'est trouve ou qu'aucun resultat pertinent n'est identifie, le LLM regenere automatiquement la requete et relance la recherche.
+Lorsqu'aucun résultat de recherche n'est trouvé ou qu'aucun résultat pertinent n'est identifié, le LLM régénère automatiquement la requête et relance la recherche.
 
-- Avec zero resultats de recherche : Regeneration de requete avec raison ``no_results``
-- Lorsqu'aucun document pertinent n'est trouve : Regeneration de requete avec raison ``no_relevant_results``
-- Retombe sur la requete originale si la regeneration echoue
+- Avec zéro résultats de recherche : Régénération de requête avec raison ``no_results``
+- Lorsqu'aucun document pertinent n'est trouvé : Régénération de requête avec raison ``no_relevant_results``
+- Retombe sur la requête originale si la régénération échoue
 
-Cette fonctionnalite est activee par defaut et integree dans les flux RAG synchrones et en streaming.
-Les prompts de regeneration de requete sont definis dans chaque plugin ``fess-llm-*``.
+Cette fonctionnalité est activée par défaut et intégrée dans les flux RAG synchrones et en streaming.
+Les prompts de régénération de requête sont définis dans chaque plugin ``fess-llm-*``.
 
 Rendu Markdown
 ==============
 
-Les reponses du mode de recherche IA sont rendues au format Markdown.
+Les réponses du mode de recherche IA sont rendues au format Markdown.
 
-- Les reponses du LLM sont analysees en Markdown et converties en HTML
-- Le HTML converti est assaini, n'autorisant que les balises et attributs surs
+- Les réponses du LLM sont analysées en Markdown et converties en HTML
+- Le HTML converti est assaini, n'autorisant que les balises et attributs sûrs
 - Prend en charge les titres, listes, blocs de code, tableaux, liens et autres syntaxes Markdown
-- Cote client, ``marked.js`` et ``DOMPurify`` sont utilises ; cote serveur, le sanitizer OWASP
+- Côté client, ``marked.js`` et ``DOMPurify`` sont utilisés ; côté serveur, le sanitizer OWASP
 
 Utilisation de l'API
 =========
 
-La fonctionnalite de mode de recherche IA est accessible via API REST (API v2).
+La fonctionnalité de mode de recherche IA est accessible via API REST (API v2).
 L'URL de base est ``http://<nom du serveur>/api/v2/``.
 
 La Chat API fournit les trois points de terminaison suivants.
@@ -391,19 +391,19 @@ La Chat API fournit les trois points de terminaison suivants.
    * - Point de terminaison
      - Description
    * - ``POST /api/v2/chat``
-     - Completion RAG groupee (non-streaming)
+     - Complétion RAG groupée (non-streaming)
    * - ``POST /api/v2/chat/stream``
-     - Completion RAG en streaming (Server-Sent Events)
+     - Complétion RAG en streaming (Server-Sent Events)
    * - ``DELETE /api/v2/chat/sessions/{session_id}``
      - Effacer l'historique de conversation d'une session
 
-Les requetes sont envoyees avec un corps JSON de type ``Content-Type: application/json``.
-Les requetes modifiant l'etat (``POST`` / ``DELETE``) necessitent un jeton CSRF (en-tete ``X-Fess-CSRF-Token``).
-Les reponses sont encapsulees dans l'enveloppe commune ``response``.
+Les requêtes sont envoyées avec un corps JSON de type ``Content-Type: application/json``.
+Les requêtes modifiant l'état (``POST`` / ``DELETE``) nécessitent un jeton CSRF (en-tête ``X-Fess-CSRF-Token``).
+Les réponses sont encapsulées dans l'enveloppe commune ``response``.
 
 .. note::
 
-   Les points de terminaison ``/api/v1/chat`` au format parametres de formulaire disponibles dans |Fess| 15.5 et anterieur ont ete supprimes.
+   Les points de terminaison ``/api/v1/chat`` au format paramètres de formulaire disponibles dans |Fess| 15.5 et antérieur ont été supprimés.
    Dans 15.8, utilisez l'API JSON sous ``/api/v2/``.
 
 API non-streaming
@@ -411,7 +411,7 @@ API non-streaming
 
 Point de terminaison : ``POST /api/v2/chat``
 
-Corps de la requete (JSON) :
+Corps de la requête (JSON) :
 
 .. list-table::
    :header-rows: 1
@@ -425,18 +425,18 @@ Corps de la requete (JSON) :
      - Message de l'utilisateur
    * - ``session_id``
      - Non
-     - ID de session (pour continuer la conversation). Si omis, le serveur le cree et le retourne dans la reponse
+     - ID de session (pour continuer la conversation). Si omis, le serveur le crée et le retourne dans la réponse
    * - ``fields``
      - Non
-     - Champs de filtre optionnels pour l'etape de recuperation (objet)
+     - Champs de filtre optionnels pour l'étape de récupération (objet)
    * - ``fields.label``
      - Non
-     - Filtre de recherche par etiquette
+     - Filtre de recherche par étiquette
    * - ``extra_queries``
      - Non
-     - Expressions de requete supplementaires pour les filtres de facettes
+     - Expressions de requête supplémentaires pour les filtres de facettes
 
-Exemple de requete :
+Exemple de requête :
 
 .. code-block:: bash
 
@@ -445,7 +445,7 @@ Exemple de requete :
          -H "X-Fess-CSRF-Token: <token>" \
          -d '{"message":"Comment installer Fess ?"}'
 
-Exemple de reponse :
+Exemple de réponse :
 
 .. code-block:: json
 
@@ -471,10 +471,10 @@ API streaming
 
 Point de terminaison : ``POST /api/v2/chat/stream``
 
-Le corps de la requete est identique a ``POST /api/v2/chat`` (JSON).
-Les reponses sont streamees au format Server-Sent Events (SSE).
+Le corps de la requête est identique à ``POST /api/v2/chat`` (JSON).
+Les réponses sont streamées au format Server-Sent Events (SSE).
 
-Exemple de requete :
+Exemple de requête :
 
 .. code-block:: bash
 
@@ -485,161 +485,161 @@ Exemple de requete :
          --no-buffer \
          -d '{"message":"Quelles sont les caracteristiques de Fess ?"}'
 
-Evenements SSE :
+Événements SSE :
 
 .. list-table::
    :header-rows: 1
    :widths: 20 80
 
-   * - Evenement
+   * - Événement
      - Description (charge utile)
    * - ``phase``
      - Transition de phase du pipeline (``intent``, ``search``, ``evaluate``, ``fetch``, ``answer``). ``{ phase, status, message?, keywords?, hit_count?, ... }``
    * - ``chunk``
-     - Fragment de texte genere (``{ content }``)
+     - Fragment de texte généré (``{ content }``)
    * - ``retry``
-     - Notifie lorsqu'une requete LLM est reessayee (``{ phase, operation, attempt, max_attempts, sleep_ms, cause? }``)
+     - Notifie lorsqu'une requête LLM est réessayée (``{ phase, operation, attempt, max_attempts, sleep_ms, cause? }``)
    * - ``waiting``
      - Progression d'une phase longue telle que l'attente d'un permis de concurrence (``{ phase, reason, elapsed_ms, timeout_ms }``)
    * - ``fallback``
-     - Notifie lorsque la requete est regeneree suite a l'absence de resultats ou de resultats pertinents (``{ phase, reason, original_query?, new_query? }``, raison : ``no_results`` ou ``no_relevant_results``)
+     - Notifie lorsque la requête est régénérée suite à l'absence de résultats ou de résultats pertinents (``{ phase, reason, original_query?, new_query? }``, raison : ``no_results`` ou ``no_relevant_results``)
    * - ``warning``
-     - Notifie lors d'un avertissement recuperable (``{ phase, code, detail? }``, ex. epuisement des tokens d'un modele de raisonnement)
+     - Notifie lors d'un avertissement récupérable (``{ phase, code, detail? }``, ex. épuisement des tokens d'un modèle de raisonnement)
    * - ``sources``
      - Informations sur les documents sources (``{ sources: [...] }``)
    * - ``done``
-     - Traitement termine (``{ session_id, html_content? }``). ``html_content`` contient la chaine HTML rendue depuis Markdown
+     - Traitement terminé (``{ session_id, html_content? }``). ``html_content`` contient la chaîne HTML rendue depuis Markdown
    * - ``error``
-     - Echec terminal en cours de stream (``{ phase?, message, error_code }``). Timeout, depassement de la longueur de contexte, modele introuvable, reponse invalide, erreur de connexion, etc.
+     - Échec terminal en cours de stream (``{ phase?, message, error_code }``). Timeout, dépassement de la longueur de contexte, modèle introuvable, réponse invalide, erreur de connexion, etc.
 
 Effacer une session
 --------------------
 
 Point de terminaison : ``DELETE /api/v2/chat/sessions/{session_id}``
 
-Efface l'historique de conversation de la session specifiee. En cas de succes, ``cleared: true`` est retourne.
+Efface l'historique de conversation de la session spécifiée. En cas de succès, ``cleared: true`` est retourné.
 
-Pour la documentation API complete (authentification, CSRF, limites de debit, codes HTTP), consultez :doc:`../api/api-chat`.
+Pour la documentation API complète (authentification, CSRF, limites de débit, codes HTTP), consultez :doc:`../api/api-chat`.
 
 Interface Web
 ===================
 
-La fonctionnalite de mode de recherche IA est accessible depuis l'ecran de recherche de l'interface Web |Fess|.
+La fonctionnalité de mode de recherche IA est accessible depuis l'écran de recherche de l'interface Web |Fess|.
 
-Demarrer un chat
+Démarrer un chat
 --------------
 
-1. Accedez a l'ecran de recherche |Fess|
-2. Cliquez sur l'icone de chat
+1. Accédez à l'écran de recherche |Fess|
+2. Cliquez sur l'icône de chat
 3. Le panneau de chat s'affiche
 
 Utiliser le chat
 --------------
 
 1. Entrez votre question dans la zone de texte
-2. Cliquez sur le bouton d'envoi ou appuyez sur Entree
-3. La reponse de l'assistant IA s'affiche
-4. La reponse inclut des liens vers les sources
+2. Cliquez sur le bouton d'envoi ou appuyez sur Entrée
+3. La réponse de l'assistant IA s'affiche
+4. La réponse inclut des liens vers les sources
 
 Continuer la conversation
 ----------
 
-- Vous pouvez continuer la conversation dans la meme session de chat
-- Les reponses tiennent compte du contexte des questions precedentes
-- Cliquez sur "Nouveau chat" pour reinitialiser la session
+- Vous pouvez continuer la conversation dans la même session de chat
+- Les réponses tiennent compte du contexte des questions précédentes
+- Cliquez sur "Nouveau chat" pour réinitialiser la session
 
-Depannage
+Dépannage
 ======================
 
-Le bouton mode IA n'apparait pas sur l'ecran de recherche
+Le bouton mode IA n'apparaît pas sur l'écran de recherche
 ---------------------------------------------------------
 
-**Symptome** : Le bouton mode IA ne s'affiche pas dans l'en-tete des resultats
-de recherche, et acceder a ``/chat`` redirige vers la page d'accueil.
+**Symptôme** : Le bouton mode IA ne s'affiche pas dans l'en-tête des résultats
+de recherche, et accéder à ``/chat`` redirige vers la page d'accueil.
 
-**Liste de verifications** : verifier les points suivants dans l'ordre.
+**Liste de vérifications** : vérifier les points suivants dans l'ordre.
 
-1. ``rag.chat.enabled=true`` est-il defini ?
+1. ``rag.chat.enabled=true`` est-il défini ?
 
    - Docker : ``-Dfess.config.rag.chat.enabled=true`` est-il inclus dans ``FESS_JAVA_OPTS`` ?
-   - Installation par paquet : est-il ecrit dans ``app/WEB-INF/conf/fess_config.properties`` ?
+   - Installation par paquet : est-il écrit dans ``app/WEB-INF/conf/fess_config.properties`` ?
 
-2. Le plugin ``fess-llm-*`` correspondant est-il installe ?
+2. Le plugin ``fess-llm-*`` correspondant est-il installé ?
 
-   - Docker : ``FESS_PLUGINS=fess-llm-gemini:15.8.0`` (ou ``fess-llm-openai`` / ``fess-llm-ollama``) doit etre defini
-   - Installation par paquet : le JAR doit etre place dans ``app/WEB-INF/plugin/``
-   - Le journal de demarrage doit inclure ``Installing fess-llm-XXX-15.8.0.jar``
+   - Docker : ``FESS_PLUGINS=fess-llm-gemini:15.8.0`` (ou ``fess-llm-openai`` / ``fess-llm-ollama``) doit être défini
+   - Installation par paquet : le JAR doit être placé dans ``app/WEB-INF/plugin/``
+   - Le journal de démarrage doit inclure ``Installing fess-llm-XXX-15.8.0.jar``
 
-3. ``rag.llm.name`` correspond-il a un plugin installe ?
+3. ``rag.llm.name`` correspond-il à un plugin installé ?
 
-   - La valeur par defaut est ``ollama``. Si seul le plugin Gemini est installe, vous devez explicitement le definir a ``gemini`` (de meme ``openai`` pour le plugin OpenAI)
-   - Methode (a) : modifier ``rag.llm.name`` depuis Administration > Systeme > General (section RAG) et enregistrer
-   - Methode (b) : inclure ``-Dfess.system.rag.llm.name=gemini`` dans ``FESS_JAVA_OPTS`` au demarrage. N'agit que comme valeur par defaut initiale avant qu'une valeur ne soit persistee dans OpenSearch
+   - La valeur par défaut est ``ollama``. Si seul le plugin Gemini est installé, vous devez explicitement le définir à ``gemini`` (de même ``openai`` pour le plugin OpenAI)
+   - Méthode (a) : modifier ``rag.llm.name`` depuis Administration > Système > General (section RAG) et enregistrer
+   - Méthode (b) : inclure ``-Dfess.system.rag.llm.name=gemini`` dans ``FESS_JAVA_OPTS`` au démarrage. N'agit que comme valeur par défaut initiale avant qu'une valeur ne soit persistée dans OpenSearch
 
-4. Un WARN comme ``[LLM] LlmClient not found. componentName=ollamaLlmClient`` se repete-t-il dans le journal ?
+4. Un WARN comme ``[LLM] LlmClient not found. componentName=ollamaLlmClient`` se répète-t-il dans le journal ?
 
-   - Symptome typique quand ``rag.llm.name`` est encore ``ollama`` mais que le plugin Ollama n'est pas installe
-   - Definir ``rag.llm.name`` au fournisseur reellement utilise resout le probleme
-   - De meme, ``componentName=geminiLlmClient`` indique que ``rag.llm.name=gemini`` est defini mais que le plugin ``fess-llm-gemini`` n'est pas installe
+   - Symptôme typique quand ``rag.llm.name`` est encore ``ollama`` mais que le plugin Ollama n'est pas installé
+   - Définir ``rag.llm.name`` au fournisseur réellement utilisé résout le problème
+   - De même, ``componentName=geminiLlmClient`` indique que ``rag.llm.name=gemini`` est défini mais que le plugin ``fess-llm-gemini`` n'est pas installé
 
-5. La cle d'API specifique au fournisseur est-elle configuree ?
+5. La clé d'API spécifique au fournisseur est-elle configurée ?
 
-   - Quand ``rag.llm.gemini.api.key`` / ``rag.llm.openai.api.key`` est vide, ``checkAvailabilityNow`` retourne ``false`` et le mode IA est desactive
-   - Activer DEBUG sur ``org.codelibs.fess.llm.gemini`` dans ``log4j2.xml`` fait apparaitre des messages comme ``[LLM:GEMINI] Gemini is not available. apiKey is blank``
+   - Quand ``rag.llm.gemini.api.key`` / ``rag.llm.openai.api.key`` est vide, ``checkAvailabilityNow`` retourne ``false`` et le mode IA est désactivé
+   - Activer DEBUG sur ``org.codelibs.fess.llm.gemini`` dans ``log4j2.xml`` fait apparaître des messages comme ``[LLM:GEMINI] Gemini is not available. apiKey is blank``
 
-6. L'hote Fess peut-il atteindre le fournisseur LLM ?
+6. L'hôte Fess peut-il atteindre le fournisseur LLM ?
 
-   - Pour les API cloud (Gemini / OpenAI), le conteneur doit avoir un acces sortant a Internet
-   - En cas de proxy, definissez ``http.proxy.host`` / ``http.proxy.port`` (et au besoin ``http.proxy.username`` / ``http.proxy.password``) dans ``fess_config.properties``. Dans un environnement Docker, ajoutez ``-Dfess.config.http.proxy.host=... -Dfess.config.http.proxy.port=...`` a ``FESS_JAVA_OPTS`` (depuis |Fess| 15.8, les clients LLM partagent la configuration de proxy commune a |Fess|)
+   - Pour les API cloud (Gemini / OpenAI), le conteneur doit avoir un accès sortant à Internet
+   - En cas de proxy, définissez ``http.proxy.host`` / ``http.proxy.port`` (et au besoin ``http.proxy.username`` / ``http.proxy.password``) dans ``fess_config.properties``. Dans un environnement Docker, ajoutez ``-Dfess.config.http.proxy.host=... -Dfess.config.http.proxy.port=...`` à ``FESS_JAVA_OPTS`` (depuis |Fess| 15.8, les clients LLM partagent la configuration de proxy commune à |Fess|)
 
 .. note::
 
-   La page "General" n'expose pas de case a cocher pour ``rag.chat.enabled`` (par conception).
-   Cette propriete de la famille FessConfig ne peut etre definie qu'a travers
+   La page "General" n'expose pas de case à cocher pour ``rag.chat.enabled`` (par conception).
+   Cette propriété de la famille FessConfig ne peut être définie qu'à travers
    ``fess_config.properties`` ou ``-Dfess.config.rag.chat.enabled=true``.
 
 Le mode de recherche IA ne s'active pas
 ------------------------
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si ``rag.chat.enabled=true`` est configure
-2. Verifier si le fournisseur LLM est correctement configure dans ``rag.llm.name``
-3. Verifier si le plugin ``fess-llm-*`` correspondant est installe
-4. Verifier si la connexion au fournisseur LLM est possible
+1. Vérifier si ``rag.chat.enabled=true`` est configuré
+2. Vérifier si le fournisseur LLM est correctement configuré dans ``rag.llm.name``
+3. Vérifier si le plugin ``fess-llm-*`` correspondant est installé
+4. Vérifier si la connexion au fournisseur LLM est possible
 
-Qualite des reponses insuffisante
+Qualité des réponses insuffisante
 ----------------
 
-**Ameliorations** :
+**Améliorations** :
 
-1. Utiliser un modele LLM plus performant
+1. Utiliser un modèle LLM plus performant
 2. Augmenter ``rag.chat.context.max.documents``
-3. Personnaliser le prompt systeme dans le DI XML
-4. Ajuster les parametres de temperature specifiques au fournisseur (consultez la documentation de chaque plugin ``fess-llm-*``)
+3. Personnaliser le prompt système dans le DI XML
+4. Ajuster les paramètres de température spécifiques au fournisseur (consultez la documentation de chaque plugin ``fess-llm-*``)
 
-Reponses lentes
+Réponses lentes
 ----------------
 
-**Ameliorations** :
+**Améliorations** :
 
-1. Utiliser un modele LLM plus rapide (ex : Gemini Flash)
-2. Reduire les parametres max.tokens specifiques au fournisseur (consultez la documentation de chaque plugin ``fess-llm-*``)
-3. Reduire ``rag.chat.context.max.documents``
+1. Utiliser un modèle LLM plus rapide (ex : Gemini Flash)
+2. Réduire les paramètres max.tokens spécifiques au fournisseur (consultez la documentation de chaque plugin ``fess-llm-*``)
+3. Réduire ``rag.chat.context.max.documents``
 
 Sessions non maintenues
 ------------------------
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si le ``session_id`` est correctement envoye cote client
-2. Verifier le parametre ``rag.chat.session.timeout.minutes``
-3. Verifier la capacite de stockage des sessions
+1. Vérifier si le ``session_id`` est correctement envoyé côté client
+2. Vérifier le paramètre ``rag.chat.session.timeout.minutes``
+3. Vérifier la capacité de stockage des sessions
 
-Configuration de debogage
+Configuration de débogage
 ------------
 
-Pour investiguer les problemes, ajustez le niveau de log pour afficher des logs detailles.
+Pour investiguer les problèmes, ajustez le niveau de log pour afficher des logs détaillés.
 
 ``app/WEB-INF/classes/log4j2.xml`` :
 
@@ -649,20 +649,20 @@ Pour investiguer les problemes, ajustez le niveau de log pour afficher des logs 
     <Logger name="org.codelibs.fess.api.v2.handlers" level="DEBUG"/>
     <Logger name="org.codelibs.fess.chat" level="DEBUG"/>
 
-Les messages de log utilisent le prefixe ``[RAG]``, avec des sous-prefixes tels que ``[RAG:INTENT]``, ``[RAG:EVAL]`` et ``[RAG:ANSWER]`` pour chaque phase.
-Au niveau INFO, les logs de fin de chat (duree, nombre de sources) sont emis. Au niveau DEBUG, les details d'utilisation des tokens, de controle de concurrence et d'empaquetage de l'historique sont emis.
+Les messages de log utilisent le préfixe ``[RAG]``, avec des sous-préfixes tels que ``[RAG:INTENT]``, ``[RAG:EVAL]`` et ``[RAG:ANSWER]`` pour chaque phase.
+Au niveau INFO, les logs de fin de chat (durée, nombre de sources) sont émis. Au niveau DEBUG, les détails d'utilisation des tokens, de contrôle de concurrence et d'empaquetage de l'historique sont émis.
 
-Journal de recherche et type d'acces
+Journal de recherche et type d'accès
 -------------------------------------
 
-Les recherches via le mode de recherche IA sont enregistrees avec le nom du fournisseur LLM (par ex. ``ollama``, ``openai``, ``gemini``) comme type d'acces dans les journaux de recherche. Cela permet de distinguer les recherches du mode IA des recherches web ou API regulieres dans les analyses.
+Les recherches via le mode de recherche IA sont enregistrées avec le nom du fournisseur LLM (par ex. ``ollama``, ``openai``, ``gemini``) comme type d'accès dans les journaux de recherche. Cela permet de distinguer les recherches du mode IA des recherches web ou API régulières dans les analyses.
 
-Informations de reference
+Informations de référence
 ========
 
-- :doc:`llm-overview` - Apercu de l'integration LLM
+- :doc:`llm-overview` - Aperçu de l'intégration LLM
 - :doc:`llm-ollama` - Configuration Ollama
 - :doc:`llm-openai` - Configuration OpenAI
 - :doc:`llm-gemini` - Configuration Google Gemini
-- :doc:`../api/api-chat` - Reference API Chat
+- :doc:`../api/api-chat` - Référence API Chat
 - :doc:`../user/chat-search` - Guide de recherche par chat pour les utilisateurs

--- a/fr/15.8/config/rate-limiting.rst
+++ b/fr/15.8/config/rate-limiting.rst
@@ -1,23 +1,23 @@
 ==================================
-Configuration de la limitation de debit
+Configuration de la limitation de débit
 ==================================
 
-Apercu
+Aperçu
 ====
 
-|Fess| dispose d'une fonctionnalite de limitation de debit pour maintenir la stabilite et les performances du systeme.
-Cette fonctionnalite protege le systeme contre les requetes excessives et permet une allocation equitable des ressources.
+|Fess| dispose d'une fonctionnalité de limitation de débit pour maintenir la stabilité et les performances du système.
+Cette fonctionnalité protège le système contre les requêtes excessives et permet une allocation équitable des ressources.
 
-La limitation de debit s'applique dans les situations suivantes :
+La limitation de débit s'applique dans les situations suivantes :
 
-- Toutes les requetes HTTP, y compris l'API de recherche, l'API de mode de recherche IA et les pages d'administration (``RateLimitFilter``)
-- Requetes du crawler (controlees par la configuration du crawl)
+- Toutes les requêtes HTTP, y compris l'API de recherche, l'API de mode de recherche IA et les pages d'administration (``RateLimitFilter``)
+- Requêtes du crawler (contrôlées par la configuration du crawl)
 
-Limitation de debit des requetes HTTP
+Limitation de débit des requêtes HTTP
 ======================================
 
-Vous pouvez limiter le nombre de requetes HTTP vers |Fess| par adresse IP.
-Cette limitation s'applique a toutes les requetes HTTP, y compris l'API de recherche, l'API de mode de recherche IA, les pages d'administration, etc.
+Vous pouvez limiter le nombre de requêtes HTTP vers |Fess| par adresse IP.
+Cette limitation s'applique à toutes les requêtes HTTP, y compris l'API de recherche, l'API de mode de recherche IA, les pages d'administration, etc.
 
 Configuration
 ----
@@ -38,38 +38,38 @@ Configuration
 Comportement
 ----
 
-- Les requetes depassant la limite de debit retournent HTTP 429 (Too Many Requests)
-- Les requetes provenant d'IP figurant dans la liste de blocage retournent HTTP 403 (Forbidden)
-- Les limites sont appliquees par adresse IP
-- Pour chaque IP, la fenetre commence au premier requete et le compteur est reinitialise apres l'expiration de la periode de la fenetre (methode de fenetre fixe)
-- Le depassement de la limite entraine le blocage de l'IP pendant la duree ``rate.limit.block.duration.ms``
+- Les requêtes dépassant la limite de débit retournent HTTP 429 (Too Many Requests)
+- Les requêtes provenant d'IP figurant dans la liste de blocage retournent HTTP 403 (Forbidden)
+- Les limites sont appliquées par adresse IP
+- Pour chaque IP, la fenêtre commence au premier requête et le compteur est réinitialisé après l'expiration de la période de la fenêtre (méthode de fenêtre fixe)
+- Le dépassement de la limite entraîne le blocage de l'IP pendant la durée ``rate.limit.block.duration.ms``
 
-Limitation de debit du mode de recherche IA
+Limitation de débit du mode de recherche IA
 ====================
 
-La fonctionnalite de mode de recherche IA dispose d'une limitation de debit pour controler les couts de l'API LLM et la consommation de ressources.
-Le mode de recherche IA est soumis a la limitation de debit des requetes HTTP decrite ci-dessus, et dispose egalement de parametres de limitation de debit specifiques au mode de recherche IA.
+La fonctionnalité de mode de recherche IA dispose d'une limitation de débit pour contrôler les coûts de l'API LLM et la consommation de ressources.
+Le mode de recherche IA est soumis à la limitation de débit des requêtes HTTP décrite ci-dessus, et dispose également de paramètres de limitation de débit spécifiques au mode de recherche IA.
 
-Pour la configuration specifique de la limitation de debit du mode de recherche IA, consultez :doc:`rag-chat`.
+Pour la configuration spécifique de la limitation de débit du mode de recherche IA, consultez :doc:`rag-chat`.
 
 .. note::
-   La limitation de debit du mode de recherche IA s'applique separement de la limitation de debit cote fournisseur LLM.
+   La limitation de débit du mode de recherche IA s'applique séparément de la limitation de débit côté fournisseur LLM.
    Configurez en tenant compte des deux limites.
 
-Limitation de debit du crawler
+Limitation de débit du crawler
 ======================
 
-Vous pouvez configurer l'intervalle entre les requetes pour eviter que le crawler ne surcharge les sites cibles.
+Vous pouvez configurer l'intervalle entre les requêtes pour éviter que le crawler ne surcharge les sites cibles.
 
 Configuration du crawl Web
 ---------------
 
-Configurez les elements suivants dans l'ecran d'administration "Crawler" -> "Web" :
+Configurez les éléments suivants dans l'écran d'administration "Crawler" -> "Web" :
 
-- **Intervalle de requetes** : Temps d'attente entre les requetes (millisecondes)
-- **Nombre de threads** : Nombre de threads de crawl paralleles
+- **Intervalle de requêtes** : Temps d'attente entre les requêtes (millisecondes)
+- **Nombre de threads** : Nombre de threads de crawl parallèles
 
-Configuration recommandee :
+Configuration recommandée :
 
 ::
 
@@ -84,7 +84,7 @@ Configuration recommandee :
 Respect de robots.txt
 ----------------
 
-|Fess| respecte par defaut la directive Crawl-delay de robots.txt.
+|Fess| respecte par défaut la directive Crawl-delay de robots.txt.
 
 ::
 
@@ -92,70 +92,70 @@ Respect de robots.txt
     User-agent: *
     Crawl-delay: 10
 
-Le traitement de robots.txt est controle par ``crawler.ignore.robots.txt`` dans
-``app/WEB-INF/classes/fess_config.properties`` (defaut : ``false``).
-En le definissant sur ``true``, le traitement de robots.txt, y compris Crawl-delay, est desactive.
+Le traitement de robots.txt est contrôlé par ``crawler.ignore.robots.txt`` dans
+``app/WEB-INF/classes/fess_config.properties`` (défaut : ``false``).
+En le définissant sur ``true``, le traitement de robots.txt, y compris Crawl-delay, est désactivé.
 
 ::
 
     # Ignorer robots.txt (defaut : false)
     crawler.ignore.robots.txt=false
 
-Liste complete des proprietes de limitation de debit
+Liste complète des propriétés de limitation de débit
 ======================
 
-Toutes les proprietes configurables dans ``app/WEB-INF/classes/fess_config.properties``.
+Toutes les propriétés configurables dans ``app/WEB-INF/classes/fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
-   * - Propriete
+   * - Propriété
      - Description
-     - Valeur par defaut
+     - Valeur par défaut
    * - ``rate.limit.enabled``
-     - Activer la limitation de debit
+     - Activer la limitation de débit
      - ``false``
    * - ``rate.limit.requests.per.window``
-     - Nombre maximum de requetes par fenetre
+     - Nombre maximum de requêtes par fenêtre
      - ``100``
    * - ``rate.limit.window.ms``
-     - Taille de la fenetre (millisecondes)
+     - Taille de la fenêtre (millisecondes)
      - ``60000``
    * - ``rate.limit.block.duration.ms``
-     - Duree de blocage de l'IP en cas de depassement (millisecondes)
+     - Durée de blocage de l'IP en cas de dépassement (millisecondes)
      - ``300000``
    * - ``rate.limit.retry.after.seconds``
-     - Valeur de l'en-tete Retry-After (secondes)
+     - Valeur de l'en-tête Retry-After (secondes)
      - ``60``
    * - ``rate.limit.whitelist.ips``
-     - Adresses IP exclues de la limitation de debit (separees par des virgules)
+     - Adresses IP exclues de la limitation de débit (séparées par des virgules)
      - ``127.0.0.1,::1``
    * - ``rate.limit.blocked.ips``
-     - Adresses IP a bloquer (separees par des virgules)
+     - Adresses IP à bloquer (séparées par des virgules)
      - (vide)
    * - ``rate.limit.trusted.proxies``
      - IP de proxies de confiance (pour obtenir l'IP client via X-Forwarded-For/X-Real-IP)
      - ``127.0.0.1,::1``
    * - ``rate.limit.cleanup.interval``
-     - Intervalle de nettoyage (nombre de requetes, reserve)
+     - Intervalle de nettoyage (nombre de requêtes, réservé)
      - ``1000``
 
 .. note::
-   ``rate.limit.cleanup.interval`` est un parametre reserve pour une utilisation future.
-   Dans l'implementation actuelle, les compteurs de requetes et les informations sur les IP bloquees
-   sont nettoyes automatiquement en fonction de l'expiration du cache interne
+   ``rate.limit.cleanup.interval`` est un paramètre réservé pour une utilisation future.
+   Dans l'implémentation actuelle, les compteurs de requêtes et les informations sur les IP bloquées
+   sont nettoyés automatiquement en fonction de l'expiration du cache interne
    (``rate.limit.window.ms`` et ``rate.limit.block.duration.ms``),
-   de sorte que cette valeur n'est pas utilisee.
+   de sorte que cette valeur n'est pas utilisée.
 
-Configuration avancee de limitation de debit
+Configuration avancée de limitation de débit
 ====================
 
-Limitation de debit personnalisee
+Limitation de débit personnalisée
 ------------------
 
-Pour appliquer des limites differentes selon des conditions specifiques,
-une implementation de composant personnalise est necessaire.
+Pour appliquer des limites différentes selon des conditions spécifiques,
+une implémentation de composant personnalisé est nécessaire.
 
 ::
 
@@ -170,7 +170,7 @@ une implementation de composant personnalise est necessaire.
 Configuration d'exclusion
 ========
 
-Vous pouvez exclure certaines adresses IP de la limitation de debit ou les bloquer.
+Vous pouvez exclure certaines adresses IP de la limitation de débit ou les bloquer.
 
 ::
 
@@ -185,27 +185,27 @@ Vous pouvez exclure certaines adresses IP de la limitation de debit ou les bloqu
 
 .. note::
    Si vous utilisez un reverse proxy, configurez l'adresse IP du proxy dans ``rate.limit.trusted.proxies``.
-   Seules les requetes provenant de proxies de confiance permettent d'obtenir l'IP client
-   via les en-tetes X-Forwarded-For et X-Real-IP.
+   Seules les requêtes provenant de proxies de confiance permettent d'obtenir l'IP client
+   via les en-têtes X-Forwarded-For et X-Real-IP.
 
 Surveillance et alertes
 ==============
 
-Configuration pour surveiller l'etat de la limitation de debit :
+Configuration pour surveiller l'état de la limitation de débit :
 
 Sortie de logs
 --------
 
-Lorsque la limitation de debit est appliquee, elle est enregistree dans les logs :
+Lorsque la limitation de débit est appliquée, elle est enregistrée dans les logs :
 
 ::
 
     <Logger name="org.codelibs.fess.helper.RateLimitHelper" level="INFO"/>
 
-Depannage
+Dépannage
 ======================
 
-Les requetes legitimes sont bloquees
+Les requêtes légitimes sont bloquées
 --------------------------------
 
 **Cause** : Les valeurs limites sont trop strictes
@@ -213,31 +213,31 @@ Les requetes legitimes sont bloquees
 **Solution** :
 
 1. Augmenter ``rate.limit.requests.per.window``
-2. Ajouter des IP specifiques a la liste blanche (``rate.limit.whitelist.ips``)
-3. Ajuster la taille de la fenetre (``rate.limit.window.ms``)
+2. Ajouter des IP spécifiques à la liste blanche (``rate.limit.whitelist.ips``)
+3. Ajuster la taille de la fenêtre (``rate.limit.window.ms``)
 
-La limitation de debit ne fonctionne pas
+La limitation de débit ne fonctionne pas
 --------------------
 
-**Cause** : La configuration n'est pas correctement appliquee
+**Cause** : La configuration n'est pas correctement appliquée
 
-**Points a verifier** :
+**Points à vérifier** :
 
-1. Verifier si ``rate.limit.enabled=true`` est configure
-2. Verifier si le fichier de configuration est correctement lu
-3. Verifier si |Fess| a ete redemarre
+1. Vérifier si ``rate.limit.enabled=true`` est configuré
+2. Vérifier si le fichier de configuration est correctement lu
+3. Vérifier si |Fess| a été redémarré
 
 Impact sur les performances
 ----------------------
 
-Si la verification de la limitation de debit affecte les performances :
+Si la vérification de la limitation de débit affecte les performances :
 
-1. Utiliser la liste blanche pour ignorer les verifications sur les IP de confiance
-2. Desactiver la limitation de debit (``rate.limit.enabled=false``)
+1. Utiliser la liste blanche pour ignorer les vérifications sur les IP de confiance
+2. Désactiver la limitation de débit (``rate.limit.enabled=false``)
 
-Informations de reference
+Informations de référence
 ========
 
-- :doc:`rag-chat` - Configuration de la fonctionnalite de mode de recherche IA
+- :doc:`rag-chat` - Configuration de la fonctionnalité de mode de recherche IA
 - :doc:`../admin/webconfig-guide` - Guide de configuration du crawl Web
-- :doc:`../api/api-overview` - Apercu des API
+- :doc:`../api/api-overview` - Aperçu des API

--- a/fr/15.8/config/scripting-groovy.rst
+++ b/fr/15.8/config/scripting-groovy.rst
@@ -2,17 +2,17 @@
 Guide de script Groovy
 ==================================
 
-Apercu
+Aperçu
 ====
 
-Groovy est le langage de script par defaut de |Fess|.
-Il fonctionne sur la machine virtuelle Java (JVM) et, tout en etant hautement compatible avec Java,
-permet d'ecrire des scripts avec une syntaxe plus concise.
+Groovy est le langage de script par défaut de |Fess|.
+Il fonctionne sur la machine virtuelle Java (JVM) et, tout en étant hautement compatible avec Java,
+permet d'écrire des scripts avec une syntaxe plus concise.
 
 Syntaxe de base
 ========
 
-Declaration de variables
+Déclaration de variables
 --------
 
 ::
@@ -25,7 +25,7 @@ Declaration de variables
     String title = "Document Title"
     int pageNum = 1
 
-Manipulation de chaines
+Manipulation de chaînes
 ----------
 
 ::
@@ -52,7 +52,7 @@ Manipulation de chaines
     title.toUpperCase()
     title.toLowerCase()
 
-Operations sur les collections
+Opérations sur les collections
 ----------------
 
 ::
@@ -113,10 +113,10 @@ Scripts de Data Store
 Exemples de scripts pour la configuration Data Store.
 
 .. note::
-   Dans les scripts de data store, chaque ligne ``champ=expression`` est evaluee independamment en tant qu'expression unique.
-   Par consequent, les instructions ``import``, les declarations ``def`` multi-lignes et les structures de controle multi-lignes qui definissent plusieurs champs a la fois (comme les blocs ``if``) ne peuvent pas etre utilisees.
-   Lorsque vous utilisez des classes Java, ecrivez-les en tant qu'expression unique avec le nom de classe complet (FQCN), et utilisez un operateur ternaire par champ pour les valeurs conditionnelles (par exemple, ``url=data.published ? data.url : null`` ).
-   Par ailleurs, le nom de variable ``data`` utilise ici n'est qu'un exemple ; le nom de variable reel depend du connecteur de data store utilise. Consultez :doc:`../admin/dataconfig-guide` pour plus de details.
+   Dans les scripts de data store, chaque ligne ``champ=expression`` est évaluée indépendamment en tant qu'expression unique.
+   Par conséquent, les instructions ``import``, les déclarations ``def`` multi-lignes et les structures de contrôle multi-lignes qui définissent plusieurs champs à la fois (comme les blocs ``if``) ne peuvent pas être utilisées.
+   Lorsque vous utilisez des classes Java, écrivez-les en tant qu'expression unique avec le nom de classe complet (FQCN), et utilisez un opérateur ternaire par champ pour les valeurs conditionnelles (par exemple, ``url=data.published ? data.url : null`` ).
+   Par ailleurs, le nom de variable ``data`` utilisé ici n'est qu'un exemple ; le nom de variable réel dépend du connecteur de data store utilisé. Consultez :doc:`../admin/dataconfig-guide` pour plus de détails.
 
 Mapping de base
 ------------------
@@ -128,7 +128,7 @@ Mapping de base
     content=data.content
     lastModified=data.updated_at
 
-Generation d'URL
+Génération d'URL
 ---------
 
 ::
@@ -170,7 +170,7 @@ Traitement des dates
 Objets disponibles
 ==================
 
-Les objets disponibles dans les scripts varient en fonction du contexte d'execution.
+Les objets disponibles dans les scripts varient en fonction du contexte d'exécution.
 
 .. list-table::
    :header-rows: 1
@@ -181,33 +181,33 @@ Les objets disponibles dans les scripts varient en fonction du contexte d'execut
      - Description
    * - Tous les contextes
      - ``container``
-     - Conteneur DI. Utilise pour acceder aux composants via ``container.getComponent("...")``
-   * - Taches planifiees
+     - Conteneur DI. Utilisé pour accéder aux composants via ``container.getComponent("...")``
+   * - Tâches planifiées
      - ``executor``
-     - Controle d'execution des jobs ( ``JobExecutor`` ). Necessaire pour le support de l'arret des jobs
+     - Contrôle d'exécution des jobs ( ``JobExecutor`` ). Nécessaire pour le support de l'arrêt des jobs
    * - Data Store
-     - (specifique au connecteur)
-     - Variables d'enregistrement de donnees fournies par chaque data store. Le nom de la variable depend du connecteur
+     - (spécifique au connecteur)
+     - Variables d'enregistrement de données fournies par chaque data store. Le nom de la variable dépend du connecteur
    * - Mappage de chemins
      - ``url`` , ``matcher``
-     - La chaine URL a convertir et le resultat de la correspondance par expression reguliere ( ``Matcher`` ). Disponible dans les parametres de remplacement avec le prefixe ``groovy:``
+     - La chaîne URL à convertir et le résultat de la correspondance par expression régulière ( ``Matcher`` ). Disponible dans les paramètres de remplacement avec le préfixe ``groovy:``
    * - Boost de document
      - (champs du document)
-     - Chaque champ du document cible est disponible en tant que variable (utilise dans les expressions de condition et de valeur de boost)
+     - Chaque champ du document cible est disponible en tant que variable (utilisé dans les expressions de condition et de valeur de boost)
 
-Scripts de taches planifiees
+Scripts de tâches planifiées
 ============================
 
-Exemples de scripts Groovy pour les taches planifiees.
-Dans les taches planifiees, ``container`` et ``executor`` sont disponibles.
-Passer ``executor`` a la methode ``execute()`` du job active le controle d'arret du job.
+Exemples de scripts Groovy pour les tâches planifiées.
+Dans les tâches planifiées, ``container`` et ``executor`` sont disponibles.
+Passer ``executor`` à la méthode ``execute()`` du job active le contrôle d'arrêt du job.
 
 .. note::
-   Un script de tache planifiee est evalue en tant que script Groovy unique et complet.
-   Par consequent, contrairement aux scripts de data store, vous pouvez utiliser des instructions ``import``, des declarations ``def`` multi-lignes et des structures de controle multi-lignes.
-   Les exemples ci-dessous « Utilisation des classes Java », « Acces aux composants Fess », « Gestion des erreurs » et « Debogage et journalisation » supposent egalement ce contexte de script complet.
+   Un script de tâche planifiée est évalué en tant que script Groovy unique et complet.
+   Par conséquent, contrairement aux scripts de data store, vous pouvez utiliser des instructions ``import``, des déclarations ``def`` multi-lignes et des structures de contrôle multi-lignes.
+   Les exemples ci-dessous « Utilisation des classes Java », « Accès aux composants Fess », « Gestion des erreurs » et « Débogage et journalisation » supposent également ce contexte de script complet.
 
-Execution d'un job de crawl
+Exécution d'un job de crawl
 --------------------
 
 ::
@@ -230,7 +230,7 @@ Crawl conditionnel
     }
     return "Skipped during business hours"
 
-Execution sequentielle de plusieurs jobs
+Exécution séquentielle de plusieurs jobs
 ------------------------
 
 ::
@@ -248,7 +248,7 @@ Execution sequentielle de plusieurs jobs
 Utilisation des classes Java
 ================
 
-Dans les scripts Groovy, vous pouvez utiliser les bibliotheques standard Java et les classes Fess.
+Dans les scripts Groovy, vous pouvez utiliser les bibliothèques standard Java et les classes Fess.
 
 Date et heure
 ----------
@@ -261,7 +261,7 @@ Date et heure
     def now = LocalDateTime.now()
     def formatted = now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
-Operations sur les fichiers
+Opérations sur les fichiers
 ------------
 
 ::
@@ -282,13 +282,13 @@ Communication HTTP
     def response = url.text
 
 .. warning::
-   L'acces aux ressources externes affecte les performances,
-   utilisez-le au minimum necessaire.
+   L'accès aux ressources externes affecte les performances,
+   utilisez-le au minimum nécessaire.
 
-Acces aux composants Fess
+Accès aux composants Fess
 ==============================
 
-Utilisez ``container`` pour acceder aux composants Fess.
+Utilisez ``container`` pour accéder aux composants Fess.
 
 System Helper
 ----------------
@@ -298,7 +298,7 @@ System Helper
     def systemHelper = container.getComponent("systemHelper")
     def currentTime = systemHelper.getCurrentTimeAsLong()
 
-Recuperation des valeurs de configuration
+Récupération des valeurs de configuration
 ------------
 
 ::
@@ -306,7 +306,7 @@ Recuperation des valeurs de configuration
     def fessConfig = container.getComponent("fessConfig")
     def indexName = fessConfig.getIndexDocumentUpdateIndex()
 
-Execution de recherche
+Exécution de recherche
 ----------
 
 ::
@@ -317,8 +317,8 @@ Execution de recherche
 Gestion des erreurs
 ==================
 
-Les instructions ``import`` doivent etre placees en haut du script (elles ne peuvent pas etre placees dans des blocs tels que ``try-catch`` ).
-Vous pouvez intercepter les exceptions avec ``try-catch`` pour controler les erreurs de job.
+Les instructions ``import`` doivent être placées en haut du script (elles ne peuvent pas être placées dans des blocs tels que ``try-catch`` ).
+Vous pouvez intercepter les exceptions avec ``try-catch`` pour contrôler les erreurs de job.
 
 ::
 
@@ -333,7 +333,7 @@ Vous pouvez intercepter les exceptions avec ``try-catch`` pour controler les err
         return "Error: " + e.message
     }
 
-Debogage et journalisation
+Débogage et journalisation
 ==================
 
 Sortie de logs
@@ -350,7 +350,7 @@ Sortie de logs
     logger.warn("Warning: {}", message)
     logger.error("Error: {}", e.message, e)
 
-Sortie de debogage
+Sortie de débogage
 ----------------
 
 ::
@@ -362,16 +362,16 @@ Sortie de debogage
 Bonnes pratiques
 ==================
 
-1. **Garder la simplicite** : Eviter les logiques complexes, privilegier un code lisible
-2. **Verification de null** : Utiliser les operateurs ``?.`` et ``?:``
-3. **Gestion des exceptions** : Gerer les erreurs inattendues avec try-catch approprie
-4. **Sortie de logs** : Afficher des logs pour faciliter le debogage
-5. **Performance** : Minimiser les acces aux ressources externes
+1. **Garder la simplicité** : Éviter les logiques complexes, privilégier un code lisible
+2. **Vérification de null** : Utiliser les opérateurs ``?.`` et ``?:``
+3. **Gestion des exceptions** : Gérer les erreurs inattendues avec try-catch approprié
+4. **Sortie de logs** : Afficher des logs pour faciliter le débogage
+5. **Performance** : Minimiser les accès aux ressources externes
 
-Informations de reference
+Informations de référence
 ========
 
 - `Documentation officielle Groovy <https://groovy-lang.org/documentation.html>`__
-- :doc:`scripting-overview` - Apercu du scripting
+- :doc:`scripting-overview` - Aperçu du scripting
 - :doc:`../admin/dataconfig-guide` - Guide de configuration Data Store
 - :doc:`../admin/scheduler-guide` - Guide de configuration du planificateur

--- a/fr/15.8/dev/script-engine-plugin.rst
+++ b/fr/15.8/dev/script-engine-plugin.rst
@@ -5,13 +5,13 @@ Plugin Script Engine
 Vue d'ensemble
 ==============
 
-En developpant un plugin Script Engine, vous pouvez ajouter le support de nouveaux
-langages de script a |Fess|.
+En développant un plugin Script Engine, vous pouvez ajouter le support de nouveaux
+langages de script à |Fess|.
 
-Implementation de base
+Implémentation de base
 ======================
 
-Implementez l'interface ``ScriptEngine``:
+Implémentez l'interface ``ScriptEngine``:
 
 .. code-block:: java
 
@@ -47,14 +47,14 @@ Enregistrement
 Exemple d'utilisation
 =====================
 
-Selection du type de script dans l'interface d'administration:
+Sélection du type de script dans l'interface d'administration:
 
 ::
 
     scriptType=example
     scriptData=your script here
 
-Informations complementaires
+Informations complémentaires
 ============================
 
 - :doc:`plugin-architecture` - Architecture des plugins


### PR DESCRIPTION
## Summary

Restores the missing **diacritical marks** in the Spanish and French documentation. A number of `es/` and `fr/` files had been translated into correct Spanish/French prose but written in **plain ASCII with all accents dropped** (e.g. "Configuracion" for "Configuración", "generer" for "générer", "parametres" for "paramètres"). This is a copy-editing pass — the wording was already correct; only the orthography is fixed.

Follow-up to the minority-language sync (#458), which flagged this as a pre-existing issue.

## Scope

- **es**: 94 files (50 in 15.7, 44 in 15.8) — accents `á é í ó ú ü ñ`
- **fr**: 66 files (43 in 15.7, 23 in 15.8) — accents `à â ç é è ê ë î ï ô û ù`
- One commit per language.

## Guarantees (orthography only)

Every change is a **1-for-1, same-length** substitution of a base letter with its accented form in **prose only**. Verified mechanically for all 160 files: **stripping the accents off the edited file reproduces the pre-change file byte-for-byte**, which proves nothing other than letter accents changed. Specifically:

- Code blocks, inline ``literals``, values, commands, URLs, property keys, and `:doc:`/`:ref:` targets are untouched (stay ASCII).
- No `¿`/`¡` punctuation and no `œ`/`æ` ligatures were introduced (kept as `oe`/`ae`), so character counts and heading-underline lengths are unchanged.
- Section-heading accents were applied consistently to any internal ```text```_ reference that points at them, so cross-references still resolve.
- Japanese example data that legitimately lives inside code blocks (e.g. the synonym-dictionary `"inputs": "検索,サーチ"` samples) was left exactly as-is.

German is not included — its umlauts were already intact.

160 files across es and fr (15.7 + 15.8).
