### PR TITLE
docs(llm): correct the 15.8 LLM overview against the implementation

### DIFF
--- a/de/15.8/config/llm-overview.rst
+++ b/de/15.8/config/llm-overview.rst
@@ -32,7 +32,7 @@ Unterstützte Anbieter
    * - OpenAI
      - ``openai``
      - ``fess-llm-openai``
-     - Cloud-API von OpenAI. Ermöglicht die Nutzung von Modellen wie GPT-4.
+     - Cloud-API von OpenAI. Ermöglicht die Nutzung von Modellen wie GPT-5.
    * - Google Gemini
      - ``gemini``
      - ``fess-llm-gemini``
@@ -67,20 +67,25 @@ Anbietervergleich
 
 .. note::
 
-   Wenn ``rag.llm.name`` nicht gesetzt ist, ist standardmäßig nur der Ollama-Client aktiv; installieren Sie den gewünschten Anbieter und wählen Sie ihn über ``rag.llm.name`` aus.
+   Der Standardwert von ``rag.llm.name`` ist ``ollama``. Dieser Wert bestimmt den Namen der zu ladenden DI-Komponente (``{rag.llm.name}LlmClient``).
+   Wenn Sie daher ``rag.llm.name`` auf dem Standardwert belassen und nur ein anderes Plugin als ``fess-llm-ollama`` installieren, wird kein einziger LLM-Client aktiv.
+   In diesem Fall erscheint im Log die Warnung ``[LLM] LlmClient not found. componentName=ollamaLlmClient``, und der KI-Suchmodus steht nicht zur Verfügung.
+   Setzen Sie ``rag.llm.name`` unbedingt entsprechend dem installierten Plugin. Mit ``none`` lässt sich die LLM-Integration explizit deaktivieren.
 
 Plugin-Installation
 ===================
 
-Die LLM-Funktion wird als Plugin bereitgestellt. Die JAR-Datei des ``fess-llm-{provider}``-Plugins für den gewünschten Anbieter muss im Plugin-Verzeichnis abgelegt werden.
+Die LLM-Funktion wird als Plugin bereitgestellt. Installieren Sie das ``fess-llm-{provider}``-Plugin, das dem gewünschten Anbieter entspricht.
 
-Als Beispiel: Wenn Sie den OpenAI-Anbieter verwenden möchten, laden Sie ``fess-llm-openai-15.8.0.jar`` herunter und legen Sie es im folgenden Verzeichnis ab.
+Die Installation ist über die Seite **System > Plugin** in der Administrationsoberfläche möglich. ``fess-llm-*``-Plugins werden in der Liste der installierbaren Plugins angezeigt.
+
+Für die manuelle Installation legen Sie die entsprechende JAR-Datei (Beispiel: ``fess-llm-openai-15.8.0.jar`` für den OpenAI-Anbieter) im folgenden Verzeichnis ab.
 
 ::
 
     app/WEB-INF/plugin/
 
-Nach der Ablage wird das Plugin beim nächsten Neustart von |Fess| geladen.
+In beiden Fällen wird das Plugin nach der Installation beim nächsten Neustart von |Fess| geladen.
 
 Architektur
 ===========
@@ -99,6 +104,13 @@ Die KI-Suchmodus-Funktion arbeitet mit dem folgenden Ablauf.
 .. note::
 
    Die interne Verarbeitung besteht aus fünf Phasen: ``intent``, ``search``, ``evaluate``, ``fetch`` und ``answer``. Der Fortschritt jeder Phase wird dem Client per Streaming (SSE) mitgeteilt.
+   Die Query-Regenerierung ist keine eigenständige Phase, sondern wird als Fallback der ``search``-Phase gemeldet; anschließend wird ``search`` erneut ausgeführt.
+
+.. note::
+
+   Der oben beschriebene Ablauf gilt für den Fall, dass die Streaming-API die Absicht als „Suche“ einstuft. Je nach Ergebnis der Absichtserkennung kann der Ablauf abweichen.
+   Wird die Frage als unklar eingestuft, wird eine Antwort ohne Suche generiert; wird eine URL-Zusammenfassung angefordert, erfolgt eine URL-Suche ohne Bewertungsphase.
+   Zudem führt das nicht-streamende ``POST /api/v2/chat`` keine Bewertungsphase aus und meldet auch keinen phasenweisen Fortschritt.
 
 Grundeinstellungen
 ==================
@@ -118,11 +130,12 @@ Konfiguration über die allgemeinen Einstellungen der Administrationsoberfläche
 fess_config.properties
 -----------------------
 
-Konfiguration in ``app/WEB-INF/conf/fess_config.properties``. Diese Datei dient der Aktivierung des KI-Suchmodus, der Sitzungs- und Verlaufskonfiguration sowie anbieterspezifischer Einstellungen (Verbindungs-URLs, API-Schlüssel, Generierungsparameter usw.).
+Konfiguration in ``app/WEB-INF/classes/fess_config.properties`` (bei der Paketversion ``/etc/fess/fess_config.properties``).
+Diese Datei dient der Aktivierung des KI-Suchmodus, der Sitzungs- und Verlaufskonfiguration sowie anbieterspezifischer Einstellungen (Verbindungs-URLs, API-Schlüssel, Generierungsparameter usw.).
 
 ::
 
-    # KI-Suchmodus-Funktion aktivieren
+    # KI-Suchmodus-Funktion aktivieren (Standard: false)
     rag.chat.enabled=true
 
     # Beispiel für anbieterspezifische Einstellungen (OpenAI)
@@ -166,7 +179,54 @@ Systemprompt
 
 Systemprompts werden nicht in Property-Dateien, sondern in den DI-XML-Dateien der jeweiligen Plugins verwaltet.
 
-Der Systemprompt wird in der Datei ``fess_llm++.xml`` definiert, die in der JAR-Datei jedes ``fess-llm-*``-Plugins enthalten ist. Da diese Datei eine im Plugin-JAR gebündelte Classpath-Ressource ist, muss die DI-XML-Datei innerhalb des JARs bearbeitet werden, um den Prompt anzupassen.
+Der Systemprompt wird in der Datei ``fess_llm++.xml`` definiert, die in der JAR-Datei jedes ``fess-llm-*``-Plugins enthalten ist.
+Um den Prompt anzupassen, müssen Sie die JAR-Datei nicht entpacken und die Datei darin bearbeiten. Dank des LastaDi-Mechanismus zur
+Neudefinition von Komponenten wird die Komponentendefinition des Plugins ersetzt, wenn Sie in ``app/WEB-INF/classes/`` eine Datei mit
+dem Namen ``fess_llm+{Komponentenname}.xml`` ablegen.
+
+Die Komponentennamen sind je nach Anbieter wie folgt:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Anbieter
+     - Komponentenname
+   * - Ollama
+     - ``ollamaLlmClient``
+   * - OpenAI
+     - ``openaiLlmClient``
+   * - Google Gemini
+     - ``geminiLlmClient``
+
+Um beispielsweise den Antwortgenerierungs-Prompt des OpenAI-Anbieters zu ändern, erstellen Sie ``app/WEB-INF/classes/fess_llm+openaiLlmClient.xml``.
+
+::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+        "http://dbflute.org/meta/lastadi10.dtd">
+    <components>
+        <component name="openaiLlmClient" class="org.codelibs.fess.llm.openai.OpenAiLlmClient">
+            <postConstruct name="register"/>
+            <postConstruct name="init"/>
+            <preDestroy name="destroy"/>
+            <property name="answerGenerationSystemPrompt">"Eigener Antwortgenerierungs-Prompt"</property>
+            <!-- Auch alle unveränderten Prompt-Eigenschaften vollständig angeben -->
+        </component>
+    </components>
+
+.. warning::
+
+   Die Neudefinitionsdatei ersetzt die Komponentendefinition vollständig. Geben Sie daher alle Inhalte an, die in der ursprünglichen
+   ``fess_llm++.xml`` enthalten sind (Klassenname, ``postConstruct``, ``preDestroy`` sowie alle unveränderten Prompt-Eigenschaften).
+   Nicht angegebene Eigenschaften werden zurückgesetzt.
+
+.. warning::
+
+   Kopieren Sie nicht einfach ``fess_llm++.xml`` selbst nach ``app/WEB-INF/classes/``.
+   Da bei DI-XML-Dateien, deren Dateiname auf ``++`` endet, alle Vorkommen im Classpath als „Ergänzung“ geladen werden, würde dieselbe
+   Komponente doppelt registriert, was zu ``TooManyRegistrationComponentException`` führt und den Start von |Fess| verhindert.
 
 Verfügbarkeitsprüfung
 ---------------------
@@ -179,10 +239,16 @@ Verfügbarkeitsprüfung
      - Beschreibung
      - Standard
    * - ``rag.llm.{provider}.availability.check.interval``
-     - Intervall zur Prüfung der LLM-Verfügbarkeit (Sekunden). 0 zum Deaktivieren
+     - Intervall zur regelmäßigen Prüfung der LLM-Verfügbarkeit (Sekunden)
      - ``60``
 
 Diese Einstellung wird in ``fess_config.properties`` vorgenommen. |Fess| überprüft regelmäßig den Verbindungsstatus zum LLM-Anbieter.
+
+.. note::
+
+   Wird für diese Eigenschaft ein Wert kleiner oder gleich ``0`` oder ein nicht-numerischer Wert angegeben, wird dieser ignoriert, und stattdessen wird der Standardwert (``60``) verwendet.
+   Mit dieser Eigenschaft lässt sich die Verfügbarkeitsprüfung nicht deaktivieren.
+   Zudem wird die Verfügbarkeitsprüfung nicht ausgeführt, wenn ``rag.chat.enabled`` auf ``false`` gesetzt ist, sowie für Anbieter, die nicht über ``rag.llm.name`` ausgewählt sind.
 
 Sitzungsverwaltung
 ==================
@@ -288,7 +354,7 @@ Prompttypen-Übersicht
      - Generiert eine Antwort im FAQ-Format
    * - Direkte Antwort
      - ``direct``
-     - Generiert eine Antwort ohne Suchumweg
+     - Generiert eine Antwort ohne Suchumweg (wird in der aktuellen Version nicht aufgerufen)
    * - Query-Regenerierung
      - ``queryregeneration``
      - Regeneriert die Abfrage, wenn keine Suchergebnisse gefunden werden
@@ -319,7 +385,52 @@ Konfigurationsbeispiel (OpenAI-Anbieter):
 
 .. note::
 
-   ``temperature``, ``max.tokens`` und ``context.max.chars`` sind bei allen Anbietern gemeinsam verfügbar. Darüber hinaus unterstützt jeder Anbieter eigene Parameter wie ``thinking.budget``, ``top.p`` oder ``reasoning.effort``. Details entnehmen Sie bitte der jeweiligen Anbieterdokumentation.
+   ``temperature``, ``max.tokens`` und ``context.max.chars`` sind bei allen Anbietern gemeinsam verfügbar. Die Standardwerte dieser Parameter unterscheiden sich jedoch je nach Anbieter und Prompttyp.
+
+Darüber hinaus unterstützt jeder Anbieter eigene Parameter. Die Unterstützung im Überblick:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 20 20
+
+   * - Parameter
+     - Ollama
+     - OpenAI
+     - Gemini
+   * - ``thinking.budget``
+     - Unterstützt
+     - Nicht unterstützt
+     - Unterstützt
+   * - ``thinking.level``
+     - Unterstützt
+     - Nicht unterstützt
+     - Nicht unterstützt
+   * - ``top.p``
+     - Unterstützt
+     - Unterstützt
+     - Nicht unterstützt
+   * - ``top.k``, ``num.ctx``
+     - Unterstützt
+     - Nicht unterstützt
+     - Nicht unterstützt
+   * - ``reasoning.effort``
+     - Nicht unterstützt
+     - Unterstützt
+     - Nicht unterstützt
+   * - ``frequency.penalty``, ``presence.penalty``
+     - Nicht unterstützt
+     - Unterstützt
+     - Nicht unterstützt
+
+.. note::
+
+   Wird ein „nicht unterstützter“ Parameter angegeben, führt dies nicht zu einem Fehler, sondern der Parameter wird einfach ignoriert. Details zur Bedeutung der einzelnen Parameter und den zulässigen Werten finden Sie in der jeweiligen Anbieterdokumentation.
+
+.. note::
+
+   Nur beim Ollama-Anbieter gibt es einen Fallback, der bei fehlender prompttypspezifischer Einstellung auf ``rag.llm.ollama.default.{Parameter}`` zurückgreift
+   (mit Ausnahme von ``context.max.chars``). Für die Anbieter OpenAI und Gemini gibt es diesen Fallback nicht; fehlt eine prompttypspezifische Einstellung,
+   wird stattdessen der im Plugin fest hinterlegte Standardwert verwendet.
 
 Nächste Schritte
 ================
@@ -329,3 +440,5 @@ Nächste Schritte
 - :doc:`llm-gemini` - Detaillierte Google Gemini-Konfiguration
 - :doc:`rag-chat` - Detaillierte Konfiguration der KI-Suchmodus-Funktion
 - :doc:`rank-fusion` - Rank Fusion Konfiguration (Zusammenführung hybrider Suchergebnisse)
+- :doc:`../user/chat-search` - Verwendung des KI-Suchmodus
+- :doc:`../api/api-chat` - Chat-API-Referenz

--- a/en/15.8/config/llm-overview.rst
+++ b/en/15.8/config/llm-overview.rst
@@ -32,7 +32,7 @@ Supported Providers
    * - OpenAI
      - ``openai``
      - ``fess-llm-openai``
-     - OpenAI's cloud API. Enables use of models such as GPT-4.
+     - OpenAI's cloud API. Enables use of models such as GPT-5.
    * - Google Gemini
      - ``gemini``
      - ``fess-llm-gemini``
@@ -67,20 +67,25 @@ Provider Comparison
 
 .. note::
 
-   If ``rag.llm.name`` is not set, only the Ollama client is active by default; install and select the provider you want with ``rag.llm.name``.
+   The default value of ``rag.llm.name`` is ``ollama``. This value is used to determine the DI component name to load (``{rag.llm.name}LlmClient``).
+   As a result, if you leave ``rag.llm.name`` at its default and install only a plugin other than ``fess-llm-ollama``, no LLM client will be active.
+   In this case, a warning ``[LLM] LlmClient not found. componentName=ollamaLlmClient`` is logged, and AI search mode becomes unavailable.
+   Be sure to set ``rag.llm.name`` to match the plugin you installed. Specify ``none`` to explicitly disable LLM integration.
 
 Plugin Installation
 ===================
 
-LLM functionality is provided as plugins. You must place the JAR file of the ``fess-llm-{provider}`` plugin corresponding to your provider in the plugin directory.
+LLM functionality is provided as plugins. Install the ``fess-llm-{provider}`` plugin corresponding to the provider you want to use.
 
-For example, to use the OpenAI provider, download ``fess-llm-openai-15.8.0.jar`` and place it in the following directory.
+You can install it from the System > Plugin page in the administration screen. ``fess-llm-*`` plugins appear in the list of installable plugins.
+
+To install manually, place the corresponding JAR file (for example, ``fess-llm-openai-15.8.0.jar`` for the OpenAI provider) in the following directory.
 
 ::
 
     app/WEB-INF/plugin/
 
-After placement, restart |Fess| to load the plugin.
+Either way, restart |Fess| after installation to load the plugin.
 
 Architecture
 ============
@@ -99,6 +104,13 @@ The AI search mode feature operates with the following flow.
 .. note::
 
    The internal processing consists of five phases — ``intent``, ``search``, ``evaluate``, ``fetch``, and ``answer`` — and the progress of each phase is reported to the client via streaming (SSE).
+   Query regeneration is not a separate phase; it is reported as a fallback within the ``search`` phase, after which ``search`` is re-executed.
+
+.. note::
+
+   The flow above applies when the streaming API classifies the intent as "search". The path taken depends on the intent classification result.
+   If the question is judged to be unclear, a response is generated without performing a search; if a URL summary is requested, a URL search is performed and the evaluation phase is not executed.
+   In addition, the non-streaming ``POST /api/v2/chat`` does not execute the evaluation phase and does not report per-phase progress.
 
 Basic Configuration
 ===================
@@ -118,11 +130,12 @@ Configure in the administration screen general settings or in ``system.propertie
 fess_config.properties
 ----------------------
 
-Configure in ``app/WEB-INF/conf/fess_config.properties``. In addition to enabling AI search mode and configuring session and history-related settings, provider-specific settings such as the connection URL, API key, and generation parameters are also specified in this file.
+Configure in ``app/WEB-INF/classes/fess_config.properties`` (``/etc/fess/fess_config.properties`` for package installations).
+In addition to enabling AI search mode and configuring session and history-related settings, provider-specific settings such as the connection URL, API key, and generation parameters are also specified in this file.
 
 ::
 
-    # Enable AI search mode functionality
+    # Enable AI search mode functionality (default: false)
     rag.chat.enabled=true
 
     # Example of provider-specific settings (for OpenAI)
@@ -166,7 +179,52 @@ System Prompt
 
 System prompts are managed in the DI XML files of each plugin rather than in properties files.
 
-The system prompt is defined in the ``fess_llm++.xml`` file bundled inside the JAR of each ``fess-llm-*`` plugin. Because this file is a classpath resource bundled within the plugin JAR, customizing a prompt requires editing the DI XML file inside the JAR.
+The system prompt is defined in the ``fess_llm++.xml`` file bundled inside the JAR of each ``fess-llm-*`` plugin.
+You do not need to extract and re-edit the JAR file to customize a prompt. Thanks to LastaDi's component redefinition mechanism,
+placing a file named ``fess_llm+{component name}.xml`` in ``app/WEB-INF/classes/`` overrides the plugin's component definition.
+
+The component names for each provider are as follows.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Provider
+     - Component Name
+   * - Ollama
+     - ``ollamaLlmClient``
+   * - OpenAI
+     - ``openaiLlmClient``
+   * - Google Gemini
+     - ``geminiLlmClient``
+
+For example, to change the answer generation prompt for the OpenAI provider, create ``app/WEB-INF/classes/fess_llm+openaiLlmClient.xml``.
+
+::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+        "http://dbflute.org/meta/lastadi10.dtd">
+    <components>
+        <component name="openaiLlmClient" class="org.codelibs.fess.llm.openai.OpenAiLlmClient">
+            <postConstruct name="register"/>
+            <postConstruct name="init"/>
+            <preDestroy name="destroy"/>
+            <property name="answerGenerationSystemPrompt">"your custom answer generation prompt"</property>
+            <!-- List every prompt property you are not changing as well -->
+        </component>
+    </components>
+
+.. warning::
+
+   A redefinition file replaces the entire component definition. Therefore, be sure to include everything defined in the original ``fess_llm++.xml`` (the class name, ``postConstruct``,
+   ``preDestroy``, and any prompt properties you are not changing). Any property you omit reverts to unset.
+
+.. warning::
+
+   Do not copy ``fess_llm++.xml`` itself and place it in ``app/WEB-INF/classes/``.
+   Because DI XML files whose name ends in ``++`` are all loaded as "additions" on the classpath, this registers a component with the same name twice,
+   causing a ``TooManyRegistrationComponentException`` and preventing |Fess| from starting.
 
 Availability Check
 ------------------
@@ -179,10 +237,16 @@ Availability Check
      - Description
      - Default
    * - ``rag.llm.{provider}.availability.check.interval``
-     - Interval (in seconds) at which LLM availability is checked. Set to 0 to disable.
+     - Interval (in seconds) at which LLM availability is periodically checked
      - ``60``
 
 This setting is configured in ``fess_config.properties``. |Fess| periodically verifies the connection status with the LLM provider.
+
+.. note::
+
+   If this property is set to a value of ``0`` or less, or to a non-numeric value, the value is ignored and the default (``60``) is used.
+   This property cannot be used to disable the availability check.
+   The availability check is not performed when ``rag.chat.enabled`` is ``false``, or for providers not selected by ``rag.llm.name``.
 
 Session Management
 ==================
@@ -288,7 +352,7 @@ Prompt Type List
      - Generates FAQ-style answers
    * - Direct Answer
      - ``direct``
-     - Generates a direct answer without going through search
+     - Generates a direct answer without going through search (not invoked in the current version)
    * - Query Regeneration
      - ``queryregeneration``
      - Regenerates the query when no search results are found
@@ -319,7 +383,52 @@ Configuration examples (for the OpenAI provider):
 
 .. note::
 
-   ``temperature``, ``max.tokens``, and ``context.max.chars`` are available across all providers. In addition, each provider supports provider-specific parameters such as ``thinking.budget``, ``top.p``, and ``reasoning.effort``. Refer to the documentation for each provider for details.
+   ``temperature``, ``max.tokens``, and ``context.max.chars`` are available across all providers. However, their default values differ by provider and by prompt type.
+
+In addition, each provider supports its own provider-specific parameters. Support status is as follows.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 20 20
+
+   * - Parameter
+     - Ollama
+     - OpenAI
+     - Gemini
+   * - ``thinking.budget``
+     - Supported
+     - Not supported
+     - Supported
+   * - ``thinking.level``
+     - Supported
+     - Not supported
+     - Not supported
+   * - ``top.p``
+     - Supported
+     - Supported
+     - Not supported
+   * - ``top.k``, ``num.ctx``
+     - Supported
+     - Not supported
+     - Not supported
+   * - ``reasoning.effort``
+     - Not supported
+     - Supported
+     - Not supported
+   * - ``frequency.penalty``, ``presence.penalty``
+     - Not supported
+     - Supported
+     - Not supported
+
+.. note::
+
+   Specifying a "Not supported" parameter does not cause an error; it is simply ignored. For details on the meaning of each parameter and its allowed values, refer to the documentation for each provider.
+
+.. note::
+
+   Only the Ollama provider has a fallback that references ``rag.llm.ollama.default.{parameter}`` when no per-prompt-type setting exists
+   (except for ``context.max.chars``). The OpenAI and Gemini providers have no such fallback; when no per-prompt-type setting exists,
+   the plugin's built-in default value is used instead.
 
 Next Steps
 ==========
@@ -329,3 +438,5 @@ Next Steps
 - :doc:`llm-gemini` - Detailed Google Gemini configuration
 - :doc:`rag-chat` - Detailed AI search mode configuration
 - :doc:`rank-fusion` - Rank Fusion settings (hybrid search result merging)
+- :doc:`../user/chat-search` - How to use AI search mode
+- :doc:`../api/api-chat` - Chat API reference

--- a/es/15.8/config/llm-overview.rst
+++ b/es/15.8/config/llm-overview.rst
@@ -32,7 +32,7 @@ Proveedores compatibles
    * - OpenAI
      - ``openai``
      - ``fess-llm-openai``
-     - API en la nube de OpenAI. Disponible para modelos como GPT-4.
+     - API en la nube de OpenAI. Disponible para modelos como GPT-5.
    * - Google Gemini
      - ``gemini``
      - ``fess-llm-gemini``
@@ -67,20 +67,25 @@ Comparación de proveedores
 
 .. note::
 
-   Si ``rag.llm.name`` no está configurado, de forma predeterminada solo el cliente Ollama está activo; instale y seleccione el proveedor que desee con ``rag.llm.name``.
+   El valor predeterminado de ``rag.llm.name`` es ``ollama``. Este valor se utiliza para determinar el nombre del componente DI que se carga (``{rag.llm.name}LlmClient``).
+   Por lo tanto, si deja ``rag.llm.name`` con su valor predeterminado e instala únicamente un plugin distinto de ``fess-llm-ollama``, ningún cliente LLM quedará activo.
+   En ese caso, en el registro se mostrará la advertencia ``[LLM] LlmClient not found. componentName=ollamaLlmClient`` y el modo de búsqueda IA no estará disponible.
+   Asegúrese de configurar siempre ``rag.llm.name`` de acuerdo con el plugin instalado. Si especifica ``none``, puede deshabilitar explícitamente la integración con LLM.
 
 Instalación del plugin
 ======================
 
-La funcionalidad LLM se proporciona como plugin. Es necesario colocar el archivo JAR del plugin ``fess-llm-{provider}`` correspondiente al proveedor que desea utilizar en el directorio de plugins.
+La funcionalidad LLM se proporciona como plugin. Instale el plugin ``fess-llm-{provider}`` correspondiente al proveedor que desea utilizar.
 
-Por ejemplo, para usar el proveedor OpenAI, descargue ``fess-llm-openai-15.8.0.jar`` y colóquelo en el siguiente directorio.
+Puede instalarlo desde la página "Sistema > Plugin" de la pantalla de administración. Los plugins ``fess-llm-*`` aparecen en la lista de plugins instalables.
+
+Si desea instalarlo manualmente, coloque el archivo JAR correspondiente (por ejemplo, ``fess-llm-openai-15.8.0.jar`` para el proveedor OpenAI) en el siguiente directorio.
 
 ::
 
     app/WEB-INF/plugin/
 
-Después de colocarlo, reinicie |Fess| para que el plugin sea cargado.
+En cualquiera de los dos métodos, después de instalarlo, reinicie |Fess| para que el plugin se cargue.
 
 Arquitectura
 ============
@@ -99,6 +104,13 @@ La funcionalidad de modo de búsqueda IA opera con el siguiente flujo.
 .. note::
 
    El procesamiento interno se compone de cinco fases: ``intent``, ``search``, ``evaluate``, ``fetch`` y ``answer``. El progreso de cada fase se notifica al cliente mediante streaming (SSE).
+   La regeneración de consulta no es una fase independiente: se notifica como una alternativa (fallback) de la fase ``search``, y a continuación ``search`` se vuelve a ejecutar.
+
+.. note::
+
+   El flujo anterior corresponde al caso en que la API de streaming determina que la intención es «búsqueda»; la ruta varía según el resultado de dicha determinación.
+   Si se determina que la pregunta es ambigua, se genera una respuesta sin realizar la búsqueda; si se solicita un resumen de una URL, se realiza una búsqueda de URL y no se ejecuta la fase de evaluación.
+   Además, el endpoint sin streaming ``POST /api/v2/chat`` no ejecuta la fase de evaluación ni realiza notificaciones de progreso por fase.
 
 Configuración básica
 ====================
@@ -118,11 +130,12 @@ Se configura en la configuración general de la pantalla de administración o en
 fess_config.properties
 -----------------------
 
-Se configura en ``app/WEB-INF/conf/fess_config.properties``. Además de habilitar el modo de búsqueda IA y configurar sesiones e historial, también se describen en este archivo la configuración específica del proveedor (URL de conexión, clave API, parámetros de generación, etc.).
+Se configura en ``app/WEB-INF/classes/fess_config.properties`` (en la versión de paquete, ``/etc/fess/fess_config.properties``).
+Además de habilitar el modo de búsqueda IA y configurar sesiones e historial, también se describen en este archivo la configuración específica del proveedor (URL de conexión, clave API, parámetros de generación, etc.).
 
 ::
 
-    # Habilitar la funcionalidad de modo de búsqueda IA
+    # Habilitar la funcionalidad de modo de búsqueda IA (el valor predeterminado es false)
     rag.chat.enabled=true
 
     # Ejemplo de configuración específica del proveedor (en el caso de OpenAI)
@@ -166,7 +179,52 @@ Prompt del sistema
 
 Los prompts del sistema se gestionan en el archivo DI XML de cada plugin, no en archivos de propiedades.
 
-Los prompts del sistema están definidos en el archivo ``fess_llm++.xml`` incluido dentro del archivo JAR de cada plugin ``fess-llm-*``. Dado que este archivo es un recurso de classpath incluido en el JAR del plugin, para personalizar los prompts es necesario editar el archivo DI XML dentro del JAR.
+Los prompts del sistema están definidos en el archivo ``fess_llm++.xml`` incluido dentro del archivo JAR de cada plugin ``fess-llm-*``.
+No es necesario descomprimir el archivo JAR ni volver a editarlo para personalizar los prompts. Gracias al mecanismo de redefinición de componentes de LastaDi,
+si coloca en ``app/WEB-INF/classes/`` un archivo llamado ``fess_llm+{nombre del componente}.xml``, puede reemplazar la definición del componente del plugin.
+
+Los nombres de componente para cada proveedor son los siguientes.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Proveedor
+     - Nombre del componente
+   * - Ollama
+     - ``ollamaLlmClient``
+   * - OpenAI
+     - ``openaiLlmClient``
+   * - Google Gemini
+     - ``geminiLlmClient``
+
+Por ejemplo, para cambiar el prompt de generación de respuesta del proveedor OpenAI, cree ``app/WEB-INF/classes/fess_llm+openaiLlmClient.xml``.
+
+::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+        "http://dbflute.org/meta/lastadi10.dtd">
+    <components>
+        <component name="openaiLlmClient" class="org.codelibs.fess.llm.openai.OpenAiLlmClient">
+            <postConstruct name="register"/>
+            <postConstruct name="init"/>
+            <preDestroy name="destroy"/>
+            <property name="answerGenerationSystemPrompt">"Prompt de generación de respuesta personalizado"</property>
+            <!-- incluya también todas las propiedades de prompt que no cambie -->
+        </component>
+    </components>
+
+.. warning::
+
+   El archivo de redefinición reemplaza la definición del componente. Por lo tanto, debe incluir todo el contenido que aparece en el ``fess_llm++.xml`` original
+   (nombre de clase, ``postConstruct``, ``preDestroy`` y las propiedades de prompt que no modifique). Las propiedades que no se especifiquen volverán a quedar sin configurar.
+
+.. warning::
+
+   No copie el propio archivo ``fess_llm++.xml`` para colocarlo en ``app/WEB-INF/classes/``.
+   Dado que los archivos DI XML cuyo nombre termina en ``++`` se cargan como una «adición» de todo lo que se encuentra en el classpath, el mismo componente quedaría
+   registrado por duplicado, lo que provoca ``TooManyRegistrationComponentException`` e impide que |Fess| se inicie.
 
 Verificación de disponibilidad
 -------------------------------
@@ -179,10 +237,16 @@ Verificación de disponibilidad
      - Descripción
      - Predeterminado
    * - ``rag.llm.{provider}.availability.check.interval``
-     - Intervalo para verificar la disponibilidad del LLM (segundos). 0 para deshabilitar
+     - Intervalo para verificar periódicamente la disponibilidad del LLM (segundos)
      - ``60``
 
 Esta configuración se realiza en ``fess_config.properties``. |Fess| verifica periódicamente el estado de conexión del proveedor LLM.
+
+.. note::
+
+   Si en esta propiedad se especifica un valor igual o inferior a ``0``, o un valor no numérico, dicho valor se ignora y se utiliza el valor predeterminado (``60``).
+   Esta propiedad no permite deshabilitar la verificación de disponibilidad.
+   Además, la verificación de disponibilidad no se ejecuta cuando ``rag.chat.enabled`` es ``false``, ni para los proveedores que no estén seleccionados mediante ``rag.llm.name``.
 
 Gestión de sesiones
 ===================
@@ -288,7 +352,7 @@ Lista de tipos de prompt
      - Genera una respuesta en formato FAQ
    * - Respuesta directa
      - ``direct``
-     - Genera una respuesta directa sin pasar por la búsqueda
+     - Genera una respuesta directa sin pasar por la búsqueda (no se invoca en la versión actual)
    * - Regeneración de consulta
      - ``queryregeneration``
      - Regenera la consulta cuando no se obtienen resultados de búsqueda
@@ -319,7 +383,52 @@ Ejemplo de configuración (en el caso del proveedor OpenAI):
 
 .. note::
 
-   ``temperature``, ``max.tokens`` y ``context.max.chars`` son parámetros comunes a todos los proveedores. Además, cada proveedor soporta parámetros específicos como ``thinking.budget``, ``top.p`` y ``reasoning.effort``. Consulte la documentación de cada proveedor para más detalles.
+   ``temperature``, ``max.tokens`` y ``context.max.chars`` son parámetros comunes a todos los proveedores. Sin embargo, sus valores predeterminados varían según el proveedor y el tipo de prompt.
+
+Además, cada proveedor soporta parámetros específicos propios. El estado de compatibilidad es el siguiente.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 20 20
+
+   * - Parámetro
+     - Ollama
+     - OpenAI
+     - Gemini
+   * - ``thinking.budget``
+     - Compatible
+     - No compatible
+     - Compatible
+   * - ``thinking.level``
+     - Compatible
+     - No compatible
+     - No compatible
+   * - ``top.p``
+     - Compatible
+     - Compatible
+     - No compatible
+   * - ``top.k``, ``num.ctx``
+     - Compatible
+     - No compatible
+     - No compatible
+   * - ``reasoning.effort``
+     - No compatible
+     - Compatible
+     - No compatible
+   * - ``frequency.penalty``, ``presence.penalty``
+     - No compatible
+     - Compatible
+     - No compatible
+
+.. note::
+
+   Especificar un parámetro «No compatible» no genera un error; simplemente se ignora. Para más detalles sobre el significado de cada parámetro y los valores configurables, consulte la documentación de cada proveedor.
+
+.. note::
+
+   Solo el proveedor Ollama dispone de un mecanismo de reserva (fallback) que, cuando no existe una configuración específica por tipo de prompt, recurre a ``rag.llm.ollama.default.{parámetro}``
+   (excepto para ``context.max.chars``). Los proveedores OpenAI y Gemini no disponen de este mecanismo de reserva; cuando no hay configuración específica por tipo de prompt,
+   se utiliza el valor predeterminado incorporado en el plugin.
 
 Siguientes pasos
 ================
@@ -329,3 +438,5 @@ Siguientes pasos
 - :doc:`llm-gemini` - Configuración detallada de Google Gemini
 - :doc:`rag-chat` - Configuración detallada de la funcionalidad de modo de búsqueda IA
 - :doc:`rank-fusion` - Configuración de Rank Fusion (fusión de resultados de búsqueda híbrida)
+- :doc:`../user/chat-search` - Cómo usar el modo de búsqueda IA
+- :doc:`../api/api-chat` - Referencia de la API de chat

--- a/fr/15.8/config/llm-overview.rst
+++ b/fr/15.8/config/llm-overview.rst
@@ -33,7 +33,7 @@ Fournisseurs pris en charge
    * - OpenAI
      - ``openai``
      - ``fess-llm-openai``
-     - API cloud d'OpenAI. Permet d'utiliser des modèles comme GPT-4.
+     - API cloud d'OpenAI. Permet d'utiliser des modèles comme GPT-5.
    * - Google Gemini
      - ``gemini``
      - ``fess-llm-gemini``
@@ -68,20 +68,25 @@ Comparaison des fournisseurs
 
 .. note::
 
-   Si ``rag.llm.name`` n'est pas défini, seul le client Ollama est actif par défaut ; installez et sélectionnez le fournisseur souhaité avec ``rag.llm.name``.
+   La valeur par défaut de ``rag.llm.name`` est ``ollama``. Cette valeur permet de déterminer le nom du composant DI à charger ( ``{rag.llm.name}LlmClient`` ).
+   Ainsi, si vous laissez ``rag.llm.name`` à sa valeur par défaut tout en installant uniquement un plugin autre que ``fess-llm-ollama``, aucun client LLM ne sera actif.
+   Dans ce cas, le journal affiche l'avertissement ``[LLM] LlmClient not found. componentName=ollamaLlmClient`` et le mode de recherche IA n'est pas disponible.
+   Veillez à toujours configurer ``rag.llm.name`` en fonction du plugin installé. La valeur ``none`` permet de désactiver explicitement l'intégration LLM.
 
 Installation du plugin
 =======================
 
-La fonctionnalité LLM est fournie sous forme de plugins. Il est nécessaire de placer le fichier JAR du plugin ``fess-llm-{provider}`` correspondant au fournisseur utilisé dans le répertoire des plugins.
+La fonctionnalité LLM est fournie sous forme de plugins. Installez le plugin ``fess-llm-{provider}`` correspondant au fournisseur utilisé.
 
-Par exemple, pour utiliser le fournisseur OpenAI, téléchargez ``fess-llm-openai-15.8.0.jar`` et placez-le dans le répertoire suivant.
+Vous pouvez l'installer depuis la page « Système > Plugin » de l'interface d'administration. Les plugins ``fess-llm-*`` apparaissent dans la liste des plugins installables.
+
+Pour une installation manuelle, placez le fichier JAR correspondant (par exemple ``fess-llm-openai-15.8.0.jar`` pour le fournisseur OpenAI) dans le répertoire suivant.
 
 ::
 
     app/WEB-INF/plugin/
 
-Après le placement, le plugin sera chargé au redémarrage de |Fess|.
+Quelle que soit la méthode utilisée, le plugin sera chargé au redémarrage de |Fess| après l'installation.
 
 Architecture
 =============
@@ -100,6 +105,13 @@ La fonctionnalité de mode de recherche IA fonctionne selon le flux suivant.
 .. note::
 
    Le traitement interne est composé de cinq phases : ``intent``, ``search``, ``evaluate``, ``fetch`` et ``answer``. La progression de chaque phase est notifiée au client par streaming (SSE).
+   La regénération de requête n'est pas une phase indépendante ; elle est notifiée comme un repli de la phase ``search``, après quoi la phase ``search`` est réexécutée.
+
+.. note::
+
+   Le déroulement décrit ci-dessus correspond au cas où l'API de streaming détermine que l'intention est « recherche ». Le chemin suivi varie selon le résultat de la détection d'intention.
+   Si la question est jugée peu claire, une réponse est générée sans effectuer de recherche ; si un résumé d'URL est demandé, une recherche d'URL est effectuée sans exécuter la phase d'évaluation.
+   Par ailleurs, l'API non-streaming ``POST /api/v2/chat`` n'exécute pas la phase d'évaluation et ne notifie pas non plus la progression phase par phase.
 
 Configuration de base
 ======================
@@ -119,11 +131,12 @@ La configuration s'effectue dans la configuration générale de l'administration
 fess_config.properties
 -----------------------
 
-La configuration s'effectue dans ``app/WEB-INF/conf/fess_config.properties``. Ce fichier permet d'activer le mode de recherche IA, de configurer les sessions et l'historique de conversation, ainsi que les paramètres spécifiques au fournisseur (URL de connexion, clé API, paramètres de génération, etc.).
+La configuration s'effectue dans ``app/WEB-INF/classes/fess_config.properties`` (dans la version paquet : ``/etc/fess/fess_config.properties`` ).
+Ce fichier permet d'activer le mode de recherche IA, de configurer les sessions et l'historique de conversation, ainsi que les paramètres spécifiques au fournisseur (URL de connexion, clé API, paramètres de génération, etc.).
 
 ::
 
-    # Activer la fonctionnalité de mode de recherche IA
+    # Activer la fonctionnalité de mode de recherche IA (par défaut : false)
     rag.chat.enabled=true
 
     # Exemple de configuration spécifique au fournisseur (cas OpenAI)
@@ -167,7 +180,52 @@ Prompt système
 
 Les prompts système sont gérés dans les fichiers DI XML de chaque plugin, et non dans les fichiers de propriétés.
 
-Le prompt système est défini dans le fichier ``fess_llm++.xml`` inclus dans le JAR de chaque plugin ``fess-llm-*``. Ce fichier est une ressource classpath intégrée au JAR du plugin ; pour personnaliser les prompts, il est nécessaire de modifier le fichier DI XML à l'intérieur du JAR.
+Le prompt système est défini dans le fichier ``fess_llm++.xml`` inclus dans le JAR de chaque plugin ``fess-llm-*``.
+Il n'est pas nécessaire d'extraire le fichier JAR pour le modifier afin de personnaliser les prompts. Grâce au mécanisme de redéfinition de composant de LastaDi,
+placer dans ``app/WEB-INF/classes/`` un fichier nommé ``fess_llm+{nom du composant}.xml`` permet de remplacer la définition de composant fournie par le plugin.
+
+Le nom du composant varie selon le fournisseur, comme indiqué ci-dessous.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Fournisseur
+     - Nom du composant
+   * - Ollama
+     - ``ollamaLlmClient``
+   * - OpenAI
+     - ``openaiLlmClient``
+   * - Google Gemini
+     - ``geminiLlmClient``
+
+Par exemple, pour modifier le prompt de génération de réponse du fournisseur OpenAI, créez ``app/WEB-INF/classes/fess_llm+openaiLlmClient.xml``.
+
+::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+        "http://dbflute.org/meta/lastadi10.dtd">
+    <components>
+        <component name="openaiLlmClient" class="org.codelibs.fess.llm.openai.OpenAiLlmClient">
+            <postConstruct name="register"/>
+            <postConstruct name="init"/>
+            <preDestroy name="destroy"/>
+            <property name="answerGenerationSystemPrompt">"Mon prompt personnalisé de génération de réponse"</property>
+            <!-- Incluez également toutes les propriétés de prompt que vous ne modifiez pas -->
+        </component>
+    </components>
+
+.. warning::
+
+   Le fichier de redéfinition remplace la définition de composant. Vous devez donc y inclure l'intégralité du contenu défini dans le ``fess_llm++.xml``
+   d'origine (nom de classe, ``postConstruct``, ``preDestroy``, ainsi que les propriétés de prompt que vous ne modifiez pas). Toute propriété omise reviendra à un état non défini.
+
+.. warning::
+
+   Ne copiez pas ``fess_llm++.xml`` tel quel dans ``app/WEB-INF/classes/``.
+   Les fichiers DI XML dont le nom se termine par ``++`` sont tous chargés comme des « ajouts » sur le classpath ; le même composant se retrouve alors enregistré deux fois,
+   ce qui provoque une ``TooManyRegistrationComponentException`` et empêche |Fess| de démarrer.
 
 Vérification de disponibilité
 -------------------------------
@@ -180,10 +238,16 @@ Vérification de disponibilité
      - Description
      - Valeur par défaut
    * - ``rag.llm.{provider}.availability.check.interval``
-     - Intervalle de vérification de disponibilité du LLM (secondes). 0 pour désactiver
+     - Intervalle de vérification périodique de la disponibilité du LLM (secondes)
      - ``60``
 
 Cette configuration s'effectue dans ``fess_config.properties``. |Fess| vérifie périodiquement l'état de connexion au fournisseur LLM.
+
+.. note::
+
+   Si vous spécifiez pour cette propriété une valeur inférieure ou égale à ``0`` ou une valeur non numérique, cette valeur est ignorée et la valeur par défaut ( ``60`` ) est utilisée.
+   Cette propriété ne permet pas de désactiver la vérification de disponibilité.
+   Notez également que la vérification de disponibilité n'est pas exécutée lorsque ``rag.chat.enabled`` vaut ``false``, ni pour les fournisseurs non sélectionnés via ``rag.llm.name``.
 
 Gestion des sessions
 =====================
@@ -289,7 +353,7 @@ Liste des types de prompt
      - Génère une réponse au format FAQ
    * - Réponse directe
      - ``direct``
-     - Génère une réponse directe sans passer par la recherche
+     - Génère une réponse directe sans passer par la recherche (non appelé dans la version actuelle)
    * - Regénération de requête
      - ``queryregeneration``
      - Regénère la requête lorsqu'aucun résultat de recherche n'est trouvé
@@ -320,7 +384,52 @@ Exemple de configuration (cas du fournisseur OpenAI) :
 
 .. note::
 
-   ``temperature``, ``max.tokens`` et ``context.max.chars`` sont utilisables avec tous les fournisseurs. En outre, chaque fournisseur prend en charge des paramètres qui lui sont propres, tels que ``thinking.budget``, ``top.p`` ou ``reasoning.effort``. Consultez la documentation de chaque fournisseur pour plus de détails.
+   ``temperature``, ``max.tokens`` et ``context.max.chars`` sont utilisables avec tous les fournisseurs. Toutefois, leurs valeurs par défaut varient selon le fournisseur et le type de prompt.
+
+En outre, chaque fournisseur prend en charge des paramètres qui lui sont propres. Le tableau suivant indique leur prise en charge.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 20 20
+
+   * - Paramètre
+     - Ollama
+     - OpenAI
+     - Gemini
+   * - ``thinking.budget``
+     - Pris en charge
+     - Non pris en charge
+     - Pris en charge
+   * - ``thinking.level``
+     - Pris en charge
+     - Non pris en charge
+     - Non pris en charge
+   * - ``top.p``
+     - Pris en charge
+     - Pris en charge
+     - Non pris en charge
+   * - ``top.k``, ``num.ctx``
+     - Pris en charge
+     - Non pris en charge
+     - Non pris en charge
+   * - ``reasoning.effort``
+     - Non pris en charge
+     - Pris en charge
+     - Non pris en charge
+   * - ``frequency.penalty``, ``presence.penalty``
+     - Non pris en charge
+     - Pris en charge
+     - Non pris en charge
+
+.. note::
+
+   Spécifier un paramètre « Non pris en charge » ne provoque pas d'erreur ; il est simplement ignoré. Pour la signification de chaque paramètre et les valeurs possibles, consultez la documentation de chaque fournisseur.
+
+.. note::
+
+   Seul le fournisseur Ollama dispose d'un repli sur ``rag.llm.ollama.default.{paramètre}`` lorsqu'aucune configuration par type de prompt n'existe
+   (à l'exception de ``context.max.chars``). Les fournisseurs OpenAI et Gemini ne disposent pas de ce repli ;
+   en l'absence de configuration par type de prompt, la valeur par défaut intégrée au plugin est utilisée.
 
 Étapes suivantes
 =================
@@ -330,3 +439,5 @@ Exemple de configuration (cas du fournisseur OpenAI) :
 - :doc:`llm-gemini` - Configuration détaillée de Google Gemini
 - :doc:`rag-chat` - Configuration détaillée de la fonctionnalité de mode de recherche IA
 - :doc:`rank-fusion` - Configuration du Rank Fusion (fusion des résultats de recherche hybride)
+- :doc:`../user/chat-search` - Utilisation du mode de recherche IA
+- :doc:`../api/api-chat` - Référence API Chat

--- a/ja/15.8/config/llm-overview.rst
+++ b/ja/15.8/config/llm-overview.rst
@@ -37,7 +37,7 @@ AI検索モードの検索ステップを含むすべての検索でRank Fusion�
    * - OpenAI
      - ``openai``
      - ``fess-llm-openai``
-     - OpenAI社のクラウドAPI。GPT-4などのモデルを利用可能。
+     - OpenAI社のクラウドAPI。GPT-5などのモデルを利用可能。
    * - Google Gemini
      - ``gemini``
      - ``fess-llm-gemini``
@@ -72,20 +72,25 @@ AI検索モードの検索ステップを含むすべての検索でRank Fusion�
 
 .. note::
 
-   ``rag.llm.name`` が未設定の場合、既定では Ollama クライアントのみが有効です。使用するプロバイダーを導入し ``rag.llm.name`` で選択してください。
+   ``rag.llm.name`` の既定値は ``ollama`` です。この値は、読み込むDIコンポーネント名（ ``{rag.llm.name}LlmClient`` ）の決定に使用されます。
+   そのため、 ``rag.llm.name`` を既定値のままにして ``fess-llm-ollama`` 以外のプラグインだけを導入した場合、LLMクライアントは1つも有効になりません。
+   このとき、ログに ``[LLM] LlmClient not found. componentName=ollamaLlmClient`` という警告が出力され、AI検索モードは利用できません。
+   導入したプラグインに合わせて、必ず ``rag.llm.name`` を設定してください。 ``none`` を指定すると、LLM連携を明示的に無効化できます。
 
 プラグイン導入
 ==============
 
-LLM機能はプラグインとして提供されます。利用するプロバイダーに対応する ``fess-llm-{provider}`` プラグインのJARファイルをプラグインディレクトリに配置する必要があります。
+LLM機能はプラグインとして提供されます。利用するプロバイダーに対応する ``fess-llm-{provider}`` プラグインを導入してください。
 
-例として、OpenAIプロバイダーを利用する場合は ``fess-llm-openai-15.8.0.jar`` をダウンロードし、以下のディレクトリに配置します。
+管理画面の「システム > プラグイン」ページからインストールできます。 ``fess-llm-*`` プラグインはインストール可能なプラグインの一覧に表示されます。
+
+手動で導入する場合は、対応するJARファイル（例: OpenAIプロバイダーの場合は ``fess-llm-openai-15.8.0.jar`` ）を以下のディレクトリに配置します。
 
 ::
 
     app/WEB-INF/plugin/
 
-配置後、 |Fess| を再起動するとプラグインが読み込まれます。
+いずれの方法の場合も、導入後に |Fess| を再起動するとプラグインが読み込まれます。
 
 アーキテクチャ
 ==============
@@ -104,6 +109,13 @@ AI検索モード機能は以下のフローで動作します。
 .. note::
 
    内部処理は ``intent`` 、 ``search`` 、 ``evaluate`` 、 ``fetch`` 、 ``answer`` の5つのフェーズで構成され、各フェーズの進行状況はストリーミング（SSE）でクライアントに通知されます。
+   クエリ再生成は独立したフェーズではなく、 ``search`` フェーズのフォールバックとして通知され、その後 ``search`` が再実行されます。
+
+.. note::
+
+   上記の流れは、ストリーミングAPIで意図が「検索」と判定された場合のものです。意図の判定結果によって経路は変わります。
+   質問が不明確と判定された場合は検索を行わずに応答を生成し、URLの要約を求められた場合はURL検索を行い評価フェーズを実行しません。
+   また、非ストリーミングの ``POST /api/v2/chat`` は評価フェーズを実行せず、フェーズ単位の進捗通知も行いません。
 
 基本設定
 ========
@@ -123,11 +135,12 @@ LLM機能の設定は、以下の2つの場所で行います。
 fess_config.properties
 ----------------------
 
-``app/WEB-INF/conf/fess_config.properties`` で設定します。AI検索モードの有効化、セッション・履歴関連の設定に加え、プロバイダー固有の設定（接続先URLやAPIキー、生成パラメーターなど）もこのファイルに記述します。
+``app/WEB-INF/classes/fess_config.properties`` （パッケージ版では ``/etc/fess/fess_config.properties`` ）で設定します。
+AI検索モードの有効化、セッション・履歴関連の設定に加え、プロバイダー固有の設定（接続先URLやAPIキー、生成パラメーターなど）もこのファイルに記述します。
 
 ::
 
-    # AI検索モード機能を有効にする
+    # AI検索モード機能を有効にする（デフォルトは false）
     rag.chat.enabled=true
 
     # プロバイダー固有設定の例（OpenAIの場合）
@@ -171,7 +184,52 @@ fess_config.properties
 
 システムプロンプトはプロパティファイルではなく、各プラグインのDI XMLファイルで管理されます。
 
-各 ``fess-llm-*`` プラグインのJARファイル内に含まれる ``fess_llm++.xml`` ファイルでシステムプロンプトが定義されています。このファイルはプラグインJARにバンドルされたクラスパスリソースであるため、プロンプトをカスタマイズするにはJAR内のDI XMLファイルを編集する必要があります。
+各 ``fess-llm-*`` プラグインのJARファイル内に含まれる ``fess_llm++.xml`` ファイルでシステムプロンプトが定義されています。
+プロンプトをカスタマイズするためにJARファイルを展開して編集し直す必要はありません。LastaDiのコンポーネント再定義の仕組みにより、
+``app/WEB-INF/classes/`` に ``fess_llm+{コンポーネント名}.xml`` という名前のファイルを配置すると、プラグイン側のコンポーネント定義を置き換えられます。
+
+コンポーネント名はプロバイダーごとに次のとおりです。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - プロバイダー
+     - コンポーネント名
+   * - Ollama
+     - ``ollamaLlmClient``
+   * - OpenAI
+     - ``openaiLlmClient``
+   * - Google Gemini
+     - ``geminiLlmClient``
+
+例として、OpenAIプロバイダーの回答生成プロンプトを変更する場合は、 ``app/WEB-INF/classes/fess_llm+openaiLlmClient.xml`` を作成します。
+
+::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+        "http://dbflute.org/meta/lastadi10.dtd">
+    <components>
+        <component name="openaiLlmClient" class="org.codelibs.fess.llm.openai.OpenAiLlmClient">
+            <postConstruct name="register"/>
+            <postConstruct name="init"/>
+            <preDestroy name="destroy"/>
+            <property name="answerGenerationSystemPrompt">"独自の回答生成プロンプト"</property>
+            <!-- 変更しないプロンプトプロパティもすべて記述する -->
+        </component>
+    </components>
+
+.. warning::
+
+   再定義ファイルはコンポーネント定義を置き換えます。そのため、元の ``fess_llm++.xml`` に記述されている内容（クラス名、 ``postConstruct`` 、
+   ``preDestroy`` 、および変更しないプロンプトプロパティ）をすべて含めてください。記述しなかったプロパティは未設定に戻ります。
+
+.. warning::
+
+   ``fess_llm++.xml`` そのものをコピーして ``app/WEB-INF/classes/`` に配置しないでください。
+   ファイル名が ``++`` で終わるDI XMLはクラスパス上のすべてが「追加」として読み込まれるため、同じ名前のコンポーネントが二重に登録され、
+   ``TooManyRegistrationComponentException`` が発生して |Fess| が起動しなくなります。
 
 可用性チェック
 --------------
@@ -184,10 +242,16 @@ fess_config.properties
      - 説明
      - デフォルト
    * - ``rag.llm.{provider}.availability.check.interval``
-     - LLMの可用性をチェックする間隔（秒）。0で無効化
+     - LLMの可用性を定期的にチェックする間隔（秒）
      - ``60``
 
 この設定は ``fess_config.properties`` で行います。 |Fess| は定期的にLLMプロバイダーの接続状態を確認します。
+
+.. note::
+
+   このプロパティに ``0`` 以下の値や数値以外の値を指定した場合、その値は無視されデフォルト値（ ``60`` ）が使用されます。
+   このプロパティで可用性チェックを無効化することはできません。
+   なお可用性チェックは、 ``rag.chat.enabled`` が ``false`` の場合、および ``rag.llm.name`` で選択されていないプロバイダーでは実行されません。
 
 セッション管理
 ==============
@@ -293,7 +357,7 @@ LLMへのリクエストの同時実行数を制御する設定です。 ``fess_
      - FAQ形式の回答を生成する
    * - 直接回答
      - ``direct``
-     - 検索を介さずに直接回答を生成する
+     - 検索を介さずに直接回答を生成する（現在のバージョンでは呼び出されません）
    * - クエリ再生成
      - ``queryregeneration``
      - 検索結果が得られない場合にクエリを再生成する
@@ -324,7 +388,52 @@ LLMへのリクエストの同時実行数を制御する設定です。 ``fess_
 
 .. note::
 
-   ``temperature`` 、 ``max.tokens`` 、 ``context.max.chars`` はすべてのプロバイダーで共通して使用できます。これに加えて、各プロバイダーは ``thinking.budget`` 、 ``top.p`` 、 ``reasoning.effort`` などのプロバイダー固有のパラメーターをサポートしています。詳細は各プロバイダーのドキュメントを参照してください。
+   ``temperature`` 、 ``max.tokens`` 、 ``context.max.chars`` はすべてのプロバイダーで共通して使用できます。ただし、これらのデフォルト値はプロバイダーおよびプロンプトタイプごとに異なります。
+
+これに加えて、各プロバイダーは固有のパラメーターをサポートしています。対応状況は以下のとおりです。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 20 20
+
+   * - パラメーター
+     - Ollama
+     - OpenAI
+     - Gemini
+   * - ``thinking.budget``
+     - 対応
+     - 非対応
+     - 対応
+   * - ``thinking.level``
+     - 対応
+     - 非対応
+     - 非対応
+   * - ``top.p``
+     - 対応
+     - 対応
+     - 非対応
+   * - ``top.k`` 、 ``num.ctx``
+     - 対応
+     - 非対応
+     - 非対応
+   * - ``reasoning.effort``
+     - 非対応
+     - 対応
+     - 非対応
+   * - ``frequency.penalty`` 、 ``presence.penalty``
+     - 非対応
+     - 対応
+     - 非対応
+
+.. note::
+
+   「非対応」のパラメーターを指定してもエラーにはならず、単に無視されます。各パラメーターの意味や設定可能な値の詳細は、各プロバイダーのドキュメントを参照してください。
+
+.. note::
+
+   Ollamaプロバイダーのみ、プロンプトタイプ別の設定が存在しない場合に ``rag.llm.ollama.default.{パラメーター}`` を参照するフォールバックがあります
+   （ ``context.max.chars`` を除く）。OpenAIプロバイダーとGeminiプロバイダーにはこのフォールバックはなく、
+   プロンプトタイプ別の設定がない場合はプラグイン組み込みのデフォルト値が使用されます。
 
 次のステップ
 ============
@@ -334,3 +443,5 @@ LLMへのリクエストの同時実行数を制御する設定です。 ``fess_
 - :doc:`llm-gemini` - Google Geminiの詳細設定
 - :doc:`rag-chat` - AI検索モード機能の詳細設定
 - :doc:`rank-fusion` - Rank Fusion設定（ハイブリッド検索の結果統合）
+- :doc:`../user/chat-search` - AI検索モードの使い方
+- :doc:`../api/api-chat` - チャットAPIリファレンス

--- a/ko/15.8/config/llm-overview.rst
+++ b/ko/15.8/config/llm-overview.rst
@@ -37,7 +37,7 @@ AI 검색 모드는 전용 벡터 인덱스가 아닌 |Fess|\ 의 표준 검색 
    * - OpenAI
      - ``openai``
      - ``fess-llm-openai``
-     - OpenAI사의 클라우드 API. GPT-4 등의 모델 이용 가능.
+     - OpenAI사의 클라우드 API. GPT-5 등의 모델 이용 가능.
    * - Google Gemini
      - ``gemini``
      - ``fess-llm-gemini``
@@ -72,21 +72,25 @@ AI 검색 모드는 전용 벡터 인덱스가 아닌 |Fess|\ 의 표준 검색 
 
 .. note::
 
-   ``rag.llm.name`` 이 설정되어 있지 않은 경우, 기본값으로는 Ollama 클라이언트만 활성화됩니다.
-   사용할 프로바이더를 도입하고 ``rag.llm.name`` 으로 선택하세요.
+   ``rag.llm.name`` 의 기본값은 ``ollama`` 입니다. 이 값은 로드할 DI 컴포넌트 이름( ``{rag.llm.name}LlmClient`` )을 결정하는 데 사용됩니다.
+   따라서 ``rag.llm.name`` 을 기본값으로 둔 채 ``fess-llm-ollama`` 이외의 플러그인만 도입한 경우, LLM 클라이언트가 하나도 활성화되지 않습니다.
+   이때 로그에 ``[LLM] LlmClient not found. componentName=ollamaLlmClient`` 라는 경고가 출력되며, AI 검색 모드를 사용할 수 없습니다.
+   도입한 플러그인에 맞춰 반드시 ``rag.llm.name`` 을 설정하세요. ``none`` 을 지정하면 LLM 연계를 명시적으로 비활성화할 수 있습니다.
 
 플러그인 도입
 ==============
 
-LLM 기능은 플러그인으로 제공됩니다. 사용할 프로바이더에 해당하는 ``fess-llm-{provider}`` 플러그인의 JAR 파일을 플러그인 디렉터리에 배치해야 합니다.
+LLM 기능은 플러그인으로 제공됩니다. 사용할 프로바이더에 해당하는 ``fess-llm-{provider}`` 플러그인을 도입하세요.
 
-예로, OpenAI 프로바이더를 사용하는 경우 ``fess-llm-openai-15.8.0.jar`` 를 다운로드하여 다음 디렉터리에 배치합니다.
+관리 화면의 「시스템 > 플러그인」 페이지에서 설치할 수 있습니다. ``fess-llm-*`` 플러그인은 설치 가능한 플러그인 목록에 표시됩니다.
+
+수동으로 도입하는 경우, 해당하는 JAR 파일(예: OpenAI 프로바이더의 경우 ``fess-llm-openai-15.8.0.jar`` )을 다음 디렉터리에 배치합니다.
 
 ::
 
     app/WEB-INF/plugin/
 
-배치 후 |Fess| 를 재시작하면 플러그인이 로드됩니다.
+어느 방법으로 도입하든, 도입 후 |Fess|\ 를 재시작하면 플러그인이 로드됩니다.
 
 아키텍처
 ==============
@@ -105,9 +109,16 @@ AI 검색 모드 기능은 다음 흐름으로 동작합니다.
 .. note::
 
    내부 처리는 ``intent`` 、 ``search`` 、 ``evaluate`` 、 ``fetch`` 、 ``answer`` 의 5단계 페이즈로 구성되며, 각 페이즈의 진행 상황은 스트리밍（SSE）으로 클라이언트에 통보됩니다.
+   쿼리 재생성은 독립된 페이즈가 아니라 ``search`` 페이즈의 폴백으로 통보되며, 이후 ``search`` 가 재실행됩니다.
+
+.. note::
+
+   위 흐름은 스트리밍 API에서 의도가 "검색"으로 판정된 경우의 흐름입니다. 의도 판정 결과에 따라 경로가 달라집니다.
+   질문이 불명확하다고 판정된 경우에는 검색을 수행하지 않고 응답을 생성하며, URL 요약을 요청받은 경우에는 URL 검색을 수행하고 평가 페이즈는 실행하지 않습니다.
+   또한 비스트리밍 방식인 ``POST /api/v2/chat`` 은 평가 페이즈를 실행하지 않으며, 페이즈 단위의 진행 상황 통보도 하지 않습니다.
 
 기본 설정
-========
+=========
 
 LLM 기능의 설정은 다음 두 곳에서 수행합니다.
 
@@ -124,11 +135,11 @@ LLM 기능의 설정은 다음 두 곳에서 수행합니다.
 fess_config.properties
 ----------------------
 
-``app/WEB-INF/conf/fess_config.properties`` 에서 설정합니다. AI 검색 모드 활성화, 세션·이력 관련 설정 외에 프로바이더 고유의 설정（접속 URL, API 키, 생성 파라미터 등）도 이 파일에 기술합니다.
+``app/WEB-INF/classes/fess_config.properties`` (패키지 버전에서는 ``/etc/fess/fess_config.properties`` )에서 설정합니다. AI 검색 모드 활성화, 세션·이력 관련 설정 외에 프로바이더 고유의 설정（접속 URL, API 키, 생성 파라미터 등）도 이 파일에 기술합니다.
 
 ::
 
-    # AI 검색 모드 기능 활성화
+    # AI 검색 모드 기능 활성화（기본값은 false）
     rag.chat.enabled=true
 
     # 프로바이더 고유 설정 예（OpenAI의 경우）
@@ -142,7 +153,7 @@ fess_config.properties
 - :doc:`llm-gemini` - Google Gemini 설정
 
 공통 설정
-========
+=========
 
 모든 LLM 프로바이더에서 공통으로 사용되는 설정 항목입니다. 이 항목들은 ``fess_config.properties`` 에서 설정합니다.
 
@@ -172,7 +183,52 @@ fess_config.properties
 
 시스템 프롬프트는 프로퍼티 파일이 아닌 각 플러그인의 DI XML 파일에서 관리됩니다.
 
-각 ``fess-llm-*`` 플러그인의 JAR 파일 내에 포함된 ``fess_llm++.xml`` 파일에서 시스템 프롬프트가 정의됩니다. 이 파일은 플러그인 JAR에 번들된 클래스패스 리소스이므로, 프롬프트를 커스터마이즈하려면 JAR 내의 DI XML 파일을 편집해야 합니다.
+각 ``fess-llm-*`` 플러그인의 JAR 파일 내에 포함된 ``fess_llm++.xml`` 파일에서 시스템 프롬프트가 정의됩니다.
+프롬프트를 커스터마이즈하기 위해 JAR 파일을 압축 해제하여 다시 편집할 필요는 없습니다. LastaDi의 컴포넌트 재정의 메커니즘을 통해
+``app/WEB-INF/classes/`` 에 ``fess_llm+{컴포넌트 이름}.xml`` 이라는 이름의 파일을 배치하면 플러그인 측의 컴포넌트 정의를 대체할 수 있습니다.
+
+컴포넌트 이름은 프로바이더별로 다음과 같습니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 프로바이더
+     - 컴포넌트 이름
+   * - Ollama
+     - ``ollamaLlmClient``
+   * - OpenAI
+     - ``openaiLlmClient``
+   * - Google Gemini
+     - ``geminiLlmClient``
+
+예로, OpenAI 프로바이더의 답변 생성 프롬프트를 변경하는 경우 ``app/WEB-INF/classes/fess_llm+openaiLlmClient.xml`` 을 작성합니다.
+
+::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+        "http://dbflute.org/meta/lastadi10.dtd">
+    <components>
+        <component name="openaiLlmClient" class="org.codelibs.fess.llm.openai.OpenAiLlmClient">
+            <postConstruct name="register"/>
+            <postConstruct name="init"/>
+            <preDestroy name="destroy"/>
+            <property name="answerGenerationSystemPrompt">"고유한 답변 생성 프롬프트"</property>
+            <!-- 변경하지 않는 프롬프트 프로퍼티도 모두 기술한다 -->
+        </component>
+    </components>
+
+.. warning::
+
+   재정의 파일은 컴포넌트 정의를 대체합니다. 따라서 원본 ``fess_llm++.xml`` 에 기술되어 있는 내용(클래스명, ``postConstruct`` ,
+   ``preDestroy`` , 그리고 변경하지 않는 프롬프트 프로퍼티)을 모두 포함해야 합니다. 기술하지 않은 프로퍼티는 미설정 상태로 돌아갑니다.
+
+.. warning::
+
+   ``fess_llm++.xml`` 자체를 복사하여 ``app/WEB-INF/classes/`` 에 배치하지 마세요.
+   파일명이 ``++`` 로 끝나는 DI XML은 클래스패스상의 모든 것이 "추가"로 로드되기 때문에 같은 이름의 컴포넌트가 이중으로 등록되어,
+   ``TooManyRegistrationComponentException`` 이 발생하여 |Fess|\ 가 시작되지 않습니다.
 
 가용성 체크
 --------------
@@ -185,10 +241,16 @@ fess_config.properties
      - 설명
      - 기본값
    * - ``rag.llm.{provider}.availability.check.interval``
-     - LLM 가용성을 체크하는 간격（초）. 0으로 비활성화
+     - LLM 가용성을 정기적으로 체크하는 간격(초)
      - ``60``
 
 이 설정은 ``fess_config.properties`` 에서 수행합니다. |Fess| 는 정기적으로 LLM 프로바이더의 연결 상태를 확인합니다.
+
+.. note::
+
+   이 프로퍼티에 ``0`` 이하의 값이나 숫자가 아닌 값을 지정한 경우, 그 값은 무시되고 기본값( ``60`` )이 사용됩니다.
+   이 프로퍼티로는 가용성 체크를 비활성화할 수 없습니다.
+   또한 가용성 체크는 ``rag.chat.enabled`` 가 ``false`` 인 경우, 그리고 ``rag.llm.name`` 에서 선택되지 않은 프로바이더에서는 실행되지 않습니다.
 
 세션 관리
 ==============
@@ -238,7 +300,7 @@ LLM으로의 요청 동시 실행 수를 제어하는 설정입니다. ``fess_co
     rag.llm.openai.max.concurrent.requests=10
 
 평가 설정
-========
+=========
 
 검색 결과 평가 관련 설정입니다. ``fess_config.properties`` 에서 설정합니다.
 
@@ -294,7 +356,7 @@ LLM으로의 요청 동시 실행 수를 제어하는 설정입니다. ``fess_co
      - FAQ 형식의 응답을 생성한다
    * - 직접 응답
      - ``direct``
-     - 검색을 거치지 않고 직접 응답을 생성한다
+     - 검색을 거치지 않고 직접 응답을 생성한다(현재 버전에서는 호출되지 않습니다)
    * - 쿼리 재생성
      - ``queryregeneration``
      - 검색 결과가 없는 경우 쿼리를 재생성한다
@@ -325,7 +387,52 @@ LLM으로의 요청 동시 실행 수를 제어하는 설정입니다. ``fess_co
 
 .. note::
 
-   ``temperature`` 、 ``max.tokens`` 、 ``context.max.chars`` 는 모든 프로바이더에서 공통으로 사용할 수 있습니다. 이 외에도 각 프로바이더는 ``thinking.budget`` 、 ``top.p`` 、 ``reasoning.effort`` 등 프로바이더 고유의 파라미터를 지원합니다. 자세한 내용은 각 프로바이더의 문서를 참조하세요.
+   ``temperature`` , ``max.tokens`` , ``context.max.chars`` 는 모든 프로바이더에서 공통으로 사용할 수 있습니다. 단, 이 값들의 기본값은 프로바이더 및 프롬프트 타입별로 다릅니다.
+
+이 외에도 각 프로바이더는 고유의 파라미터를 지원합니다. 지원 현황은 다음과 같습니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 20 20
+
+   * - 파라미터
+     - Ollama
+     - OpenAI
+     - Gemini
+   * - ``thinking.budget``
+     - 지원
+     - 미지원
+     - 지원
+   * - ``thinking.level``
+     - 지원
+     - 미지원
+     - 미지원
+   * - ``top.p``
+     - 지원
+     - 지원
+     - 미지원
+   * - ``top.k`` , ``num.ctx``
+     - 지원
+     - 미지원
+     - 미지원
+   * - ``reasoning.effort``
+     - 미지원
+     - 지원
+     - 미지원
+   * - ``frequency.penalty`` , ``presence.penalty``
+     - 미지원
+     - 지원
+     - 미지원
+
+.. note::
+
+   "미지원" 파라미터를 지정해도 오류가 발생하지 않으며 단순히 무시됩니다. 각 파라미터의 의미나 설정 가능한 값에 대한 자세한 내용은 각 프로바이더의 문서를 참조하세요.
+
+.. note::
+
+   Ollama 프로바이더에서만, 프롬프트 타입별 설정이 존재하지 않는 경우 ``rag.llm.ollama.default.{파라미터}`` 를 참조하는 폴백이 있습니다
+   ( ``context.max.chars`` 는 제외). OpenAI 프로바이더와 Gemini 프로바이더에는 이 폴백이 없으며,
+   프롬프트 타입별 설정이 없는 경우 플러그인에 내장된 기본값이 사용됩니다.
 
 다음 단계
 ============
@@ -335,3 +442,5 @@ LLM으로의 요청 동시 실행 수를 제어하는 설정입니다. ``fess_co
 - :doc:`llm-gemini` - Google Gemini 상세 설정
 - :doc:`rag-chat` - AI 검색 모드 기능 상세 설정
 - :doc:`rank-fusion` - Rank Fusion 설정（하이브리드 검색 결과 통합）
+- :doc:`../user/chat-search` - AI 검색 모드 사용법
+- :doc:`../api/api-chat` - 채팅 API 레퍼런스

--- a/zh-cn/15.8/config/llm-overview.rst
+++ b/zh-cn/15.8/config/llm-overview.rst
@@ -35,7 +35,7 @@ Rank Fusion，无需为了让语义搜索器参与其中而进行 AI 搜索模�
    * - OpenAI
      - ``openai``
      - ``fess-llm-openai``
-     - OpenAI 公司的云 API。可使用 GPT-4 等模型。
+     - OpenAI 公司的云 API。可使用 GPT-5 等模型。
    * - Google Gemini
      - ``gemini``
      - ``fess-llm-gemini``
@@ -70,20 +70,22 @@ Rank Fusion，无需为了让语义搜索器参与其中而进行 AI 搜索模�
 
 .. note::
 
-   当 ``rag.llm.name`` 未设置时，默认情况下仅 Ollama 客户端处于启用状态。请安装您要使用的提供商，并通过 ``rag.llm.name`` 进行选择。
+   ``rag.llm.name`` 的默认值为 ``ollama`` 。该值用于确定要加载的 DI 组件名称（ ``{rag.llm.name}LlmClient`` ）。因此，如果将 ``rag.llm.name`` 保持为默认值，而仅安装了 ``fess-llm-ollama`` 以外的插件，则不会启用任何 LLM 客户端。此时，日志中会输出警告 ``[LLM] LlmClient not found. componentName=ollamaLlmClient`` ，AI 搜索模式将无法使用。请务必根据所安装的插件设置 ``rag.llm.name`` 。指定 ``none`` 可明确禁用 LLM 集成。
 
 插件安装
 ========
 
-LLM 功能以插件形式提供。需要将与所用提供商对应的 ``fess-llm-{provider}`` 插件 JAR 文件放置到插件目录。
+LLM 功能以插件形式提供。请安装与所用提供商对应的 ``fess-llm-{provider}`` 插件。
 
-以使用 OpenAI 提供商为例，请下载 ``fess-llm-openai-15.8.0.jar`` 并放置到以下目录。
+可从管理界面「系统 > 插件」页面进行安装。 ``fess-llm-*`` 插件会显示在可安装插件列表中。
+
+如需手动安装，请将对应的 JAR 文件（例如 OpenAI 提供商对应的 ``fess-llm-openai-15.8.0.jar`` ）放置到以下目录。
 
 ::
 
     app/WEB-INF/plugin/
 
-放置后，重启 |Fess| 即可加载插件。
+无论采用哪种方式，安装后重启 |Fess| 即可加载插件。
 
 架构
 ====
@@ -101,7 +103,11 @@ AI 搜索模式功能按以下流程运作。
 
 .. note::
 
-   内部处理由 ``intent`` 、 ``search`` 、 ``evaluate`` 、 ``fetch`` 、 ``answer`` 五个阶段构成，各阶段的进度通过流式传输（SSE）通知客户端。
+   内部处理由 ``intent`` 、 ``search`` 、 ``evaluate`` 、 ``fetch`` 、 ``answer`` 五个阶段构成，各阶段的进度通过流式传输（SSE）通知客户端。查询再生成并非独立的阶段，而是作为 ``search`` 阶段的回退（fallback）进行通知，之后会重新执行 ``search`` 。
+
+.. note::
+
+   上述流程是在流式 API 中意图被判定为"搜索"时的情况，实际路径会因意图判定结果而变化。当问题被判定为不明确时，将不经过搜索直接生成响应；当被要求对 URL 进行摘要时，将执行 URL 搜索但不执行评估阶段。此外，非流式的 ``POST /api/v2/chat`` 不执行评估阶段，也不进行按阶段的进度通知。
 
 基本配置
 ========
@@ -121,11 +127,11 @@ LLM 功能的配置在以下两处进行。
 fess_config.properties
 ----------------------
 
-在 ``app/WEB-INF/conf/fess_config.properties`` 中进行配置。用于启用 AI 搜索模式、会话及历史记录相关设置，以及提供商专属配置（连接 URL、API 密钥、生成参数等）。
+在 ``app/WEB-INF/classes/fess_config.properties`` （软件包版中为 ``/etc/fess/fess_config.properties`` ）中进行配置。除启用 AI 搜索模式、配置会话及历史记录相关设置外，提供商专属配置（连接 URL、API 密钥、生成参数等）也记录在此文件中。
 
 ::
 
-    # 启用AI搜索模式功能
+    # 启用AI搜索模式功能（默认为false）
     rag.chat.enabled=true
 
     # 提供商专属配置示例（以OpenAI为例）
@@ -169,7 +175,52 @@ fess_config.properties
 
 系统提示在各插件的 DI XML 文件中进行管理，而非属性文件。
 
-各 ``fess-llm-*`` 插件的 JAR 文件内包含的 ``fess_llm++.xml`` 文件中定义了系统提示。由于该文件是打包在插件 JAR 中的类路径资源，如需自定义提示，需要编辑 JAR 内的 DI XML 文件。
+各 ``fess-llm-*`` 插件的 JAR 文件内包含的 ``fess_llm++.xml`` 文件中定义了系统提示。
+无需解压 JAR 文件重新编辑即可自定义提示词。借助 LastaDi 的组件重定义机制，在
+``app/WEB-INF/classes/`` 下放置名为 ``fess_llm+{组件名}.xml`` 的文件，即可替换插件侧的组件定义。
+
+各提供商对应的组件名称如下。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 提供商
+     - 组件名称
+   * - Ollama
+     - ``ollamaLlmClient``
+   * - OpenAI
+     - ``openaiLlmClient``
+   * - Google Gemini
+     - ``geminiLlmClient``
+
+例如，若要修改 OpenAI 提供商的回答生成提示词，请创建 ``app/WEB-INF/classes/fess_llm+openaiLlmClient.xml`` 。
+
+::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE components PUBLIC "-//DBFLUTE//DTD LastaDi 1.0//EN"
+        "http://dbflute.org/meta/lastadi10.dtd">
+    <components>
+        <component name="openaiLlmClient" class="org.codelibs.fess.llm.openai.OpenAiLlmClient">
+            <postConstruct name="register"/>
+            <postConstruct name="init"/>
+            <preDestroy name="destroy"/>
+            <property name="answerGenerationSystemPrompt">"自定义回答生成提示词"</property>
+            <!-- 未修改的提示属性也需要全部写出 -->
+        </component>
+    </components>
+
+.. warning::
+
+   重定义文件会替换组件定义。因此，请务必包含原始 ``fess_llm++.xml`` 中记述的全部内容（类名、 ``postConstruct`` 、
+   ``preDestroy`` ，以及未修改的提示属性）。未记述的属性将恢复为未设置状态。
+
+.. warning::
+
+   请勿直接复制 ``fess_llm++.xml`` 本身并放置到 ``app/WEB-INF/classes/`` 下。
+   文件名以 ``++`` 结尾的 DI XML 会将类路径上所有同名文件都作为"追加"加载，因此同名组件会被重复注册，
+   导致抛出 ``TooManyRegistrationComponentException`` ，使 |Fess| 无法启动。
 
 可用性检查
 ----------
@@ -182,10 +233,14 @@ fess_config.properties
      - 说明
      - 默认值
    * - ``rag.llm.{provider}.availability.check.interval``
-     - 检查 LLM 可用性的间隔（秒）。设为 0 可禁用
+     - 定期检查 LLM 可用性的间隔（秒）
      - ``60``
 
 此配置在 ``fess_config.properties`` 中进行。 |Fess| 会定期检查 LLM 提供商的连接状态。
+
+.. note::
+
+   如果为该属性指定 ``0`` 以下的值或非数值，则该值将被忽略，转而使用默认值（ ``60`` ）。无法通过该属性禁用可用性检查。此外，当 ``rag.chat.enabled`` 为 ``false`` 时，以及未在 ``rag.llm.name`` 中选中的提供商，均不会执行可用性检查。
 
 会话管理
 ========
@@ -291,7 +346,7 @@ fess_config.properties
      - 生成 FAQ 形式的回答
    * - 直接回答
      - ``direct``
-     - 不经过搜索直接生成回答
+     - 不经过搜索直接生成回答（当前版本不会被调用）
    * - 查询再生成
      - ``queryregeneration``
      - 当没有搜索结果时重新生成查询
@@ -322,7 +377,52 @@ fess_config.properties
 
 .. note::
 
-   ``temperature`` 、 ``max.tokens`` 、 ``context.max.chars`` 可在所有提供商中通用。此外，各提供商还支持 ``thinking.budget`` 、 ``top.p`` 、 ``reasoning.effort`` 等提供商专属参数。详情请参阅各提供商的文档。
+   ``temperature`` 、 ``max.tokens`` 、 ``context.max.chars`` 可在所有提供商中通用。不过，这些参数的默认值因提供商和提示类型而异。
+
+此外，各提供商还支持各自专属的参数。支持情况如下。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 20 20
+
+   * - 参数
+     - Ollama
+     - OpenAI
+     - Gemini
+   * - ``thinking.budget``
+     - 支持
+     - 不支持
+     - 支持
+   * - ``thinking.level``
+     - 支持
+     - 不支持
+     - 不支持
+   * - ``top.p``
+     - 支持
+     - 支持
+     - 不支持
+   * - ``top.k`` 、 ``num.ctx``
+     - 支持
+     - 不支持
+     - 不支持
+   * - ``reasoning.effort``
+     - 不支持
+     - 支持
+     - 不支持
+   * - ``frequency.penalty`` 、 ``presence.penalty``
+     - 不支持
+     - 支持
+     - 不支持
+
+.. note::
+
+   即使指定了"不支持"的参数，也不会报错，只是会被忽略。有关各参数的含义及可设置的值，详情请参阅各提供商的文档。
+
+.. note::
+
+   仅 Ollama 提供商在不存在按提示类型分别设置的情况下，具有回退到 ``rag.llm.ollama.default.{参数}`` 的机制
+   （ ``context.max.chars`` 除外）。OpenAI 提供商和 Gemini 提供商没有此回退机制，
+   若不存在按提示类型的设置，则使用插件内置的默认值。
 
 后续步骤
 ========
@@ -332,3 +432,5 @@ fess_config.properties
 - :doc:`llm-gemini` - Google Gemini 详细配置
 - :doc:`rag-chat` - AI 搜索模式功能详细配置
 - :doc:`rank-fusion` - Rank Fusion 配置（混合搜索结果融合）
+- :doc:`../user/chat-search` - AI 搜索模式的使用方法
+- :doc:`../api/api-chat` - 聊天 API 参考


### PR DESCRIPTION
## Summary

Reviewed `15.8/config/llm-overview.rst` against the implementation and corrected it, then propagated the result to all seven languages (ja, en, de, es, fr, ko, zh-cn).

Sources of truth: `fess` (master) `AbstractLlmClient` / `LlmClientManager` / `ChatClient` / `ChatPhaseCallback` / `fess_config.properties`, and the `fess-llm-ollama`, `fess-llm-openai` and `fess-llm-gemini` plugins.

## Corrections

| Topic | Was | Now |
|---|---|---|
| `availability.check.interval` | "0 disables it" | The value is read via `getConfigInt()`, which accepts only values `> 0`, so `0` falls back to the default `60`. The check cannot be disabled through this property. |
| System prompt customization | "You must edit the DI XML inside the JAR" | Documents the supported LastaDi component redefinition file `app/WEB-INF/classes/fess_llm+<componentName>.xml`, with the provider-to-component-name table. |
| `rag.llm.name` | "Only the Ollama client is enabled by default" | The default is `ollama`, and the value selects the DI component name `{rag.llm.name}LlmClient`. Leaving the default while installing only a non-Ollama plugin enables no client at all and logs `[LLM] LlmClient not found. componentName=ollamaLlmClient`. Also documents `none`. |
| `fess_config.properties` path | `app/WEB-INF/conf/` | `app/WEB-INF/classes/` (and `/etc/fess/` for package installs), consistent with the rest of the docs. |
| Provider-specific parameters | Implied all providers support `thinking.budget`, `top.p` and `reasoning.effort` | Per-provider support matrix. `reasoning.effort` is OpenAI only, `top.p` is not available for Gemini, and `thinking.budget` is ignored by OpenAI. Also notes that the `default.*` fallback tier is Ollama only. |
| Architecture | One unconditional eight-step flow | Scoped to the streaming search intent. Query regeneration is a `search`-phase fallback, not a phase, and the non-streaming `POST /api/v2/chat` runs no evaluation phase. |
| OpenAI description | GPT-4 | GPT-5, matching the `gpt-5-mini` default. |

Two `.. warning::` blocks were added to the system prompt section: a redefinition file replaces the whole component definition (omitted properties revert to unset), and copying `fess_llm++.xml` itself into `app/WEB-INF/classes/` registers the component twice and prevents startup with `TooManyRegistrationComponentException`.

## Additions

- `rag.chat.enabled` default value (`false`).
- Plugin installation through the admin UI, in addition to manual JAR placement.
- A note that the `direct` prompt type is not invoked in the current version.
- Links to the chat search guide and the chat API reference.

## Verification

- The system prompt override behaviour was confirmed empirically against lasta-di 2.0.0, not only by reading the source: a redefinition file overrides a component declared in a plugin's `fess_llm++.xml`, while a second `fess_llm++.xml` on the classpath fails with `TooManyRegistrationComponentException`.
- All seven files build without warnings under Sphinx.
- All seven files are structurally identical: 44 table rows, 114 literal tokens and 12 `:doc:` targets each. The only literal differences between languages are two placeholders that are prose rather than identifiers (`fess_llm+{component name}.xml` and `rag.llm.ollama.default.{parameter}`).
- Values confirmed unchanged because they are already correct: the three default models and endpoints, the authentication headers, `rag.chat.*` defaults, `max.concurrent.requests` (5), `concurrency.wait.timeout` (30000, and the resulting error really is a rate-limit error), `chat.evaluation.max.relevant.docs` (3), the ten prompt type names, and the five phase names.

Three Korean section underlines that were shorter than their East Asian display width are also fixed; they produced Sphinx warnings and predate this change.

## Follow-ups (not in this PR)

- `rag-chat.rst` documents copying `fess_llm++.xml` into `app/WEB-INF/`, which is the procedure that breaks startup, and describes the concurrency wait timeout as a timeout error when the code raises a rate-limit error.
- `llm-ollama.rst`, `llm-openai.rst`, `llm-gemini.rst` and `rag-chat.rst` all still use the `app/WEB-INF/conf/fess_config.properties` path.
- The 15.7 copies of this page carry the same claims, but should be checked against the 15.7 branch rather than master.
