### PR TITLE
docs(sso): document the SAML role-attribute risk and the SameSite requirement

### DIFF
--- a/de/15.8/config/sso-saml.rst
+++ b/de/15.8/config/sso-saml.rst
@@ -232,10 +232,21 @@ Beispiel::
    Wenn Attribute nicht vom IdP abgerufen werden können, werden Standardwerte verwendet.
    Bei Verwendung der rollenbasierten Suche konfigurieren Sie entsprechende Gruppen oder Rollen.
 
+.. warning::
+   Wenn ``saml.attribute.role.name`` gesetzt ist, werden die vom IdP gesendeten Attributwerte
+   unverändert zu |Fess|-Rollen. Da ``authentication.admin.roles`` in ``fess_config.properties``
+   standardmäßig ``admin`` lautet, erhält jeder Benutzer, dessen Rollenattribut ``admin`` enthält,
+   Administratorrechte in |Fess|. Prüfen Sie, wer das Rollenattribut auf der IdP-Seite steuern kann,
+   und ändern Sie ``authentication.admin.roles`` bei Bedarf in einen anderen Namen.
+
 Sicherheitskonfiguration
 ========================
 
 Für Produktionsumgebungen wird empfohlen, die folgenden Sicherheitseinstellungen zu aktivieren.
+
+.. note::
+   Wenn nicht empfohlene Einstellungen bestehen bleiben, wird beim Laden der SAML-Einstellungen eine
+   Warnung ``Insecure SAML settings: ...`` in das Protokoll geschrieben.
 
 Signatureinstellungen
 ---------------------
@@ -400,6 +411,11 @@ Kann nach der Authentifizierung nicht zu Fess zurückkehren
 
 - Überprüfen Sie, ob die ACS URL auf der IdP-Seite korrekt konfiguriert ist
 - Stellen Sie sicher, dass der Wert von ``saml.sp.base.url`` mit der IdP-Konfiguration übereinstimmt
+- Die SAML-Assertion trifft als seitenübergreifender POST vom IdP ein. Wenn
+  ``tomcat.sameSiteCookies`` in ``tomcat_config.properties`` auf ``lax`` (Standard) steht, sendet der
+  Browser das Sitzungs-Cookie nicht mit, sodass |Fess| keinen SAML-Status findet und erneut zum IdP
+  weiterleitet, was eine Schleife ergibt. Setzen Sie in diesem Fall
+  ``tomcat.sameSiteCookies = none`` (``SameSite=None`` erfordert HTTPS)
 
 Signaturüberprüfungsfehler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/en/15.8/config/sso-saml.rst
+++ b/en/15.8/config/sso-saml.rst
@@ -232,10 +232,21 @@ Example::
    If attributes cannot be obtained from the IdP, default values will be used.
    When using role-based search, configure appropriate groups or roles.
 
+.. warning::
+   When ``saml.attribute.role.name`` is set, the attribute values sent by the IdP become |Fess| roles
+   as they are. Because ``authentication.admin.roles`` in ``fess_config.properties`` defaults to
+   ``admin``, any user whose role attribute contains ``admin`` gains |Fess| administrator privileges.
+   Check who can control the role attribute on the IdP side, and change
+   ``authentication.admin.roles`` to a different name if necessary.
+
 Security Configuration
 ======================
 
 For production environments, it is recommended to enable the following security settings.
+
+.. note::
+   When settings that are not recommended remain in place, an ``Insecure SAML settings: ...``
+   warning is written to the log as the SAML settings are loaded.
 
 Signature Settings
 ------------------
@@ -400,6 +411,10 @@ Cannot return to Fess after authentication
 
 - Verify that the ACS URL is correctly configured on the IdP side
 - Ensure the ``saml.sp.base.url`` value matches the IdP configuration
+- The SAML assertion arrives as a cross-site POST from the IdP. When ``tomcat.sameSiteCookies`` in
+  ``tomcat_config.properties`` is ``lax`` (the default), the browser does not send the session cookie
+  with it, so |Fess| finds no SAML state and redirects to the IdP again, which loops. Set
+  ``tomcat.sameSiteCookies = none`` in that case (``SameSite=None`` requires HTTPS)
 
 Signature verification error
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/es/15.8/config/sso-saml.rst
+++ b/es/15.8/config/sso-saml.rst
@@ -232,10 +232,22 @@ Ejemplo::
    Si los atributos no pueden obtenerse del IdP, se usarán los valores por defecto.
    Al usar búsqueda basada en roles, configure los grupos o roles apropiados.
 
+.. warning::
+   Cuando se configura ``saml.attribute.role.name``, los valores de atributo enviados por el IdP se
+   convierten directamente en roles de |Fess|. Como ``authentication.admin.roles`` en
+   ``fess_config.properties`` tiene el valor predeterminado ``admin``, cualquier usuario cuyo
+   atributo de rol contenga ``admin`` obtiene privilegios de administrador en |Fess|. Compruebe
+   quién puede controlar el atributo de rol en el IdP y, si es necesario, cambie
+   ``authentication.admin.roles`` por otro nombre.
+
 Configuración de seguridad
 ==========================
 
 Para entornos de producción, se recomienda habilitar las siguientes configuraciones de seguridad.
+
+.. note::
+   Si permanecen configuraciones no recomendadas, se escribe en el registro una advertencia
+   ``Insecure SAML settings: ...`` al cargar la configuración SAML.
 
 Configuración de firma
 ----------------------
@@ -400,6 +412,11 @@ No se puede regresar a Fess después de la autenticación
 
 - Verifique que la URL ACS esté configurada correctamente en el lado del IdP
 - Asegúrese de que el valor de ``saml.sp.base.url`` coincida con la configuración del IdP
+- La aserción SAML llega como un POST entre sitios desde el IdP. Cuando
+  ``tomcat.sameSiteCookies`` en ``tomcat_config.properties`` es ``lax`` (el valor predeterminado), el
+  navegador no envía la cookie de sesión con ella, por lo que |Fess| no encuentra el estado SAML y
+  redirige de nuevo al IdP, entrando en un bucle. En ese caso, configure
+  ``tomcat.sameSiteCookies = none`` (``SameSite=None`` requiere HTTPS)
 
 Error de verificación de firma
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/fr/15.8/config/sso-saml.rst
+++ b/fr/15.8/config/sso-saml.rst
@@ -232,10 +232,22 @@ Exemple ::
    Si les attributs ne peuvent pas être obtenus de l'IdP, les valeurs par défaut seront utilisées.
    Lors de l'utilisation de la recherche basée sur les rôles, configurez les groupes ou rôles appropriés.
 
+.. warning::
+   Lorsque ``saml.attribute.role.name`` est défini, les valeurs d'attribut envoyées par l'IdP
+   deviennent telles quelles des rôles |Fess|. Comme ``authentication.admin.roles`` dans
+   ``fess_config.properties`` vaut ``admin`` par défaut, tout utilisateur dont l'attribut de rôle
+   contient ``admin`` obtient les privilèges d'administrateur de |Fess|. Vérifiez qui peut contrôler
+   l'attribut de rôle côté IdP et, si nécessaire, remplacez ``authentication.admin.roles`` par un
+   autre nom.
+
 Configuration de sécurité
 =========================
 
 Pour les environnements de production, il est recommandé d'activer les paramètres de sécurité suivants.
+
+.. note::
+   Si des paramètres déconseillés subsistent, un avertissement ``Insecure SAML settings: ...`` est
+   écrit dans le journal lors du chargement des paramètres SAML.
 
 Paramètres de signature
 -----------------------
@@ -400,6 +412,11 @@ Impossible de retourner à Fess après l'authentification
 
 - Vérifiez que l'URL ACS est correctement configurée côté IdP
 - Assurez-vous que la valeur de ``saml.sp.base.url`` correspond à la configuration de l'IdP
+- L'assertion SAML arrive sous forme de POST intersite depuis l'IdP. Lorsque
+  ``tomcat.sameSiteCookies`` dans ``tomcat_config.properties`` vaut ``lax`` (la valeur par défaut),
+  le navigateur n'envoie pas le cookie de session avec cette requête ; |Fess| ne trouve alors aucun
+  état SAML et redirige à nouveau vers l'IdP, ce qui provoque une boucle. Dans ce cas, définissez
+  ``tomcat.sameSiteCookies = none`` (``SameSite=None`` nécessite HTTPS)
 
 Erreur de vérification de signature
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ja/15.8/config/sso-saml.rst
+++ b/ja/15.8/config/sso-saml.rst
@@ -233,10 +233,21 @@ SAMLアサーションから取得したユーザー属性を、|Fess| のグル
    IdPから属性が取得できない場合は、デフォルト値が使用されます。
    ロールベース検索を使用する場合は、適切なグループまたはロールを設定してください。
 
+.. warning::
+   ``saml.attribute.role.name`` を設定すると、IdPから送信された属性値がそのまま |Fess| のロールになります。
+   ``fess_config.properties`` の ``authentication.admin.roles`` は既定で ``admin`` であるため、
+   IdPがロール属性に ``admin`` を含めて送信したユーザーは |Fess| の管理者権限を得ます。
+   IdP側でロール属性の値を管理できる範囲を確認し、必要に応じて ``authentication.admin.roles`` を
+   別の名前に変更してください。
+
 セキュリティ設定
 ================
 
 本番環境では、以下のセキュリティ設定を有効にすることを推奨します。
+
+.. note::
+   推奨されない設定が残っている場合、SAMLの設定を読み込んだ時点で
+   ``Insecure SAML settings: ...`` という警告がログに出力されます。
 
 署名の設定
 ----------
@@ -407,6 +418,10 @@ SPの秘密鍵とX.509証明書を設定する必要があります。
 
 - IdP側のACS URLが正しく設定されているか確認してください
 - ``saml.sp.base.url`` の値がIdP側の設定と一致しているか確認してください
+- IdPからのSAMLアサーションはクロスサイトのPOSTで送信されます。``tomcat_config.properties`` の
+  ``tomcat.sameSiteCookies`` が ``lax``（既定値）の場合、ブラウザはセッションCookieを送信しないため、
+  |Fess| はSAMLの状態を見つけられず、再びIdPへリダイレクトしてループします。この場合は
+  ``tomcat.sameSiteCookies = none`` を設定してください（``SameSite=None`` はHTTPSが必須です）
 
 署名検証エラー
 ~~~~~~~~~~~~~~

--- a/ko/15.8/config/sso-saml.rst
+++ b/ko/15.8/config/sso-saml.rst
@@ -233,10 +233,21 @@ SAML 어서션에서 취득한 사용자 속성을 |Fess| 의 그룹이나 역�
    IdP에서 속성을 취득할 수 없는 경우 기본값이 사용됩니다.
    역할 기반 검색을 사용하는 경우 적절한 그룹 또는 역할을 설정하십시오.
 
+.. warning::
+   ``saml.attribute.role.name`` 을 설정하면 IdP가 보낸 속성 값이 그대로 |Fess| 의 역할이 됩니다.
+   ``fess_config.properties`` 의 ``authentication.admin.roles`` 기본값은 ``admin`` 이므로,
+   IdP가 역할 속성에 ``admin`` 을 포함해 보낸 사용자는 |Fess| 의 관리자 권한을 갖게 됩니다.
+   IdP 측에서 역할 속성 값을 제어할 수 있는 범위를 확인하고, 필요하다면
+   ``authentication.admin.roles`` 를 다른 이름으로 변경하십시오.
+
 보안 설정
 =========
 
 운영 환경에서는 다음 보안 설정을 활성화하는 것을 권장합니다.
+
+.. note::
+   권장되지 않는 설정이 남아 있으면 SAML 설정을 읽어 들일 때 ``Insecure SAML settings: ...``
+   경고가 로그에 출력됩니다.
 
 서명 설정
 ---------
@@ -407,6 +418,10 @@ SP의 비밀 키와 X.509 인증서를 설정해야 합니다.
 
 - IdP 측의 ACS URL이 올바르게 설정되어 있는지 확인하십시오
 - ``saml.sp.base.url`` 의 값이 IdP 측의 설정과 일치하는지 확인하십시오
+- SAML 어설션은 IdP에서 교차 사이트 POST로 전송됩니다. ``tomcat_config.properties`` 의
+  ``tomcat.sameSiteCookies`` 가 ``lax`` (기본값)인 경우 브라우저가 세션 쿠키를 함께 보내지 않으므로
+  |Fess| 는 SAML 상태를 찾지 못하고 다시 IdP로 리다이렉트하여 루프가 발생합니다. 이 경우
+  ``tomcat.sameSiteCookies = none`` 을 설정하십시오 (``SameSite=None`` 은 HTTPS가 필요합니다)
 
 서명 검증 오류
 ~~~~~~~~~~~~~~

--- a/zh-cn/15.8/config/sso-saml.rst
+++ b/zh-cn/15.8/config/sso-saml.rst
@@ -232,10 +232,19 @@ IdP侧配置
    如果无法从IdP获取属性，将使用默认值。
    使用基于角色的搜索时，请配置适当的组或角色。
 
+.. warning::
+   设置\ ``saml.attribute.role.name``\ 后，IdP发送的属性值将直接成为 |Fess| 的角色。
+   由于\ ``fess_config.properties``\ 中\ ``authentication.admin.roles``\ 的默认值为\ ``admin``\ ，
+   角色属性中包含\ ``admin``\ 的用户将获得 |Fess| 的管理员权限。
+   请确认IdP侧可以控制角色属性的范围，必要时将\ ``authentication.admin.roles``\ 更改为其他名称。
+
 安全配置
 ========
 
 对于生产环境，建议启用以下安全设置。
+
+.. note::
+   如果保留了不推荐的设置，在加载SAML设置时会向日志输出\ ``Insecure SAML settings: ...``\ 警告。
 
 签名设置
 --------
@@ -400,6 +409,10 @@ SP证书与私钥配置
 
 - 验证ACS URL是否在IdP侧正确配置
 - 确保\ ``saml.sp.base.url``\ 的值与IdP配置匹配
+- SAML断言以来自IdP的跨站POST方式发送。
+  当\ ``tomcat_config.properties``\ 中的\ ``tomcat.sameSiteCookies``\ 为\ ``lax``\ （默认值）时，
+  浏览器不会随该请求发送会话Cookie，因此 |Fess| 找不到SAML状态并再次重定向到IdP，形成循环。
+  此时请设置\ ``tomcat.sameSiteCookies = none``\ （``SameSite=None``\ 需要HTTPS）
 
 签名验证错误
 ~~~~~~~~~~~~


### PR DESCRIPTION
Three additions to `15.8/config/sso-saml.rst`, applied to all seven languages (ja, en, de, es, fr, ko, zh-cn).

## 1. The role attribute can hand out administrator rights

`saml.attribute.role.name` is documented as a plain attribute mapping, but `SamlCredential#getDefaultRolesAsArray` copies the IdP attribute values into the Fess roles verbatim, and `authentication.admin.roles` defaults to `admin` in `fess_config.properties`. Any user whose role attribute contains `admin` therefore becomes a Fess administrator.

This is how Fess SSO works generally — the Entra ID authenticator maps Graph `directoryRole` objects into roles the same way — so this is a warning on the page rather than a code change. But the page gave no hint of it, and the example it shows is `saml.attribute.role.name=roles`, which is exactly the configuration where it matters.

## 2. SameSite breaks the ACS callback

`tomcat_config.properties` ships `tomcat.sameSiteCookies = lax`, which `FessBoot` applies to every context's cookie processor, so `JSESSIONID` carries `SameSite=Lax`.

The SAML assertion reaches `/sso/` as a cross-site POST from the IdP's auto-submitting form, and a cookie with an explicit `SameSite=Lax` is not sent with it. `getLoginCredential()` then sees no session, treats the request as a fresh visit and issues another AuthnRequest — the login loops between Fess and the IdP.

Added to the existing "cannot return to Fess after authentication" troubleshooting entry, with `tomcat.sameSiteCookies = none` as the fix and the note that `SameSite=None` requires HTTPS. The comment in `tomcat_config.properties` only mentioned OAuth/OIDC, whose callback is a top-level GET and is unaffected; codelibs/fess#3224 corrects that comment.

## 3. The insecure-settings warning

codelibs/fess#3224 makes Fess log `Insecure SAML settings: ...` when java-saml reports weak configuration. Mentioned in the security section so operators can connect the log line to the settings on this page.

> Item 3 describes behaviour from codelibs/fess#3224. Items 1 and 2 describe the current release and are accurate today.

## Verification

Each file was parsed with docutils (Sphinx-only directives and roles filtered out) — no structural, indentation or escape errors in any of the seven. The zh-cn text follows the existing `\ ``literal``\ ` spacing convention used elsewhere on the page.
