### PR TITLE
docs(sso-spnego): correct the Kerberos settings for current AD and JDK 21

### DIFF
--- a/de/15.7/config/sso-spnego.rst
+++ b/de/15.7/config/sso-spnego.rst
@@ -1,6 +1,6 @@
-=============================================
+============================================================
 SSO-Konfiguration mit Windows-integrierter Authentifizierung
-=============================================
+============================================================
 
 Übersicht
 =========
@@ -83,9 +83,9 @@ Erstellen Sie ``app/WEB-INF/classes/krb5.conf`` mit der Kerberos-Konfiguration.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,19 @@ Erstellen Sie ``app/WEB-INF/classes/krb5.conf`` mit der Kerberos-Konfiguration.
 
 .. note::
    Ersetzen Sie ``EXAMPLE.LOCAL`` durch Ihren AD-Domänennamen (Großbuchstaben) und ``AD-SERVER.EXAMPLE.LOCAL`` durch Ihren AD-Server-Hostnamen.
+
+.. warning::
+   Ein Service-Ticket mit einem Verschlüsselungstyp, der nicht in ``permitted_enctypes`` aufgeführt ist,
+   wird von der Kerberos-Gegenstelle mit ``encryption type not in permitted_enctypes list`` abgelehnt.
+   Active Directory stellt in der Regel AES256-Service-Tickets aus, daher muss AES256 enthalten sein.
+
+.. note::
+   RC4 (``rc4-hmac``), 3DES und DES sind ab Java 17 standardmäßig deaktiviert; sie aufzuführen hat
+   keine Wirkung. Das obige Beispiel gibt daher nur AES an.
+   ``aes256-cts-hmac-sha384-192`` und ``aes128-cts-hmac-sha256-128`` sind die von Windows Server 2025
+   unterstützten AES-SHA2-Typen (RFC 8009).
+   Ein Dienstkonto, das nur einen RC4-Schlüssel besitzt, kann nicht für die Kerberos-Authentifizierung
+   verwendet werden. Setzen Sie sein Kennwort zurück, damit AES-Schlüssel erzeugt werden.
 
 Login-Konfigurationsdatei
 -------------------------
@@ -119,7 +132,7 @@ Erstellen Sie ``app/WEB-INF/classes/auth_login.conf`` mit der JAAS-Login-Konfigu
 
 .. note::
    Die Standarddateinamen für ``krb5.conf`` und ``auth_login.conf`` werden über ``spnego.krb5.conf`` bzw. ``spnego.login.conf`` festgelegt, die Dateien selbst müssen jedoch zwingend erstellt werden.
-   Sind diese Dateien nicht im Classpath vorhanden, schlägt die SPNEGO-Initialisierung fehl und |Fess| kann nicht gestartet werden.
+   SPNEGO wird bei der ersten Anmeldung initialisiert. Fehlen diese Dateien, startet |Fess| zwar, die SSO-Anmeldung schlägt jedoch fehl.
 
 Erforderliche Einstellungen
 ---------------------------
@@ -179,9 +192,6 @@ Die folgenden Einstellungen können bei Bedarf hinzugefügt werden.
    * - ``spnego.allow.delegation``
      - Delegierung erlauben
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - Von der Authentifizierung ausgeschlossene Verzeichnisse (kommagetrennt)
-     - (Keine)
    * - ``spnego.logger.level``
      - Interner Protokollierungsgrad der SPNEGO-Bibliothek (``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE; alle anderen Werte einschließlich ``0`` und ``5`` werden als INFO behandelt)
      - (Automatisch)
@@ -280,9 +290,9 @@ Das Folgende ist ein minimales Konfigurationsbeispiel für eine Testumgebung.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +372,27 @@ Gruppeninformationen können nicht abgerufen werden
 - Überprüfen Sie, ob die LDAP-Einstellungen korrekt sind
 - Überprüfen Sie, ob Bind-DN und Passwort korrekt sind
 - Überprüfen Sie, ob der Benutzer in AD zu Gruppen gehört
+
+Die Anmeldung liefert HTTP 400
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bei Benutzern mit vielen Gruppenmitgliedschaften wird das Kerberos-Ticket (PAC) groß, und der
+``Authorization``-Header kann Tomcats Standardgrenze von 8 KB überschreiten, was mit 400 beantwortet wird.
+Die Anfrage erreicht |Fess| nie, daher wird nichts protokolliert.
+Erhöhen Sie das Limit in ``tomcat_config.properties``.
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+Nach Änderung des Dienstkonto-Kennworts schlägt die Authentifizierung fehl
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Die Server-Anmeldeinformationen werden einmalig bei der ersten Anmeldung ermittelt und für die
+Laufzeit des Prozesses zwischengespeichert.
+Starten Sie |Fess| neu, nachdem Sie das Kennwort des Dienstkontos in AD geändert oder die
+Keytab-Datei ersetzt haben. Ebenso ist nach einer Änderung von ``spnego.*``-Einstellungen ein
+Neustart erforderlich.
 
 Debug-Einstellungen
 --------------------

--- a/de/15.8/config/sso-spnego.rst
+++ b/de/15.8/config/sso-spnego.rst
@@ -1,6 +1,6 @@
-=============================================
+============================================================
 SSO-Konfiguration mit Windows-integrierter Authentifizierung
-=============================================
+============================================================
 
 Übersicht
 =========
@@ -83,9 +83,9 @@ Erstellen Sie ``app/WEB-INF/classes/krb5.conf`` mit der Kerberos-Konfiguration.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,19 @@ Erstellen Sie ``app/WEB-INF/classes/krb5.conf`` mit der Kerberos-Konfiguration.
 
 .. note::
    Ersetzen Sie ``EXAMPLE.LOCAL`` durch Ihren AD-Domänennamen (Großbuchstaben) und ``AD-SERVER.EXAMPLE.LOCAL`` durch Ihren AD-Server-Hostnamen.
+
+.. warning::
+   Ein Service-Ticket mit einem Verschlüsselungstyp, der nicht in ``permitted_enctypes`` aufgeführt ist,
+   wird von der Kerberos-Gegenstelle mit ``encryption type not in permitted_enctypes list`` abgelehnt.
+   Active Directory stellt in der Regel AES256-Service-Tickets aus, daher muss AES256 enthalten sein.
+
+.. note::
+   RC4 (``rc4-hmac``), 3DES und DES sind ab Java 17 standardmäßig deaktiviert; sie aufzuführen hat
+   keine Wirkung. Das obige Beispiel gibt daher nur AES an.
+   ``aes256-cts-hmac-sha384-192`` und ``aes128-cts-hmac-sha256-128`` sind die von Windows Server 2025
+   unterstützten AES-SHA2-Typen (RFC 8009).
+   Ein Dienstkonto, das nur einen RC4-Schlüssel besitzt, kann nicht für die Kerberos-Authentifizierung
+   verwendet werden. Setzen Sie sein Kennwort zurück, damit AES-Schlüssel erzeugt werden.
 
 Login-Konfigurationsdatei
 -------------------------
@@ -119,7 +132,7 @@ Erstellen Sie ``app/WEB-INF/classes/auth_login.conf`` mit der JAAS-Login-Konfigu
 
 .. note::
    Die Standarddateinamen für ``krb5.conf`` und ``auth_login.conf`` werden über ``spnego.krb5.conf`` bzw. ``spnego.login.conf`` festgelegt, die Dateien selbst müssen jedoch zwingend erstellt werden.
-   Sind diese Dateien nicht im Classpath vorhanden, schlägt die SPNEGO-Initialisierung fehl und |Fess| kann nicht gestartet werden.
+   SPNEGO wird bei der ersten Anmeldung initialisiert. Fehlen diese Dateien, startet |Fess| zwar, die SSO-Anmeldung schlägt jedoch fehl.
 
 Erforderliche Einstellungen
 ---------------------------
@@ -146,6 +159,24 @@ Fügen Sie die folgenden Einstellungen zu ``app/WEB-INF/conf/system.properties``
      - Pfad zur Login-Konfigurationsdatei
      - ``auth_login.conf``
 
+.. note::
+   Bleiben ``spnego.preauth.username`` und ``spnego.preauth.password`` beide leer, verwendet das
+   Server-Login-Modul eine Keytab-Datei.
+   Wenn Sie das Kennwort des AD-Dienstkontos nicht in einer |Fess|-Konfigurationsdatei speichern
+   möchten, erstellen Sie eine Keytab-Datei und konfigurieren Sie ``spnego-server`` in
+   ``auth_login.conf`` wie folgt.
+
+   ::
+
+       spnego-server {
+           com.sun.security.auth.module.Krb5LoginModule required
+           useKeyTab=true
+           keyTab="/var/lib/fess/fess.keytab"
+           principal="HTTP/fess-server.example.local@EXAMPLE.LOCAL"
+           storeKey=true
+           isInitiator=false;
+       };
+
 Optionale Einstellungen
 -----------------------
 
@@ -169,18 +200,18 @@ Die folgenden Einstellungen können bei Bedarf hinzugefügt werden.
      - ``true``
    * - ``spnego.allow.unsecure.basic``
      - Unsichere Basic-Authentifizierung erlauben
-     - ``true``
+     - ``false``
    * - ``spnego.prompt.ntlm``
      - Bei Empfang eines NTLM-Tokens auf Basic-Authentifizierung zurückfallen
      - ``true``
    * - ``spnego.allow.localhost``
      - Localhost-Zugriff erlauben
-     - ``true``
+     - ``false``
    * - ``spnego.allow.delegation``
      - Delegierung erlauben
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - Von der Authentifizierung ausgeschlossene Verzeichnisse (kommagetrennt)
+   * - ``spnego.allowed.realms``
+     - Zusätzlich zur Server-Realm akzeptierte Kerberos-Realms (kommagetrennt)
      - (Keine)
    * - ``spnego.logger.level``
      - Interner Protokollierungsgrad der SPNEGO-Bibliothek (``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE; alle anderen Werte einschließlich ``0`` und ``5`` werden als INFO behandelt)
@@ -280,9 +311,9 @@ Das Folgende ist ein minimales Konfigurationsbeispiel für eine Testumgebung.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +393,27 @@ Gruppeninformationen können nicht abgerufen werden
 - Überprüfen Sie, ob die LDAP-Einstellungen korrekt sind
 - Überprüfen Sie, ob Bind-DN und Passwort korrekt sind
 - Überprüfen Sie, ob der Benutzer in AD zu Gruppen gehört
+
+Die Anmeldung liefert HTTP 400
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bei Benutzern mit vielen Gruppenmitgliedschaften wird das Kerberos-Ticket (PAC) groß, und der
+``Authorization``-Header kann Tomcats Standardgrenze von 8 KB überschreiten, was mit 400 beantwortet wird.
+Die Anfrage erreicht |Fess| nie, daher wird nichts protokolliert.
+Erhöhen Sie das Limit in ``tomcat_config.properties``.
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+Nach Änderung des Dienstkonto-Kennworts schlägt die Authentifizierung fehl
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Die Server-Anmeldeinformationen werden einmalig bei der ersten Anmeldung ermittelt und für die
+Laufzeit des Prozesses zwischengespeichert.
+Starten Sie |Fess| neu, nachdem Sie das Kennwort des Dienstkontos in AD geändert oder die
+Keytab-Datei ersetzt haben. Ebenso ist nach einer Änderung von ``spnego.*``-Einstellungen ein
+Neustart erforderlich.
 
 Debug-Einstellungen
 --------------------

--- a/de/15.8/config/sso-spnego.rst
+++ b/de/15.8/config/sso-spnego.rst
@@ -222,6 +222,22 @@ Die folgenden Einstellungen können bei Bedarf hinzugefügt werden.
    Für Produktionsumgebungen wird dringend empfohlen, dies auf ``false`` zu setzen und HTTPS zu verwenden.
 
 .. note::
+   Mit ``spnego.allow.unsecure.basic=false`` (Standard) wird die Basic-Authentifizierung nur für
+   Anfragen angeboten, bei denen ``HttpServletRequest#isSecure()`` ``true`` zurückgibt.
+   Wird TLS an einem Reverse-Proxy terminiert und die Anfrage per HTTP an |Fess| weitergeleitet,
+   ist dieser Wert ``false``. Ein Client, der kein Kerberos-Ticket erhalten kann und auf NTLM
+   zurückfällt, kann sich dann nicht anmelden. Setzen Sie ``tomcat.secure=true`` in
+   ``tomcat_config.properties``, damit |Fess| die Anfrage als über HTTPS eingegangen behandelt.
+
+.. warning::
+   In |Fess| 15.8 wird eine Anmeldung standardmäßig abgelehnt, wenn sich die Realm des
+   Client-Principals von der Realm des Servers unterscheidet. Melden sich Benutzer aus einer
+   untergeordneten Domäne einer AD-Domänenstruktur oder aus einer vertrauten Gesamtstruktur an,
+   tragen Sie diese Realms kommagetrennt in ``spnego.allowed.realms`` ein. Andernfalls werden
+   Benutzer, die sich bis 15.7 anmelden konnten, mit ``Kerberos realm is not allowed``
+   abgewiesen.
+
+.. note::
    Wenn ``spnego.prompt.ntlm=true`` (Standard), muss auch ``spnego.allow.basic`` auf ``true`` gesetzt sein.
    Wenn Sie ``spnego.allow.basic=false`` setzen, müssen Sie gleichzeitig ``spnego.prompt.ntlm=false`` setzen.
    Wird diese Bedingung nicht erfüllt, tritt bei der SPNEGO-Initialisierung ein Fehler auf.

--- a/en/15.7/config/sso-spnego.rst
+++ b/en/15.7/config/sso-spnego.rst
@@ -83,9 +83,9 @@ Create ``app/WEB-INF/classes/krb5.conf`` with the Kerberos configuration.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,19 @@ Create ``app/WEB-INF/classes/krb5.conf`` with the Kerberos configuration.
 
 .. note::
    Replace ``EXAMPLE.LOCAL`` with your AD domain name (uppercase) and ``AD-SERVER.EXAMPLE.LOCAL`` with your AD server hostname.
+
+.. warning::
+   A service ticket encrypted with a type that is not listed in ``permitted_enctypes`` is rejected by
+   the Kerberos acceptor as ``encryption type not in permitted_enctypes list``.
+   Active Directory normally issues AES256 service tickets, so AES256 must be listed.
+
+.. note::
+   RC4 (``rc4-hmac``), 3DES and DES are disabled by default in Java 17 and later, so listing them has
+   no effect; the example above specifies AES only.
+   ``aes256-cts-hmac-sha384-192`` and ``aes128-cts-hmac-sha256-128`` are the AES-SHA2 (RFC 8009) types
+   supported by Windows Server 2025.
+   A service account that holds only an RC4 key cannot be used for Kerberos authentication; reset its
+   password so that AES keys are generated.
 
 Login Configuration File
 ------------------------
@@ -119,7 +132,7 @@ Create ``app/WEB-INF/classes/auth_login.conf`` with the JAAS login configuration
 
 .. note::
    ``krb5.conf`` and ``auth_login.conf`` have their default filenames set via ``spnego.krb5.conf`` / ``spnego.login.conf``, but the files themselves must be created.
-   If these files do not exist on the classpath, SPNEGO initialization will fail and |Fess| will not start.
+   SPNEGO is initialized on the first login, so |Fess| itself still starts when these files are missing, but SSO login fails.
 
 Required Settings
 -----------------
@@ -179,9 +192,6 @@ The following settings can be added as needed.
    * - ``spnego.allow.delegation``
      - Allow delegation
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - Directories to exclude from authentication (comma-separated)
-     - (None)
    * - ``spnego.logger.level``
      - Internal log level of the SPNEGO library (``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE; any other value including ``0`` and ``5`` is treated as INFO)
      - (Auto)
@@ -280,9 +290,9 @@ The following is a minimal configuration example for a test environment.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +372,25 @@ Cannot Retrieve Group Information
 - Verify that LDAP settings are correct
 - Check that Bind DN and password are correct
 - Verify that the user belongs to groups in AD
+
+Login returns HTTP 400
+~~~~~~~~~~~~~~~~~~~~~~
+
+For a user who belongs to many groups the Kerberos ticket (PAC) grows large, and the
+``Authorization`` header can exceed Tomcat's default limit of 8KB, which is answered with 400.
+The request never reaches |Fess|, so nothing is written to the log.
+Raise the limit in ``tomcat_config.properties``.
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+Authentication fails after the service account password is changed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The server credential is obtained once on the first login and cached for the lifetime of the process.
+Restart |Fess| after changing the service account password in AD or replacing the keytab.
+A restart is likewise required after changing any ``spnego.*`` setting.
 
 Debug Settings
 --------------

--- a/en/15.8/config/sso-spnego.rst
+++ b/en/15.8/config/sso-spnego.rst
@@ -221,6 +221,21 @@ The following settings can be added as needed.
    For production environments, it is strongly recommended to set this to ``false`` and use HTTPS.
 
 .. note::
+   With ``spnego.allow.unsecure.basic=false`` (the default), Basic authentication is only offered
+   for requests where ``HttpServletRequest#isSecure()`` returns ``true``.
+   When TLS is terminated at a reverse proxy and the request is forwarded to |Fess| over HTTP,
+   that value is ``false``, so a client that cannot obtain a Kerberos ticket and falls back to
+   NTLM cannot log in. Set ``tomcat.secure=true`` in ``tomcat_config.properties`` to tell |Fess|
+   that the request arrived over HTTPS.
+
+.. warning::
+   In |Fess| 15.8, a login is rejected by default when the realm of the client principal differs
+   from the server realm. If users log in from a child domain of an AD domain tree or from a
+   trusted forest, list those realms in ``spnego.allowed.realms``, separated by commas.
+   Otherwise users who could log in up to 15.7 are rejected with
+   ``Kerberos realm is not allowed``.
+
+.. note::
    When ``spnego.prompt.ntlm=true`` (the default), ``spnego.allow.basic`` must also be ``true``.
    If you set ``spnego.allow.basic=false``, you must also set ``spnego.prompt.ntlm=false``.
    If this condition is not met, an error will occur during SPNEGO initialization.

--- a/en/15.8/config/sso-spnego.rst
+++ b/en/15.8/config/sso-spnego.rst
@@ -83,9 +83,9 @@ Create ``app/WEB-INF/classes/krb5.conf`` with the Kerberos configuration.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,19 @@ Create ``app/WEB-INF/classes/krb5.conf`` with the Kerberos configuration.
 
 .. note::
    Replace ``EXAMPLE.LOCAL`` with your AD domain name (uppercase) and ``AD-SERVER.EXAMPLE.LOCAL`` with your AD server hostname.
+
+.. warning::
+   A service ticket encrypted with a type that is not listed in ``permitted_enctypes`` is rejected by
+   the Kerberos acceptor as ``encryption type not in permitted_enctypes list``.
+   Active Directory normally issues AES256 service tickets, so AES256 must be listed.
+
+.. note::
+   RC4 (``rc4-hmac``), 3DES and DES are disabled by default in Java 17 and later, so listing them has
+   no effect; the example above specifies AES only.
+   ``aes256-cts-hmac-sha384-192`` and ``aes128-cts-hmac-sha256-128`` are the AES-SHA2 (RFC 8009) types
+   supported by Windows Server 2025.
+   A service account that holds only an RC4 key cannot be used for Kerberos authentication; reset its
+   password so that AES keys are generated.
 
 Login Configuration File
 ------------------------
@@ -119,7 +132,7 @@ Create ``app/WEB-INF/classes/auth_login.conf`` with the JAAS login configuration
 
 .. note::
    ``krb5.conf`` and ``auth_login.conf`` have their default filenames set via ``spnego.krb5.conf`` / ``spnego.login.conf``, but the files themselves must be created.
-   If these files do not exist on the classpath, SPNEGO initialization will fail and |Fess| will not start.
+   SPNEGO is initialized on the first login, so |Fess| itself still starts when these files are missing, but SSO login fails.
 
 Required Settings
 -----------------
@@ -146,6 +159,23 @@ Add the following settings to ``app/WEB-INF/conf/system.properties``.
      - Login configuration file path
      - ``auth_login.conf``
 
+.. note::
+   Leaving both ``spnego.preauth.username`` and ``spnego.preauth.password`` empty makes the server
+   login module use a keytab.
+   If you do not want to store the AD service account password in a |Fess| configuration file, create
+   a keytab and configure ``spnego-server`` in ``auth_login.conf`` as follows.
+
+   ::
+
+       spnego-server {
+           com.sun.security.auth.module.Krb5LoginModule required
+           useKeyTab=true
+           keyTab="/var/lib/fess/fess.keytab"
+           principal="HTTP/fess-server.example.local@EXAMPLE.LOCAL"
+           storeKey=true
+           isInitiator=false;
+       };
+
 Optional Settings
 -----------------
 
@@ -169,18 +199,18 @@ The following settings can be added as needed.
      - ``true``
    * - ``spnego.allow.unsecure.basic``
      - Allow unsecure Basic authentication
-     - ``true``
+     - ``false``
    * - ``spnego.prompt.ntlm``
      - Fall back to Basic authentication when an NTLM token is received
      - ``true``
    * - ``spnego.allow.localhost``
      - Allow localhost access
-     - ``true``
+     - ``false``
    * - ``spnego.allow.delegation``
      - Allow delegation
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - Directories to exclude from authentication (comma-separated)
+   * - ``spnego.allowed.realms``
+     - Kerberos realms accepted in addition to the server realm (comma-separated)
      - (None)
    * - ``spnego.logger.level``
      - Internal log level of the SPNEGO library (``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE; any other value including ``0`` and ``5`` is treated as INFO)
@@ -280,9 +310,9 @@ The following is a minimal configuration example for a test environment.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +392,25 @@ Cannot Retrieve Group Information
 - Verify that LDAP settings are correct
 - Check that Bind DN and password are correct
 - Verify that the user belongs to groups in AD
+
+Login returns HTTP 400
+~~~~~~~~~~~~~~~~~~~~~~
+
+For a user who belongs to many groups the Kerberos ticket (PAC) grows large, and the
+``Authorization`` header can exceed Tomcat's default limit of 8KB, which is answered with 400.
+The request never reaches |Fess|, so nothing is written to the log.
+Raise the limit in ``tomcat_config.properties``.
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+Authentication fails after the service account password is changed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The server credential is obtained once on the first login and cached for the lifetime of the process.
+Restart |Fess| after changing the service account password in AD or replacing the keytab.
+A restart is likewise required after changing any ``spnego.*`` setting.
 
 Debug Settings
 --------------

--- a/es/15.7/config/sso-spnego.rst
+++ b/es/15.7/config/sso-spnego.rst
@@ -83,9 +83,9 @@ Cree ``app/WEB-INF/classes/krb5.conf`` con la configuración de Kerberos.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,19 @@ Cree ``app/WEB-INF/classes/krb5.conf`` con la configuración de Kerberos.
 
 .. note::
    Reemplace ``EXAMPLE.LOCAL`` con su nombre de dominio AD (en mayúsculas) y ``AD-SERVER.EXAMPLE.LOCAL`` con el nombre de host de su servidor AD.
+
+.. warning::
+   Un ticket de servicio cifrado con un tipo que no aparece en ``permitted_enctypes`` es rechazado por
+   el aceptador de Kerberos con ``encryption type not in permitted_enctypes list``.
+   Active Directory suele emitir tickets de servicio AES256, por lo que AES256 debe estar incluido.
+
+.. note::
+   RC4 (``rc4-hmac``), 3DES y DES están deshabilitados de forma predeterminada en Java 17 y posteriores,
+   por lo que incluirlos no tiene efecto; el ejemplo anterior especifica solo AES.
+   ``aes256-cts-hmac-sha384-192`` y ``aes128-cts-hmac-sha256-128`` son los tipos AES-SHA2 (RFC 8009)
+   compatibles con Windows Server 2025.
+   Una cuenta de servicio que solo tiene una clave RC4 no puede usarse para la autenticación Kerberos;
+   restablezca su contraseña para que se generen claves AES.
 
 Archivo de configuración de inicio de sesión
 ---------------------------------------------
@@ -119,7 +132,7 @@ Cree ``app/WEB-INF/classes/auth_login.conf`` con la configuración de inicio de 
 
 .. note::
    Los nombres de archivo predeterminados para ``krb5.conf`` y ``auth_login.conf`` están definidos en ``spnego.krb5.conf`` y ``spnego.login.conf`` respectivamente, pero los archivos en sí deben crearse obligatoriamente.
-   Si estos archivos no están presentes en el classpath, la inicialización de SPNEGO fallará y |Fess| no podrá iniciarse.
+   SPNEGO se inicializa en el primer inicio de sesión, por lo que |Fess| arranca aunque falten estos archivos, pero el inicio de sesión SSO falla.
 
 Configuración requerida
 -----------------------
@@ -179,9 +192,6 @@ Las siguientes configuraciones pueden agregarse según sea necesario.
    * - ``spnego.allow.delegation``
      - Permitir delegación
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - Directorios excluidos de autenticación (separados por comas)
-     - (Ninguno)
    * - ``spnego.logger.level``
      - Nivel de log interno de la biblioteca SPNEGO (``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE; cualquier otro valor, incluidos ``0`` y ``5``, se trata como INFO)
      - (Automático)
@@ -280,9 +290,9 @@ El siguiente es un ejemplo de configuración mínima para un entorno de pruebas.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +372,26 @@ No se puede recuperar la información de grupo
 - Verifique que la configuración LDAP es correcta
 - Verifique que el Bind DN y la contraseña son correctos
 - Verifique que el usuario pertenece a grupos en AD
+
+El inicio de sesión devuelve HTTP 400
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Para un usuario que pertenece a muchos grupos, el ticket Kerberos (PAC) crece y la cabecera
+``Authorization`` puede superar el límite predeterminado de Tomcat de 8 KB, que se responde con 400.
+La petición nunca llega a |Fess|, por lo que no se registra nada en el log.
+Aumente el límite en ``tomcat_config.properties``.
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+La autenticación falla tras cambiar la contraseña de la cuenta de servicio
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+La credencial del servidor se obtiene una sola vez en el primer inicio de sesión y se almacena en
+caché durante toda la vida del proceso.
+Reinicie |Fess| después de cambiar la contraseña de la cuenta de servicio en AD o de sustituir el
+keytab. También es necesario reiniciar tras modificar cualquier ajuste ``spnego.*``.
 
 Configuración de depuración
 -----------------------------

--- a/es/15.8/config/sso-spnego.rst
+++ b/es/15.8/config/sso-spnego.rst
@@ -83,9 +83,9 @@ Cree ``app/WEB-INF/classes/krb5.conf`` con la configuración de Kerberos.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,19 @@ Cree ``app/WEB-INF/classes/krb5.conf`` con la configuración de Kerberos.
 
 .. note::
    Reemplace ``EXAMPLE.LOCAL`` con su nombre de dominio AD (en mayúsculas) y ``AD-SERVER.EXAMPLE.LOCAL`` con el nombre de host de su servidor AD.
+
+.. warning::
+   Un ticket de servicio cifrado con un tipo que no aparece en ``permitted_enctypes`` es rechazado por
+   el aceptador de Kerberos con ``encryption type not in permitted_enctypes list``.
+   Active Directory suele emitir tickets de servicio AES256, por lo que AES256 debe estar incluido.
+
+.. note::
+   RC4 (``rc4-hmac``), 3DES y DES están deshabilitados de forma predeterminada en Java 17 y posteriores,
+   por lo que incluirlos no tiene efecto; el ejemplo anterior especifica solo AES.
+   ``aes256-cts-hmac-sha384-192`` y ``aes128-cts-hmac-sha256-128`` son los tipos AES-SHA2 (RFC 8009)
+   compatibles con Windows Server 2025.
+   Una cuenta de servicio que solo tiene una clave RC4 no puede usarse para la autenticación Kerberos;
+   restablezca su contraseña para que se generen claves AES.
 
 Archivo de configuración de inicio de sesión
 ---------------------------------------------
@@ -119,7 +132,7 @@ Cree ``app/WEB-INF/classes/auth_login.conf`` con la configuración de inicio de 
 
 .. note::
    Los nombres de archivo predeterminados para ``krb5.conf`` y ``auth_login.conf`` están definidos en ``spnego.krb5.conf`` y ``spnego.login.conf`` respectivamente, pero los archivos en sí deben crearse obligatoriamente.
-   Si estos archivos no están presentes en el classpath, la inicialización de SPNEGO fallará y |Fess| no podrá iniciarse.
+   SPNEGO se inicializa en el primer inicio de sesión, por lo que |Fess| arranca aunque falten estos archivos, pero el inicio de sesión SSO falla.
 
 Configuración requerida
 -----------------------
@@ -146,6 +159,23 @@ Agregue la siguiente configuración a ``app/WEB-INF/conf/system.properties``.
      - Ruta del archivo de configuración de inicio de sesión
      - ``auth_login.conf``
 
+.. note::
+   Si deja vacíos tanto ``spnego.preauth.username`` como ``spnego.preauth.password``, el módulo de
+   inicio de sesión del servidor utiliza un keytab.
+   Si no desea almacenar la contraseña de la cuenta de servicio de AD en un archivo de configuración
+   de |Fess|, cree un keytab y configure ``spnego-server`` en ``auth_login.conf`` de la siguiente manera.
+
+   ::
+
+       spnego-server {
+           com.sun.security.auth.module.Krb5LoginModule required
+           useKeyTab=true
+           keyTab="/var/lib/fess/fess.keytab"
+           principal="HTTP/fess-server.example.local@EXAMPLE.LOCAL"
+           storeKey=true
+           isInitiator=false;
+       };
+
 Configuración opcional
 ----------------------
 
@@ -169,18 +199,18 @@ Las siguientes configuraciones pueden agregarse según sea necesario.
      - ``true``
    * - ``spnego.allow.unsecure.basic``
      - Permitir autenticación Basic no segura
-     - ``true``
+     - ``false``
    * - ``spnego.prompt.ntlm``
      - Retroceder a autenticación Basic cuando se recibe un token NTLM
      - ``true``
    * - ``spnego.allow.localhost``
      - Permitir acceso desde localhost
-     - ``true``
+     - ``false``
    * - ``spnego.allow.delegation``
      - Permitir delegación
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - Directorios excluidos de autenticación (separados por comas)
+   * - ``spnego.allowed.realms``
+     - Reinos Kerberos aceptados además del reino del servidor (separados por comas)
      - (Ninguno)
    * - ``spnego.logger.level``
      - Nivel de log interno de la biblioteca SPNEGO (``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE; cualquier otro valor, incluidos ``0`` y ``5``, se trata como INFO)
@@ -280,9 +310,9 @@ El siguiente es un ejemplo de configuración mínima para un entorno de pruebas.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +392,26 @@ No se puede recuperar la información de grupo
 - Verifique que la configuración LDAP es correcta
 - Verifique que el Bind DN y la contraseña son correctos
 - Verifique que el usuario pertenece a grupos en AD
+
+El inicio de sesión devuelve HTTP 400
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Para un usuario que pertenece a muchos grupos, el ticket Kerberos (PAC) crece y la cabecera
+``Authorization`` puede superar el límite predeterminado de Tomcat de 8 KB, que se responde con 400.
+La petición nunca llega a |Fess|, por lo que no se registra nada en el log.
+Aumente el límite en ``tomcat_config.properties``.
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+La autenticación falla tras cambiar la contraseña de la cuenta de servicio
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+La credencial del servidor se obtiene una sola vez en el primer inicio de sesión y se almacena en
+caché durante toda la vida del proceso.
+Reinicie |Fess| después de cambiar la contraseña de la cuenta de servicio en AD o de sustituir el
+keytab. También es necesario reiniciar tras modificar cualquier ajuste ``spnego.*``.
 
 Configuración de depuración
 -----------------------------

--- a/es/15.8/config/sso-spnego.rst
+++ b/es/15.8/config/sso-spnego.rst
@@ -221,6 +221,22 @@ Las siguientes configuraciones pueden agregarse según sea necesario.
    Para entornos de producción, se recomienda encarecidamente establecer esto en ``false`` y usar HTTPS.
 
 .. note::
+   Con ``spnego.allow.unsecure.basic=false`` (valor predeterminado), la autenticación básica solo
+   se ofrece en las peticiones en las que ``HttpServletRequest#isSecure()`` devuelve ``true``.
+   Si TLS se termina en un proxy inverso y la petición se reenvía a |Fess| por HTTP, ese valor es
+   ``false``, por lo que un cliente que no puede obtener un tique de Kerberos y recurre a NTLM no
+   puede iniciar sesión. Establezca ``tomcat.secure=true`` en ``tomcat_config.properties`` para
+   indicar a |Fess| que la petición llegó por HTTPS.
+
+.. warning::
+   En |Fess| 15.8, un inicio de sesión se rechaza de forma predeterminada cuando el reino del
+   principal del cliente difiere del reino del servidor. Si los usuarios inician sesión desde un
+   dominio secundario de un árbol de dominios de AD o desde un bosque de confianza, indique esos
+   reinos en ``spnego.allowed.realms``, separados por comas. De lo contrario, los usuarios que
+   podían iniciar sesión hasta la versión 15.7 son rechazados con
+   ``Kerberos realm is not allowed``.
+
+.. note::
    Cuando ``spnego.prompt.ntlm=true`` (valor predeterminado), ``spnego.allow.basic`` también debe ser ``true``.
    Si establece ``spnego.allow.basic=false``, debe establecer también ``spnego.prompt.ntlm=false``.
    Si no se cumple esta condición, se producirá un error durante la inicialización de SPNEGO.

--- a/fr/15.7/config/sso-spnego.rst
+++ b/fr/15.7/config/sso-spnego.rst
@@ -83,9 +83,9 @@ Créez ``app/WEB-INF/classes/krb5.conf`` avec la configuration Kerberos.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,19 @@ Créez ``app/WEB-INF/classes/krb5.conf`` avec la configuration Kerberos.
 
 .. note::
    Remplacez ``EXAMPLE.LOCAL`` par votre nom de domaine AD (en majuscules) et ``AD-SERVER.EXAMPLE.LOCAL`` par le nom d'hôte de votre serveur AD.
+
+.. warning::
+   Un ticket de service chiffré avec un type absent de ``permitted_enctypes`` est rejeté par
+   l'accepteur Kerberos avec ``encryption type not in permitted_enctypes list``.
+   Active Directory émet normalement des tickets de service AES256 : AES256 doit donc figurer dans la liste.
+
+.. note::
+   RC4 (``rc4-hmac``), 3DES et DES sont désactivés par défaut à partir de Java 17 ; les mentionner n'a
+   donc aucun effet et l'exemple ci-dessus ne spécifie que AES.
+   ``aes256-cts-hmac-sha384-192`` et ``aes128-cts-hmac-sha256-128`` sont les types AES-SHA2 (RFC 8009)
+   pris en charge par Windows Server 2025.
+   Un compte de service ne disposant que d'une clé RC4 ne peut pas servir à l'authentification Kerberos :
+   réinitialisez son mot de passe afin que des clés AES soient générées.
 
 Fichier de configuration de connexion
 -------------------------------------
@@ -119,7 +132,7 @@ Créez ``app/WEB-INF/classes/auth_login.conf`` avec la configuration de connexio
 
 .. note::
    Les noms de fichier par défaut de ``krb5.conf`` et ``auth_login.conf`` sont définis respectivement par ``spnego.krb5.conf`` et ``spnego.login.conf``, mais ces fichiers doivent impérativement être créés.
-   Si ces fichiers sont absents du classpath, l'initialisation de SPNEGO échoue et |Fess| ne peut pas démarrer.
+   SPNEGO est initialisé lors de la première connexion : |Fess| démarre donc même si ces fichiers sont absents, mais la connexion SSO échoue.
 
 Paramètres requis
 -----------------
@@ -179,9 +192,6 @@ Les paramètres suivants peuvent être ajoutés si nécessaire.
    * - ``spnego.allow.delegation``
      - Autoriser la délégation
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - Répertoires exclus de l'authentification (séparés par des virgules)
-     - (Aucun)
    * - ``spnego.logger.level``
      - Niveau de log interne de la bibliothèque SPNEGO (``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE ; toute autre valeur, y compris ``0`` et ``5``, est traitée comme INFO)
      - (Automatique)
@@ -280,9 +290,9 @@ Voici un exemple de configuration minimale pour un environnement de test.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +372,26 @@ Impossible de récupérer les informations de groupe
 - Vérifiez que les paramètres LDAP sont corrects
 - Vérifiez que le Bind DN et le mot de passe sont corrects
 - Vérifiez que l'utilisateur appartient à des groupes dans AD
+
+La connexion renvoie HTTP 400
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pour un utilisateur appartenant à de nombreux groupes, le ticket Kerberos (PAC) devient volumineux et
+l'en-tête ``Authorization`` peut dépasser la limite par défaut de Tomcat (8 Ko), ce qui donne un 400.
+La requête n'atteint jamais |Fess| : rien n'est écrit dans le journal.
+Augmentez la limite dans ``tomcat_config.properties``.
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+L'authentification échoue après le changement du mot de passe du compte de service
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Les informations d'identification du serveur sont obtenues une seule fois lors de la première
+connexion, puis mises en cache pour toute la durée de vie du processus.
+Redémarrez |Fess| après avoir changé le mot de passe du compte de service dans AD ou remplacé le
+keytab. Un redémarrage est également requis après toute modification d'un paramètre ``spnego.*``.
 
 Paramètres de débogage
 ----------------------

--- a/fr/15.8/config/sso-spnego.rst
+++ b/fr/15.8/config/sso-spnego.rst
@@ -222,6 +222,21 @@ Les paramètres suivants peuvent être ajoutés si nécessaire.
    Pour les environnements de production, il est fortement recommandé de définir cette valeur sur ``false`` et d'utiliser HTTPS.
 
 .. note::
+   Avec ``spnego.allow.unsecure.basic=false`` (valeur par défaut), l'authentification Basic n'est
+   proposée que pour les requêtes dont ``HttpServletRequest#isSecure()`` renvoie ``true``.
+   Lorsque TLS est terminé par un proxy inverse et que la requête est transmise à |Fess| en HTTP,
+   cette valeur est ``false`` : un client qui ne peut pas obtenir de ticket Kerberos et bascule
+   vers NTLM ne peut donc pas se connecter. Définissez ``tomcat.secure=true`` dans
+   ``tomcat_config.properties`` pour indiquer à |Fess| que la requête est arrivée en HTTPS.
+
+.. warning::
+   Dans |Fess| 15.8, une connexion est refusée par défaut lorsque le domaine Kerberos du principal
+   client diffère de celui du serveur. Si des utilisateurs se connectent depuis un domaine enfant
+   d'une arborescence de domaines AD ou depuis une forêt approuvée, indiquez ces domaines dans
+   ``spnego.allowed.realms``, séparés par des virgules. Sinon, les utilisateurs qui pouvaient se
+   connecter jusqu'à la version 15.7 sont refusés avec ``Kerberos realm is not allowed``.
+
+.. note::
    Lorsque ``spnego.prompt.ntlm=true`` (valeur par défaut), ``spnego.allow.basic`` doit également être ``true``.
    Si vous définissez ``spnego.allow.basic=false``, vous devez également définir ``spnego.prompt.ntlm=false``.
    Si cette condition n'est pas respectée, une erreur se produit lors de l'initialisation de SPNEGO.

--- a/fr/15.8/config/sso-spnego.rst
+++ b/fr/15.8/config/sso-spnego.rst
@@ -83,9 +83,9 @@ Créez ``app/WEB-INF/classes/krb5.conf`` avec la configuration Kerberos.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,19 @@ Créez ``app/WEB-INF/classes/krb5.conf`` avec la configuration Kerberos.
 
 .. note::
    Remplacez ``EXAMPLE.LOCAL`` par votre nom de domaine AD (en majuscules) et ``AD-SERVER.EXAMPLE.LOCAL`` par le nom d'hôte de votre serveur AD.
+
+.. warning::
+   Un ticket de service chiffré avec un type absent de ``permitted_enctypes`` est rejeté par
+   l'accepteur Kerberos avec ``encryption type not in permitted_enctypes list``.
+   Active Directory émet normalement des tickets de service AES256 : AES256 doit donc figurer dans la liste.
+
+.. note::
+   RC4 (``rc4-hmac``), 3DES et DES sont désactivés par défaut à partir de Java 17 ; les mentionner n'a
+   donc aucun effet et l'exemple ci-dessus ne spécifie que AES.
+   ``aes256-cts-hmac-sha384-192`` et ``aes128-cts-hmac-sha256-128`` sont les types AES-SHA2 (RFC 8009)
+   pris en charge par Windows Server 2025.
+   Un compte de service ne disposant que d'une clé RC4 ne peut pas servir à l'authentification Kerberos :
+   réinitialisez son mot de passe afin que des clés AES soient générées.
 
 Fichier de configuration de connexion
 -------------------------------------
@@ -119,7 +132,7 @@ Créez ``app/WEB-INF/classes/auth_login.conf`` avec la configuration de connexio
 
 .. note::
    Les noms de fichier par défaut de ``krb5.conf`` et ``auth_login.conf`` sont définis respectivement par ``spnego.krb5.conf`` et ``spnego.login.conf``, mais ces fichiers doivent impérativement être créés.
-   Si ces fichiers sont absents du classpath, l'initialisation de SPNEGO échoue et |Fess| ne peut pas démarrer.
+   SPNEGO est initialisé lors de la première connexion : |Fess| démarre donc même si ces fichiers sont absents, mais la connexion SSO échoue.
 
 Paramètres requis
 -----------------
@@ -146,6 +159,24 @@ Ajoutez les paramètres suivants à ``app/WEB-INF/conf/system.properties``.
      - Chemin du fichier de configuration de connexion
      - ``auth_login.conf``
 
+.. note::
+   Si ``spnego.preauth.username`` et ``spnego.preauth.password`` sont tous deux vides, le module de
+   connexion serveur utilise un keytab.
+   Si vous ne souhaitez pas stocker le mot de passe du compte de service AD dans un fichier de
+   configuration |Fess|, créez un keytab et configurez ``spnego-server`` dans ``auth_login.conf``
+   comme suit.
+
+   ::
+
+       spnego-server {
+           com.sun.security.auth.module.Krb5LoginModule required
+           useKeyTab=true
+           keyTab="/var/lib/fess/fess.keytab"
+           principal="HTTP/fess-server.example.local@EXAMPLE.LOCAL"
+           storeKey=true
+           isInitiator=false;
+       };
+
 Paramètres optionnels
 ---------------------
 
@@ -169,18 +200,18 @@ Les paramètres suivants peuvent être ajoutés si nécessaire.
      - ``true``
    * - ``spnego.allow.unsecure.basic``
      - Autoriser l'authentification Basic non sécurisée
-     - ``true``
+     - ``false``
    * - ``spnego.prompt.ntlm``
      - Revenir à l'authentification Basic lors de la réception d'un jeton NTLM
      - ``true``
    * - ``spnego.allow.localhost``
      - Autoriser l'accès depuis localhost
-     - ``true``
+     - ``false``
    * - ``spnego.allow.delegation``
      - Autoriser la délégation
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - Répertoires exclus de l'authentification (séparés par des virgules)
+   * - ``spnego.allowed.realms``
+     - Domaines Kerberos acceptés en plus du domaine du serveur (séparés par des virgules)
      - (Aucun)
    * - ``spnego.logger.level``
      - Niveau de log interne de la bibliothèque SPNEGO (``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE ; toute autre valeur, y compris ``0`` et ``5``, est traitée comme INFO)
@@ -280,9 +311,9 @@ Voici un exemple de configuration minimale pour un environnement de test.
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +393,26 @@ Impossible de récupérer les informations de groupe
 - Vérifiez que les paramètres LDAP sont corrects
 - Vérifiez que le Bind DN et le mot de passe sont corrects
 - Vérifiez que l'utilisateur appartient à des groupes dans AD
+
+La connexion renvoie HTTP 400
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pour un utilisateur appartenant à de nombreux groupes, le ticket Kerberos (PAC) devient volumineux et
+l'en-tête ``Authorization`` peut dépasser la limite par défaut de Tomcat (8 Ko), ce qui donne un 400.
+La requête n'atteint jamais |Fess| : rien n'est écrit dans le journal.
+Augmentez la limite dans ``tomcat_config.properties``.
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+L'authentification échoue après le changement du mot de passe du compte de service
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Les informations d'identification du serveur sont obtenues une seule fois lors de la première
+connexion, puis mises en cache pour toute la durée de vie du processus.
+Redémarrez |Fess| après avoir changé le mot de passe du compte de service dans AD ou remplacé le
+keytab. Un redémarrage est également requis après toute modification d'un paramètre ``spnego.*``.
 
 Paramètres de débogage
 ----------------------

--- a/ja/15.7/config/sso-spnego.rst
+++ b/ja/15.7/config/sso-spnego.rst
@@ -83,9 +83,9 @@ Kerberos設定ファイル
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,19 @@ Kerberos設定ファイル
 
 .. note::
    ``EXAMPLE.LOCAL`` はお使いのADドメイン名（大文字）に、 ``AD-SERVER.EXAMPLE.LOCAL`` はADサーバーのホスト名に置き換えてください。
+
+.. warning::
+   ``permitted_enctypes`` に含まれていない暗号化方式のサービスチケットは、Kerberos の受け入れ側で
+   ``encryption type not in permitted_enctypes list`` として拒否されます。
+   Active Directory は通常 AES256 のサービスチケットを発行するため、AES256 を必ず含めてください。
+
+.. note::
+   Java 17 以降では RC4（ ``rc4-hmac`` ）、3DES、DES が既定で無効化されているため、
+   これらを列挙しても使用されません。上記の例では AES のみを指定しています。
+   ``aes256-cts-hmac-sha384-192`` と ``aes128-cts-hmac-sha256-128`` は、Windows Server 2025 が対応する
+   AES-SHA2（RFC 8009）の暗号化方式です。
+   RC4 の鍵しか持たないサービスアカウントでは Kerberos 認証に失敗するため、
+   パスワードを再設定して AES の鍵を生成してください。
 
 ログイン設定ファイル
 --------------------
@@ -119,7 +132,7 @@ Kerberos設定ファイル
 
 .. note::
    ``krb5.conf`` と ``auth_login.conf`` は、 ``spnego.krb5.conf`` / ``spnego.login.conf`` でデフォルトのファイル名が設定されますが、ファイル自体は必ず作成しておく必要があります。
-   これらのファイルがクラスパス上に存在しない場合、SPNEGOの初期化に失敗し |Fess| が起動できません。
+   SPNEGO の初期化は最初のログイン時に行われるため、これらのファイルが存在しなくても |Fess| 自体は起動しますが、SSO ログインが失敗します。
 
 必須設定
 --------
@@ -179,9 +192,6 @@ Kerberos設定ファイル
    * - ``spnego.allow.delegation``
      - 委任を許可
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - 認証除外ディレクトリ（カンマ区切り）
-     - （なし）
    * - ``spnego.logger.level``
      - SPNEGOライブラリ内部のログレベル（``1`` =FINEST、 ``2`` =FINER、 ``3`` =FINE、 ``4`` =CONFIG、 ``6`` =WARNING、 ``7`` =SEVERE。これら以外の値（ ``0`` 、 ``5`` を含む）はINFO扱い）
      - （自動）
@@ -280,9 +290,9 @@ Mozilla Firefox
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +372,25 @@ Mozilla Firefox
 - LDAP設定が正しいか確認
 - Bind DNとパスワードが正しいか確認
 - ユーザーがADでグループに所属しているか確認
+
+ログインがHTTP 400になる
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+所属グループが多いユーザーはKerberosチケット（PAC）が大きくなり、 ``Authorization`` ヘッダーが
+Tomcatの既定の上限（8KB）を超えて400が返されることがあります。
+このときリクエストは |Fess| に届かないため、ログには何も記録されません。
+``tomcat_config.properties`` で上限を引き上げてください。
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+サービスアカウントのパスワード変更後に認証できない
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+サーバーの資格情報は最初のログイン時に一度だけ取得され、以後プロセスが終了するまでキャッシュされます。
+AD側でサービスアカウントのパスワードを変更した場合やkeytabを差し替えた場合は、 |Fess| を再起動してください。
+``spnego.*`` の設定を変更した場合も同様に再起動が必要です。
 
 デバッグ設定
 ------------

--- a/ja/15.8/config/sso-spnego.rst
+++ b/ja/15.8/config/sso-spnego.rst
@@ -221,6 +221,21 @@ Kerberos設定ファイル
    本番環境では ``false`` に設定し、HTTPSを使用することを強く推奨します。
 
 .. note::
+   ``spnego.allow.unsecure.basic=false`` （デフォルト）の場合、Basic認証は
+   ``HttpServletRequest#isSecure()`` が ``true`` を返すリクエストにのみ提示されます。
+   TLSをリバースプロキシで終端して |Fess| へHTTPで転送している構成ではこの値が ``false`` になるため、
+   Kerberosチケットを取得できずNTLMにフォールバックしたクライアントはログインできません。
+   ``tomcat_config.properties`` で ``tomcat.secure=true`` を設定し、リクエストがHTTPS由来であることを
+   |Fess| に伝えてください。
+
+.. warning::
+   |Fess| 15.8 では、クライアントのプリンシパルのレルムがサーバーのレルムと異なる場合、
+   そのログインは既定で拒否されます。ADのドメインツリーの子ドメインや、信頼関係を結んだフォレストの
+   ユーザーがログインする構成では、 ``spnego.allowed.realms`` に該当するレルムをカンマ区切りで
+   列挙してください。列挙しない場合、15.7 まではログインできていたユーザーが
+   ``Kerberos realm is not allowed`` として拒否されます。
+
+.. note::
    ``spnego.prompt.ntlm=true`` （デフォルト）の場合、 ``spnego.allow.basic`` も ``true`` である必要があります。
    ``spnego.allow.basic=false`` に設定する場合は、 ``spnego.prompt.ntlm=false`` も併せて設定してください。
    この条件を満たさない場合、SPNEGOの初期化時にエラーが発生します。

--- a/ja/15.8/config/sso-spnego.rst
+++ b/ja/15.8/config/sso-spnego.rst
@@ -83,9 +83,9 @@ Kerberos設定ファイル
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,19 @@ Kerberos設定ファイル
 
 .. note::
    ``EXAMPLE.LOCAL`` はお使いのADドメイン名（大文字）に、 ``AD-SERVER.EXAMPLE.LOCAL`` はADサーバーのホスト名に置き換えてください。
+
+.. warning::
+   ``permitted_enctypes`` に含まれていない暗号化方式のサービスチケットは、Kerberos の受け入れ側で
+   ``encryption type not in permitted_enctypes list`` として拒否されます。
+   Active Directory は通常 AES256 のサービスチケットを発行するため、AES256 を必ず含めてください。
+
+.. note::
+   Java 17 以降では RC4（ ``rc4-hmac`` ）、3DES、DES が既定で無効化されているため、
+   これらを列挙しても使用されません。上記の例では AES のみを指定しています。
+   ``aes256-cts-hmac-sha384-192`` と ``aes128-cts-hmac-sha256-128`` は、Windows Server 2025 が対応する
+   AES-SHA2（RFC 8009）の暗号化方式です。
+   RC4 の鍵しか持たないサービスアカウントでは Kerberos 認証に失敗するため、
+   パスワードを再設定して AES の鍵を生成してください。
 
 ログイン設定ファイル
 --------------------
@@ -119,7 +132,7 @@ Kerberos設定ファイル
 
 .. note::
    ``krb5.conf`` と ``auth_login.conf`` は、 ``spnego.krb5.conf`` / ``spnego.login.conf`` でデフォルトのファイル名が設定されますが、ファイル自体は必ず作成しておく必要があります。
-   これらのファイルがクラスパス上に存在しない場合、SPNEGOの初期化に失敗し |Fess| が起動できません。
+   SPNEGO の初期化は最初のログイン時に行われるため、これらのファイルが存在しなくても |Fess| 自体は起動しますが、SSO ログインが失敗します。
 
 必須設定
 --------
@@ -146,6 +159,23 @@ Kerberos設定ファイル
      - ログイン設定ファイルパス
      - ``auth_login.conf``
 
+.. note::
+   ``spnego.preauth.username`` と ``spnego.preauth.password`` を両方とも空にすると、
+   サーバー側のログインモジュールが keytab を使用します。
+   AD のサービスアカウントのパスワードを |Fess| の設定ファイルに保存したくない場合は、
+   keytab を作成して ``auth_login.conf`` の ``spnego-server`` を次のように設定してください。
+
+   ::
+
+       spnego-server {
+           com.sun.security.auth.module.Krb5LoginModule required
+           useKeyTab=true
+           keyTab="/var/lib/fess/fess.keytab"
+           principal="HTTP/fess-server.example.local@EXAMPLE.LOCAL"
+           storeKey=true
+           isInitiator=false;
+       };
+
 オプション設定
 --------------
 
@@ -169,18 +199,18 @@ Kerberos設定ファイル
      - ``true``
    * - ``spnego.allow.unsecure.basic``
      - 非セキュアなBasic認証を許可
-     - ``true``
+     - ``false``
    * - ``spnego.prompt.ntlm``
      - NTLMトークン受信時にBasic認証へフォールバックする
      - ``true``
    * - ``spnego.allow.localhost``
      - localhostからのアクセスを許可
-     - ``true``
+     - ``false``
    * - ``spnego.allow.delegation``
      - 委任を許可
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - 認証除外ディレクトリ（カンマ区切り）
+   * - ``spnego.allowed.realms``
+     - サーバーのレルムに加えて許可する Kerberos レルム（カンマ区切り）
      - （なし）
    * - ``spnego.logger.level``
      - SPNEGOライブラリ内部のログレベル（``1`` =FINEST、 ``2`` =FINER、 ``3`` =FINE、 ``4`` =CONFIG、 ``6`` =WARNING、 ``7`` =SEVERE。これら以外の値（ ``0`` 、 ``5`` を含む）はINFO扱い）
@@ -280,9 +310,9 @@ Mozilla Firefox
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +392,25 @@ Mozilla Firefox
 - LDAP設定が正しいか確認
 - Bind DNとパスワードが正しいか確認
 - ユーザーがADでグループに所属しているか確認
+
+ログインがHTTP 400になる
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+所属グループが多いユーザーはKerberosチケット（PAC）が大きくなり、 ``Authorization`` ヘッダーが
+Tomcatの既定の上限（8KB）を超えて400が返されることがあります。
+このときリクエストは |Fess| に届かないため、ログには何も記録されません。
+``tomcat_config.properties`` で上限を引き上げてください。
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+サービスアカウントのパスワード変更後に認証できない
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+サーバーの資格情報は最初のログイン時に一度だけ取得され、以後プロセスが終了するまでキャッシュされます。
+AD側でサービスアカウントのパスワードを変更した場合やkeytabを差し替えた場合は、 |Fess| を再起動してください。
+``spnego.*`` の設定を変更した場合も同様に再起動が必要です。
 
 デバッグ設定
 ------------

--- a/ko/15.7/config/sso-spnego.rst
+++ b/ko/15.7/config/sso-spnego.rst
@@ -83,9 +83,9 @@ Kerberos 설정 파일
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,19 @@ Kerberos 설정 파일
 
 .. note::
    ``EXAMPLE.LOCAL`` 은 사용 중인 AD 도메인 이름(대문자)으로, ``AD-SERVER.EXAMPLE.LOCAL`` 은 AD 서버의 호스트명으로 교체하십시오.
+
+.. warning::
+   ``permitted_enctypes`` 에 없는 암호화 방식으로 암호화된 서비스 티켓은 Kerberos 수신 측에서
+   ``encryption type not in permitted_enctypes list`` 로 거부됩니다.
+   Active Directory 는 일반적으로 AES256 서비스 티켓을 발급하므로 AES256 을 반드시 포함해야 합니다.
+
+.. note::
+   Java 17 이상에서는 RC4( ``rc4-hmac`` ), 3DES, DES 가 기본적으로 비활성화되어 있어 나열해도
+   사용되지 않습니다. 위 예에서는 AES 만 지정했습니다.
+   ``aes256-cts-hmac-sha384-192`` 와 ``aes128-cts-hmac-sha256-128`` 은 Windows Server 2025 가 지원하는
+   AES-SHA2(RFC 8009) 암호화 방식입니다.
+   RC4 키만 가진 서비스 계정은 Kerberos 인증에 사용할 수 없으므로, 비밀번호를 재설정하여
+   AES 키가 생성되도록 하십시오.
 
 로그인 설정 파일
 -----------------
@@ -119,7 +132,7 @@ Kerberos 설정 파일
 
 .. note::
    ``krb5.conf`` 와 ``auth_login.conf`` 는 ``spnego.krb5.conf`` / ``spnego.login.conf`` 로 기본 파일명이 설정되어 있지만, 파일 자체는 반드시 생성해 두어야 합니다.
-   이 파일들이 클래스패스 상에 존재하지 않으면 SPNEGO 초기화에 실패하여 |Fess| 가 시작되지 않습니다.
+   SPNEGO 는 첫 로그인 시 초기화되므로 이 파일들이 없어도 |Fess| 자체는 시작되지만 SSO 로그인이 실패합니다.
 
 필수 설정
 ----------
@@ -179,9 +192,6 @@ Kerberos 설정 파일
    * - ``spnego.allow.delegation``
      - 위임 허용
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - 인증 제외 디렉터리(쉼표 구분)
-     - (없음)
    * - ``spnego.logger.level``
      - SPNEGO 라이브러리 내부 로그 레벨( ``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE. 이 외의 값( ``0``, ``5`` 포함)은 INFO로 처리)
      - (자동)
@@ -280,9 +290,9 @@ Mozilla Firefox
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +372,25 @@ Mozilla Firefox
 - LDAP 설정이 올바른지 확인
 - Bind DN과 비밀번호가 올바른지 확인
 - 사용자가 AD에서 그룹에 속해 있는지 확인
+
+로그인이 HTTP 400을 반환한다
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+소속 그룹이 많은 사용자는 Kerberos 티켓(PAC)이 커져 ``Authorization`` 헤더가 Tomcat의 기본 상한
+(8KB)을 초과하여 400이 반환될 수 있습니다.
+이때 요청은 |Fess| 에 도달하지 않으므로 로그에 아무것도 기록되지 않습니다.
+``tomcat_config.properties`` 에서 상한을 늘리십시오.
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+서비스 계정 비밀번호 변경 후 인증되지 않는다
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+서버 자격 증명은 첫 로그인 시 한 번만 취득되어 프로세스가 종료될 때까지 캐시됩니다.
+AD에서 서비스 계정의 비밀번호를 변경했거나 keytab을 교체한 경우에는 |Fess| 를 재시작하십시오.
+``spnego.*`` 설정을 변경한 경우에도 마찬가지로 재시작이 필요합니다.
 
 디버그 설정
 -----------

--- a/ko/15.8/config/sso-spnego.rst
+++ b/ko/15.8/config/sso-spnego.rst
@@ -83,9 +83,9 @@ Kerberos 설정 파일
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,19 @@ Kerberos 설정 파일
 
 .. note::
    ``EXAMPLE.LOCAL`` 은 사용 중인 AD 도메인 이름(대문자)으로, ``AD-SERVER.EXAMPLE.LOCAL`` 은 AD 서버의 호스트명으로 교체하십시오.
+
+.. warning::
+   ``permitted_enctypes`` 에 없는 암호화 방식으로 암호화된 서비스 티켓은 Kerberos 수신 측에서
+   ``encryption type not in permitted_enctypes list`` 로 거부됩니다.
+   Active Directory 는 일반적으로 AES256 서비스 티켓을 발급하므로 AES256 을 반드시 포함해야 합니다.
+
+.. note::
+   Java 17 이상에서는 RC4( ``rc4-hmac`` ), 3DES, DES 가 기본적으로 비활성화되어 있어 나열해도
+   사용되지 않습니다. 위 예에서는 AES 만 지정했습니다.
+   ``aes256-cts-hmac-sha384-192`` 와 ``aes128-cts-hmac-sha256-128`` 은 Windows Server 2025 가 지원하는
+   AES-SHA2(RFC 8009) 암호화 방식입니다.
+   RC4 키만 가진 서비스 계정은 Kerberos 인증에 사용할 수 없으므로, 비밀번호를 재설정하여
+   AES 키가 생성되도록 하십시오.
 
 로그인 설정 파일
 -----------------
@@ -119,7 +132,7 @@ Kerberos 설정 파일
 
 .. note::
    ``krb5.conf`` 와 ``auth_login.conf`` 는 ``spnego.krb5.conf`` / ``spnego.login.conf`` 로 기본 파일명이 설정되어 있지만, 파일 자체는 반드시 생성해 두어야 합니다.
-   이 파일들이 클래스패스 상에 존재하지 않으면 SPNEGO 초기화에 실패하여 |Fess| 가 시작되지 않습니다.
+   SPNEGO 는 첫 로그인 시 초기화되므로 이 파일들이 없어도 |Fess| 자체는 시작되지만 SSO 로그인이 실패합니다.
 
 필수 설정
 ----------
@@ -146,6 +159,23 @@ Kerberos 설정 파일
      - 로그인 설정 파일 경로
      - ``auth_login.conf``
 
+.. note::
+   ``spnego.preauth.username`` 과 ``spnego.preauth.password`` 를 모두 비워 두면 서버 로그인 모듈이
+   keytab 을 사용합니다.
+   AD 서비스 계정의 비밀번호를 |Fess| 설정 파일에 저장하고 싶지 않은 경우, keytab 을 만들고
+   ``auth_login.conf`` 의 ``spnego-server`` 를 다음과 같이 설정하십시오.
+
+   ::
+
+       spnego-server {
+           com.sun.security.auth.module.Krb5LoginModule required
+           useKeyTab=true
+           keyTab="/var/lib/fess/fess.keytab"
+           principal="HTTP/fess-server.example.local@EXAMPLE.LOCAL"
+           storeKey=true
+           isInitiator=false;
+       };
+
 옵션 설정
 ----------
 
@@ -169,18 +199,18 @@ Kerberos 설정 파일
      - ``true``
    * - ``spnego.allow.unsecure.basic``
      - 비보안 Basic 인증 허용
-     - ``true``
+     - ``false``
    * - ``spnego.prompt.ntlm``
      - NTLM 토큰 수신 시 Basic 인증으로 폴백
      - ``true``
    * - ``spnego.allow.localhost``
      - localhost에서의 접근 허용
-     - ``true``
+     - ``false``
    * - ``spnego.allow.delegation``
      - 위임 허용
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - 인증 제외 디렉터리(쉼표 구분)
+   * - ``spnego.allowed.realms``
+     - 서버 렘에 더해 허용할 Kerberos 렘(쉼표 구분)
      - (없음)
    * - ``spnego.logger.level``
      - SPNEGO 라이브러리 내부 로그 레벨( ``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE. 이 외의 값( ``0``, ``5`` 포함)은 INFO로 처리)
@@ -280,9 +310,9 @@ Mozilla Firefox
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +392,25 @@ Mozilla Firefox
 - LDAP 설정이 올바른지 확인
 - Bind DN과 비밀번호가 올바른지 확인
 - 사용자가 AD에서 그룹에 속해 있는지 확인
+
+로그인이 HTTP 400을 반환한다
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+소속 그룹이 많은 사용자는 Kerberos 티켓(PAC)이 커져 ``Authorization`` 헤더가 Tomcat의 기본 상한
+(8KB)을 초과하여 400이 반환될 수 있습니다.
+이때 요청은 |Fess| 에 도달하지 않으므로 로그에 아무것도 기록되지 않습니다.
+``tomcat_config.properties`` 에서 상한을 늘리십시오.
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+서비스 계정 비밀번호 변경 후 인증되지 않는다
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+서버 자격 증명은 첫 로그인 시 한 번만 취득되어 프로세스가 종료될 때까지 캐시됩니다.
+AD에서 서비스 계정의 비밀번호를 변경했거나 keytab을 교체한 경우에는 |Fess| 를 재시작하십시오.
+``spnego.*`` 설정을 변경한 경우에도 마찬가지로 재시작이 필요합니다.
 
 디버그 설정
 -----------

--- a/ko/15.8/config/sso-spnego.rst
+++ b/ko/15.8/config/sso-spnego.rst
@@ -221,6 +221,21 @@ Kerberos 설정 파일
    프로덕션 환경에서는 ``false`` 로 설정하고 HTTPS를 사용할 것을 강력히 권장합니다.
 
 .. note::
+   ``spnego.allow.unsecure.basic=false`` (기본값)인 경우 Basic 인증은
+   ``HttpServletRequest#isSecure()`` 가 ``true`` 를 반환하는 요청에만 제공됩니다.
+   리버스 프록시에서 TLS를 종료하고 |Fess| 로 HTTP로 전달하는 구성에서는 이 값이 ``false`` 이므로,
+   Kerberos 티켓을 받지 못해 NTLM으로 대체된 클라이언트는 로그인할 수 없습니다.
+   ``tomcat_config.properties`` 에서 ``tomcat.secure=true`` 를 설정하여 요청이 HTTPS로 도착했음을
+   |Fess| 에 알려 주십시오.
+
+.. warning::
+   |Fess| 15.8에서는 클라이언트 주체의 영역이 서버의 영역과 다르면 로그인이 기본적으로 거부됩니다.
+   AD 도메인 트리의 하위 도메인이나 신뢰 관계를 맺은 포리스트의 사용자가 로그인하는 구성에서는
+   ``spnego.allowed.realms`` 에 해당 영역을 쉼표로 구분하여 나열하십시오.
+   나열하지 않으면 15.7까지 로그인할 수 있었던 사용자가 ``Kerberos realm is not allowed`` 로
+   거부됩니다.
+
+.. note::
    ``spnego.prompt.ntlm=true`` (기본값)인 경우, ``spnego.allow.basic`` 도 ``true`` 이어야 합니다.
    ``spnego.allow.basic=false`` 로 설정하는 경우에는 ``spnego.prompt.ntlm=false`` 도 함께 설정하십시오.
    이 조건을 충족하지 않으면 SPNEGO 초기화 시 오류가 발생합니다.

--- a/ko/15.8/config/sso-spnego.rst
+++ b/ko/15.8/config/sso-spnego.rst
@@ -210,7 +210,7 @@ Kerberos 설정 파일
      - 위임 허용
      - ``false``
    * - ``spnego.allowed.realms``
-     - 서버 렘에 더해 허용할 Kerberos 렘(쉼표 구분)
+     - 서버 영역에 더해 허용할 Kerberos 영역(쉼표 구분)
      - (없음)
    * - ``spnego.logger.level``
      - SPNEGO 라이브러리 내부 로그 레벨( ``1`` =FINEST, ``2`` =FINER, ``3`` =FINE, ``4`` =CONFIG, ``6`` =WARNING, ``7`` =SEVERE. 이 외의 값( ``0``, ``5`` 포함)은 INFO로 처리)

--- a/zh-cn/15.7/config/sso-spnego.rst
+++ b/zh-cn/15.7/config/sso-spnego.rst
@@ -83,9 +83,9 @@ Kerberos配置文件
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,18 @@ Kerberos配置文件
 
 .. note::
    将 ``EXAMPLE.LOCAL`` 替换为您的AD域名（大写），将 ``AD-SERVER.EXAMPLE.LOCAL`` 替换为您的AD服务器主机名。
+
+.. warning::
+   使用 ``permitted_enctypes`` 中未列出的加密方式加密的服务票据，会被 Kerberos 接收端以
+   ``encryption type not in permitted_enctypes list`` 拒绝。
+   Active Directory 通常签发 AES256 服务票据，因此必须包含 AES256。
+
+.. note::
+   Java 17 及以后版本默认禁用 RC4（ ``rc4-hmac`` ）、3DES 和 DES，即使列出也不会使用，
+   因此上例仅指定 AES。
+   ``aes256-cts-hmac-sha384-192`` 和 ``aes128-cts-hmac-sha256-128`` 是 Windows Server 2025 支持的
+   AES-SHA2（RFC 8009）加密方式。
+   仅持有 RC4 密钥的服务账户无法用于 Kerberos 认证，请重置其密码以生成 AES 密钥。
 
 登录配置文件
 ------------
@@ -119,7 +131,7 @@ Kerberos配置文件
 
 .. note::
    ``krb5.conf`` 和 ``auth_login.conf`` 的默认文件名分别由 ``spnego.krb5.conf`` / ``spnego.login.conf`` 指定，但这两个文件本身必须事先创建好。
-   如果这些文件不存在于类路径上，SPNEGO初始化将失败，|Fess| 将无法启动。
+   SPNEGO 在首次登录时初始化，因此即使缺少这些文件 |Fess| 本身仍能启动，但 SSO 登录会失败。
 
 必需设置
 --------
@@ -179,9 +191,6 @@ Kerberos配置文件
    * - ``spnego.allow.delegation``
      - 允许委托
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - 排除认证的目录（逗号分隔）
-     - （无）
    * - ``spnego.logger.level``
      - SPNEGO库内部日志级别（``1`` =FINEST、``2`` =FINER、``3`` =FINE、``4`` =CONFIG、``6`` =WARNING、``7`` =SEVERE。这些值以外的值（包括 ``0`` 和 ``5``）均视为INFO）
      - （自动）
@@ -280,9 +289,9 @@ Mozilla Firefox
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +371,25 @@ Mozilla Firefox
 - 验证LDAP设置是否正确
 - 检查Bind DN和密码是否正确
 - 验证用户是否在AD中属于组
+
+登录返回 HTTP 400
+~~~~~~~~~~~~~~~~~
+
+对于所属组较多的用户，Kerberos 票据（PAC）会变大， ``Authorization`` 请求头可能超过 Tomcat 的
+默认上限（8KB），从而返回 400。
+此时请求不会到达 |Fess| ，日志中也不会有任何记录。
+请在 ``tomcat_config.properties`` 中提高上限。
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+更改服务账户密码后无法认证
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+服务器凭据仅在首次登录时获取一次，之后会缓存到进程结束为止。
+在 AD 中更改服务账户密码或替换 keytab 后，请重启 |Fess| 。
+更改 ``spnego.*`` 设置后同样需要重启。
 
 调试设置
 --------

--- a/zh-cn/15.8/config/sso-spnego.rst
+++ b/zh-cn/15.8/config/sso-spnego.rst
@@ -83,9 +83,9 @@ Kerberos配置文件
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -99,6 +99,18 @@ Kerberos配置文件
 
 .. note::
    将 ``EXAMPLE.LOCAL`` 替换为您的AD域名（大写），将 ``AD-SERVER.EXAMPLE.LOCAL`` 替换为您的AD服务器主机名。
+
+.. warning::
+   使用 ``permitted_enctypes`` 中未列出的加密方式加密的服务票据，会被 Kerberos 接收端以
+   ``encryption type not in permitted_enctypes list`` 拒绝。
+   Active Directory 通常签发 AES256 服务票据，因此必须包含 AES256。
+
+.. note::
+   Java 17 及以后版本默认禁用 RC4（ ``rc4-hmac`` ）、3DES 和 DES，即使列出也不会使用，
+   因此上例仅指定 AES。
+   ``aes256-cts-hmac-sha384-192`` 和 ``aes128-cts-hmac-sha256-128`` 是 Windows Server 2025 支持的
+   AES-SHA2（RFC 8009）加密方式。
+   仅持有 RC4 密钥的服务账户无法用于 Kerberos 认证，请重置其密码以生成 AES 密钥。
 
 登录配置文件
 ------------
@@ -119,7 +131,7 @@ Kerberos配置文件
 
 .. note::
    ``krb5.conf`` 和 ``auth_login.conf`` 的默认文件名分别由 ``spnego.krb5.conf`` / ``spnego.login.conf`` 指定，但这两个文件本身必须事先创建好。
-   如果这些文件不存在于类路径上，SPNEGO初始化将失败，|Fess| 将无法启动。
+   SPNEGO 在首次登录时初始化，因此即使缺少这些文件 |Fess| 本身仍能启动，但 SSO 登录会失败。
 
 必需设置
 --------
@@ -146,6 +158,22 @@ Kerberos配置文件
      - 登录配置文件路径
      - ``auth_login.conf``
 
+.. note::
+   如果 ``spnego.preauth.username`` 和 ``spnego.preauth.password`` 都留空，服务器端登录模块将使用 keytab。
+   如果不希望将 AD 服务账户的密码保存在 |Fess| 的配置文件中，请创建 keytab 并按如下方式配置
+   ``auth_login.conf`` 中的 ``spnego-server`` 。
+
+   ::
+
+       spnego-server {
+           com.sun.security.auth.module.Krb5LoginModule required
+           useKeyTab=true
+           keyTab="/var/lib/fess/fess.keytab"
+           principal="HTTP/fess-server.example.local@EXAMPLE.LOCAL"
+           storeKey=true
+           isInitiator=false;
+       };
+
 可选设置
 --------
 
@@ -169,18 +197,18 @@ Kerberos配置文件
      - ``true``
    * - ``spnego.allow.unsecure.basic``
      - 允许非安全Basic认证
-     - ``true``
+     - ``false``
    * - ``spnego.prompt.ntlm``
      - 收到NTLM令牌时回退到Basic认证
      - ``true``
    * - ``spnego.allow.localhost``
      - 允许localhost访问
-     - ``true``
+     - ``false``
    * - ``spnego.allow.delegation``
      - 允许委托
      - ``false``
-   * - ``spnego.exclude.dirs``
-     - 排除认证的目录（逗号分隔）
+   * - ``spnego.allowed.realms``
+     - 除服务器领域外还允许的 Kerberos 领域（逗号分隔）
      - （无）
    * - ``spnego.logger.level``
      - SPNEGO库内部日志级别（``1`` =FINEST、``2`` =FINER、``3`` =FINE、``4`` =CONFIG、``6`` =WARNING、``7`` =SEVERE。这些值以外的值（包括 ``0`` 和 ``5``）均视为INFO）
@@ -280,9 +308,9 @@ Mozilla Firefox
 
     [libdefaults]
         default_realm = EXAMPLE.LOCAL
-        default_tkt_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        default_tgs_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
-        permitted_enctypes   = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
+        default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
+        permitted_enctypes   = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128
 
     [realms]
         EXAMPLE.LOCAL = {
@@ -362,6 +390,25 @@ Mozilla Firefox
 - 验证LDAP设置是否正确
 - 检查Bind DN和密码是否正确
 - 验证用户是否在AD中属于组
+
+登录返回 HTTP 400
+~~~~~~~~~~~~~~~~~
+
+对于所属组较多的用户，Kerberos 票据（PAC）会变大， ``Authorization`` 请求头可能超过 Tomcat 的
+默认上限（8KB），从而返回 400。
+此时请求不会到达 |Fess| ，日志中也不会有任何记录。
+请在 ``tomcat_config.properties`` 中提高上限。
+
+::
+
+    tomcat.maxHttpHeaderSize=65536
+
+更改服务账户密码后无法认证
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+服务器凭据仅在首次登录时获取一次，之后会缓存到进程结束为止。
+在 AD 中更改服务账户密码或替换 keytab 后，请重启 |Fess| 。
+更改 ``spnego.*`` 设置后同样需要重启。
 
 调试设置
 --------

--- a/zh-cn/15.8/config/sso-spnego.rst
+++ b/zh-cn/15.8/config/sso-spnego.rst
@@ -219,6 +219,19 @@ Kerberos配置文件
    对于生产环境，强烈建议将此设置为 ``false`` 并使用HTTPS。
 
 .. note::
+   当 ``spnego.allow.unsecure.basic=false`` （默认值）时，仅对 ``HttpServletRequest#isSecure()``
+   返回 ``true`` 的请求提供 Basic 认证。
+   如果在反向代理上终止 TLS 并以 HTTP 转发到 |Fess| ，该值为 ``false`` ，
+   因此无法获取 Kerberos 票据而回退到 NTLM 的客户端将无法登录。
+   请在 ``tomcat_config.properties`` 中设置 ``tomcat.secure=true`` ，以告知 |Fess| 该请求来自 HTTPS。
+
+.. warning::
+   在 |Fess| 15.8 中，如果客户端主体的领域与服务器的领域不同，登录将默认被拒绝。
+   如果用户来自 AD 域树的子域或建立了信任关系的林，
+   请在 ``spnego.allowed.realms`` 中以逗号分隔列出这些领域。
+   否则，在 15.7 之前能够登录的用户将因 ``Kerberos realm is not allowed`` 而被拒绝。
+
+.. note::
    ``spnego.prompt.ntlm=true``\ （默认值）时，``spnego.allow.basic`` 也必须为 ``true``\ 。
    若要将 ``spnego.allow.basic`` 设为 ``false``，则必须同时将 ``spnego.prompt.ntlm`` 设为 ``false``\ 。
    不满足此条件时，SPNEGO初始化时将发生错误。


### PR DESCRIPTION
## Summary

The SPNEGO page told operators to build a `krb5.conf` that breaks against a current Active Directory, and its settings table described defaults that no longer match the implementation. Both 15.7 (current release) and 15.8 are updated; the parts that depend on 15.8-only code changes are applied to 15.8 only.

## The `krb5.conf` sample could not authenticate against a current AD

The sample listed:

```
permitted_enctypes = aes128-cts rc4-hmac des3-cbc-sha1 des-cbc-md5 des-cbc-crc
```

Two problems compound:

1. **RC4, 3DES and DES are disabled by default in Java 17+**, so everything after `aes128-cts` is inert. On JDK 21 the built-in default encryption types are exactly `18, 17, 20, 19` — AES only.
2. **AES256 was never in the list.** The Kerberos acceptor validates the incoming service ticket against `permitted_enctypes` (`sun.security.krb5.KrbApReq` → `"encryption type not in permitted_enctypes list"`), so the moment the KDC issues an AES256 service ticket — the normal case for any service account whose password was set on a modern DC — authentication fails.

The sample now lists AES-SHA1 256/128 followed by the AES-SHA2 (RFC 8009) types `aes256-cts-hmac-sha384-192` / `aes128-cts-hmac-sha256-128` that Windows Server 2025 supports, with:

- a **warning** naming the exact failure (`encryption type not in permitted_enctypes list`) and stating that AES256 must be listed;
- a **note** explaining that RC4/3DES/DES are inert on Java 17+, and that a service account holding only an RC4 key must have its password reset so AES keys are generated — relevant given Microsoft's RC4 phase-out.

## Corrections applied to both 15.7 and 15.8

| Was | Now |
|---|---|
| "If these files do not exist on the classpath, SPNEGO initialization will fail and Fess will not start." | SPNEGO initializes on the **first login**, so Fess starts normally; only SSO login fails. |
| `spnego.exclude.dirs` documented as "directories to exclude from authentication" | Row removed. Only `SpnegoHttpFilter` consumes it, and Fess calls `SpnegoAuthenticator#authenticate` directly instead of installing that filter, so it never excluded anything. |

Two new troubleshooting entries, both for failures that leave **nothing** in the Fess log:

- **Login returns HTTP 400** — a user in many groups produces a large PAC, the `Authorization` header exceeds Tomcat's default 8KB limit, and the request is rejected before it reaches Fess. Documents `tomcat.maxHttpHeaderSize` in `tomcat_config.properties`.
- **Authentication fails after the service account password is changed** — the server credential is obtained once on the first login and cached for the lifetime of the process, so a password rotation or keytab swap needs a restart. Same for any `spnego.*` change, since `SpnegoFilterConfig` is a JVM-wide singleton.

## 15.8 only

These follow code that is on `master` but not in 15.7:

- `spnego.allow.unsecure.basic` and `spnego.allow.localhost` now document **`false`**. The table said `true` for both — telling operators the localhost bypass (which authenticates same-host requests as the server OS user with no Kerberos verification) is on when it is off.
- `spnego.allowed.realms` is documented — the allowlist for intentional cross-realm trust. It appeared nowhere before.
- A note showing the **keytab** form of the `spnego-server` login module, which became reachable once `spnego.preauth.username` / `.password` started defaulting to empty.

## Verification

All 14 pages parse with **zero** docutils messages. This also fixes a pre-existing German title overline (45 characters under a 60-character title), which was the only warning before.

Related: codelibs/fess#3216 (authenticator fixes, including removing the `spnego.exclude.dirs` mapping) and codelibs/fess#3220 (admin screen field for `spnego.allowed.realms`).
