### PR TITLE
docs(semantic): drop the fess_config.properties comment reference from the content_chunker note

### DIFF
--- a/de/15.8/config/search-semantic.rst
+++ b/de/15.8/config/search-semantic.rst
@@ -121,12 +121,11 @@ Start registriert wird, **erfordert diese Änderung einen Neustart, um wirksam z
 
 .. note::
 
-   Die Liste der ``content_chunker.*``-Schlüssel ist auch in ``fess_config.properties`` als
-   Kommentar aufgeführt, gelesen werden diese Schlüssel jedoch ausschließlich über den Kanal
-   ``system.properties``. Einträge in ``fess_config.properties`` oder ``-Dfess.config.<key>``
-   werden ignoriert — konfigurieren Sie sie daher stets in ``system.properties``. Der
-   Admin-Bildschirm **Systeminformationen > Konfigurationsinformationen** zeigt lediglich die
-   aktuellen Werte an und ist **rein lesend**; ``content_chunker.*`` lässt sich dort nicht setzen.
+   Die ``content_chunker.*``-Schlüssel werden ausschließlich über den Kanal ``system.properties``
+   gelesen. Einträge in ``fess_config.properties`` oder ``-Dfess.config.<key>`` werden ignoriert —
+   konfigurieren Sie sie daher stets in ``system.properties``. Der Admin-Bildschirm
+   **Systeminformationen > Konfigurationsinformationen** zeigt lediglich die aktuellen Werte an
+   und ist **rein lesend**; ``content_chunker.*`` lässt sich dort nicht setzen.
 
 Einstellungen in system.properties
 ------------------------------------

--- a/en/15.8/config/search-semantic.rst
+++ b/en/15.8/config/search-semantic.rst
@@ -116,11 +116,11 @@ registered at startup, **this change requires a restart to take effect**.
 
 .. note::
 
-   The ``content_chunker.*`` keys are also listed as comments in ``fess_config.properties``, but
-   they are only read from the ``system.properties`` channel. Writing them in
-   ``fess_config.properties`` or passing them as ``-Dfess.config.<key>`` has no effect, so always
-   set them in ``system.properties``. Note also that the admin **System Info > Config Info** screen
-   is a **read-only** view of the current values — you cannot set ``content_chunker.*`` from it.
+   The ``content_chunker.*`` keys are only read from the ``system.properties`` channel. Writing
+   them in ``fess_config.properties`` or passing them as ``-Dfess.config.<key>`` has no effect, so
+   always set them in ``system.properties``. Note also that the admin **System Info > Config
+   Info** screen is a **read-only** view of the current values — you cannot set
+   ``content_chunker.*`` from it.
 
 system.properties Settings
 ----------------------------

--- a/es/15.8/config/search-semantic.rst
+++ b/es/15.8/config/search-semantic.rst
@@ -121,13 +121,12 @@ registra al iniciar, **este cambio requiere un reinicio para surtir efecto**.
 
 .. note::
 
-   La lista de claves ``content_chunker.*`` también aparece como comentarios en
-   ``fess_config.properties``, pero solo se leen desde el canal ``system.properties``.
-   Escribirlas en ``fess_config.properties`` o en ``-Dfess.config.<key>`` no surte ningún
-   efecto, así que configúrelas siempre en ``system.properties``. Tenga además en cuenta que la
-   pantalla de administración **Información del sistema > Información de configuración** es una
-   vista de **solo lectura** de los valores actuales: desde ella no se pueden establecer las
-   claves ``content_chunker.*``.
+   Las claves ``content_chunker.*`` solo se leen desde el canal ``system.properties``. Escribirlas
+   en ``fess_config.properties`` o en ``-Dfess.config.<key>`` no surte ningún efecto, así que
+   configúrelas siempre en ``system.properties``. Tenga además en cuenta que la pantalla de
+   administración **Información del sistema > Información de configuración** es una vista de
+   **solo lectura** de los valores actuales: desde ella no se pueden establecer las claves
+   ``content_chunker.*``.
 
 Configuraciones en system.properties
 ---------------------------------------

--- a/fr/15.8/config/search-semantic.rst
+++ b/fr/15.8/config/search-semantic.rst
@@ -124,13 +124,12 @@ pour prendre effet**.
 
 .. note::
 
-   La liste des clés ``content_chunker.*`` figure également sous forme de commentaires dans
-   ``fess_config.properties``, mais ces clés ne sont lues que depuis le canal
-   ``system.properties``. Les écrire dans ``fess_config.properties`` ou via
-   ``-Dfess.config.<key>`` reste sans effet : définissez-les impérativement dans
-   ``system.properties``. Notez par ailleurs que l'écran d'administration **Informations système
-   > Informations de configuration** affiche les valeurs courantes **en lecture seule** ; il ne
-   permet pas d'y définir les réglages ``content_chunker.*``.
+   Les clés ``content_chunker.*`` ne sont lues que depuis le canal ``system.properties``. Les
+   écrire dans ``fess_config.properties`` ou via ``-Dfess.config.<key>`` reste sans effet :
+   définissez-les impérativement dans ``system.properties``. Notez par ailleurs que l'écran
+   d'administration **Informations système > Informations de configuration** affiche les valeurs
+   courantes **en lecture seule** ; il ne permet pas d'y définir les réglages
+   ``content_chunker.*``.
 
 Réglages dans system.properties
 ----------------------------------

--- a/ja/15.8/config/search-semantic.rst
+++ b/ja/15.8/config/search-semantic.rst
@@ -110,8 +110,7 @@ Docker 版は ``/opt/fess/system.properties``）に設定するか、起動オ�
 
 .. note::
 
-   ``content_chunker.*`` のキー一覧は ``fess_config.properties`` にもコメントとして記載されて
-   いますが、これらは ``system.properties`` チャネルからのみ読み込まれます。
+   ``content_chunker.*`` の設定は ``system.properties`` チャネルからのみ読み込まれます。
    ``fess_config.properties`` や ``-Dfess.config.<キー名>`` に記述しても無視されるため、必ず
    ``system.properties`` に設定してください。なお 管理画面 > システム情報 > 設定情報 は現在値の
    **閲覧専用** の画面で、この画面から ``content_chunker.*`` を設定することはできません。

--- a/ko/15.8/config/search-semantic.rst
+++ b/ko/15.8/config/search-semantic.rst
@@ -111,11 +111,10 @@
 
 .. note::
 
-   ``content_chunker.*`` 의 키 목록은 ``fess_config.properties`` 에도 주석으로 기재되어 있지만,
-   이 값들은 ``system.properties`` 채널에서만 읽힙니다. ``fess_config.properties`` 나
-   ``-Dfess.config.<키>`` 에 기술해도 무시되므로 반드시 ``system.properties`` 에 설정하세요.
-   또한 관리 화면의 「시스템 정보」→「설정 정보」는 현재 값을 **확인만 할 수 있는** 화면이며,
-   이 화면에서 ``content_chunker.*`` 를 설정할 수는 없습니다.
+   ``content_chunker.*`` 설정은 ``system.properties`` 채널에서만 읽힙니다.
+   ``fess_config.properties`` 나 ``-Dfess.config.<키>`` 에 기술해도 무시되므로 반드시
+   ``system.properties`` 에 설정하세요. 또한 관리 화면의 「시스템 정보」→「설정 정보」는 현재 값을
+   **확인만 할 수 있는** 화면이며, 이 화면에서 ``content_chunker.*`` 를 설정할 수는 없습니다.
 
 system.properties 설정
 ------------------------

--- a/zh-cn/15.8/config/search-semantic.rst
+++ b/zh-cn/15.8/config/search-semantic.rst
@@ -102,11 +102,10 @@
 
 .. note::
 
-   ``content_chunker.*`` 的键名也以注释的形式列在 ``fess_config.properties`` 中，但这些配置项
-   只会从 ``system.properties`` 通道读取。写在 ``fess_config.properties`` 或
-   ``-Dfess.config.<键名>`` 中都会被忽略，因此请务必设置在 ``system.properties`` 中。另外，
-   管理界面的「系统信息」→「配置信息」是查看当前值的\ **只读**\ 页面，无法通过该页面设置
-   ``content_chunker.*``\ 。
+   ``content_chunker.*`` 配置项只会从 ``system.properties`` 通道读取。写在
+   ``fess_config.properties`` 或 ``-Dfess.config.<键名>`` 中都会被忽略，因此请务必设置在
+   ``system.properties`` 中。另外，管理界面的「系统信息」→「配置信息」是查看当前值的\ **只读**\ 页面，
+   无法通过该页面设置 ``content_chunker.*``\ 。
 
 system.properties 配置
 ------------------------


### PR DESCRIPTION
## Summary

Follow-up to codelibs/fess#3248, which removes the `content_chunker.*` comment block from `fess_config.properties`.

The note on `config/search-semantic` opened by saying the key list is *also* listed as comments in `fess_config.properties`. Once that block is gone, the sentence points at nothing, so it is dropped.

Everything else in the note is unchanged and still correct:

- the keys are read **only** from the `system.properties` channel
- writing them in `fess_config.properties` or passing `-Dfess.config.<key>` has no effect
- **System Info > Config Info** is a read-only view of the current values

Applies to all 7 languages: en, ja, de, es, fr, ko, zh-cn.

The other `fess_config.properties` references on the page -- `scheduler.target.name` for pinning the indexer job, and `jvm.chunk.options` for the child JVM heap -- are accurate (both keys really are defined there) and are left alone.

## Verification

Each changed file was parsed with docutils before and after; the warning set is identical for all 7 languages (only the pre-existing `|Fess|` substitution noise that comes from `rst_prolog`).
