### PR TITLE
fix(docs): repair zh-cn 15.8 markup, and run the lint that was added but never ran

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,63 @@
+# Nothing ran these checks automatically before, so a defect they were
+# written to catch could still be merged. They are cheap and need no
+# dependencies beyond the standard library.
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  tools:
+    name: tools
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Unit tests
+        run: python -m unittest discover -s tools -p 'test_*.py' -v
+
+      - name: Every eol.rst matches versions.json
+        run: python tools/update_eol.py --check
+
+  headings:
+    name: section titles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # reStructuredText requires the overline and underline of a section
+      # title to be the same length. Where they differ docutils refuses to
+      # build the section and the next one silently becomes the page title,
+      # without failing the build. Scoped to the versions versions.json
+      # calls current, so it follows a release instead of needing an edit,
+      # and so the archived versions -- which still carry mismatches and are
+      # consolidated by canonical anyway -- do not block unrelated work.
+      - name: Section title rules in the current documentation versions
+        run: |
+          set -eu
+          versions=$(python -c \
+            "import json; d = json.load(open('versions.json')); \
+             print(d['release'], d['development'])")
+          dirs=""
+          for v in $versions; do
+            for d in */"$v"; do
+              [ -d "$d" ] && dirs="$dirs $d"
+            done
+          done
+          if [ -z "$dirs" ]; then
+            echo "versions.json names no directory that exists" >&2
+            exit 1
+          fi
+          echo "linting:$dirs"
+          python tools/check_headings.py $dirs

--- a/zh-cn/15.8/config/llm-gemini.rst
+++ b/zh-cn/15.8/config/llm-gemini.rst
@@ -5,7 +5,7 @@ Google Gemini配置（AI 搜索 / RAG）
 概述
 ====
 
-本页说明如何配置 ``fess-llm-gemini`` 插件，以便 |Fess| 使用 Google Gemini 实现其**AI搜索模式（RAG：Retrieval-Augmented Generation）** —— 基于引用来源，直接从您的企业搜索索引回答自然语言问题。|Fess| 会调用 Google AI API（Generative Language API），使用 Gemini 模型对已爬取的文档执行 RAG。
+本页说明如何配置 ``fess-llm-gemini`` 插件，以便 |Fess| 使用 Google Gemini 实现其\ **AI搜索模式（RAG：Retrieval-Augmented Generation）** —— 基于引用来源，直接从您的企业搜索索引回答自然语言问题。|Fess| 会调用 Google AI API（Generative Language API），使用 Gemini 模型对已爬取的文档执行 RAG。
 
 Google Gemini是Google公司提供的最先进的大型语言模型（LLM）。
 |Fess| 可以使用Google AI API（Generative Language API）通过Gemini模型实现AI搜索模式功能。

--- a/zh-cn/15.8/config/llm-ollama.rst
+++ b/zh-cn/15.8/config/llm-ollama.rst
@@ -5,7 +5,7 @@ Ollama配置（本地 LLM / RAG）
 概述
 ====
 
-本页说明如何配置 ``fess-llm-ollama`` 插件，以便 |Fess| 使用本地部署的 Ollama 模型实现其**AI搜索模式（RAG：Retrieval-Augmented Generation）** —— 基于引用来源，直接从您的企业搜索索引回答自然语言问题，且无需将数据发送至外部 API。|Fess| 会调用本地 Ollama API，对已爬取的文档执行 RAG。
+本页说明如何配置 ``fess-llm-ollama`` 插件，以便 |Fess| 使用本地部署的 Ollama 模型实现其\ **AI搜索模式（RAG：Retrieval-Augmented Generation）** —— 基于引用来源，直接从您的企业搜索索引回答自然语言问题，且无需将数据发送至外部 API。|Fess| 会调用本地 Ollama API，对已爬取的文档执行 RAG。
 
 Ollama是用于在本地环境运行大型语言模型（LLM）的开源平台。
 |Fess| 的Ollama集成功能以插件 ``fess-llm-ollama`` 的形式提供，适合在私有环境中使用。

--- a/zh-cn/15.8/config/llm-openai.rst
+++ b/zh-cn/15.8/config/llm-openai.rst
@@ -5,7 +5,7 @@ OpenAI配置（AI 搜索 / RAG）
 概述
 ====
 
-本页说明如何配置 ``fess-llm-openai`` 插件，以便 |Fess| 使用 OpenAI 实现其**AI搜索模式（RAG：Retrieval-Augmented Generation）** —— 基于引用来源，直接从您的企业搜索索引回答自然语言问题。|Fess| 会调用 OpenAI API，使用 GPT 模型对已爬取的文档执行 RAG。
+本页说明如何配置 ``fess-llm-openai`` 插件，以便 |Fess| 使用 OpenAI 实现其\ **AI搜索模式（RAG：Retrieval-Augmented Generation）** —— 基于引用来源，直接从您的企业搜索索引回答自然语言问题。|Fess| 会调用 OpenAI API，使用 GPT 模型对已爬取的文档执行 RAG。
 
 OpenAI是提供GPT-4等高性能大型语言模型（LLM）的云服务。
 |Fess| 可以使用OpenAI API实现AI搜索模式功能。


### PR DESCRIPTION
Two follow-ups to #465.

## Bold text that never opened, in the zh-cn 15.8 LLM guides

Inline markup cannot open against a CJK character, so `实现其**AI搜索模式` was never read as strong emphasis. The asterisks stayed in the text and reached the rendered page and its `meta description`.

The 15.7 copies of these three pages were repaired in #465. These are their 15.8 counterparts, left out at the time to avoid colliding with work in progress, and fixed here with the same escaped space this repository already uses for CJK-adjacent markup.

`zh-cn/15.8/config/rank-fusion.rst` carries the same defect and is deliberately **not** touched — it is already repaired on the branch that rewrites the 15.8 semantic search guides, and changing it here would only conflict with that.

15.8 is not published yet, so nothing live changes. This keeps the defect from shipping with the release.

## CI

This repository had no CI at all. `tools/check_headings.py` was added in #465 to stop a defect class from coming back — a section title whose overline and underline differ is dropped by docutils, and the next section silently becomes the page title without anything failing the build — but nothing ran it, so it could only catch what someone remembered to check by hand. The same was true of `tools/test_update_eol.py`.

Two jobs, nothing beyond the standard library:

- **tools** — the unit tests, plus `update_eol.py --check`, which fails when an `eol.rst` has drifted from `versions.json`. Its date warnings are reported without failing the build, so time passing cannot turn the build red on its own.
- **section titles** — the heading lint, scoped to the versions `versions.json` calls current. Reading the version from `versions.json` means a release moves the scope by itself instead of needing an edit here, and it keeps the archived versions, which still carry mismatches and are consolidated by canonical anyway, from blocking unrelated work.

Verified green on the current tree, and red with the expected one-line report when a heading rule is shortened by a single character.

## Noted, not changed here

`update_eol.py` reports that 14.19 reached end of life on 2026-08-01 while `versions.json` still lists it as supported. Whether a version is still supported is a decision recorded in `versions.json`, not something a tool should infer, so it is left for the maintainer.
