### PR TITLE
docs(sso): document the session cookie setting SAML requires (7 languages)

### DIFF
--- a/de/15.8/config/sso-saml.rst
+++ b/de/15.8/config/sso-saml.rst
@@ -57,6 +57,23 @@ Um die SAML-Authentifizierung zu aktivieren, fügen Sie die folgende Einstellung
    Im Admin-Bereich vorgenommene Änderungen werden in ``system.properties`` gespeichert und bleiben nach einem Neustart erhalten.
    Sicherheitseinstellungen wie Signierung/Verschlüsselung sowie das SP-Zertifikat und der private Schlüssel können jedoch nicht über die Administrationsseite konfiguriert werden und müssen direkt in ``system.properties`` eingetragen werden.
 
+Konfiguration des Sitzungs-Cookies
+----------------------------------
+
+Der IdP sendet die Assertion als **seitenübergreifenden POST** an |Fess| zurück. Ein ``SameSite=Lax``-Cookie wird bei einer solchen Anfrage nicht mitgesendet, sodass die SAML-Anmeldung mit dem von |Fess| ausgelieferten Standardwert nicht abgeschlossen wird.
+
+Ändern Sie ``tomcat.sameSiteCookies`` in ``tomcat_config.properties`` auf ``none``. Diese Datei liegt beim ZIP-Paket unter ``lib/classes/`` und bei den DEB-/RPM-Paketen unter ``/etc/fess/``.
+
+::
+
+    tomcat.sameSiteCookies = none
+
+.. warning::
+   Browser akzeptieren ``none`` nur bei einem Cookie, das auch das Attribut ``Secure`` trägt. |Fess| muss daher über HTTPS bereitgestellt werden. Über einfaches HTTP macht diese Einstellung eine Anmeldung bei |Fess| unmöglich.
+
+.. note::
+   Der Standardwert ``lax`` ist für SSO-Verfahren gedacht, deren Callback als Weiterleitung (GET) zurückkommt. Die HTTP-POST-Bindung von SAML gehört nicht dazu, daher ist diese Änderung nur bei Verwendung von SAML erforderlich. Nach der Änderung muss |Fess| neu gestartet werden.
+
 SP (Service Provider) Konfiguration
 -----------------------------------
 

--- a/en/15.8/config/sso-saml.rst
+++ b/en/15.8/config/sso-saml.rst
@@ -57,6 +57,23 @@ To enable SAML authentication, add the following setting to ``app/WEB-INF/conf/s
    Settings changed in the admin UI are saved to ``system.properties`` and persist after restart.
    However, security settings such as signing/encryption and the SP certificate/private key cannot be configured in the admin UI, so write them directly in ``system.properties``.
 
+Session Cookie Configuration
+----------------------------
+
+The IdP returns the assertion to |Fess| as a **cross-site POST**. A ``SameSite=Lax`` cookie is not sent on such a request, so SAML login does not complete with the default value shipped with |Fess|.
+
+Change ``tomcat.sameSiteCookies`` to ``none`` in ``tomcat_config.properties``. This file is located in ``lib/classes/`` for the ZIP package and in ``/etc/fess/`` for the DEB/RPM packages.
+
+::
+
+    tomcat.sameSiteCookies = none
+
+.. warning::
+   Browsers only accept ``none`` on a cookie that also carries the ``Secure`` attribute, so |Fess| must be served over HTTPS. Over plain HTTP, this setting makes it impossible to log in to |Fess|.
+
+.. note::
+   The default ``lax`` is set for SSO methods whose callback returns as a redirect (GET). SAML's HTTP-POST binding is not one of them, so this change is only needed when using SAML. |Fess| must be restarted after changing the setting.
+
 SP (Service Provider) Configuration
 ------------------------------------
 

--- a/es/15.8/config/sso-saml.rst
+++ b/es/15.8/config/sso-saml.rst
@@ -57,6 +57,23 @@ Para habilitar la autenticación SAML, agregue la siguiente configuración en ``
    Los cambios realizados en el panel de administración se guardan en ``system.properties`` y se conservan tras el reinicio.
    Sin embargo, los ajustes de seguridad como firma/cifrado y el certificado/clave privada del SP no pueden configurarse desde el panel de administración, por lo que deben escribirse directamente en ``system.properties``.
 
+Configuración de la cookie de sesión
+------------------------------------
+
+El IdP devuelve la aserción a |Fess| mediante un **POST entre sitios**. Una cookie ``SameSite=Lax`` no se envía en ese tipo de petición, por lo que el inicio de sesión SAML no se completa con el valor predeterminado que incluye |Fess|.
+
+Cambie ``tomcat.sameSiteCookies`` a ``none`` en ``tomcat_config.properties``. Este archivo se encuentra en ``lib/classes/`` en el paquete ZIP y en ``/etc/fess/`` en los paquetes DEB/RPM.
+
+::
+
+    tomcat.sameSiteCookies = none
+
+.. warning::
+   Los navegadores solo aceptan ``none`` en una cookie que además tenga el atributo ``Secure``, por lo que |Fess| debe servirse mediante HTTPS. Sobre HTTP simple, esta opción impide iniciar sesión en |Fess|.
+
+.. note::
+   El valor predeterminado ``lax`` está pensado para los métodos de SSO cuya respuesta vuelve como redirección (GET). El enlace HTTP-POST de SAML no lo es, por lo que este cambio solo es necesario al usar SAML. |Fess| debe reiniciarse tras cambiar la configuración.
+
 Configuración del SP (Service Provider)
 ---------------------------------------
 

--- a/fr/15.8/config/sso-saml.rst
+++ b/fr/15.8/config/sso-saml.rst
@@ -57,6 +57,23 @@ Pour activer l'authentification SAML, ajoutez le paramètre suivant dans ``app/W
    Les paramètres modifiés dans l'interface d'administration sont enregistrés dans ``system.properties`` et persistent après redémarrage.
    Cependant, les paramètres de sécurité tels que la signature/le chiffrement ainsi que le certificat SP et la clé privée ne peuvent pas être configurés dans l'interface d'administration ; écrivez-les directement dans ``system.properties``.
 
+Configuration du cookie de session
+----------------------------------
+
+L'IdP renvoie l'assertion à |Fess| via un **POST intersites**. Un cookie ``SameSite=Lax`` n'est pas envoyé sur une telle requête, si bien que la connexion SAML n'aboutit pas avec la valeur par défaut livrée avec |Fess|.
+
+Remplacez ``tomcat.sameSiteCookies`` par ``none`` dans ``tomcat_config.properties``. Ce fichier se trouve dans ``lib/classes/`` pour le paquet ZIP et dans ``/etc/fess/`` pour les paquets DEB/RPM.
+
+::
+
+    tomcat.sameSiteCookies = none
+
+.. warning::
+   Les navigateurs n'acceptent ``none`` que sur un cookie portant également l'attribut ``Secure``. |Fess| doit donc être servi en HTTPS. En HTTP simple, ce réglage rend la connexion à |Fess| impossible.
+
+.. note::
+   La valeur par défaut ``lax`` est prévue pour les méthodes SSO dont le rappel revient sous forme de redirection (GET). La liaison HTTP-POST de SAML n'en fait pas partie, ce changement n'est donc nécessaire qu'avec SAML. |Fess| doit être redémarré après la modification.
+
 Configuration du SP (Service Provider)
 --------------------------------------
 

--- a/ja/15.8/config/sso-saml.rst
+++ b/ja/15.8/config/sso-saml.rst
@@ -57,6 +57,23 @@ SAML認証を有効にするには、``app/WEB-INF/conf/system.properties`` に�
    管理画面で変更した設定は ``system.properties`` に保存され、再起動後も保持されます。
    ただし、署名・暗号化などのセキュリティ設定やSP証明書・秘密鍵は管理画面では設定できないため、``system.properties`` に直接記述してください。
 
+セッションCookieの設定
+----------------------
+
+IdPはアサーションを |Fess| へ **クロスサイトのPOST** で返します。``SameSite=Lax`` のCookieはこのリクエストに送信されないため、|Fess| が同梱する既定値のままではSAMLログインが完了しません。
+
+``tomcat_config.properties`` の ``tomcat.sameSiteCookies`` を ``none`` に変更してください。このファイルはZIP版では ``lib/classes/`` 、DEB/RPM版では ``/etc/fess/`` に配置されています。
+
+::
+
+    tomcat.sameSiteCookies = none
+
+.. warning::
+   ``none`` はブラウザが ``Secure`` 属性付きCookieに対してのみ受け入れます。したがって |Fess| をHTTPSで提供する必要があります。HTTPのままでは |Fess| にログインできなくなります。
+
+.. note::
+   既定値の ``lax`` はリダイレクト（GET）で戻るSSO方式のために設定されています。SAMLのHTTP-POSTバインディングはこれに該当しないため、SAMLを利用する場合のみ変更が必要です。設定変更後は |Fess| の再起動が必要です。
+
 SP（Service Provider）設定
 --------------------------
 

--- a/ko/15.8/config/sso-saml.rst
+++ b/ko/15.8/config/sso-saml.rst
@@ -57,6 +57,23 @@ SAML 인증을 활성화하려면 ``app/WEB-INF/conf/system.properties`` 에 다
    관리 화면에서 변경한 설정은 ``system.properties`` 에 저장되며, 재시작 후에도 유지됩니다.
    단, 서명·암호화 등의 보안 설정이나 SP 인증서·비밀 키는 관리 화면에서 설정할 수 없으므로 ``system.properties`` 에 직접 기술하십시오.
 
+세션 쿠키 설정
+--------------
+
+IdP는 어설션을 |Fess| 로 **크로스 사이트 POST** 로 반환합니다. ``SameSite=Lax`` 쿠키는 이러한 요청에 전송되지 않으므로, |Fess| 에 포함된 기본값 그대로는 SAML 로그인이 완료되지 않습니다.
+
+``tomcat_config.properties`` 의 ``tomcat.sameSiteCookies`` 를 ``none`` 으로 변경하십시오. 이 파일은 ZIP 패키지에서는 ``lib/classes/`` , DEB/RPM 패키지에서는 ``/etc/fess/`` 에 있습니다.
+
+::
+
+    tomcat.sameSiteCookies = none
+
+.. warning::
+   브라우저는 ``Secure`` 속성이 함께 있는 쿠키에 대해서만 ``none`` 을 허용하므로 |Fess| 를 HTTPS로 제공해야 합니다. 일반 HTTP에서는 이 설정으로 인해 |Fess| 에 로그인할 수 없게 됩니다.
+
+.. note::
+   기본값 ``lax`` 는 콜백이 리디렉션(GET)으로 돌아오는 SSO 방식을 위한 것입니다. SAML의 HTTP-POST 바인딩은 여기에 해당하지 않으므로 SAML을 사용할 때만 변경이 필요합니다. 설정 변경 후에는 |Fess| 를 재시작해야 합니다.
+
 SP（Service Provider）설정
 --------------------------
 

--- a/zh-cn/15.8/config/sso-saml.rst
+++ b/zh-cn/15.8/config/sso-saml.rst
@@ -57,6 +57,23 @@ SAML认证的工作原理
    在管理界面中更改的设置将保存到 ``system.properties`` 中，重启后也会保留。
    但是，签名/加密等安全设置以及SP证书/私钥无法在管理界面中配置，因此请直接写入 ``system.properties``\ 。
 
+会话Cookie配置
+--------------
+
+IdP 通过 **跨站 POST** 将断言返回给 |Fess| 。``SameSite=Lax`` 的 Cookie 不会随此类请求发送，因此使用 |Fess| 附带的默认值时，SAML 登录无法完成。
+
+请将 ``tomcat_config.properties`` 中的 ``tomcat.sameSiteCookies`` 改为 ``none`` 。该文件在 ZIP 软件包中位于 ``lib/classes/`` ，在 DEB/RPM 软件包中位于 ``/etc/fess/`` 。
+
+::
+
+    tomcat.sameSiteCookies = none
+
+.. warning::
+   浏览器仅对同时带有 ``Secure`` 属性的 Cookie 接受 ``none`` ，因此 |Fess| 必须通过 HTTPS 提供服务。在普通 HTTP 下，此设置会导致无法登录 |Fess| 。
+
+.. note::
+   默认值 ``lax`` 是为回调以重定向（GET）返回的 SSO 方式设定的。SAML 的 HTTP-POST 绑定不属于此类，因此仅在使用 SAML 时才需要修改。修改设置后需要重启 |Fess| 。
+
 SP（服务提供者）配置
 --------------------
 


### PR DESCRIPTION
## Problem

The SAML configuration page never mentioned `tomcat.sameSiteCookies`, yet **SAML SSO does not work on a default install without changing it**.

The IdP returns the assertion to Fess as a **cross-site POST** (SAML's HTTP-POST binding). A `SameSite=Lax` cookie is not sent on such a request, and Fess ships `tomcat.sameSiteCookies = lax` in `tomcat_config.properties`. Because the attribute is set *explicitly*, Chrome's two-minute "Lax + POST" grace period does not apply either — that only covers cookies with no `SameSite` attribute at all. The session that holds the AuthnRequest ID is therefore unreachable when the assertion arrives, and the login cannot complete.

The comment on the setting in `tomcat_config.properties` already names SAML's HTTP-POST binding as a case that needs `none`. The SAML page did not, so there was no way to discover the requirement from the documentation.

## Change

Adds a **"Session Cookie Configuration"** section after "Enabling SSO", covering:

- the value to set, and why the shipped default does not work for SAML
- where the file lives per package — `lib/classes/` for the ZIP, `/etc/fess/` for DEB/RPM (verified against `src/main/assemblies/common-bin.xml` and the jdeb/rpm mappings in `pom.xml`, not assumed)
- a warning that `none` is only accepted on a `Secure` cookie, so Fess must be served over HTTPS — on plain HTTP the setting makes login impossible
- a note that the `lax` default exists for redirect-based (GET) SSO callbacks, so this change is only needed for SAML, and that a restart is required

Applied to the 15.8 pages in all seven languages.

Companion to codelibs/fess#3239, which stops the same missing cookie turning into an infinite redirect loop. That change makes the failure visible and logged; this one tells operators how to avoid it.

## Checks

```
tools/check_headings.py over the versions.json current versions (15.7, 15.8): exit 0
  - and no new findings vs master across the whole tree
tools/update_eol.py --check: every translation matches versions.json
python -m unittest discover -s tools: Ran 23 tests, OK
```

All seven changed pages were also parsed with docutils: no title underline or section title errors (the CJK underline widths were computed, not eyeballed).
