### PR TITLE
docs(sso): record the Entra ID callback change and the new response mode

### DIFF
--- a/de/15.8/config/sso-entraid.rst
+++ b/de/15.8/config/sso-entraid.rst
@@ -21,6 +21,14 @@ Bei der Entra ID-Authentifizierung fungiert |Fess| als OAuth 2.0/OpenID Connect-
 6. |Fess| verwendet die Microsoft Graph API, um die Gruppen- und Rolleninformationen des Benutzers abzurufen
 7. Benutzer wird angemeldet und Gruppeninformationen werden auf die rollenbasierte Suche angewendet
 
+.. note::
+   Ab |Fess| 15.8 wird die Autorisierungsantwort in Schritt 4 als GET-Anfrage zurückgegeben, da
+   |Fess| beim Autorisierungsendpunkt ``response_mode=query`` anfordert. Bis 15.7 erfolgte dies
+   über einen websiteübergreifenden POST, bei dem der ausgelieferte Standardwert
+   ``tomcat.sameSiteCookies = lax`` das Sitzungscookie nicht mitsendet; deshalb war
+   ``tomcat.sameSiteCookies = none`` als Umgehungslösung erforderlich. Wenn Sie ``none`` nur aus
+   diesem Grund gesetzt haben, können Sie zum Standardwert zurückkehren.
+
 Informationen zur Integration mit der rollenbasierten Suche finden Sie unter :doc:`security-role`.
 
 Voraussetzungen
@@ -91,6 +99,9 @@ Die folgenden Einstellungen können bei Bedarf hinzugefügt werden.
    * - ``entraid.state.ttl``
      - State-Lebensdauer (Sekunden)
      - ``3600``
+   * - ``entraid.response.mode``
+     - Art, wie die Autorisierungsantwort zurückgegeben wird. Entweder ``query`` oder ``form_post``.
+     - ``query``
    * - ``entraid.default.groups``
      - Standardgruppen (kommagetrennt)
      - (Keine)
@@ -124,6 +135,16 @@ Die folgenden Einstellungen können bei Bedarf hinzugefügt werden.
    passt sie auch auf Dokumente, deren Zugriffsrechte die integrierte Windows-Gruppe
    ``Administrators`` benennen. Prüfen Sie vor dem Hinzufügen, dass die Namen nicht mit den bereits
    in Ihren Zugriffsrechten verwendeten kollidieren.
+
+.. note::
+   Beim Standardwert ``query`` steht der Autorisierungscode in der Query-Zeichenfolge der
+   Callback-URL. ``form_post`` hält den Code aus der URL heraus und damit auch aus dem
+   Browserverlauf und den Zugriffsprotokollen vorgelagerter Proxys oder einer WAF. Allerdings wird
+   der Callback dadurch zu einem websiteübergreifenden POST und erfordert
+   ``tomcat.sameSiteCookies = none``. Ohne diese Einstellung wird das Sitzungscookie nicht
+   zurückgesendet und die Anmeldung schlägt fehl; die meisten Installationen sollten daher beim
+   Standardwert bleiben. Andere Werte werden mit einer Warnung ignoriert und ``query`` wird
+   verwendet.
 
 Konfiguration auf der Entra ID-Seite
 ====================================
@@ -195,6 +216,7 @@ Konfigurieren der API-Berechtigungen
 
 .. note::
    |Fess| fordert beim Token-Abruf den Scope ``https://graph.microsoft.com/.default`` an.
+   Ab 15.8 wird zusätzlich ``openid profile offline_access https://graph.microsoft.com/.default`` an den Autorisierungsendpunkt gesendet, sodass die Zustimmung für denselben Umfang eingeholt wird.
    Das bedeutet, dass alle in der App-Registrierung konfigurierten und genehmigten Zugriffsberechtigungen verwendet werden.
    Um Gruppeninformationen abzurufen, muss daher die oben genannte Berechtigung ``Group.Read.All`` zur App-Registrierung hinzugefügt und die Administratorzustimmung erteilt werden.
 
@@ -299,6 +321,7 @@ Kann nach der Authentifizierung nicht zu Fess zurückkehren
 - Stellen Sie sicher, dass der Wert von ``entraid.reply.url`` genau mit der Azure Portal-Konfiguration übereinstimmt
 - Überprüfen Sie, ob das Protokoll (HTTP/HTTPS) übereinstimmt
 - Überprüfen Sie, ob die Umleitungs-URI mit ``/`` endet
+- Wenn ``entraid.response.mode`` auf ``form_post`` gesetzt ist, überprüfen Sie, ob ``tomcat.sameSiteCookies = none`` konfiguriert ist. Andernfalls wird das Sitzungscookie beim Callback nicht mitgesendet und die Anmeldeseite erscheint immer wieder
 
 Authentifizierungsfehler treten auf
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/en/15.8/config/sso-entraid.rst
+++ b/en/15.8/config/sso-entraid.rst
@@ -21,6 +21,13 @@ In Entra ID authentication, |Fess| operates as an OAuth 2.0/OpenID Connect clien
 6. |Fess| uses Microsoft Graph API to retrieve user's group and role information
 7. User is logged in and group information is applied to role-based search
 
+.. note::
+   From |Fess| 15.8, the authorization response in step 4 is returned as a GET request, because
+   |Fess| asks the authorization endpoint for ``response_mode=query``. Up to 15.7 it was returned
+   as a cross-site POST, and the shipped default ``tomcat.sameSiteCookies = lax`` does not send the
+   session cookie on such a request, so ``tomcat.sameSiteCookies = none`` was required as a
+   workaround. If you set ``none`` only for that reason, you can restore the default.
+
 For role-based search integration, see :doc:`security-role`.
 
 Prerequisites
@@ -91,6 +98,9 @@ The following settings can be added as needed.
    * - ``entraid.state.ttl``
      - State time-to-live (seconds)
      - ``3600``
+   * - ``entraid.response.mode``
+     - How the authorization response is returned. Either ``query`` or ``form_post``.
+     - ``query``
    * - ``entraid.default.groups``
      - Default groups (comma-separated)
      - (None)
@@ -122,6 +132,14 @@ The following settings can be added as needed.
    default. For example, if Entra ID has a group named ``Administrators``, it also matches
    documents whose access rights name the built-in Windows ``Administrators`` group. Before adding
    it, check that the names do not collide with the ones already used in your access rights.
+
+.. note::
+   With the default ``query``, the authorization code is included in the query string of the
+   callback URL. ``form_post`` keeps the code out of the URL, and therefore out of browser history
+   and the access logs of any front-end proxy or WAF, but it makes the callback a cross-site POST
+   and requires ``tomcat.sameSiteCookies = none``. Without that setting the session cookie is not
+   sent back and login fails, so most deployments should keep the default. Any other value is
+   ignored with a warning and ``query`` is used.
 
 Entra ID Side Configuration
 ===========================
@@ -192,7 +210,7 @@ Configuring API Permissions
    Admin consent requires tenant administrator privileges.
 
 .. note::
-   |Fess| requests the ``https://graph.microsoft.com/.default`` scope when acquiring a token. This means that all access permissions configured and consented to on the app registration are used. Therefore, to retrieve group information, you must add the ``Group.Read.All`` permission above to the app registration and grant administrator consent.
+   |Fess| requests the ``https://graph.microsoft.com/.default`` scope when acquiring a token, and from 15.8 it also sends ``openid profile offline_access https://graph.microsoft.com/.default`` to the authorization endpoint so that consent is requested for the same set. This means that all access permissions configured and consented to on the app registration are used. Therefore, to retrieve group information, you must add the ``Group.Read.All`` permission above to the app registration and grant administrator consent.
 
 Information to Obtain
 ---------------------
@@ -295,6 +313,7 @@ Cannot Return to Fess After Authentication
 - Ensure the ``entraid.reply.url`` value exactly matches the Azure Portal configuration
 - Check that the protocol (HTTP/HTTPS) matches
 - Verify the Redirect URI ends with ``/``
+- If ``entraid.response.mode`` is set to ``form_post``, verify that ``tomcat.sameSiteCookies = none`` is configured. Without it, the session cookie is not sent with the callback and the sign-in screen keeps reappearing
 
 Authentication Errors Occur
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/es/15.8/config/sso-entraid.rst
+++ b/es/15.8/config/sso-entraid.rst
@@ -21,6 +21,14 @@ En la autenticación de Entra ID, |Fess| opera como un cliente OAuth 2.0/OpenID 
 6. |Fess| utiliza la API de Microsoft Graph para recuperar la información de grupo y rol del usuario
 7. El usuario inicia sesión y la información de grupo se aplica a la búsqueda basada en roles
 
+.. note::
+   A partir de |Fess| 15.8, la respuesta de autorización del paso 4 se devuelve como una solicitud
+   GET, ya que |Fess| solicita ``response_mode=query`` al endpoint de autorización. Hasta la
+   versión 15.7 se devolvía mediante un POST entre sitios, y el valor por defecto incluido
+   ``tomcat.sameSiteCookies = lax`` no envía la cookie de sesión en ese caso, por lo que era
+   necesario ``tomcat.sameSiteCookies = none`` como solución alternativa. Si configuró ``none``
+   únicamente por ese motivo, puede volver al valor por defecto.
+
 Para la integración con la búsqueda basada en roles, consulte :doc:`security-role`.
 
 Prerrequisitos
@@ -91,6 +99,9 @@ Las siguientes configuraciones pueden agregarse según sea necesario.
    * - ``entraid.state.ttl``
      - Tiempo de vida del state (segundos)
      - ``3600``
+   * - ``entraid.response.mode``
+     - Forma en que se devuelve la respuesta de autorización. Puede ser ``query`` o ``form_post``.
+     - ``query``
    * - ``entraid.default.groups``
      - Grupos por defecto (separados por comas)
      - (Ninguno)
@@ -124,6 +135,15 @@ Las siguientes configuraciones pueden agregarse según sea necesario.
    coincidirá con documentos cuyos derechos de acceso indiquen el grupo integrado de Windows
    ``Administrators``. Antes de agregarlo, compruebe que los nombres no entren en conflicto con los
    que ya se usan en sus derechos de acceso.
+
+.. note::
+   Con el valor por defecto ``query``, el código de autorización se incluye en la cadena de
+   consulta de la URL de callback. ``form_post`` mantiene el código fuera de la URL y, por lo
+   tanto, fuera del historial del navegador y de los registros de acceso de cualquier proxy
+   frontal o WAF, pero convierte el callback en un POST entre sitios y requiere
+   ``tomcat.sameSiteCookies = none``. Sin esa configuración, la cookie de sesión no se devuelve y
+   el inicio de sesión falla, por lo que la mayoría de las instalaciones deberían mantener el valor
+   por defecto. Cualquier otro valor se ignora con una advertencia y se utiliza ``query``.
 
 Configuración del lado de Entra ID
 ==================================
@@ -195,6 +215,7 @@ Configurar permisos de API
 
 .. note::
    |Fess| solicita el ámbito ``https://graph.microsoft.com/.default`` al adquirir un token.
+   Desde la versión 15.8, también se envía ``openid profile offline_access https://graph.microsoft.com/.default`` al endpoint de autorización, de modo que el consentimiento se solicita para el mismo conjunto.
    Esto significa que se utilizan todos los permisos de acceso configurados y para los que se ha dado consentimiento en el registro de la aplicación.
    Por lo tanto, para recuperar información de grupos, debe agregar el permiso ``Group.Read.All`` indicado anteriormente al registro de la aplicación y otorgar el consentimiento del administrador.
 
@@ -299,6 +320,7 @@ No se puede regresar a Fess después de la autenticación
 - Asegúrese de que el valor de ``entraid.reply.url`` coincida exactamente con la configuración del portal Azure
 - Verifique que el protocolo (HTTP/HTTPS) coincida
 - Verifique que la URI de redirección termine con ``/``
+- Si ``entraid.response.mode`` está establecido en ``form_post``, verifique que ``tomcat.sameSiteCookies = none`` esté configurado. De lo contrario, la cookie de sesión no se envía con el callback y la pantalla de inicio de sesión vuelve a aparecer una y otra vez
 
 Ocurren errores de autenticación
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/fr/15.8/config/sso-entraid.rst
+++ b/fr/15.8/config/sso-entraid.rst
@@ -21,6 +21,14 @@ Dans l'authentification Entra ID, |Fess| opère en tant que client OAuth 2.0/Ope
 6. |Fess| utilise l'API Microsoft Graph pour récupérer les informations de groupe et de rôle de l'utilisateur
 7. L'utilisateur est connecté et les informations de groupe sont appliquées à la recherche basée sur les rôles
 
+.. note::
+   À partir de |Fess| 15.8, la réponse d'autorisation de l'étape 4 est renvoyée via une requête
+   GET, car |Fess| demande ``response_mode=query`` au point de terminaison d'autorisation.
+   Jusqu'à la version 15.7, elle était renvoyée via un POST inter-sites, et la valeur par défaut
+   fournie ``tomcat.sameSiteCookies = lax`` n'envoie pas le cookie de session dans ce cas ;
+   ``tomcat.sameSiteCookies = none`` était donc nécessaire comme contournement. Si vous avez
+   défini ``none`` uniquement pour cette raison, vous pouvez revenir à la valeur par défaut.
+
 Pour l'intégration avec la recherche basée sur les rôles, consultez :doc:`security-role`.
 
 Prérequis
@@ -91,6 +99,9 @@ Les paramètres suivants peuvent être ajoutés si nécessaire.
    * - ``entraid.state.ttl``
      - Durée de vie du state (secondes)
      - ``3600``
+   * - ``entraid.response.mode``
+     - Mode de renvoi de la réponse d'autorisation. Soit ``query``, soit ``form_post``.
+     - ``query``
    * - ``entraid.default.groups``
      - Groupes par défaut (séparés par des virgules)
      - (Aucun)
@@ -125,6 +136,15 @@ Les paramètres suivants peuvent être ajoutés si nécessaire.
    correspondra aussi aux documents dont les droits d'accès désignent le groupe Windows intégré
    ``Administrators``. Avant de l'ajouter, vérifiez que les noms n'entrent pas en conflit avec ceux
    déjà utilisés dans vos droits d'accès.
+
+.. note::
+   Avec la valeur par défaut ``query``, le code d'autorisation figure dans la chaîne de requête de
+   l'URL de callback. ``form_post`` maintient le code hors de l'URL, et donc hors de l'historique
+   du navigateur et des journaux d'accès des proxys frontaux ou d'un WAF, mais il transforme le
+   callback en un POST inter-sites et nécessite ``tomcat.sameSiteCookies = none``. Sans ce
+   paramètre, le cookie de session n'est pas renvoyé et la connexion échoue : la plupart des
+   installations doivent donc conserver la valeur par défaut. Toute autre valeur est ignorée avec
+   un avertissement et ``query`` est utilisé.
 
 Configuration côté Entra ID
 ===========================
@@ -196,6 +216,7 @@ Configuration des autorisations d'API
 
 .. note::
    |Fess| demande le scope ``https://graph.microsoft.com/.default`` lors de l'acquisition d'un jeton.
+   Depuis la version 15.8, ``openid profile offline_access https://graph.microsoft.com/.default`` est également envoyé au point de terminaison d'autorisation, afin que le consentement soit demandé pour le même ensemble.
    Cela signifie que toutes les autorisations d'accès configurées et consenties sur l'inscription d'application sont utilisées.
    Par conséquent, pour récupérer les informations de groupe, vous devez ajouter l'autorisation ``Group.Read.All`` ci-dessus à l'inscription d'application et accorder le consentement administrateur.
 
@@ -298,6 +319,7 @@ Impossible de revenir à Fess après l'authentification
 - Assurez-vous que la valeur de ``entraid.reply.url`` correspond exactement à la configuration du portail Azure
 - Vérifiez que le protocole (HTTP/HTTPS) correspond
 - Vérifiez que l'URI de redirection se termine par ``/``
+- Si ``entraid.response.mode`` est défini sur ``form_post``, vérifiez que ``tomcat.sameSiteCookies = none`` est configuré. Sinon, le cookie de session n'est pas renvoyé avec le callback et l'écran de connexion réapparaît sans cesse
 
 Des erreurs d'authentification se produisent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ja/15.8/config/sso-entraid.rst
+++ b/ja/15.8/config/sso-entraid.rst
@@ -21,6 +21,12 @@ Entra ID認証では、|Fess| がOAuth 2.0/OpenID Connectのクライアント�
 6. |Fess| がMicrosoft Graph APIを使用してユーザーのグループ・ロール情報を取得
 7. ユーザーをログインし、グループ情報をロールベース検索に適用
 
+.. note::
+   |Fess| 15.8 以降は認可エンドポイントに ``response_mode=query`` を要求するため、手順4の認可レスポンスはGETで返されます。
+   15.7 以前はクロスサイトのPOSTで返されており、|Fess| の既定値である ``tomcat.sameSiteCookies = lax``
+   ではセッションクッキーが送信されないため、``tomcat.sameSiteCookies = none`` への変更が回避策として必要でした。
+   この回避策のためだけに ``none`` を設定していた場合は、既定値に戻せます。
+
 ロールベース検索との連携については、:doc:`security-role` を参照してください。
 
 前提条件
@@ -91,6 +97,9 @@ Entra IDから取得した情報を設定します。
    * - ``entraid.state.ttl``
      - State有効期限（秒）
      - ``3600``
+   * - ``entraid.response.mode``
+     - 認可レスポンスの受け取り方法。\ ``query`` または ``form_post`` を指定します。
+     - ``query``
    * - ``entraid.default.groups``
      - デフォルトグループ（カンマ区切り）
      - （なし）
@@ -121,6 +130,15 @@ Entra IDから取得した情報を設定します。
    たとえばEntra ID側に ``Administrators`` という名前のグループがあると、
    Windowsの組み込みグループ ``Administrators`` を指定した文書にも一致します。
    追加する際は、既存のアクセス権で使われている名前と衝突しないことを確認してください。
+
+.. note::
+   既定の ``query`` では、認可コードがコールバックURLのクエリ文字列に含まれます。
+   ``form_post`` を指定すると認可コードはURLに現れないため、ブラウザの履歴や、
+   フロントエンドのプロキシ・WAFのアクセスログにも残りません。
+   ただし ``form_post`` はクロスサイトのPOSTになるため、``tomcat.sameSiteCookies = none`` が必要です。
+   設定していない場合はセッションクッキーが送信されず、ログインに失敗します。
+   通常は既定値のまま使用してください。
+   ``query`` と ``form_post`` 以外を指定した場合は、警告を出力して ``query`` として扱います。
 
 Entra ID側での設定
 ==================
@@ -192,6 +210,8 @@ APIアクセス許可の設定
 
 .. note::
    |Fess| はトークン取得時に ``https://graph.microsoft.com/.default`` スコープを要求します。
+   15.8 以降は、認可エンドポイントにも ``openid profile offline_access https://graph.microsoft.com/.default``
+   を要求し、同じ範囲の同意を求めます。
    これは、アプリ登録で構成・同意済みのすべてのアクセス許可が使用されることを意味します。
    そのため、グループ情報を取得するには、上記の ``Group.Read.All`` をアプリ登録に追加し、
    管理者の同意を与えておく必要があります。
@@ -297,6 +317,7 @@ Entra ID認証では、Microsoft Graph APIを使用してユーザーが所属�
 - ``entraid.reply.url`` の値がAzure Portalの設定と完全に一致しているか確認してください
 - プロトコル（HTTP/HTTPS）が一致しているか確認してください
 - リダイレクトURIの末尾に ``/`` が含まれているか確認してください
+- ``entraid.response.mode`` に ``form_post`` を指定している場合は、``tomcat.sameSiteCookies = none`` が設定されているか確認してください。未設定の場合、コールバック時にセッションクッキーが送信されず、ログイン画面に戻る動作を繰り返します
 
 認証エラーが発生する
 ~~~~~~~~~~~~~~~~~~~~

--- a/ko/15.8/config/sso-entraid.rst
+++ b/ko/15.8/config/sso-entraid.rst
@@ -21,6 +21,13 @@ Entra ID 인증에서는 |Fess| 가 OAuth 2.0/OpenID Connect의 클라이언트�
 6. |Fess| 가 Microsoft Graph API를 사용하여 사용자의 그룹 및 역할 정보를 취득
 7. 사용자를 로그인하고 그룹 정보를 역할 기반 검색에 적용
 
+.. note::
+   |Fess| 15.8 이상에서는 인가 엔드포인트에 ``response_mode=query`` 를 요청하므로, 4번의 인가
+   응답은 GET으로 반환됩니다. 15.7 이전에는 크로스 사이트 POST로 반환되었고, |Fess| 의 기본값인
+   ``tomcat.sameSiteCookies = lax`` 에서는 세션 쿠키가 전송되지 않기 때문에
+   ``tomcat.sameSiteCookies = none`` 으로 변경하는 우회 방법이 필요했습니다.
+   이 우회 방법을 위해서만 ``none`` 을 설정했다면 기본값으로 되돌릴 수 있습니다.
+
 역할 기반 검색과의 연동에 대해서는 :doc:`security-role` 을 참조하십시오.
 
 전제조건
@@ -91,6 +98,9 @@ Entra ID에서 취득한 정보를 설정합니다.
    * - ``entraid.state.ttl``
      - State 유효 기간（초）
      - ``3600``
+   * - ``entraid.response.mode``
+     - 인가 응답을 받는 방식. ``query`` 또는 ``form_post`` 를 지정합니다.
+     - ``query``
    * - ``entraid.default.groups``
      - 기본 그룹（쉼표 구분）
      - （없음）
@@ -122,6 +132,14 @@ Entra ID에서 취득한 정보를 설정합니다.
    않습니다. 예를 들어 Entra ID에 ``Administrators`` 라는 이름의 그룹이 있으면, Windows 기본 제공
    그룹 ``Administrators`` 를 지정한 문서에도 일치합니다. 추가하기 전에 기존 액세스 권한에서
    사용 중인 이름과 충돌하지 않는지 확인하십시오.
+
+.. note::
+   기본값인 ``query`` 에서는 인가 코드가 콜백 URL의 쿼리 문자열에 포함됩니다.
+   ``form_post`` 를 지정하면 인가 코드가 URL에 나타나지 않으므로 브라우저 기록이나 프런트엔드
+   프록시・WAF의 액세스 로그에도 남지 않습니다. 다만 ``form_post`` 는 콜백이 크로스 사이트
+   POST가 되므로 ``tomcat.sameSiteCookies = none`` 이 필요합니다. 설정하지 않으면 세션 쿠키가
+   전송되지 않아 로그인에 실패하므로, 대부분의 환경에서는 기본값 그대로 사용하십시오.
+   그 외의 값을 지정한 경우에는 경고를 출력하고 ``query`` 로 처리합니다.
 
 Entra ID 측 설정
 ==================
@@ -193,6 +211,8 @@ API 접근 권한 설정
 
 .. note::
    |Fess| 는 토큰 취득 시 ``https://graph.microsoft.com/.default`` 스코프를 요청합니다.
+   15.8 이상에서는 인가 엔드포인트에도 ``openid profile offline_access https://graph.microsoft.com/.default``
+   를 요청하여 동일한 범위의 동의를 요구합니다.
    이는 앱 등록에서 구성 및 동의된 모든 접근 권한이 사용됨을 의미합니다.
    따라서 그룹 정보를 취득하려면 위의 ``Group.Read.All`` 을 앱 등록에 추가하고
    관리자 동의를 부여해야 합니다.
@@ -298,6 +318,7 @@ Entra ID 인증에서는 Microsoft Graph API를 사용하여 사용자가 소속
 - ``entraid.reply.url`` 의 값이 Azure Portal의 설정과 완전히 일치하는지 확인하십시오
 - 프로토콜（HTTP/HTTPS）이 일치하는지 확인하십시오
 - 리다이렉트 URI의 끝에 ``/`` 가 포함되어 있는지 확인하십시오
+- ``entraid.response.mode`` 에 ``form_post`` 를 지정한 경우에는 ``tomcat.sameSiteCookies = none`` 이 설정되어 있는지 확인하십시오. 설정되어 있지 않으면 콜백 시 세션 쿠키가 전송되지 않아 로그인 화면으로 되돌아가는 동작이 반복됩니다
 
 인증 오류가 발생함
 ~~~~~~~~~~~~~~~~~~~~

--- a/zh-cn/15.8/config/sso-entraid.rst
+++ b/zh-cn/15.8/config/sso-entraid.rst
@@ -21,6 +21,12 @@ Entra ID认证的工作原理
 6. |Fess| 使用Microsoft Graph API获取用户的组和角色信息
 7. 用户登录，组信息应用于基于角色的搜索
 
+.. note::
+   |Fess| 15.8 及以后版本会向授权端点请求 ``response_mode=query``\ ，因此步骤4的授权响应以GET方式返回。
+   15.7 及之前版本以跨站POST方式返回，而 |Fess| 的默认值 ``tomcat.sameSiteCookies = lax``
+   在该情况下不会发送会话Cookie，因此需要将其改为 ``tomcat.sameSiteCookies = none`` 作为规避方法。
+   如果您仅出于该原因设置了 ``none``\ ，现在可以恢复为默认值。
+
 有关基于角色的搜索集成，请参阅 :doc:`security-role`。
 
 前提条件
@@ -91,6 +97,9 @@ Entra ID认证的工作原理
    * - ``entraid.state.ttl``
      - State有效期（秒）
      - ``3600``
+   * - ``entraid.response.mode``
+     - 授权响应的返回方式。可指定 ``query`` 或 ``form_post``\ 。
+     - ``query``
    * - ``entraid.default.groups``
      - 默认组（逗号分隔）
      - （无）
@@ -120,6 +129,13 @@ Entra ID认证的工作原理
    ``displayName`` 不带域限定且不唯一，因此未包含在默认值中。
    例如，如果Entra ID中存在名为 ``Administrators`` 的组，它也会匹配访问权限指定了Windows内置组
    ``Administrators`` 的文档。添加前请确认这些名称不会与访问权限中已使用的名称冲突。
+
+.. note::
+   使用默认值 ``query`` 时，授权码会包含在回调URL的查询字符串中。
+   指定 ``form_post`` 后，授权码不会出现在URL中，因此也不会留在浏览器历史记录以及前端代理或WAF的访问日志中。
+   但 ``form_post`` 会使回调成为跨站POST，因此需要 ``tomcat.sameSiteCookies = none``\ 。
+   未进行该设置时，会话Cookie不会被发送，登录将失败，因此大多数环境应保持默认值。
+   指定其他值时，将输出警告并按 ``query`` 处理。
 
 Entra ID侧配置
 ==============
@@ -191,6 +207,7 @@ Entra ID侧配置
 
 .. note::
    |Fess| 在获取令牌时会请求 ``https://graph.microsoft.com/.default`` 作用域。
+   15.8 及以后版本还会向授权端点发送 ``openid profile offline_access https://graph.microsoft.com/.default``\ ，以便针对同一组权限请求同意。
    这意味着将使用在应用注册中配置并已授予同意的所有访问权限。
    因此，若要获取组信息，必须将上述 ``Group.Read.All`` 权限添加到应用注册中，并授予管理员同意。
 
@@ -293,6 +310,7 @@ Entra ID侧配置
 - 确保 ``entraid.reply.url`` 的值与Azure Portal配置完全匹配
 - 验证协议（HTTP/HTTPS）是否匹配
 - 验证重定向URI是否以 ``/`` 结尾
+- 如果将 ``entraid.response.mode`` 设置为 ``form_post``\ ，请确认已配置 ``tomcat.sameSiteCookies = none``\ 。否则回调时不会发送会话Cookie，会反复返回登录页面
 
 发生认证错误
 ~~~~~~~~~~~~


### PR DESCRIPTION
Documents a behaviour change that shipped in 15.8 without a word in the manual, and the setting
added in codelibs/fess#3243.

## The callback is now a GET

Up to 15.7 Fess asked the authorization endpoint for `response_mode=form_post`, so the
authorization response came back as a cross-site POST. Fess ships
`tomcat.sameSiteCookies = lax`, and a Lax cookie is not sent on such a request, so the callback
arrived without the session cookie and the sign-in screen kept reappearing. Administrators worked
around it by setting `sameSiteCookies = none`.

15.8 asks for `response_mode=query`, so the response arrives as a GET and the shipped default
works. None of this was in the document, and the "cannot return to Fess after authentication"
section listed only redirect URI causes.

Added: a note in the overview recording the change and that the `none` workaround can be reverted,
and the lost-session cause in the troubleshooting list.

## The new setting

`entraid.response.mode` (legacy `aad.response.mode`) selects `query` or `form_post`, defaulting to
`query`. `form_post` keeps the authorization code out of the callback URL — and out of browser
history and any front-end proxy or WAF access log — but requires `sameSiteCookies = none`, so most
deployments should keep the default. Added as a row in the optional settings table plus a note on
the trade-off.

## Scope note

The existing note said the `https://graph.microsoft.com/.default` scope is requested at token
acquisition. Since 15.8 it is also sent to the authorization endpoint, so consent is asked for the
same set. One clause added; the rest of the note is unchanged.

## Notes

All seven languages, 15.8 only. Checked with the repository's own tooling — the heading checker,
the EOL checker and the `tools` unit tests all pass, and every changed file parses with docutils
with no new messages. A full Sphinx build does not run here: it fails before reading any `.rst`,
on a pre-existing non-raw string in `conf/conf.py` that Python 3.12 rejects.

Please merge after codelibs/fess#3243, since `entraid.response.mode` does not exist before it.
