### PR TITLE
docs(sso): document the 15.8 SAML changes in the upgrade notes

### DIFF
--- a/de/15.8/install/upgrade.rst
+++ b/de/15.8/install/upgrade.rst
@@ -505,6 +505,30 @@ Realms kommagetrennt in ``spnego.allowed.realms`` ein, entweder über die Verwal
 Benutzer, die sich bis 15.7 anmelden konnten, mit ``Kerberos realm is not allowed`` abgewiesen.
 Einzelheiten finden Sie unter :doc:`../config/sso-spnego`.
 
+Falls Sie SAML-Authentifizierung (SSO) genutzt haben
+----------------------------------------------------
+
+Ab 15.8 bindet |Fess| jede SAML-Antwort an die ID der von ihm gesendeten AuthnRequest, sodass
+IdP-initiiertes (unaufgefordertes) SSO nicht mehr funktioniert. Eine Anmeldung, die von einer
+|Fess|-Kachel in einem IdP-Portal wie dem Okta-Dashboard oder dem Portal „Meine Apps" von
+Microsoft Entra ID aus gestartet wird, hat keine zugehörige AuthnRequest und wird abgelehnt. Bis
+15.7 funktionierte dies, weil |Fess| die nicht zuordenbare Antwort an den IdP zurückschickte und
+der IdP sofort eine angeforderte Assertion lieferte. Wenn Sie auf der IdP-Seite eine Kachel
+anlegen, lassen Sie diese auf den |Fess|-Endpunkt ``/sso/`` verweisen, damit die Anmeldung
+SP-initiiert erfolgt.
+
+Zudem sendet der IdP die Assertion als seitenübergreifenden POST zurück, weshalb
+``tomcat.sameSiteCookies`` in ``tomcat_config.properties`` auf ``none`` gesetzt werden muss. Mit
+dem ausgelieferten Standardwert ``lax`` wird das Sitzungs-Cookie bei dieser Anfrage nicht
+mitgesendet und die SAML-Anmeldung kann nicht abgeschlossen werden. Diese Datei liegt beim
+ZIP-Paket unter ``lib/classes/`` und bei den DEB-/RPM-Paketen unter ``/etc/fess/``; nach der
+Änderung muss |Fess| neu gestartet werden. Browser akzeptieren ``none`` nur bei einem Cookie, das
+auch das Attribut ``Secure`` trägt, sodass |Fess| über HTTPS bereitgestellt werden muss. Bis 15.7
+führte dieselbe Fehlkonfiguration nicht zu einem klaren Fehler, sondern zu einer endlosen
+Weiterleitungsschleife zum IdP; prüfen Sie die Einstellung daher auch bei einer Installation, die
+zu funktionieren schien. In 15.8 schlägt die Anmeldung einmalig fehl, statt in einer Schleife zu
+laufen. Einzelheiten finden Sie unter :doc:`../config/sso-saml`.
+
 Aktualisierung der Plugin-Versionen
 -----------------------------------
 

--- a/en/15.8/install/upgrade.rst
+++ b/en/15.8/install/upgrade.rst
@@ -499,6 +499,26 @@ from a trusted forest, list those realms in ``spnego.allowed.realms``, separated
 users who could log in up to 15.7 are rejected with ``Kerberos realm is not allowed``. For
 details, see :doc:`../config/sso-spnego`.
 
+If You Were Using SAML Authentication (SSO)
+-------------------------------------------
+
+Starting with 15.8, |Fess| binds every SAML response to the ID of the AuthnRequest it sent, so
+IdP-initiated (unsolicited) SSO no longer works. A login started from a |Fess| tile in an IdP
+portal, such as the Okta dashboard or the Microsoft Entra ID "My Apps" portal, has no AuthnRequest
+to match against and is rejected. It worked up to 15.7 because |Fess| bounced the unmatched
+response back to the IdP and the IdP immediately returned a solicited assertion. If you place a
+tile on the IdP side, point it at the |Fess| ``/sso/`` endpoint so that the login is SP-initiated.
+
+The IdP also returns the assertion as a cross-site POST, so ``tomcat.sameSiteCookies`` in
+``tomcat_config.properties`` must be set to ``none``. With the shipped default ``lax`` the session
+cookie is not sent on that request and the SAML login cannot complete. This file is located in
+``lib/classes/`` for the ZIP package and in ``/etc/fess/`` for the DEB/RPM packages, and |Fess|
+must be restarted after the change. Browsers only accept ``none`` on a cookie that also carries
+the ``Secure`` attribute, so |Fess| must be served over HTTPS. Up to 15.7 the same
+misconfiguration did not produce a clean error but an endless redirect loop back to the IdP, so
+check the setting even on a site that appeared to work; 15.8 fails once instead of looping. For
+details, see :doc:`../config/sso-saml`.
+
 Updating Plugin Versions
 ------------------------
 

--- a/es/15.8/install/upgrade.rst
+++ b/es/15.8/install/upgrade.rst
@@ -508,6 +508,30 @@ usuarios que podían iniciar sesión hasta la versión 15.7 son rechazados con
 ``Kerberos realm is not allowed``. Consulte :doc:`../config/sso-spnego` para conocer más
 detalles.
 
+Si Utilizaba la Autenticación SAML (SSO)
+----------------------------------------
+
+A partir de la versión 15.8, |Fess| vincula cada respuesta SAML al identificador de la
+AuthnRequest que envió, por lo que el SSO iniciado por el IdP (no solicitado) ya no funciona. Un
+inicio de sesión que comienza en un icono de |Fess| dentro de un portal del IdP, como el panel de
+Okta o el portal "Mis aplicaciones" de Microsoft Entra ID, no tiene ninguna AuthnRequest con la
+que emparejarse y se rechaza. Hasta la versión 15.7 funcionaba porque |Fess| devolvía al IdP la
+respuesta que no podía emparejar y el IdP entregaba de inmediato una aserción solicitada. Si
+coloca un icono en el lado del IdP, haga que apunte al endpoint ``/sso/`` de |Fess| para que el
+inicio de sesión lo inicie el SP.
+
+Además, el IdP devuelve la aserción mediante un POST entre sitios, por lo que
+``tomcat.sameSiteCookies`` debe establecerse en ``none`` en ``tomcat_config.properties``. Con el
+valor predeterminado ``lax`` que se incluye, la cookie de sesión no se envía en esa petición y el
+inicio de sesión SAML no puede completarse. Este archivo se encuentra en ``lib/classes/`` en el
+paquete ZIP y en ``/etc/fess/`` en los paquetes DEB/RPM, y es necesario reiniciar |Fess| tras el
+cambio. Los navegadores solo aceptan ``none`` en una cookie que además tenga el atributo
+``Secure``, por lo que |Fess| debe servirse mediante HTTPS. Hasta la versión 15.7, esta
+configuración incorrecta no producía un error claro, sino un bucle interminable de redirecciones
+al IdP, así que compruebe el ajuste incluso en un sitio que parecía funcionar; en la versión 15.8
+falla una sola vez en lugar de entrar en bucle. Consulte :doc:`../config/sso-saml` para conocer
+más detalles.
+
 Actualización de la Versión de los Plugins
 ---------------------------------------------
 

--- a/fr/15.8/install/upgrade.rst
+++ b/fr/15.8/install/upgrade.rst
@@ -511,6 +511,29 @@ qui pouvaient se connecter jusqu'à la version 15.7 sont refusés avec
 ``Kerberos realm is not allowed``. Pour plus de détails, consultez
 :doc:`../config/sso-spnego`.
 
+Si vous utilisiez l'authentification SAML (SSO)
+-----------------------------------------------
+
+À partir de la 15.8, |Fess| associe chaque réponse SAML à l'identifiant de l'AuthnRequest qu'il
+a émise, si bien que le SSO initié par l'IdP (non sollicité) ne fonctionne plus. Une connexion
+démarrée depuis une vignette |Fess| dans un portail IdP, tel que le tableau de bord Okta ou le
+portail « Mes applications » de Microsoft Entra ID, n'a aucune AuthnRequest correspondante et est
+rejetée. Cela fonctionnait jusqu'à la 15.7 parce que |Fess| renvoyait à l'IdP la réponse qu'il ne
+pouvait pas associer et que l'IdP retournait immédiatement une assertion sollicitée. Si vous
+placez une vignette côté IdP, faites-la pointer vers le point d'accès ``/sso/`` de |Fess| afin que
+la connexion soit initiée par le SP.
+
+Par ailleurs, l'IdP renvoie l'assertion via un POST intersites : ``tomcat.sameSiteCookies`` doit
+donc être défini sur ``none`` dans ``tomcat_config.properties``. Avec la valeur par défaut livrée
+``lax``, le cookie de session n'est pas envoyé sur cette requête et la connexion SAML ne peut pas
+aboutir. Ce fichier se trouve dans ``lib/classes/`` pour le paquet ZIP et dans ``/etc/fess/`` pour
+les paquets DEB/RPM, et |Fess| doit être redémarré après la modification. Les navigateurs
+n'acceptent ``none`` que sur un cookie portant également l'attribut ``Secure`` : |Fess| doit donc
+être servi en HTTPS. Jusqu'à la 15.7, la même erreur de configuration ne provoquait pas d'échec
+net mais une boucle de redirections sans fin vers l'IdP ; vérifiez donc le paramètre même sur un
+site qui semblait fonctionner. En 15.8, la connexion échoue une seule fois au lieu de boucler.
+Pour plus de détails, consultez :doc:`../config/sso-saml`.
+
 Mise à jour de la version des plugins
 -------------------------------------
 

--- a/ja/15.8/install/upgrade.rst
+++ b/ja/15.8/install/upgrade.rst
@@ -495,6 +495,27 @@ SPNEGO ログインは拒否されます。AD のドメインツリーの子ド�
 ``Kerberos realm is not allowed`` として拒否されます。
 詳細は :doc:`../config/sso-spnego` を参照してください。
 
+SAML 認証（SSO）を利用していた場合
+----------------------------------
+
+15.8 から、\ |Fess| は送信した AuthnRequest の ID と SAML レスポンスを対応付けて検証するため、
+IdP-Initiated（未承諾・unsolicited）SSO は動作しなくなりました。IdP のポータル（Okta の
+ダッシュボードや Microsoft Entra ID の「マイアプリ」など）に置いたタイルから開始したログインは、
+対応付ける AuthnRequest が存在せず拒否されます。15.7 では、\ |Fess| が対応付けできないレスポンスを
+IdP へ差し戻し、IdP が即座に SP-Initiated のアサーションを返していたため動作していました。
+IdP 側にタイルを配置する場合は、リンク先を |Fess| の ``/sso/`` に変更し、SP-Initiated の
+ログインにしてください。
+
+また、IdP はアサーションをクロスサイトの POST で返すため、``tomcat_config.properties`` の
+``tomcat.sameSiteCookies`` に ``none`` を設定する必要があります。同梱の既定値 ``lax`` のままでは
+セッション Cookie がこのリクエストに送信されず、SAML ログインが完了しません。このファイルは
+ZIP 版では ``lib/classes/``\ 、DEB/RPM 版では ``/etc/fess/`` に配置されており、変更後は
+|Fess| の再起動が必要です。``none`` はブラウザーが ``Secure`` 属性付きの Cookie に対してのみ
+受け入れるため、\ |Fess| を HTTPS で提供する必要があります。15.7 までは同じ設定不備が明確な
+エラーにならず、IdP への再リダイレクトが繰り返されるループになっていたため、動作しているように
+見えていた環境でも設定を確認してください。15.8 ではループせずに 1 回で失敗します。
+詳細は :doc:`../config/sso-saml` を参照してください。
+
 プラグインのバージョン更新
 --------------------------
 

--- a/ko/15.8/install/upgrade.rst
+++ b/ko/15.8/install/upgrade.rst
@@ -494,6 +494,26 @@ AD 도메인 트리의 하위 도메인이나 신뢰 관계를 맺은 포리스�
 15.7까지 로그인할 수 있었던 사용자가 ``Kerberos realm is not allowed`` 로 거부됩니다.
 자세한 내용은 :doc:`../config/sso-spnego` 를 참조하십시오.
 
+SAML 인증(SSO)을 사용하고 있었던 경우
+-------------------------------------
+
+15.8부터 |Fess| 는 전송한 AuthnRequest의 ID와 SAML 응답을 대응시켜 검증하므로
+IdP-Initiated(미요청·unsolicited) SSO는 동작하지 않습니다. IdP 포털(Okta 대시보드나
+Microsoft Entra ID의 「내 앱」 등)에 배치한 타일에서 시작한 로그인은 대응시킬 AuthnRequest가
+없어 거부됩니다. 15.7까지는 |Fess| 가 대응시키지 못한 응답을 IdP로 되돌려 보내고, IdP가 즉시
+SP-Initiated 어서션을 반환했기 때문에 동작했습니다. IdP 측에 타일을 배치하는 경우에는 링크
+대상을 |Fess| 의 ``/sso/`` 로 지정하여 SP-Initiated 로그인이 되도록 하십시오.
+
+또한 IdP는 어서션을 크로스 사이트 POST로 반환하므로 ``tomcat_config.properties`` 의
+``tomcat.sameSiteCookies`` 를 ``none`` 으로 설정해야 합니다. 포함된 기본값 ``lax`` 그대로는
+세션 쿠키가 이 요청에 전송되지 않아 SAML 로그인을 완료할 수 없습니다. 이 파일은 ZIP 패키지에서는
+``lib/classes/`` , DEB/RPM 패키지에서는 ``/etc/fess/`` 에 있으며, 변경 후에는 |Fess| 를
+재시작해야 합니다. 브라우저는 ``Secure`` 속성이 함께 있는 쿠키에 대해서만 ``none`` 을
+허용하므로 |Fess| 를 HTTPS로 제공해야 합니다. 15.7까지는 같은 설정 오류가 명확한 오류가 아니라
+IdP로의 무한 리다이렉트 루프로 나타났으므로, 동작하는 것처럼 보였던 사이트에서도 설정을
+확인하십시오. 15.8에서는 루프에 빠지지 않고 한 번에 실패합니다.
+자세한 내용은 :doc:`../config/sso-saml` 을 참조하십시오.
+
 플러그인 버전 갱신
 ------------------------
 

--- a/zh-cn/15.8/install/upgrade.rst
+++ b/zh-cn/15.8/install/upgrade.rst
@@ -489,6 +489,25 @@ Docker 版::
 这些领域。否则，在 15.7 之前能够登录的用户将因 ``Kerberos realm is not allowed`` 而被拒绝。
 详细内容请参阅 :doc:`../config/sso-spnego`\ 。
 
+若此前使用过 SAML 认证（SSO）
+-----------------------------
+
+自 15.8 起，|Fess| 会将每个 SAML 响应与自身发出的 AuthnRequest 的 ID 进行绑定校验，
+因此 IdP 发起（未经请求的 unsolicited）的 SSO 无法再使用。从 IdP 门户（如 Okta 仪表板或
+Microsoft Entra ID 的「我的应用」）中的 |Fess| 磁贴发起的登录没有可匹配的 AuthnRequest，
+会被拒绝。在 15.7 之前它之所以可用，是因为 |Fess| 会将无法匹配的响应退回给 IdP，
+而 IdP 会立即返回一个经过请求的断言。如果要在 IdP 侧放置磁贴，请将其链接指向 |Fess| 的
+``/sso/`` 端点，使登录由 SP 发起。
+
+此外，IdP 通过跨站 POST 返回断言，因此必须将 ``tomcat_config.properties`` 中的
+``tomcat.sameSiteCookies`` 设置为 ``none``\ 。使用附带的默认值 ``lax`` 时，会话 Cookie
+不会随该请求发送，SAML 登录无法完成。该文件在 ZIP 软件包中位于 ``lib/classes/``\ ，
+在 DEB/RPM 软件包中位于 ``/etc/fess/``\ ，修改后需要重启 |Fess|\ 。浏览器仅对同时带有
+``Secure`` 属性的 Cookie 接受 ``none``\ ，因此 |Fess| 必须通过 HTTPS 提供服务。
+在 15.7 之前，同样的配置错误不会产生明确的错误，而是表现为不断重定向到 IdP 的死循环，
+因此即使站点看起来正常，也请确认该设置。15.8 不再循环，而是一次性失败。
+详细内容请参阅 :doc:`../config/sso-saml`\ 。
+
 插件版本更新
 ------------------------
 


### PR DESCRIPTION
`15.8/install/upgrade.rst` had no SAML section, even though 15.8 changed SAML SSO in two ways that break a working 15.7 deployment. Both are already described in `15.8/config/sso-saml.rst` (#483), but that is not where someone planning an upgrade looks. The sibling SSO breaking change for SPNEGO already has its own section in the upgrade notes (#482), so this adds the SAML one directly after it.

## What is documented

1. **IdP-initiated (unsolicited) SSO no longer works.** 15.8 binds every SAML response to the ID of the AuthnRequest Fess sent, so a login started from a tile in the IdP portal has nothing to match against. It worked up to 15.7 only because Fess bounced the unmatched response back to the IdP, which immediately returned a solicited assertion. Remedy: point the tile at `/sso/` so the login is SP-initiated.
2. **`tomcat.sameSiteCookies` must be `none`.** The IdP returns the assertion as a cross-site POST and a `SameSite=Lax` cookie is not sent on one, so the shipped default cannot complete a SAML login. `none` is only accepted on a `Secure` cookie, hence HTTPS. Up to 15.7 the same misconfiguration produced an endless redirect loop instead of a clean error, so a site that appeared to work should still be checked.

The two facts are kept in separate paragraphs on purpose. With `SameSite=Lax` the SP-initiated flow never completes at all, so the bounce is what made *IdP-initiated* login succeed in 15.7 -- it is not the case that a working 15.7 SP-initiated site was relying on the loop. Paragraph 1 carries the bounce, paragraph 2 says only that the misconfiguration used to loop rather than fail cleanly.

## Scope

All seven languages that have `15.8/install/upgrade.rst`: ja, en, de, es, fr, ko, zh-cn. Every one of them already had the SPNEGO section, and the new section goes in the same slot in each -- after SPNEGO, before the plugin-version section -- at the same heading level, with no admonition directives, matching how the SPNEGO section is written.

Each language is translated against the terminology its own `15.8/config/sso-saml.rst` already uses, and follows that file's own quoting convention where it differs.

## Validation

The repo's `conf/ext.py` is Python 2, so a build with the real config is not possible offline. Instead each language's whole `15.8/` tree (~186 docs) was built with `sphinx-build -b dummy` under a minimal `conf.py` supplying the `|Fess|` substitution, capturing warnings before and after the edit: **byte-identical warning output in all seven languages, and zero warnings referencing `install/upgrade.rst`**.

As a positive control -- so "no new warnings" is falsifiable -- a copy of the `en` tree was given a short underline, a `:doc:` pointing at a nonexistent target and an undefined substitution; the harness reported all three. `-b text` output was also read back for ja, zh-cn, de and ko to confirm the inline literals, the escaped `\ ` spaces and the `:doc:` link titles render correctly. Heading underlines were sized with `docutils.utils.column_width`, so the CJK headings match the existing convention. `git diff --check` is clean.
