### PR TITLE
docs(sso): correct the SAML guide for 15.8 behaviour

### DIFF
--- a/de/15.8/config/sso-saml.rst
+++ b/de/15.8/config/sso-saml.rst
@@ -19,6 +19,19 @@ Bei der SAML-Authentifizierung fungiert |Fess| als SP (Service Provider) und arb
 4. IdP sendet SAML-Assertion an |Fess|
 5. |Fess| validiert die Assertion und meldet den Benutzer an
 
+.. note::
+   Unterstützt wird ausschließlich die SP-initiierte Anmeldung, die wie oben beschrieben am
+   |Fess| SSO-Endpunkt (``/sso/``) beginnt. |Fess| bindet jede SAML-Antwort an die ID der von ihm
+   gesendeten AuthnRequest. Eine IdP-initiierte (unaufgeforderte) Antwort, etwa von einer
+   |Fess| -Kachel im Okta-Dashboard oder im Portal „Meine Apps" von Microsoft Entra ID, hat daher
+   keine zugehörige AuthnRequest und wird abgelehnt. Wenn Sie auf der IdP-Seite eine Kachel
+   anlegen, lassen Sie diese auf den |Fess| -Endpunkt ``/sso/`` verweisen.
+
+   Beachten Sie: In 15.7 funktionierte eine IdP-initiierte Anmeldung zufällig, wenn
+   ``tomcat.sameSiteCookies=none`` gesetzt war. |Fess| schickte die nicht zuordenbare Antwort an den
+   IdP zurück, und der IdP lieferte sofort eine angeforderte Assertion. In 15.8 erfolgt dieses
+   Zurückschicken nicht mehr, sodass die IdP-initiierte Anmeldung nicht funktioniert.
+
 Für die Integration mit rollenbasierter Suche siehe :doc:`security-role`.
 
 Voraussetzungen
@@ -56,6 +69,12 @@ Um die SAML-Authentifizierung zu aktivieren, fügen Sie die folgende Einstellung
    ``sso.type`` und die grundlegenden SAML-Einstellungen (IdP-Informationen, SP-Informationen, Benutzerattribut-Zuordnung) können auch über die Administrationsseite „System > Allgemein" konfiguriert werden.
    Im Admin-Bereich vorgenommene Änderungen werden in ``system.properties`` gespeichert und bleiben nach einem Neustart erhalten.
    Sicherheitseinstellungen wie Signierung/Verschlüsselung sowie das SP-Zertifikat und der private Schlüssel können jedoch nicht über die Administrationsseite konfiguriert werden und müssen direkt in ``system.properties`` eingetragen werden.
+
+.. note::
+   Einstellungen, die mit ``saml.`` beginnen, werden ausschließlich aus ``system.properties`` gelesen.
+   JVM-Systemeigenschaften wie ``-Dsaml.security....`` oder ``-Dfess.saml.security....`` werden nicht ausgewertet.
+   Insbesondere ``saml.security.*``, ``saml.strict`` und ``saml.debug`` haben auch kein Feld auf der Administrationsseite;
+   der einzige Weg, sie zu setzen, ist der direkte Eintrag in ``system.properties``.
 
 Konfiguration des Sitzungs-Cookies
 ----------------------------------
@@ -290,10 +309,32 @@ Signatureinstellungen
    * - ``saml.security.logoutresponse_signed``
      - Logout-Antworten signieren
      - ``false``
+   * - ``saml.security.reject_deprecated_alg``
+     - Veraltete Signaturalgorithmen wie SHA-1 ablehnen
+     - ``false``
 
 .. warning::
    Sicherheitsfunktionen sind standardmäßig deaktiviert.
    Für Produktionsumgebungen wird dringend empfohlen, mindestens ``saml.security.want_assertions_signed=true`` zu setzen.
+
+.. note::
+   Solange ``saml.security.reject_deprecated_alg`` auf ``false`` steht, werden auch Assertions und
+   Nachrichten akzeptiert, die mit SHA-1 (``rsa-sha1`` und ``dsa-sha1``) signiert wurden.
+   Die Option ist nicht standardmäßig aktiviert, weil sie IdPs ablehnt, die weiterhin mit SHA-1 signieren.
+   Stellen Sie sicher, dass Ihr IdP mit SHA-256 oder stärker signiert, und setzen Sie anschließend
+   ``saml.security.reject_deprecated_alg=true``.
+
+.. warning::
+   Wenn Single Logout konfiguriert ist (``saml.idp.single_logout_service.url``), setzen Sie unbedingt
+   auch ``saml.security.want_messages_signed=true``.
+   Solange die Option ``false`` ist, wird für eine an ``/sso/logout`` eingehende LogoutRequest keine
+   Signatur verlangt. Geprüft werden lediglich das XML-Schema, ``NotOnOrAfter`` (falls vorhanden),
+   ``Destination`` (falls vorhanden) und die Übereinstimmung des Issuers mit ``saml.idp.entityid``;
+   die NameID in der LogoutRequest wird nie mit dem angemeldeten Benutzer verglichen.
+   Ein Angreifer, der die Entity-ID des IdP kennt (eine öffentliche Information), kann daher eine
+   unsignierte LogoutRequest erzeugen und die Sitzung eines authentifizierten Benutzers beenden,
+   indem er diesen auf die entsprechende URL lockt.
+   Die Auswirkung ist eine erzwungene Abmeldung (Denial of Service), keine Kontoübernahme.
 
 Verschlüsselungseinstellungen
 -----------------------------
@@ -417,6 +458,9 @@ Das Folgende ist ein empfohlenes Konfigurationsbeispiel für Produktionsumgebung
     saml.security.want_assertions_signed=true
     saml.security.want_messages_signed=true
 
+    # Aktivieren, nachdem bestätigt wurde, dass der IdP mit SHA-256 oder stärker signiert
+    saml.security.reject_deprecated_alg=true
+
 Fehlerbehebung
 ==============
 
@@ -430,9 +474,51 @@ Kann nach der Authentifizierung nicht zu Fess zurückkehren
 - Stellen Sie sicher, dass der Wert von ``saml.sp.base.url`` mit der IdP-Konfiguration übereinstimmt
 - Die SAML-Assertion trifft als seitenübergreifender POST vom IdP ein. Wenn
   ``tomcat.sameSiteCookies`` in ``tomcat_config.properties`` auf ``lax`` (Standard) steht, sendet der
-  Browser das Sitzungs-Cookie nicht mit, sodass |Fess| keinen SAML-Status findet und erneut zum IdP
-  weiterleitet, was eine Schleife ergibt. Setzen Sie in diesem Fall
-  ``tomcat.sameSiteCookies = none`` (``SameSite=None`` erfordert HTTPS)
+  Browser das Sitzungs-Cookie nicht mit. |Fess| findet dann keine passende AuthnRequest-ID und lässt
+  die Anmeldung an dieser Stelle einmalig fehlschlagen. Der Browser kehrt zur Anmeldeseite mit der
+  Meldung „SSO-Anmeldevorgang fehlgeschlagen." zurück, und im Protokoll erscheint eine Warnung, die
+  mit ``Received a SAML response with no matching AuthnRequest ID in the session.`` beginnt.
+  Setzen Sie in diesem Fall ``tomcat.sameSiteCookies = none`` (``SameSite=None`` erfordert HTTPS)
+
+.. note::
+   In 15.7 leitete |Fess| in derselben Situation immer wieder zum IdP weiter, sodass die Anmeldung in
+   einer Schleife lief. In 15.8 schlägt sie stattdessen einmalig fehl. An der Konfigurationslösung
+   ändert sich nichts.
+
+Destination-Validierung schlägt hinter einem Reverse Proxy fehl
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Wenn |Fess| hinter einem TLS-terminierenden Reverse Proxy oder Load Balancer betrieben wird, kann die
+Assertion-Validierung fehlschlagen, obwohl ``saml.sp.base.url`` korrekt gesetzt ist.
+
+Die Ursache: Die SAML-Bibliothek vergleicht das Attribut ``Destination`` der Assertion mit der vom
+Servlet-Container rekonstruierten Anfrage-URL und nicht mit der konfigurierten ACS-URL. Wenn der Proxy
+HTTPS terminiert, sieht |Fess| eine interne Anfrage-URL wie
+``http://<interner-host>:<interner-port>/sso/``, die nicht mit der vom IdP gesendeten URL
+``https://fess.example.com/sso/`` übereinstimmt. ``saml.sp.base.url`` wird für diesen Vergleich nicht
+herangezogen; die Einstellung allein behebt das Problem daher nicht.
+
+Setzen Sie ``saml.debug=true``, damit der Grund ins Protokoll geschrieben wird:
+
+::
+
+    The response was received at http://... instead of https://fess.example.com/sso/
+
+Passen Sie die Connector-Einstellungen in ``tomcat_config.properties`` an das von außen sichtbare
+Schema und den Port an. Diese Einstellungen werden auskommentiert ausgeliefert:
+
+::
+
+    tomcat.secure=true
+    tomcat.scheme=https
+    tomcat.proxyPort=443
+
+Konfigurieren Sie außerdem den Reverse Proxy so, dass er den ursprünglichen ``Host``-Header an |Fess|
+durchreicht, denn der Hostname-Teil der Anfrage-URL wird aus diesem Header gebildet. Nach Änderungen
+an ``tomcat_config.properties`` muss |Fess| neu gestartet werden.
+
+Dieselbe Prüfung gilt für Single-Logout-Nachrichten; konfigurieren Sie dies bei Verwendung von SLO
+entsprechend.
 
 Signaturüberprüfungsfehler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/en/15.8/config/sso-saml.rst
+++ b/en/15.8/config/sso-saml.rst
@@ -19,6 +19,17 @@ In SAML authentication, |Fess| operates as an SP (Service Provider) and collabor
 4. IdP sends SAML assertion to |Fess|
 5. |Fess| validates the assertion and logs in the user
 
+.. note::
+   Only SP-initiated login, which starts at the |Fess| SSO endpoint (``/sso/``) as shown above, is supported.
+   |Fess| binds every SAML response to the ID of the AuthnRequest it sent, so an IdP-initiated
+   (unsolicited) response, for example from a |Fess| tile on an Okta dashboard or in the Microsoft
+   Entra ID "My Apps" portal, has no AuthnRequest to match against and is rejected.
+   If you place a tile on the IdP side, point it at the |Fess| ``/sso/`` endpoint.
+
+   Note that in 15.7 an IdP-initiated login happened to work when ``tomcat.sameSiteCookies=none``
+   was set: |Fess| bounced the unmatched response back to the IdP, and the IdP immediately returned
+   a solicited assertion. 15.8 no longer bounces the response, so IdP-initiated login does not work.
+
 For role-based search integration, see :doc:`security-role`.
 
 Prerequisites
@@ -56,6 +67,12 @@ To enable SAML authentication, add the following setting to ``app/WEB-INF/conf/s
    ``sso.type`` and the basic SAML settings (IdP info, SP info, user attribute mapping) can also be configured from the admin "System > General" page.
    Settings changed in the admin UI are saved to ``system.properties`` and persist after restart.
    However, security settings such as signing/encryption and the SP certificate/private key cannot be configured in the admin UI, so write them directly in ``system.properties``.
+
+.. note::
+   Settings that start with ``saml.`` are read only from ``system.properties``.
+   JVM system properties such as ``-Dsaml.security....`` or ``-Dfess.saml.security....`` are not consulted.
+   In particular, ``saml.security.*``, ``saml.strict`` and ``saml.debug`` have no field in the admin UI either,
+   so writing them directly in ``system.properties`` is the only way to set them.
 
 Session Cookie Configuration
 ----------------------------
@@ -290,10 +307,30 @@ Signature Settings
    * - ``saml.security.logoutresponse_signed``
      - Sign logout responses
      - ``false``
+   * - ``saml.security.reject_deprecated_alg``
+     - Reject deprecated signature algorithms such as SHA-1
+     - ``false``
 
 .. warning::
    Security features are disabled by default.
    For production environments, it is strongly recommended to set at least ``saml.security.want_assertions_signed=true``.
+
+.. note::
+   While ``saml.security.reject_deprecated_alg`` is ``false``, assertions and messages signed with
+   SHA-1 (``rsa-sha1`` and ``dsa-sha1``) are also accepted. It is not enabled by default because
+   turning it on rejects IdPs that still sign with SHA-1.
+   Confirm that your IdP signs with SHA-256 or stronger, then set ``saml.security.reject_deprecated_alg=true``.
+
+.. warning::
+   When Single Logout is configured (``saml.idp.single_logout_service.url``), always set
+   ``saml.security.want_messages_signed=true`` as well.
+   While it is ``false``, no signature is required on a LogoutRequest received at ``/sso/logout``.
+   The only checks performed are the XML schema, ``NotOnOrAfter`` (if present), ``Destination``
+   (if present), and that the Issuer matches ``saml.idp.entityid``; the NameID in the LogoutRequest
+   is never compared against the logged-in user.
+   An attacker who knows the IdP entity ID, which is public information, can therefore craft an
+   unsigned LogoutRequest and terminate an authenticated user's session by luring that user to the URL.
+   The impact is a forced logout (denial of service), not account takeover.
 
 Encryption Settings
 -------------------
@@ -417,6 +454,9 @@ The following is a recommended configuration example for production environments
     saml.security.want_assertions_signed=true
     saml.security.want_messages_signed=true
 
+    # Enable after confirming the IdP signs with SHA-256 or stronger
+    saml.security.reject_deprecated_alg=true
+
 Troubleshooting
 ===============
 
@@ -430,8 +470,48 @@ Cannot return to Fess after authentication
 - Ensure the ``saml.sp.base.url`` value matches the IdP configuration
 - The SAML assertion arrives as a cross-site POST from the IdP. When ``tomcat.sameSiteCookies`` in
   ``tomcat_config.properties`` is ``lax`` (the default), the browser does not send the session cookie
-  with it, so |Fess| finds no SAML state and redirects to the IdP again, which loops. Set
-  ``tomcat.sameSiteCookies = none`` in that case (``SameSite=None`` requires HTTPS)
+  with it, so |Fess| finds no matching AuthnRequest ID and fails the login once, on the spot. The
+  browser returns to the login page showing "SSO login process failed.", and a warning beginning with
+  ``Received a SAML response with no matching AuthnRequest ID in the session.`` is written to the log.
+  Set ``tomcat.sameSiteCookies = none`` in that case (``SameSite=None`` requires HTTPS)
+
+.. note::
+   In 15.7 the same situation caused |Fess| to redirect to the IdP again and again, looping the login.
+   15.8 fails once instead of looping. The configuration remedy is unchanged.
+
+Destination validation fails behind a reverse proxy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When |Fess| runs behind a TLS-terminating reverse proxy or load balancer, assertion validation can
+fail even though ``saml.sp.base.url`` is set correctly.
+
+The cause is that the SAML library compares the ``Destination`` attribute of the assertion against
+the request URL reconstructed by the servlet container, not against the configured ACS URL. When the
+proxy terminates HTTPS, the request URL |Fess| sees is an internal one such as
+``http://<internal-host>:<internal-port>/sso/``, which does not match the
+``https://fess.example.com/sso/`` sent by the IdP. ``saml.sp.base.url`` is not used for this
+comparison, so setting it alone does not fix the problem.
+
+Set ``saml.debug=true`` to have the reason written to the log:
+
+::
+
+    The response was received at http://... instead of https://fess.example.com/sso/
+
+Align the connector settings in ``tomcat_config.properties`` with the externally visible scheme and
+port. These settings ship commented out:
+
+::
+
+    tomcat.secure=true
+    tomcat.scheme=https
+    tomcat.proxyPort=443
+
+Also configure the reverse proxy to pass the original ``Host`` header through to |Fess|, because the
+host part of the request URL is built from that header. |Fess| must be restarted after changing
+``tomcat_config.properties``.
+
+The same validation applies to Single Logout messages, so configure this when using SLO as well.
 
 Signature verification error
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/es/15.8/config/sso-saml.rst
+++ b/es/15.8/config/sso-saml.rst
@@ -19,6 +19,19 @@ En la autenticación SAML, |Fess| opera como un SP (Service Provider) y colabora
 4. El IdP envía la aserción SAML a |Fess|
 5. |Fess| valida la aserción e inicia sesión del usuario
 
+.. note::
+   Solo se admite el inicio de sesión iniciado por el SP, que comienza en el endpoint SSO de |Fess|
+   (``/sso/``) tal como se describe arriba. |Fess| vincula cada respuesta SAML al identificador de la
+   AuthnRequest que envió, por lo que una respuesta iniciada por el IdP (no solicitada), por ejemplo
+   desde un icono de |Fess| en el panel de Okta o en el portal «Mis aplicaciones» de Microsoft Entra
+   ID, no tiene ninguna AuthnRequest con la que emparejarse y se rechaza. Si coloca un icono en el
+   lado del IdP, haga que apunte al endpoint ``/sso/`` de |Fess|.
+
+   Tenga en cuenta que en 15.7 el inicio de sesión iniciado por el IdP funcionaba de forma incidental
+   cuando se establecía ``tomcat.sameSiteCookies=none``: |Fess| devolvía al IdP la respuesta que no
+   podía emparejar y el IdP entregaba de inmediato una aserción solicitada. En 15.8 ya no se devuelve
+   la respuesta, por lo que el inicio de sesión iniciado por el IdP no funciona.
+
 Para la integración con búsqueda basada en roles, consulte :doc:`security-role`.
 
 Prerrequisitos
@@ -56,6 +69,12 @@ Para habilitar la autenticación SAML, agregue la siguiente configuración en ``
    ``sso.type`` y la configuración SAML básica (información del IdP, información del SP, mapeo de atributos de usuario) también pueden configurarse desde la página «Sistema > General» del panel de administración.
    Los cambios realizados en el panel de administración se guardan en ``system.properties`` y se conservan tras el reinicio.
    Sin embargo, los ajustes de seguridad como firma/cifrado y el certificado/clave privada del SP no pueden configurarse desde el panel de administración, por lo que deben escribirse directamente en ``system.properties``.
+
+.. note::
+   Los ajustes que comienzan por ``saml.`` se leen únicamente de ``system.properties``.
+   Las propiedades de sistema de la JVM, como ``-Dsaml.security....`` o ``-Dfess.saml.security....``, no se consultan.
+   En particular, ``saml.security.*``, ``saml.strict`` y ``saml.debug`` tampoco tienen ningún campo en el panel de administración,
+   por lo que escribirlos directamente en ``system.properties`` es la única forma de configurarlos.
 
 Configuración de la cookie de sesión
 ------------------------------------
@@ -291,10 +310,32 @@ Configuración de firma
    * - ``saml.security.logoutresponse_signed``
      - Firmar respuestas de cierre de sesión
      - ``false``
+   * - ``saml.security.reject_deprecated_alg``
+     - Rechazar algoritmos de firma obsoletos como SHA-1
+     - ``false``
 
 .. warning::
    Las funciones de seguridad están deshabilitadas por defecto.
    Para entornos de producción, se recomienda encarecidamente configurar al menos ``saml.security.want_assertions_signed=true``.
+
+.. note::
+   Mientras ``saml.security.reject_deprecated_alg`` sea ``false``, también se aceptan aserciones y
+   mensajes firmados con SHA-1 (``rsa-sha1`` y ``dsa-sha1``). No está habilitado por defecto porque
+   activarlo hace que se rechacen los IdP que siguen firmando con SHA-1.
+   Confirme que su IdP firma con SHA-256 o superior y, a continuación, configure
+   ``saml.security.reject_deprecated_alg=true``.
+
+.. warning::
+   Cuando se configura el cierre de sesión único (``saml.idp.single_logout_service.url``), establezca
+   siempre también ``saml.security.want_messages_signed=true``.
+   Mientras sea ``false``, no se exige ninguna firma en una LogoutRequest recibida en ``/sso/logout``.
+   Las únicas comprobaciones que se realizan son el esquema XML, ``NotOnOrAfter`` (si está presente),
+   ``Destination`` (si está presente) y que el Issuer coincida con ``saml.idp.entityid``; el NameID de
+   la LogoutRequest nunca se compara con el usuario que ha iniciado sesión.
+   Por tanto, un atacante que conozca el identificador de entidad del IdP, que es información pública,
+   puede crear una LogoutRequest sin firmar y terminar la sesión de un usuario autenticado atrayéndolo
+   a esa URL.
+   El impacto es un cierre de sesión forzado (denegación de servicio), no una apropiación de la cuenta.
 
 Configuración de cifrado
 ------------------------
@@ -418,6 +459,9 @@ El siguiente es un ejemplo de configuración recomendada para entornos de produc
     saml.security.want_assertions_signed=true
     saml.security.want_messages_signed=true
 
+    # Habilitar tras confirmar que el IdP firma con SHA-256 o superior
+    saml.security.reject_deprecated_alg=true
+
 Solución de problemas
 =====================
 
@@ -431,9 +475,52 @@ No se puede regresar a Fess después de la autenticación
 - Asegúrese de que el valor de ``saml.sp.base.url`` coincida con la configuración del IdP
 - La aserción SAML llega como un POST entre sitios desde el IdP. Cuando
   ``tomcat.sameSiteCookies`` en ``tomcat_config.properties`` es ``lax`` (el valor predeterminado), el
-  navegador no envía la cookie de sesión con ella, por lo que |Fess| no encuentra el estado SAML y
-  redirige de nuevo al IdP, entrando en un bucle. En ese caso, configure
-  ``tomcat.sameSiteCookies = none`` (``SameSite=None`` requiere HTTPS)
+  navegador no envía la cookie de sesión con ella, por lo que |Fess| no encuentra ninguna AuthnRequest
+  con la que emparejar y el inicio de sesión falla una sola vez, en ese momento. El navegador vuelve a
+  la página de inicio de sesión mostrando «Error en el proceso de inicio de sesión SSO.» y en el
+  registro se escribe una advertencia que empieza por
+  ``Received a SAML response with no matching AuthnRequest ID in the session.``.
+  En ese caso, configure ``tomcat.sameSiteCookies = none`` (``SameSite=None`` requiere HTTPS)
+
+.. note::
+   En 15.7, la misma situación hacía que |Fess| redirigiera una y otra vez al IdP, dejando el inicio de
+   sesión en un bucle. En 15.8 falla una sola vez en lugar de entrar en bucle. La solución de
+   configuración no cambia.
+
+La validación de Destination falla detrás de un proxy inverso
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Cuando |Fess| se ejecuta detrás de un proxy inverso o balanceador de carga que termina TLS, la
+validación de la aserción puede fallar aunque ``saml.sp.base.url`` esté configurado correctamente.
+
+La causa es que la biblioteca SAML compara el atributo ``Destination`` de la aserción con la URL de la
+solicitud reconstruida por el contenedor de servlets, y no con la URL ACS configurada. Cuando el proxy
+termina HTTPS, la URL de solicitud que ve |Fess| es interna, como
+``http://<host-interno>:<puerto-interno>/sso/``, y no coincide con la
+``https://fess.example.com/sso/`` enviada por el IdP. ``saml.sp.base.url`` no se utiliza para esta
+comparación, por lo que configurarlo por sí solo no resuelve el problema.
+
+Configure ``saml.debug=true`` para que el motivo se escriba en el registro:
+
+::
+
+    The response was received at http://... instead of https://fess.example.com/sso/
+
+Ajuste la configuración del conector en ``tomcat_config.properties`` al esquema y puerto visibles desde
+el exterior. Estos ajustes se distribuyen comentados:
+
+::
+
+    tomcat.secure=true
+    tomcat.scheme=https
+    tomcat.proxyPort=443
+
+Configure además el proxy inverso para que transmita a |Fess| la cabecera ``Host`` original, ya que la
+parte del nombre de host de la URL de solicitud se construye a partir de esa cabecera. Es necesario
+reiniciar |Fess| después de modificar ``tomcat_config.properties``.
+
+La misma validación se aplica a los mensajes de cierre de sesión único, así que configúrelo también si
+utiliza SLO.
 
 Error de verificación de firma
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/fr/15.8/config/sso-saml.rst
+++ b/fr/15.8/config/sso-saml.rst
@@ -19,6 +19,19 @@ Dans l'authentification SAML, |Fess| fonctionne comme un SP (Service Provider) e
 4. L'IdP envoie l'assertion SAML à |Fess|
 5. |Fess| valide l'assertion et connecte l'utilisateur
 
+.. note::
+   Seule la connexion initiée par le SP, qui démarre au point d'accès SSO de |Fess| (``/sso/``) comme
+   décrit ci-dessus, est prise en charge. |Fess| associe chaque réponse SAML à l'identifiant de
+   l'AuthnRequest qu'il a émise ; une réponse initiée par l'IdP (non sollicitée), par exemple depuis
+   une vignette |Fess| dans le tableau de bord Okta ou dans le portail « Mes applications » de
+   Microsoft Entra ID, n'a donc aucune AuthnRequest correspondante et est rejetée. Si vous placez une
+   vignette côté IdP, faites-la pointer vers le point d'accès ``/sso/`` de |Fess|.
+
+   Notez qu'en 15.7, une connexion initiée par l'IdP fonctionnait incidemment lorsque
+   ``tomcat.sameSiteCookies=none`` était défini : |Fess| renvoyait à l'IdP la réponse qu'il ne pouvait
+   pas associer, et l'IdP retournait immédiatement une assertion sollicitée. En 15.8, ce renvoi n'a
+   plus lieu, si bien que la connexion initiée par l'IdP ne fonctionne pas.
+
 Pour l'intégration avec la recherche basée sur les rôles, voir :doc:`security-role`.
 
 Prérequis
@@ -56,6 +69,12 @@ Pour activer l'authentification SAML, ajoutez le paramètre suivant dans ``app/W
    ``sso.type`` ainsi que les paramètres SAML de base (informations IdP, informations SP, mappage des attributs utilisateur) peuvent également être configurés depuis la page « Système > Général » de l'interface d'administration.
    Les paramètres modifiés dans l'interface d'administration sont enregistrés dans ``system.properties`` et persistent après redémarrage.
    Cependant, les paramètres de sécurité tels que la signature/le chiffrement ainsi que le certificat SP et la clé privée ne peuvent pas être configurés dans l'interface d'administration ; écrivez-les directement dans ``system.properties``.
+
+.. note::
+   Les paramètres commençant par ``saml.`` sont lus uniquement depuis ``system.properties``.
+   Les propriétés système de la JVM telles que ``-Dsaml.security....`` ou ``-Dfess.saml.security....`` ne sont pas consultées.
+   En particulier, ``saml.security.*``, ``saml.strict`` et ``saml.debug`` n'ont pas non plus de champ dans l'interface d'administration :
+   les écrire directement dans ``system.properties`` est le seul moyen de les définir.
 
 Configuration du cookie de session
 ----------------------------------
@@ -291,10 +310,32 @@ Paramètres de signature
    * - ``saml.security.logoutresponse_signed``
      - Signer les réponses de déconnexion
      - ``false``
+   * - ``saml.security.reject_deprecated_alg``
+     - Rejeter les algorithmes de signature obsolètes tels que SHA-1
+     - ``false``
 
 .. warning::
    Les fonctionnalités de sécurité sont désactivées par défaut.
    Pour les environnements de production, il est fortement recommandé de définir au moins ``saml.security.want_assertions_signed=true``.
+
+.. note::
+   Tant que ``saml.security.reject_deprecated_alg`` vaut ``false``, les assertions et messages signés
+   avec SHA-1 (``rsa-sha1`` et ``dsa-sha1``) sont également acceptés. Ce paramètre n'est pas activé par
+   défaut, car son activation entraîne le rejet des IdP qui signent encore avec SHA-1.
+   Vérifiez que votre IdP signe avec SHA-256 ou plus fort, puis définissez
+   ``saml.security.reject_deprecated_alg=true``.
+
+.. warning::
+   Lorsque la déconnexion unique est configurée (``saml.idp.single_logout_service.url``), définissez
+   impérativement aussi ``saml.security.want_messages_signed=true``.
+   Tant que ce paramètre vaut ``false``, aucune signature n'est exigée sur une LogoutRequest reçue sur
+   ``/sso/logout``. Les seules vérifications effectuées sont le schéma XML, ``NotOnOrAfter`` (s'il est
+   présent), ``Destination`` (s'il est présent) et la correspondance de l'Issuer avec
+   ``saml.idp.entityid`` ; le NameID de la LogoutRequest n'est jamais comparé à l'utilisateur connecté.
+   Un attaquant qui connaît l'identifiant d'entité de l'IdP, une information publique, peut donc forger
+   une LogoutRequest non signée et mettre fin à la session d'un utilisateur authentifié en l'attirant
+   vers cette URL.
+   L'impact est une déconnexion forcée (déni de service), et non une prise de contrôle du compte.
 
 Paramètres de chiffrement
 -------------------------
@@ -418,6 +459,9 @@ Voici un exemple de configuration recommandée pour les environnements de produc
     saml.security.want_assertions_signed=true
     saml.security.want_messages_signed=true
 
+    # À activer après avoir vérifié que l'IdP signe avec SHA-256 ou plus fort
+    saml.security.reject_deprecated_alg=true
+
 Dépannage
 =========
 
@@ -432,8 +476,51 @@ Impossible de retourner à Fess après l'authentification
 - L'assertion SAML arrive sous forme de POST intersite depuis l'IdP. Lorsque
   ``tomcat.sameSiteCookies`` dans ``tomcat_config.properties`` vaut ``lax`` (la valeur par défaut),
   le navigateur n'envoie pas le cookie de session avec cette requête ; |Fess| ne trouve alors aucun
-  état SAML et redirige à nouveau vers l'IdP, ce qui provoque une boucle. Dans ce cas, définissez
-  ``tomcat.sameSiteCookies = none`` (``SameSite=None`` nécessite HTTPS)
+  identifiant d'AuthnRequest correspondant et fait échouer la connexion une seule fois, sur place. Le
+  navigateur revient à la page de connexion en affichant « Le processus de connexion SSO a échoué. »,
+  et un avertissement commençant par
+  ``Received a SAML response with no matching AuthnRequest ID in the session.`` est écrit dans le
+  journal. Dans ce cas, définissez ``tomcat.sameSiteCookies = none`` (``SameSite=None`` nécessite HTTPS)
+
+.. note::
+   En 15.7, la même situation faisait rediriger |Fess| encore et encore vers l'IdP, mettant la connexion
+   en boucle. En 15.8, elle échoue une seule fois au lieu de boucler. La solution de configuration reste
+   la même.
+
+La validation de Destination échoue derrière un proxy inverse
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Lorsque |Fess| s'exécute derrière un proxy inverse ou un répartiteur de charge qui termine TLS, la
+validation de l'assertion peut échouer même si ``saml.sp.base.url`` est correctement défini.
+
+La cause est que la bibliothèque SAML compare l'attribut ``Destination`` de l'assertion à l'URL de
+requête reconstruite par le conteneur de servlets, et non à l'URL ACS configurée. Lorsque le proxy
+termine HTTPS, l'URL de requête vue par |Fess| est une URL interne telle que
+``http://<hôte-interne>:<port-interne>/sso/``, qui ne correspond pas à
+``https://fess.example.com/sso/`` envoyée par l'IdP. ``saml.sp.base.url`` n'intervient pas dans cette
+comparaison ; le définir seul ne résout donc pas le problème.
+
+Définissez ``saml.debug=true`` pour que la raison soit écrite dans le journal :
+
+::
+
+    The response was received at http://... instead of https://fess.example.com/sso/
+
+Alignez les paramètres du connecteur dans ``tomcat_config.properties`` sur le schéma et le port
+visibles depuis l'extérieur. Ces paramètres sont livrés commentés :
+
+::
+
+    tomcat.secure=true
+    tomcat.scheme=https
+    tomcat.proxyPort=443
+
+Configurez également le proxy inverse pour qu'il transmette l'en-tête ``Host`` d'origine à |Fess|, car
+la partie nom d'hôte de l'URL de requête est construite à partir de cet en-tête. |Fess| doit être
+redémarré après modification de ``tomcat_config.properties``.
+
+La même validation s'applique aux messages de déconnexion unique ; configurez-la également si vous
+utilisez le SLO.
 
 Erreur de vérification de signature
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ja/15.8/config/sso-saml.rst
+++ b/ja/15.8/config/sso-saml.rst
@@ -19,6 +19,18 @@ SAML認証では、|Fess| がSP（Service Provider）として動作し、外部
 4. IdPがSAMLアサーションを |Fess| に送信
 5. |Fess| がアサーションを検証し、ユーザーをログイン
 
+.. note::
+   サポートされるのは、上記のように |Fess| 側（``/sso/``）から開始するSP-Initiatedログインのみです。
+   |Fess| は送信したAuthnRequestのIDとSAMLレスポンスを対応付けて検証するため、
+   IdPのポータル（Oktaのダッシュボードや Microsoft Entra ID の「マイアプリ」など）に置いたタイルから
+   開始するIdP-Initiated（未承諾・unsolicited）SSOは、対応付けるAuthnRequestが存在せず拒否されます。
+   IdP側にタイルを配置する場合は、リンク先を |Fess| の ``/sso/`` にしてください。
+
+   なお 15.7 では、``tomcat.sameSiteCookies=none`` を設定していると、IdP-Initiatedのログインが
+   結果的に動作していました。|Fess| が対応付けできないレスポンスをIdPへ差し戻し、IdPが即座に
+   SP-Initiatedのアサーションを返していたためです。15.8 ではこの差し戻しを行わなくなったため、
+   IdP-Initiatedのログインは動作しません。
+
 ロールベース検索との連携については、:doc:`security-role` を参照してください。
 
 前提条件
@@ -56,6 +68,12 @@ SAML認証を有効にするには、``app/WEB-INF/conf/system.properties`` に�
    ``sso.type`` および基本的なSAML設定（IdP情報、SP情報、ユーザー属性マッピング）は、管理画面の「システム > 全般」ページからも設定・変更できます。
    管理画面で変更した設定は ``system.properties`` に保存され、再起動後も保持されます。
    ただし、署名・暗号化などのセキュリティ設定やSP証明書・秘密鍵は管理画面では設定できないため、``system.properties`` に直接記述してください。
+
+.. note::
+   ``saml.`` で始まる設定は ``system.properties`` からのみ読み込まれます。
+   JVMのシステムプロパティ（``-Dsaml.security....`` や ``-Dfess.saml.security....``）で指定しても参照されません。
+   特に ``saml.security.*`` 、 ``saml.strict`` 、 ``saml.debug`` は管理画面にも項目がないため、
+   ``system.properties`` に直接記述する以外に設定する方法はありません。
 
 セッションCookieの設定
 ----------------------
@@ -291,10 +309,30 @@ SAMLアサーションから取得したユーザー属性を、|Fess| のグル
    * - ``saml.security.logoutresponse_signed``
      - ログアウトレスポンスに署名する
      - ``false``
+   * - ``saml.security.reject_deprecated_alg``
+     - SHA-1などの非推奨署名アルゴリズムを拒否する
+     - ``false``
 
 .. warning::
    デフォルトではセキュリティ機能が無効になっています。
    本番環境では、少なくとも ``saml.security.want_assertions_signed=true`` を設定することを強く推奨します。
+
+.. note::
+   ``saml.security.reject_deprecated_alg`` が ``false`` の間は、SHA-1（``rsa-sha1`` および ``dsa-sha1``）で
+   署名されたアサーションやメッセージも受け入れられます。既定で有効になっていないのは、
+   有効にするとSHA-1で署名を行うIdPを拒否してしまうためです。
+   IdPがSHA-256以上で署名していることを確認したうえで、``saml.security.reject_deprecated_alg=true`` を設定してください。
+
+.. warning::
+   シングルログアウト（``saml.idp.single_logout_service.url``）を設定する場合は、
+   ``saml.security.want_messages_signed=true`` を必ず併せて設定してください。
+   ``false`` のままでは、``/sso/logout`` が受け取るLogoutRequestに署名が要求されません。
+   検証されるのはXMLスキーマ、``NotOnOrAfter``（存在する場合）、``Destination``（存在する場合）、
+   および Issuer が ``saml.idp.entityid`` と一致することだけで、
+   LogoutRequest内のNameIDがログイン中のユーザーと一致するかは検査されません。
+   このため、公開情報であるIdPのEntity IDを知っている攻撃者は、署名のないLogoutRequestを作成し、
+   そのURLをユーザーに踏ませることで認証済みセッションを終了させられます。
+   影響は強制ログアウト（サービス妨害）であり、アカウントの乗っ取りではありません。
 
 暗号化の設定
 ------------
@@ -424,6 +462,9 @@ SPの秘密鍵とX.509証明書を設定する必要があります。
     saml.security.want_assertions_signed=true
     saml.security.want_messages_signed=true
 
+    # IdPがSHA-256以上で署名していることを確認してから有効化する
+    saml.security.reject_deprecated_alg=true
+
 トラブルシューティング
 ======================
 
@@ -437,8 +478,48 @@ SPの秘密鍵とX.509証明書を設定する必要があります。
 - ``saml.sp.base.url`` の値がIdP側の設定と一致しているか確認してください
 - IdPからのSAMLアサーションはクロスサイトのPOSTで送信されます。``tomcat_config.properties`` の
   ``tomcat.sameSiteCookies`` が ``lax``（既定値）の場合、ブラウザはセッションCookieを送信しないため、
-  |Fess| はSAMLの状態を見つけられず、再びIdPへリダイレクトしてループします。この場合は
-  ``tomcat.sameSiteCookies = none`` を設定してください（``SameSite=None`` はHTTPSが必須です）
+  |Fess| は対応するAuthnRequestのIDを見つけられず、その場で1回だけログインに失敗します。
+  ブラウザはログイン画面に戻り「SSOログイン処理に失敗しました。」が表示され、ログには
+  ``Received a SAML response with no matching AuthnRequest ID in the session.``
+  で始まる警告が出力されます。この場合は ``tomcat.sameSiteCookies = none`` を設定してください
+  （``SameSite=None`` はHTTPSが必須です）
+
+.. note::
+   15.7 では同じ状況でIdPへの再リダイレクトが繰り返され、ログインがループしていました。
+   15.8 ではループせずに1回で失敗するよう変更されています。設定の対処方法は変わりません。
+
+リバースプロキシ経由でDestinationの検証に失敗する
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TLSを終端するリバースプロキシやロードバランサーの背後に |Fess| を配置すると、
+``saml.sp.base.url`` を正しく設定していてもアサーションの検証に失敗することがあります。
+
+原因は、SAMLライブラリがアサーションの ``Destination`` 属性を、設定されたACS URLではなく
+サーブレットコンテナが組み立てたリクエストURLと比較するためです。プロキシがHTTPSを終端すると、
+|Fess| が認識するリクエストURLは ``http://<内部ホスト名>:<内部ポート>/sso/`` のような内部向けの値になり、
+IdPが送ってきた ``https://fess.example.com/sso/`` と一致しません。
+``saml.sp.base.url`` はこの比較には使われないため、この設定だけでは解決しません。
+
+``saml.debug=true`` を設定すると、ログに以下のような理由が出力されます。
+
+::
+
+    The response was received at http://... instead of https://fess.example.com/sso/
+
+この場合は ``tomcat_config.properties`` のコネクタ設定を、外部から見えるスキームとポートに合わせてください。
+以下の設定は既定ではコメントアウトされています。
+
+::
+
+    tomcat.secure=true
+    tomcat.scheme=https
+    tomcat.proxyPort=443
+
+あわせて、リバースプロキシが元の ``Host`` ヘッダーをそのまま |Fess| へ渡すように設定してください。
+リクエストURLのホスト名部分は ``Host`` ヘッダーから組み立てられます。
+``tomcat_config.properties`` を変更した後は |Fess| の再起動が必要です。
+
+同じ検証はシングルログアウトのメッセージにも適用されるため、SLOを利用する場合も同様に設定してください。
 
 署名検証エラー
 ~~~~~~~~~~~~~~

--- a/ko/15.8/config/sso-saml.rst
+++ b/ko/15.8/config/sso-saml.rst
@@ -19,6 +19,18 @@ SAML 인증에서는 |Fess| 가 SP（Service Provider）로 동작하여 외부 
 4. IdP가 SAML 어서션을 |Fess| 에 전송
 5. |Fess| 가 어서션을 검증하고 사용자를 로그인
 
+.. note::
+   지원되는 것은 위와 같이 |Fess| 측（``/sso/``）에서 시작하는 SP-Initiated 로그인뿐입니다.
+   |Fess| 는 전송한 AuthnRequest의 ID와 SAML 응답을 대응시켜 검증하므로,
+   IdP 포털（Okta 대시보드나 Microsoft Entra ID의 「내 앱」 등）에 배치한 타일에서 시작하는
+   IdP-Initiated（미요청·unsolicited）SSO는 대응시킬 AuthnRequest가 없어 거부됩니다.
+   IdP 측에 타일을 배치하는 경우에는 링크 대상을 |Fess| 의 ``/sso/`` 로 지정하십시오.
+
+   참고로 15.7에서는 ``tomcat.sameSiteCookies=none`` 을 설정하면 IdP-Initiated 로그인이 결과적으로
+   동작했습니다. |Fess| 가 대응시키지 못한 응답을 IdP로 되돌려 보내고, IdP가 즉시 SP-Initiated
+   어서션을 반환했기 때문입니다. 15.8에서는 이 되돌려 보내기를 하지 않으므로 IdP-Initiated 로그인은
+   동작하지 않습니다.
+
 역할 기반 검색과의 연동에 대해서는 :doc:`security-role` 을 참조하십시오.
 
 전제 조건
@@ -56,6 +68,12 @@ SAML 인증을 활성화하려면 ``app/WEB-INF/conf/system.properties`` 에 다
    ``sso.type`` 및 기본적인 SAML 설정（IdP 정보, SP 정보, 사용자 속성 매핑）은 관리 화면의 「시스템 > 전체」 페이지에서도 설정·변경할 수 있습니다.
    관리 화면에서 변경한 설정은 ``system.properties`` 에 저장되며, 재시작 후에도 유지됩니다.
    단, 서명·암호화 등의 보안 설정이나 SP 인증서·비밀 키는 관리 화면에서 설정할 수 없으므로 ``system.properties`` 에 직접 기술하십시오.
+
+.. note::
+   ``saml.`` 로 시작하는 설정은 ``system.properties`` 에서만 읽어 들입니다.
+   JVM 시스템 프로퍼티（``-Dsaml.security....`` 나 ``-Dfess.saml.security....``）로 지정해도 참조되지 않습니다.
+   특히 ``saml.security.*`` , ``saml.strict`` , ``saml.debug`` 는 관리 화면에도 항목이 없으므로
+   ``system.properties`` 에 직접 기술하는 것 외에는 설정할 방법이 없습니다.
 
 세션 쿠키 설정
 --------------
@@ -291,10 +309,30 @@ SAML 어서션에서 취득한 사용자 속성을 |Fess| 의 그룹이나 역�
    * - ``saml.security.logoutresponse_signed``
      - 로그아웃 응답에 서명한다
      - ``false``
+   * - ``saml.security.reject_deprecated_alg``
+     - SHA-1 등 사용이 권장되지 않는 서명 알고리즘을 거부한다
+     - ``false``
 
 .. warning::
    기본값에서는 보안 기능이 비활성화되어 있습니다.
    운영 환경에서는 최소한 ``saml.security.want_assertions_signed=true`` 를 설정하도록 강력히 권장합니다.
+
+.. note::
+   ``saml.security.reject_deprecated_alg`` 가 ``false`` 인 동안에는 SHA-1（``rsa-sha1`` 및 ``dsa-sha1``）로
+   서명된 어서션이나 메시지도 허용됩니다. 기본적으로 활성화되어 있지 않은 이유는, 활성화하면 아직 SHA-1로
+   서명하는 IdP를 거부하게 되기 때문입니다.
+   IdP가 SHA-256 이상으로 서명하는지 확인한 후 ``saml.security.reject_deprecated_alg=true`` 를 설정하십시오.
+
+.. warning::
+   싱글 로그아웃（``saml.idp.single_logout_service.url``）을 설정하는 경우에는
+   ``saml.security.want_messages_signed=true`` 도 반드시 함께 설정하십시오.
+   ``false`` 인 상태에서는 ``/sso/logout`` 이 수신하는 LogoutRequest에 서명이 요구되지 않습니다.
+   검증되는 것은 XML 스키마, ``NotOnOrAfter``（존재하는 경우）, ``Destination``（존재하는 경우）,
+   그리고 Issuer가 ``saml.idp.entityid`` 와 일치하는지뿐이며,
+   LogoutRequest 안의 NameID가 로그인 중인 사용자와 일치하는지는 검사하지 않습니다.
+   따라서 공개 정보인 IdP의 Entity ID를 아는 공격자는 서명 없는 LogoutRequest를 만들어,
+   해당 URL로 사용자를 유도함으로써 인증된 세션을 종료시킬 수 있습니다.
+   영향은 강제 로그아웃（서비스 거부）이며, 계정 탈취는 아닙니다.
 
 암호화 설정
 -----------
@@ -424,6 +462,9 @@ SP의 비밀 키와 X.509 인증서를 설정해야 합니다.
     saml.security.want_assertions_signed=true
     saml.security.want_messages_signed=true
 
+    # IdP가 SHA-256 이상으로 서명하는지 확인한 후 활성화한다
+    saml.security.reject_deprecated_alg=true
+
 문제 해결
 =========
 
@@ -437,8 +478,48 @@ SP의 비밀 키와 X.509 인증서를 설정해야 합니다.
 - ``saml.sp.base.url`` 의 값이 IdP 측의 설정과 일치하는지 확인하십시오
 - SAML 어설션은 IdP에서 교차 사이트 POST로 전송됩니다. ``tomcat_config.properties`` 의
   ``tomcat.sameSiteCookies`` 가 ``lax`` (기본값)인 경우 브라우저가 세션 쿠키를 함께 보내지 않으므로
-  |Fess| 는 SAML 상태를 찾지 못하고 다시 IdP로 리다이렉트하여 루프가 발생합니다. 이 경우
+  |Fess| 는 대응하는 AuthnRequest의 ID를 찾지 못하고 그 자리에서 한 번만 로그인에 실패합니다.
+  브라우저는 로그인 화면으로 돌아가 「SSO 로그인 프로세스에 실패했습니다.」가 표시되고, 로그에는
+  ``Received a SAML response with no matching AuthnRequest ID in the session.``
+  으로 시작하는 경고가 출력됩니다. 이 경우
   ``tomcat.sameSiteCookies = none`` 을 설정하십시오 (``SameSite=None`` 은 HTTPS가 필요합니다)
+
+.. note::
+   15.7에서는 같은 상황에서 IdP로의 재리다이렉트가 반복되어 로그인이 루프에 빠졌습니다.
+   15.8에서는 루프 없이 한 번만 실패하도록 변경되었습니다. 설정으로 대처하는 방법은 동일합니다.
+
+리버스 프록시 환경에서 Destination 검증에 실패함
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TLS를 종단하는 리버스 프록시나 로드 밸런서 뒤에 |Fess| 를 배치하면,
+``saml.sp.base.url`` 을 올바르게 설정했더라도 어설션 검증에 실패할 수 있습니다.
+
+원인은 SAML 라이브러리가 어설션의 ``Destination`` 속성을 설정된 ACS URL이 아니라
+서블릿 컨테이너가 조립한 요청 URL과 비교하기 때문입니다. 프록시가 HTTPS를 종단하면
+|Fess| 가 인식하는 요청 URL은 ``http://<내부-호스트명>:<내부-포트>/sso/`` 와 같은 내부용 값이 되어,
+IdP가 보낸 ``https://fess.example.com/sso/`` 와 일치하지 않습니다.
+``saml.sp.base.url`` 은 이 비교에 사용되지 않으므로 이 설정만으로는 해결되지 않습니다.
+
+``saml.debug=true`` 를 설정하면 로그에 다음과 같은 이유가 출력됩니다.
+
+::
+
+    The response was received at http://... instead of https://fess.example.com/sso/
+
+이 경우 ``tomcat_config.properties`` 의 커넥터 설정을 외부에서 보이는 스킴과 포트에 맞추십시오.
+다음 설정은 기본적으로 주석 처리되어 있습니다.
+
+::
+
+    tomcat.secure=true
+    tomcat.scheme=https
+    tomcat.proxyPort=443
+
+아울러 리버스 프록시가 원래의 ``Host`` 헤더를 그대로 |Fess| 로 전달하도록 설정하십시오.
+요청 URL의 호스트명 부분은 ``Host`` 헤더로부터 조립됩니다.
+``tomcat_config.properties`` 를 변경한 후에는 |Fess| 의 재시작이 필요합니다.
+
+같은 검증이 싱글 로그아웃 메시지에도 적용되므로, SLO를 사용하는 경우에도 동일하게 설정하십시오.
 
 서명 검증 오류
 ~~~~~~~~~~~~~~

--- a/zh-cn/15.8/config/sso-saml.rst
+++ b/zh-cn/15.8/config/sso-saml.rst
@@ -19,6 +19,17 @@ SAML认证的工作原理
 4. IdP将SAML断言发送给\ |Fess|
 5. |Fess|\ 验证断言并登录用户
 
+.. note::
+   仅支持如上所述从\ |Fess|\ 的SSO端点（``/sso/``）发起的SP发起（SP-Initiated）登录。
+   |Fess|\ 会将每个SAML响应与自身发出的AuthnRequest的ID进行绑定校验，
+   因此从IdP门户（如Okta仪表板或Microsoft Entra ID的"我的应用"）上的磁贴发起的
+   IdP发起（IdP-Initiated，即未经请求的unsolicited）SSO没有可匹配的AuthnRequest，会被拒绝。
+   如果要在IdP侧放置磁贴，请将其链接指向\ |Fess|\ 的\ ``/sso/``\ 端点。
+
+   请注意，在15.7中，若设置了\ ``tomcat.sameSiteCookies=none``\ ，IdP发起的登录会碰巧可用：
+   |Fess|\ 会将无法匹配的响应退回给IdP，而IdP会立即返回一个经过请求的断言。
+   15.8不再执行这种退回，因此IdP发起的登录无法使用。
+
 有关基于角色的搜索集成，请参阅:doc:`security-role`。
 
 前提条件
@@ -56,6 +67,12 @@ SAML认证的工作原理
    ``sso.type`` 及基本SAML设置（IdP信息、SP信息、用户属性映射）也可以从管理界面的"系统 > 全局"页面进行配置和更改。
    在管理界面中更改的设置将保存到 ``system.properties`` 中，重启后也会保留。
    但是，签名/加密等安全设置以及SP证书/私钥无法在管理界面中配置，因此请直接写入 ``system.properties``\ 。
+
+.. note::
+   以\ ``saml.``\ 开头的设置仅从\ ``system.properties``\ 中读取。
+   通过JVM系统属性（如\ ``-Dsaml.security....``\ 或\ ``-Dfess.saml.security....``\ ）指定不会被读取。
+   特别是\ ``saml.security.*``\ 、\ ``saml.strict``\ 和\ ``saml.debug``\ 在管理界面中也没有对应项，
+   因此只能直接写入\ ``system.properties``\ 。
 
 会话Cookie配置
 --------------
@@ -288,10 +305,28 @@ IdP侧配置
    * - ``saml.security.logoutresponse_signed``
      - 对登出响应签名
      - ``false``
+   * - ``saml.security.reject_deprecated_alg``
+     - 拒绝SHA-1等已弃用的签名算法
+     - ``false``
 
 .. warning::
    安全功能默认是禁用的。
    对于生产环境，强烈建议至少设置\ ``saml.security.want_assertions_signed=true``\ 。
+
+.. note::
+   当\ ``saml.security.reject_deprecated_alg``\ 为\ ``false``\ 时，使用SHA-1（``rsa-sha1``\ 和\ ``dsa-sha1``\ ）
+   签名的断言和消息同样会被接受。之所以默认不启用，是因为启用后会拒绝仍使用SHA-1签名的IdP。
+   请先确认IdP使用SHA-256或更强的算法签名，然后再设置\ ``saml.security.reject_deprecated_alg=true``\ 。
+
+.. warning::
+   配置单点登出（``saml.idp.single_logout_service.url``）时，请务必同时设置\
+   ``saml.security.want_messages_signed=true``\ 。
+   若保持为\ ``false``\ ，则不会对\ ``/sso/logout``\ 收到的LogoutRequest要求签名。
+   此时仅校验XML架构、``NotOnOrAfter``\ （若存在）、``Destination``\ （若存在）以及Issuer是否与\
+   ``saml.idp.entityid``\ 一致；LogoutRequest中的NameID从不与已登录用户进行比对。
+   因此，知晓IdP实体ID（属于公开信息）的攻击者可以构造未签名的LogoutRequest，
+   诱导用户访问该URL，从而终止已认证用户的会话。
+   其影响是强制登出（拒绝服务），而不是账户接管。
 
 加密设置
 --------
@@ -415,6 +450,9 @@ SP证书与私钥配置
     saml.security.want_assertions_signed=true
     saml.security.want_messages_signed=true
 
+    # 确认IdP使用SHA-256或更强的算法签名后再启用
+    saml.security.reject_deprecated_alg=true
+
 故障排除
 ========
 
@@ -428,8 +466,47 @@ SP证书与私钥配置
 - 确保\ ``saml.sp.base.url``\ 的值与IdP配置匹配
 - SAML断言以来自IdP的跨站POST方式发送。
   当\ ``tomcat_config.properties``\ 中的\ ``tomcat.sameSiteCookies``\ 为\ ``lax``\ （默认值）时，
-  浏览器不会随该请求发送会话Cookie，因此 |Fess| 找不到SAML状态并再次重定向到IdP，形成循环。
+  浏览器不会随该请求发送会话Cookie，因此 |Fess| 找不到可匹配的AuthnRequest ID，当场只失败一次。
+  浏览器会返回登录页面并显示"SSO登录处理失败。"，日志中会输出以\
+  ``Received a SAML response with no matching AuthnRequest ID in the session.``\ 开头的警告。
   此时请设置\ ``tomcat.sameSiteCookies = none``\ （``SameSite=None``\ 需要HTTPS）
+
+.. note::
+   在15.7中，同样的情况会导致\ |Fess|\ 反复重定向到IdP，使登录陷入循环。
+   15.8改为只失败一次而不再循环。配置层面的处理方法保持不变。
+
+通过反向代理时Destination验证失败
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+当\ |Fess|\ 运行在终结TLS的反向代理或负载均衡器之后时，
+即使\ ``saml.sp.base.url``\ 设置正确，断言验证也可能失败。
+
+原因在于SAML库将断言的\ ``Destination``\ 属性与Servlet容器重建的请求URL进行比较，
+而不是与配置的ACS URL比较。当代理终结HTTPS时，\ |Fess|\ 看到的请求URL是形如\
+``http://<内部主机名>:<内部端口>/sso/``\ 的内部地址，
+与IdP发送的\ ``https://fess.example.com/sso/``\ 不一致。
+``saml.sp.base.url``\ 不参与该比较，因此仅设置它无法解决问题。
+
+设置\ ``saml.debug=true``\ 后，日志中会输出如下原因：
+
+::
+
+    The response was received at http://... instead of https://fess.example.com/sso/
+
+此时请将\ ``tomcat_config.properties``\ 中的连接器设置调整为对外可见的协议和端口。
+以下设置默认处于注释状态：
+
+::
+
+    tomcat.secure=true
+    tomcat.scheme=https
+    tomcat.proxyPort=443
+
+同时请配置反向代理，将原始的\ ``Host``\ 请求头透传给\ |Fess|\ ，
+因为请求URL中的主机名部分是根据该请求头构建的。
+修改\ ``tomcat_config.properties``\ 后需要重启\ |Fess|\ 。
+
+同样的验证也适用于单点登出消息，因此使用SLO时请一并配置。
 
 签名验证错误
 ~~~~~~~~~~~~


### PR DESCRIPTION
Corrections to the SAML SSO guide, found while reviewing `org/codelibs/fess/sso/saml` against 15.7. Applied to all seven languages. Companion to codelibs/fess#3246.

## 1. The cross-site POST entry described 15.7 behaviour

It said Fess cannot find the SAML state and redirects to the IdP again, looping. Since codelibs/fess#3239 an assertion that matches no AuthnRequest fails **once** and returns to the login page with a specific warning in the log.

Rewritten to match, quoting the actual message and warning text. The `tomcat.sameSiteCookies = none` remedy and the HTTPS caveat are unchanged and still required, because `lax` is still what ships.

## 2. IdP-initiated SSO is not supported (was undocumented)

Fess binds every response to the AuthnRequest it sent, so an unsolicited response started from a portal tile has nothing to match and is rejected. Worth stating plainly because it worked in 15.7 when `sameSiteCookies` was `none` — Fess bounced the response back to the IdP, which answered with a solicited assertion — and no longer does. Administrators upgrading need to know before they configure a tile and file a bug.

## 3. Destination validation behind a reverse proxy (new)

The most likely cause of "works in staging, fails behind the load balancer". The library compares the assertion's `Destination` attribute with the URL the servlet container reconstructs, **not** with the configured assertion consumer service URL. Behind a TLS-terminating proxy the reconstructed URL is the internal one, so validation fails with a destination mismatch even when `saml.sp.base.url` is set correctly — that setting is not used for this comparison.

The fix is `tomcat.secure`, `tomcat.scheme` and `tomcat.proxyPort`, which ship commented out, plus passing the original `Host` header through. The same comparison applies to single logout messages.

## 4. Two security settings

- `saml.security.reject_deprecated_alg` added to the table, the notes and the recommended production block. It defaults to `false`, so SHA-1 signed assertions are accepted. The note explains why it is not the default: enabling it rejects IdPs that still sign with SHA-1, so it should be turned on after confirming the IdP uses SHA-256.
- Why `saml.security.want_messages_signed=true` matters specifically once single logout is configured: with it `false`, a LogoutRequest needs no signature and its NameID is never compared with the logged-in user, so someone who knows the IdP entity ID can end an authenticated session. Stated as forced logout / denial of service, explicitly **not** account takeover.

## 5. Where `saml.*` has to be written

`saml.*` is read only from `system.properties`. JVM system properties are not consulted, and `saml.security.*`, `saml.strict` and `saml.debug` have no admin screen field. No file claimed otherwise, so this is an addition rather than a correction, but it is the question that follows every one of the settings above.

## Verification

Every key mentioned was confirmed to exist in the source before being written, and each behavioural claim was traced to the code that implements it, including the exact message strings quoted for each language.

**The repository's own doc build could not be run**: `conf/conf.py` and `conf/ext.py` are still Python 2 and no python2 is available here. That is pre-existing and unrelated to this change. Validated instead with a standalone Sphinx build supplying the same substitutions — all seven files build with `-W --keep-going` and no warnings attributable to `sso-saml.rst` — plus a heading-underline width check that accounts for East Asian character width, and a structural comparison confirming the same sections were added to each language.
