### PR TITLE
docs(sso): cover the 15.8 Entra ID changes and correct the Graph permissions

### DIFF
--- a/de/15.8/config/sso-entraid.rst
+++ b/de/15.8/config/sso-entraid.rst
@@ -108,6 +108,9 @@ Die folgenden Einstellungen können bei Bedarf hinzugefügt werden.
    * - ``entraid.default.roles``
      - Standardrollen (kommagetrennt)
      - (Keine)
+   * - ``entraid.require.membership``
+     - Verhalten, wenn die Gruppen und Rollen des Benutzers bei der Anmeldung nicht von Microsoft Graph abgerufen werden können. Bei ``true`` wird die Anmeldung abgelehnt. Bei ``false`` wird eine Warnung protokolliert und die Anmeldung fortgesetzt; der Benutzer besitzt dann nur die oben genannten Standardgruppen und Standardrollen.
+     - ``false``
    * - ``entraid.permission.fields``
      - Gruppen-/Rollenfelder (kommagetrennt), die zusätzlich als Berechtigungswerte verwendet werden. Die Gruppen-/Rollen-ID (GUID) wird stets als Berechtigung verwendet; die hier angegebenen Felder (z.B. ``mail``) werden zusätzlich hinzugefügt.
      - ``mail``
@@ -205,7 +208,8 @@ Konfigurieren der API-Berechtigungen
 
 5. Fügen Sie die folgende Berechtigung hinzu:
 
-   - ``Group.Read.All`` - Erforderlich zum Abrufen von Benutzergruppeninformationen
+   - ``User.Read`` - Erforderlich zum Abrufen der Gruppenmitgliedschaften des angemeldeten Benutzers (``/me/memberOf``). Wird beim Erstellen der App-Registrierung standardmäßig erteilt
+   - ``GroupMember.Read.All`` - Erforderlich zum Lesen von Gruppenattributen wie dem Gruppennamen und zum Auflösen verschachtelter Gruppen
 
 6. Klicken Sie auf **Berechtigungen hinzufügen**
 
@@ -215,10 +219,17 @@ Konfigurieren der API-Berechtigungen
    Die Administratorzustimmung erfordert Mandantenadministratorrechte.
 
 .. note::
+   Anstelle von ``GroupMember.Read.All`` können auch ``Group.Read.All`` oder
+   ``Directory.Read.All`` erteilt werden; das Abrufen der Gruppenattribute und das Auflösen
+   verschachtelter Gruppen funktioniert damit ebenfalls. ``/me/memberOf`` wird durch
+   ``Group.Read.All`` jedoch nicht autorisiert, sodass ``User.Read`` in jedem Fall erforderlich
+   ist.
+
+.. note::
    |Fess| fordert beim Token-Abruf den Scope ``https://graph.microsoft.com/.default`` an.
    Ab 15.8 wird zusätzlich ``openid profile offline_access https://graph.microsoft.com/.default`` an den Autorisierungsendpunkt gesendet, sodass die Zustimmung für denselben Umfang eingeholt wird.
    Das bedeutet, dass alle in der App-Registrierung konfigurierten und genehmigten Zugriffsberechtigungen verwendet werden.
-   Um Gruppeninformationen abzurufen, muss daher die oben genannte Berechtigung ``Group.Read.All`` zur App-Registrierung hinzugefügt und die Administratorzustimmung erteilt werden.
+   Um Gruppeninformationen abzurufen, müssen daher die oben genannten Berechtigungen zur App-Registrierung hinzugefügt und die Administratorzustimmung erteilt werden.
 
 Zu erhaltende Informationen
 ---------------------------
@@ -333,9 +344,20 @@ Authentifizierungsfehler treten auf
 Gruppeninformationen können nicht abgerufen werden
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Überprüfen Sie, ob die Berechtigung ``Group.Read.All`` erteilt wurde
+- Überprüfen Sie, ob die Berechtigungen ``User.Read`` und ``GroupMember.Read.All`` erteilt wurden
+  (``GroupMember.Read.All`` kann durch ``Group.Read.All`` oder ``Directory.Read.All`` ersetzt
+  werden, ``/me/memberOf`` benötigt jedoch weiterhin ``User.Read``)
 - Überprüfen Sie, ob die Administratorzustimmung erteilt wurde
 - Überprüfen Sie, ob der Benutzer in Entra ID zu Gruppen gehört
+- Wenn verschachtelte übergeordnete Gruppen nicht aufgelöst werden können, wird die Warnung
+  ``Not allowed to read the parent groups of ...`` protokolliert. Erteilen Sie in diesem Fall
+  ``GroupMember.Read.All``
+- Mit dem Standardwert ``entraid.require.membership=false`` wird die Anmeldung auch dann
+  fortgesetzt, wenn die Gruppen nicht abgerufen werden können. Der Benutzer besitzt dann nur
+  ``entraid.default.groups`` und ``entraid.default.roles``, sodass Dokumente, die er eigentlich
+  sehen dürfte, in den Suchergebnissen fehlen
+- Setzen Sie ``entraid.require.membership=true``, um eine solche Anmeldung stattdessen abzulehnen,
+  wenn Benutzer nicht mit unvollständigen Berechtigungen suchen sollen
 
 Debug-Einstellungen
 -------------------

--- a/de/15.8/install/upgrade.rst
+++ b/de/15.8/install/upgrade.rst
@@ -529,6 +529,25 @@ Weiterleitungsschleife zum IdP; prüfen Sie die Einstellung daher auch bei einer
 zu funktionieren schien. In 15.8 schlägt die Anmeldung einmalig fehl, statt in einer Schleife zu
 laufen. Einzelheiten finden Sie unter :doc:`../config/sso-saml`.
 
+Falls Sie Microsoft Entra ID (Azure AD) genutzt haben
+-----------------------------------------------------
+
+Ab 15.8 lautet der Standardwert des beim Autorisierungsendpunkt angeforderten Response-Modus
+``query`` statt ``form_post``. Bis 15.7 wurde der Callback als websiteübergreifender POST
+zurückgegeben, und beim |Fess|-Standardwert ``tomcat.sameSiteCookies = lax`` wird das
+Sitzungscookie dabei nicht mitgesendet, sodass ``tomcat.sameSiteCookies = none`` erforderlich
+war. Wenn Sie ``none`` nur aus diesem Grund gesetzt haben, können Sie zum Standardwert
+zurückkehren. Um das bisherige Verhalten beizubehalten, setzen Sie
+``entraid.response.mode=form_post`` und belassen ``tomcat.sameSiteCookies = none``.
+
+Außerdem führt 15.8 ``entraid.require.membership`` ein. Damit legen Sie fest, was geschieht, wenn
+Microsoft Graph bei der Anmeldung die Gruppen und Rollen des Benutzers nicht zurückgibt. Der
+Standardwert ``false`` verhält sich wie 15.7: Es wird eine Warnung protokolliert und die
+Anmeldung wird fortgesetzt. Der Benutzer besitzt dann jedoch nur ``entraid.default.groups`` und
+``entraid.default.roles``, sodass Dokumente, die er eigentlich sehen dürfte, in den
+Suchergebnissen fehlen. Mit ``true`` wird eine solche Anmeldung stattdessen abgelehnt.
+Einzelheiten finden Sie unter :doc:`../config/sso-entraid`.
+
 Aktualisierung der Plugin-Versionen
 -----------------------------------
 

--- a/en/15.8/config/sso-entraid.rst
+++ b/en/15.8/config/sso-entraid.rst
@@ -107,6 +107,9 @@ The following settings can be added as needed.
    * - ``entraid.default.roles``
      - Default roles (comma-separated)
      - (None)
+   * - ``entraid.require.membership``
+     - What happens when the user's groups and roles cannot be retrieved from Microsoft Graph at login. When ``true``, the login is rejected. When ``false``, a warning is logged and the login continues, but the user holds only the default groups and roles above.
+     - ``false``
    * - ``entraid.permission.fields``
      - Group/role fields (comma-separated) to additionally use as permission values. The group/role ID (GUID) is always used as a permission, and the values of the fields specified here (e.g., ``mail``) are added.
      - ``mail``
@@ -200,7 +203,8 @@ Configuring API Permissions
 
 5. Add the following permission:
 
-   - ``Group.Read.All`` - Required to retrieve user group information
+   - ``User.Read`` - Required to retrieve the signed-in user's group memberships (``/me/memberOf``). Granted by default when the app registration is created
+   - ``GroupMember.Read.All`` - Required to read group attributes such as the group name, and to resolve nested groups
 
 6. Click **Add permissions**
 
@@ -210,7 +214,13 @@ Configuring API Permissions
    Admin consent requires tenant administrator privileges.
 
 .. note::
-   |Fess| requests the ``https://graph.microsoft.com/.default`` scope when acquiring a token, and from 15.8 it also sends ``openid profile offline_access https://graph.microsoft.com/.default`` to the authorization endpoint so that consent is requested for the same set. This means that all access permissions configured and consented to on the app registration are used. Therefore, to retrieve group information, you must add the ``Group.Read.All`` permission above to the app registration and grant administrator consent.
+   ``Group.Read.All`` or ``Directory.Read.All`` can be granted instead of
+   ``GroupMember.Read.All``, and the group attribute lookup and the nested group resolution still
+   work. However, ``/me/memberOf`` is not authorized by ``Group.Read.All``, so ``User.Read`` is
+   required in either case.
+
+.. note::
+   |Fess| requests the ``https://graph.microsoft.com/.default`` scope when acquiring a token, and from 15.8 it also sends ``openid profile offline_access https://graph.microsoft.com/.default`` to the authorization endpoint so that consent is requested for the same set. This means that all access permissions configured and consented to on the app registration are used. Therefore, to retrieve group information, you must add the permissions above to the app registration and grant administrator consent.
 
 Information to Obtain
 ---------------------
@@ -325,9 +335,19 @@ Authentication Errors Occur
 Cannot Retrieve Group Information
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Verify that ``Group.Read.All`` permission has been granted
+- Verify that the ``User.Read`` and ``GroupMember.Read.All`` permissions have been granted
+  (``Group.Read.All`` or ``Directory.Read.All`` can replace ``GroupMember.Read.All``, but
+  ``/me/memberOf`` still requires ``User.Read``)
 - Verify that admin consent has been granted
 - Check that the user belongs to groups in Entra ID
+- If nested parent groups cannot be resolved, ``Not allowed to read the parent groups of ...`` is
+  logged as a warning. Grant ``GroupMember.Read.All`` in that case
+- With the default ``entraid.require.membership=false``, the login still completes when the groups
+  cannot be retrieved. The user then holds only ``entraid.default.groups`` and
+  ``entraid.default.roles``, so documents they should be able to see are missing from search
+  results
+- Set ``entraid.require.membership=true`` to reject such a login instead, if you would rather not
+  let users search with incomplete permissions
 
 Debug Settings
 --------------

--- a/en/15.8/install/upgrade.rst
+++ b/en/15.8/install/upgrade.rst
@@ -519,6 +519,23 @@ misconfiguration did not produce a clean error but an endless redirect loop back
 check the setting even on a site that appeared to work; 15.8 fails once instead of looping. For
 details, see :doc:`../config/sso-saml`.
 
+If You Were Using Microsoft Entra ID (Azure AD)
+-----------------------------------------------
+
+Starting with 15.8, the response mode requested from the authorization endpoint defaults to
+``query`` instead of ``form_post``. Up to 15.7 the callback was returned as a cross-site POST,
+and the |Fess| default ``tomcat.sameSiteCookies = lax`` does not send the session cookie with
+such a request, so ``tomcat.sameSiteCookies = none`` was required. If you set ``none`` only for
+that reason, you can restore the default. To keep the previous behaviour, set
+``entraid.response.mode=form_post`` and leave ``tomcat.sameSiteCookies = none`` in place.
+
+15.8 also adds ``entraid.require.membership``, which selects what happens when Microsoft Graph
+does not return the user's groups and roles at login. The default, ``false``, behaves as 15.7
+did: a warning is logged and the login completes. The user then holds only
+``entraid.default.groups`` and ``entraid.default.roles``, so documents they should be able to see
+are missing from search results. Set it to ``true`` to reject such a login instead. For details,
+see :doc:`../config/sso-entraid`.
+
 Updating Plugin Versions
 ------------------------
 

--- a/es/15.8/config/sso-entraid.rst
+++ b/es/15.8/config/sso-entraid.rst
@@ -108,6 +108,9 @@ Las siguientes configuraciones pueden agregarse según sea necesario.
    * - ``entraid.default.roles``
      - Roles por defecto (separados por comas)
      - (Ninguno)
+   * - ``entraid.require.membership``
+     - Qué ocurre cuando los grupos y roles del usuario no se pueden recuperar de Microsoft Graph durante el inicio de sesión. Con ``true``, el inicio de sesión se rechaza. Con ``false``, se registra una advertencia y el inicio de sesión continúa, pero el usuario solo dispone de los grupos y roles por defecto indicados arriba.
+     - ``false``
    * - ``entraid.permission.fields``
      - Campos de grupo/rol (separados por comas) que se utilizan adicionalmente como valores de permiso. El ID de grupo/rol (GUID) siempre se usa como permiso, y los valores de los campos especificados aquí (ej: ``mail``) se agregan.
      - ``mail``
@@ -204,7 +207,8 @@ Configurar permisos de API
 
 5. Agregue el siguiente permiso:
 
-   - ``Group.Read.All`` - Requerido para recuperar la información de grupo del usuario
+   - ``User.Read`` - Requerido para recuperar las pertenencias a grupos del usuario que ha iniciado sesión (``/me/memberOf``). Se concede por defecto al crear el registro de la aplicación
+   - ``GroupMember.Read.All`` - Requerido para leer atributos del grupo, como su nombre, y para resolver los grupos anidados
 
 6. Haga clic en **Agregar permisos**
 
@@ -214,10 +218,16 @@ Configurar permisos de API
    El consentimiento del administrador requiere privilegios de administrador del tenant.
 
 .. note::
+   En lugar de ``GroupMember.Read.All`` también se pueden conceder ``Group.Read.All`` o
+   ``Directory.Read.All``: la lectura de los atributos del grupo y la resolución de los grupos
+   anidados siguen funcionando. Sin embargo, ``/me/memberOf`` no está autorizado por
+   ``Group.Read.All``, por lo que ``User.Read`` es necesario en cualquier caso.
+
+.. note::
    |Fess| solicita el ámbito ``https://graph.microsoft.com/.default`` al adquirir un token.
    Desde la versión 15.8, también se envía ``openid profile offline_access https://graph.microsoft.com/.default`` al endpoint de autorización, de modo que el consentimiento se solicita para el mismo conjunto.
    Esto significa que se utilizan todos los permisos de acceso configurados y para los que se ha dado consentimiento en el registro de la aplicación.
-   Por lo tanto, para recuperar información de grupos, debe agregar el permiso ``Group.Read.All`` indicado anteriormente al registro de la aplicación y otorgar el consentimiento del administrador.
+   Por lo tanto, para recuperar información de grupos, debe agregar los permisos indicados anteriormente al registro de la aplicación y otorgar el consentimiento del administrador.
 
 Información a obtener
 ---------------------
@@ -332,9 +342,19 @@ Ocurren errores de autenticación
 No se puede recuperar la información de grupo
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Verifique que se haya otorgado el permiso ``Group.Read.All``
+- Verifique que se hayan otorgado los permisos ``User.Read`` y ``GroupMember.Read.All``
+  (``GroupMember.Read.All`` puede sustituirse por ``Group.Read.All`` o ``Directory.Read.All``,
+  pero ``/me/memberOf`` sigue requiriendo ``User.Read``)
 - Verifique que se haya otorgado el consentimiento del administrador
 - Verifique que el usuario pertenezca a grupos en Entra ID
+- Si no se pueden resolver los grupos padre anidados, se registra la advertencia
+  ``Not allowed to read the parent groups of ...``. En ese caso, otorgue ``GroupMember.Read.All``
+- Con el valor por defecto ``entraid.require.membership=false``, el inicio de sesión continúa
+  aunque no se puedan recuperar los grupos. El usuario solo dispone entonces de
+  ``entraid.default.groups`` y ``entraid.default.roles``, por lo que los documentos que debería
+  poder ver no aparecen en los resultados de búsqueda
+- Establezca ``entraid.require.membership=true`` para rechazar ese inicio de sesión si prefiere que
+  los usuarios no busquen con permisos incompletos
 
 Configuración de depuración
 ---------------------------

--- a/es/15.8/install/upgrade.rst
+++ b/es/15.8/install/upgrade.rst
@@ -532,6 +532,25 @@ al IdP, así que compruebe el ajuste incluso en un sitio que parecía funcionar;
 falla una sola vez en lugar de entrar en bucle. Consulte :doc:`../config/sso-saml` para conocer
 más detalles.
 
+Si Utilizaba Microsoft Entra ID (Azure AD)
+------------------------------------------
+
+A partir de la versión 15.8, el modo de respuesta solicitado al endpoint de autorización es
+``query`` por defecto, en lugar de ``form_post``. Hasta la versión 15.7 el callback se devolvía
+como un POST entre sitios, y con el valor por defecto de |Fess| ``tomcat.sameSiteCookies = lax``
+la cookie de sesión no se envía en esa petición, por lo que era necesario
+``tomcat.sameSiteCookies = none``. Si estableció ``none`` únicamente por ese motivo, puede volver
+al valor por defecto. Para mantener el comportamiento anterior, establezca
+``entraid.response.mode=form_post`` y conserve ``tomcat.sameSiteCookies = none``.
+
+La versión 15.8 también añade ``entraid.require.membership``, que determina qué ocurre cuando
+Microsoft Graph no devuelve los grupos y roles del usuario durante el inicio de sesión. El valor
+por defecto, ``false``, se comporta como en la versión 15.7: se registra una advertencia y el
+inicio de sesión continúa. Sin embargo, el usuario solo dispone entonces de
+``entraid.default.groups`` y ``entraid.default.roles``, por lo que los documentos que debería
+poder ver no aparecen en los resultados de búsqueda. Establézcalo en ``true`` para rechazar ese
+inicio de sesión. Consulte :doc:`../config/sso-entraid` para conocer más detalles.
+
 Actualización de la Versión de los Plugins
 ---------------------------------------------
 

--- a/fr/15.8/config/sso-entraid.rst
+++ b/fr/15.8/config/sso-entraid.rst
@@ -108,6 +108,9 @@ Les paramètres suivants peuvent être ajoutés si nécessaire.
    * - ``entraid.default.roles``
      - Rôles par défaut (séparés par des virgules)
      - (Aucun)
+   * - ``entraid.require.membership``
+     - Comportement lorsque les groupes et rôles de l'utilisateur ne peuvent pas être récupérés depuis Microsoft Graph lors de la connexion. Avec ``true``, la connexion est refusée. Avec ``false``, un avertissement est journalisé et la connexion aboutit, mais l'utilisateur ne dispose que des groupes et rôles par défaut ci-dessus.
+     - ``false``
    * - ``entraid.permission.fields``
      - Champs de groupe/rôle (séparés par des virgules) à utiliser en plus comme valeurs de permission. L'ID (GUID) du groupe/rôle est toujours utilisé comme permission, et les valeurs des champs indiqués ici (ex : ``mail``) sont ajoutées.
      - ``mail``
@@ -205,7 +208,8 @@ Configuration des autorisations d'API
 
 5. Ajoutez l'autorisation suivante :
 
-   - ``Group.Read.All`` - Requis pour récupérer les informations de groupe de l'utilisateur
+   - ``User.Read`` - Requis pour récupérer les appartenances aux groupes de l'utilisateur connecté (``/me/memberOf``). Accordé par défaut lors de la création de l'inscription d'application
+   - ``GroupMember.Read.All`` - Requis pour lire les attributs de groupe tels que le nom du groupe et pour résoudre les groupes imbriqués
 
 6. Cliquez sur **Ajouter des autorisations**
 
@@ -215,10 +219,16 @@ Configuration des autorisations d'API
    Le consentement administrateur nécessite des privilèges d'administrateur de tenant.
 
 .. note::
+   ``Group.Read.All`` ou ``Directory.Read.All`` peuvent être accordés à la place de
+   ``GroupMember.Read.All`` : la lecture des attributs de groupe et la résolution des groupes
+   imbriqués fonctionnent également. En revanche, ``/me/memberOf`` n'est pas autorisé par
+   ``Group.Read.All``, si bien que ``User.Read`` reste nécessaire dans tous les cas.
+
+.. note::
    |Fess| demande le scope ``https://graph.microsoft.com/.default`` lors de l'acquisition d'un jeton.
    Depuis la version 15.8, ``openid profile offline_access https://graph.microsoft.com/.default`` est également envoyé au point de terminaison d'autorisation, afin que le consentement soit demandé pour le même ensemble.
    Cela signifie que toutes les autorisations d'accès configurées et consenties sur l'inscription d'application sont utilisées.
-   Par conséquent, pour récupérer les informations de groupe, vous devez ajouter l'autorisation ``Group.Read.All`` ci-dessus à l'inscription d'application et accorder le consentement administrateur.
+   Par conséquent, pour récupérer les informations de groupe, vous devez ajouter les autorisations ci-dessus à l'inscription d'application et accorder le consentement administrateur.
 
 Informations à obtenir
 ----------------------
@@ -331,9 +341,20 @@ Des erreurs d'authentification se produisent
 Impossible de récupérer les informations de groupe
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Vérifiez que l'autorisation ``Group.Read.All`` a été accordée
+- Vérifiez que les autorisations ``User.Read`` et ``GroupMember.Read.All`` ont été accordées
+  (``GroupMember.Read.All`` peut être remplacé par ``Group.Read.All`` ou ``Directory.Read.All``,
+  mais ``/me/memberOf`` exige toujours ``User.Read``)
 - Vérifiez que le consentement administrateur a été accordé
 - Vérifiez que l'utilisateur appartient à des groupes dans Entra ID
+- Si les groupes parents imbriqués ne peuvent pas être résolus, l'avertissement
+  ``Not allowed to read the parent groups of ...`` est journalisé. Accordez alors
+  ``GroupMember.Read.All``
+- Avec la valeur par défaut ``entraid.require.membership=false``, la connexion aboutit même si les
+  groupes ne peuvent pas être récupérés. L'utilisateur ne dispose alors que de
+  ``entraid.default.groups`` et ``entraid.default.roles``, si bien que les documents qu'il devrait
+  pouvoir consulter n'apparaissent pas dans les résultats de recherche
+- Définissez ``entraid.require.membership=true`` pour refuser une telle connexion si vous préférez
+  que les utilisateurs ne recherchent pas avec des permissions incomplètes
 
 Paramètres de débogage
 ----------------------

--- a/fr/15.8/install/upgrade.rst
+++ b/fr/15.8/install/upgrade.rst
@@ -534,6 +534,25 @@ net mais une boucle de redirections sans fin vers l'IdP ; vérifiez donc le para
 site qui semblait fonctionner. En 15.8, la connexion échoue une seule fois au lieu de boucler.
 Pour plus de détails, consultez :doc:`../config/sso-saml`.
 
+Si vous utilisiez Microsoft Entra ID (Azure AD)
+-----------------------------------------------
+
+À partir de la 15.8, le mode de réponse demandé au point de terminaison d'autorisation vaut
+``query`` par défaut au lieu de ``form_post``. Jusqu'à la 15.7, le callback était renvoyé par un
+POST intersite, et la valeur par défaut de |Fess| ``tomcat.sameSiteCookies = lax`` n'envoie pas
+le cookie de session avec une telle requête ; ``tomcat.sameSiteCookies = none`` était donc
+nécessaire. Si vous aviez défini ``none`` uniquement pour cette raison, vous pouvez revenir à la
+valeur par défaut. Pour conserver le comportement précédent, définissez
+``entraid.response.mode=form_post`` et laissez ``tomcat.sameSiteCookies = none`` en place.
+
+La 15.8 ajoute également ``entraid.require.membership``, qui détermine ce qui se passe lorsque
+Microsoft Graph ne renvoie pas les groupes et rôles de l'utilisateur lors de la connexion. La
+valeur par défaut ``false`` reproduit le comportement de la 15.7 : un avertissement est
+journalisé et la connexion aboutit. L'utilisateur ne dispose alors que de
+``entraid.default.groups`` et ``entraid.default.roles``, si bien que les documents qu'il devrait
+pouvoir consulter n'apparaissent pas dans les résultats de recherche. Définissez ``true`` pour
+refuser une telle connexion. Pour plus de détails, consultez :doc:`../config/sso-entraid`.
+
 Mise à jour de la version des plugins
 -------------------------------------
 

--- a/ja/15.8/config/sso-entraid.rst
+++ b/ja/15.8/config/sso-entraid.rst
@@ -106,6 +106,9 @@ Entra IDから取得した情報を設定します。
    * - ``entraid.default.roles``
      - デフォルトロール（カンマ区切り）
      - （なし）
+   * - ``entraid.require.membership``
+     - ログイン時にMicrosoft Graphからユーザーのグループ・ロール情報を取得できなかった場合の扱い。\ ``true`` の場合はログインを拒否します。\ ``false`` の場合は警告をログに出力してログインを継続しますが、ユーザーの権限は上記のデフォルトグループ・デフォルトロールだけになります。
+     - ``false``
    * - ``entraid.permission.fields``
      - 権限値として追加で使用するグループ/ロールのフィールド（カンマ区切り）。グループ/ロールのID（GUID）は常に権限として使用され、ここで指定したフィールド（例: ``mail``）の値が追加されます。
      - ``mail``
@@ -199,7 +202,8 @@ APIアクセス許可の設定
 
 5. 以下のアクセス許可を追加:
 
-   - ``Group.Read.All`` - ユーザーのグループ情報を取得するために必要
+   - ``User.Read`` - サインインしたユーザーの所属グループ（``/me/memberOf``）の取得に必要。アプリ登録の作成時に既定で付与されます
+   - ``GroupMember.Read.All`` - グループ名などのグループ属性の取得、およびネストされたグループの解決に必要
 
 6. **アクセス許可の追加** をクリック
 
@@ -209,11 +213,17 @@ APIアクセス許可の設定
    管理者の同意は、テナント管理者権限が必要です。
 
 .. note::
+   ``GroupMember.Read.All`` の代わりに ``Group.Read.All`` や ``Directory.Read.All`` を付与しても、
+   グループ属性の取得とネストされたグループの解決は動作します。
+   一方、\ ``/me/memberOf`` は ``Group.Read.All`` では認可されないため、
+   いずれの場合も ``User.Read`` は必要です。
+
+.. note::
    |Fess| はトークン取得時に ``https://graph.microsoft.com/.default`` スコープを要求します。
    15.8 以降は、認可エンドポイントにも ``openid profile offline_access https://graph.microsoft.com/.default``
    を要求し、同じ範囲の同意を求めます。
    これは、アプリ登録で構成・同意済みのすべてのアクセス許可が使用されることを意味します。
-   そのため、グループ情報を取得するには、上記の ``Group.Read.All`` をアプリ登録に追加し、
+   そのため、グループ情報を取得するには、上記のアクセス許可をアプリ登録に追加し、
    管理者の同意を与えておく必要があります。
 
 取得する情報
@@ -329,9 +339,13 @@ Entra ID認証では、Microsoft Graph APIを使用してユーザーが所属�
 グループ情報が取得できない
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``Group.Read.All`` のアクセス許可が付与されているか確認してください
+- ``User.Read`` と ``GroupMember.Read.All`` のアクセス許可が付与されているか確認してください
+  （``GroupMember.Read.All`` は ``Group.Read.All`` や ``Directory.Read.All`` でも代用できますが、\ ``/me/memberOf`` には ``User.Read`` が必要です）
 - 管理者の同意が与えられているか確認してください
 - ユーザーがEntra ID上でグループに所属しているか確認してください
+- ネストされた親グループを解決できない場合は、\ ``Not allowed to read the parent groups of ...`` という警告がログに出力されます。この場合は ``GroupMember.Read.All`` を付与してください
+- 既定の ``entraid.require.membership=false`` では、グループ情報を取得できなくてもログインは継続します。このときユーザーの権限は ``entraid.default.groups`` と ``entraid.default.roles`` だけになるため、本来参照できる文書が検索結果に出なくなります
+- ``entraid.require.membership=true`` を指定すると、この状態でのログインは拒否されます。権限が欠けたまま検索されることを避けたい場合に指定してください
 
 デバッグ設定
 ------------

--- a/ja/15.8/install/upgrade.rst
+++ b/ja/15.8/install/upgrade.rst
@@ -516,6 +516,23 @@ ZIP 版では ``lib/classes/``\ 、DEB/RPM 版では ``/etc/fess/`` に配置さ
 見えていた環境でも設定を確認してください。15.8 ではループせずに 1 回で失敗します。
 詳細は :doc:`../config/sso-saml` を参照してください。
 
+Microsoft Entra ID（Azure AD）を利用していた場合
+------------------------------------------------
+
+15.8 から、認可エンドポイントに要求するレスポンスモードの既定値が ``form_post`` から ``query``
+に変わりました。15.7 まではコールバックがクロスサイトの POST で返るため、\ |Fess| の既定値である
+``tomcat.sameSiteCookies = lax`` ではセッションクッキーが送信されず、\ ``none`` への変更が必要で
+した。この回避策のためだけに ``none`` を設定していた場合は、既定値に戻せます。従来どおり
+``form_post`` を使う場合は ``entraid.response.mode=form_post`` を指定し、
+``tomcat.sameSiteCookies = none`` を維持してください。
+
+また 15.8 では、ログイン時に Microsoft Graph からユーザーのグループ・ロール情報を取得できなかった
+場合の扱いを ``entraid.require.membership`` で選択できます。既定値の ``false`` は 15.7 と同じ動作
+で、警告をログに出力したうえでログインを継続します。ただしこのときユーザーの権限は
+``entraid.default.groups`` と ``entraid.default.roles`` だけになるため、本来参照できる文書が
+検索結果に出なくなります。\ ``true`` を指定すると、この状態でのログインは拒否されます。
+詳細は :doc:`../config/sso-entraid` を参照してください。
+
 プラグインのバージョン更新
 --------------------------
 

--- a/ko/15.8/config/sso-entraid.rst
+++ b/ko/15.8/config/sso-entraid.rst
@@ -107,6 +107,9 @@ Entra ID에서 취득한 정보를 설정합니다.
    * - ``entraid.default.roles``
      - 기본 역할（쉼표 구분）
      - （없음）
+   * - ``entraid.require.membership``
+     - 로그인 시 Microsoft Graph에서 사용자의 그룹·역할 정보를 취득하지 못한 경우의 동작. ``true`` 인 경우 로그인을 거부합니다. ``false`` 인 경우 경고를 로그에 출력하고 로그인을 계속하지만, 사용자의 권한은 위의 기본 그룹·기본 역할뿐입니다.
+     - ``false``
    * - ``entraid.permission.fields``
      - 권한 값으로 추가로 사용할 그룹/역할 필드（쉼표 구분）. 그룹/역할의 ID（GUID）는 항상 권한으로 사용되며, 여기서 지정한 필드（예: ``mail``）의 값이 추가됩니다.
      - ``mail``
@@ -200,7 +203,8 @@ API 접근 권한 설정
 
 5. 다음 접근 권한을 추가:
 
-   - ``Group.Read.All`` - 사용자의 그룹 정보를 취득하기 위해 필요
+   - ``User.Read`` - 로그인한 사용자의 소속 그룹（``/me/memberOf``）을 취득하기 위해 필요. 앱 등록 생성 시 기본으로 부여됩니다
+   - ``GroupMember.Read.All`` - 그룹 이름 등 그룹 속성의 취득과 중첩된 그룹의 해결에 필요
 
 6. **권한 추가** 를 클릭
 
@@ -210,11 +214,16 @@ API 접근 권한 설정
    관리자 동의는 테넌트 관리자 권한이 필요합니다.
 
 .. note::
+   ``GroupMember.Read.All`` 대신 ``Group.Read.All`` 이나 ``Directory.Read.All`` 을 부여해도
+   그룹 속성의 취득과 중첩된 그룹의 해결은 동작합니다. 다만 ``/me/memberOf`` 는
+   ``Group.Read.All`` 로는 인가되지 않으므로 어느 경우에도 ``User.Read`` 는 필요합니다.
+
+.. note::
    |Fess| 는 토큰 취득 시 ``https://graph.microsoft.com/.default`` 스코프를 요청합니다.
    15.8 이상에서는 인가 엔드포인트에도 ``openid profile offline_access https://graph.microsoft.com/.default``
    를 요청하여 동일한 범위의 동의를 요구합니다.
    이는 앱 등록에서 구성 및 동의된 모든 접근 권한이 사용됨을 의미합니다.
-   따라서 그룹 정보를 취득하려면 위의 ``Group.Read.All`` 을 앱 등록에 추가하고
+   따라서 그룹 정보를 취득하려면 위의 접근 권한을 앱 등록에 추가하고
    관리자 동의를 부여해야 합니다.
 
 취득하는 정보
@@ -330,9 +339,13 @@ Entra ID 인증에서는 Microsoft Graph API를 사용하여 사용자가 소속
 그룹 정보를 취득할 수 없음
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ``Group.Read.All`` 의 접근 권한이 부여되어 있는지 확인하십시오
+- ``User.Read`` 와 ``GroupMember.Read.All`` 의 접근 권한이 부여되어 있는지 확인하십시오
+  （``GroupMember.Read.All`` 은 ``Group.Read.All`` 이나 ``Directory.Read.All`` 로 대체할 수 있지만, ``/me/memberOf`` 에는 ``User.Read`` 가 필요합니다）
 - 관리자 동의가 부여되어 있는지 확인하십시오
 - 사용자가 Entra ID에서 그룹에 소속되어 있는지 확인하십시오
+- 중첩된 상위 그룹을 해결할 수 없는 경우에는 ``Not allowed to read the parent groups of ...`` 경고가 로그에 출력됩니다. 이 경우에는 ``GroupMember.Read.All`` 을 부여하십시오
+- 기본값인 ``entraid.require.membership=false`` 에서는 그룹 정보를 취득하지 못해도 로그인은 계속됩니다. 이때 사용자의 권한은 ``entraid.default.groups`` 와 ``entraid.default.roles`` 뿐이므로, 원래 참조할 수 있는 문서가 검색 결과에 나오지 않습니다
+- ``entraid.require.membership=true`` 를 지정하면 이러한 로그인은 거부됩니다. 권한이 부족한 상태로 검색되는 것을 피하려면 지정하십시오
 
 디버그 설정
 ------------

--- a/ko/15.8/install/upgrade.rst
+++ b/ko/15.8/install/upgrade.rst
@@ -514,6 +514,23 @@ IdP로의 무한 리다이렉트 루프로 나타났으므로, 동작하는 것�
 확인하십시오. 15.8에서는 루프에 빠지지 않고 한 번에 실패합니다.
 자세한 내용은 :doc:`../config/sso-saml` 을 참조하십시오.
 
+Microsoft Entra ID(Azure AD)를 사용하고 있었던 경우
+---------------------------------------------------
+
+15.8부터 인가 엔드포인트에 요청하는 응답 모드의 기본값이 ``form_post`` 에서 ``query`` 로
+변경되었습니다. 15.7까지는 콜백이 교차 사이트 POST로 반환되므로, |Fess| 의 기본값인
+``tomcat.sameSiteCookies = lax`` 에서는 세션 쿠키가 전송되지 않아 ``none`` 으로 변경해야
+했습니다. 이 회피책만을 위해 ``none`` 을 설정했다면 기본값으로 되돌릴 수 있습니다. 기존과 같이
+``form_post`` 를 사용하려면 ``entraid.response.mode=form_post`` 를 지정하고
+``tomcat.sameSiteCookies = none`` 을 유지하십시오.
+
+또한 15.8에서는 로그인 시 Microsoft Graph에서 사용자의 그룹·역할 정보를 취득하지 못한 경우의
+동작을 ``entraid.require.membership`` 으로 선택할 수 있습니다. 기본값 ``false`` 는 15.7과 동일
+하게 경고를 로그에 출력하고 로그인을 계속합니다. 다만 이때 사용자의 권한은
+``entraid.default.groups`` 와 ``entraid.default.roles`` 뿐이므로, 원래 참조할 수 있는 문서가
+검색 결과에 나오지 않습니다. ``true`` 를 지정하면 이러한 로그인은 거부됩니다.
+자세한 내용은 :doc:`../config/sso-entraid` 를 참조하십시오.
+
 플러그인 버전 갱신
 ------------------------
 

--- a/zh-cn/15.8/config/sso-entraid.rst
+++ b/zh-cn/15.8/config/sso-entraid.rst
@@ -106,6 +106,9 @@ Entra ID认证的工作原理
    * - ``entraid.default.roles``
      - 默认角色（逗号分隔）
      - （无）
+   * - ``entraid.require.membership``
+     - 登录时无法从Microsoft Graph获取用户的组和角色信息时的处理方式。设为 ``true`` 时拒绝登录。设为 ``false`` 时输出警告日志并继续登录，但用户的权限仅为上述默认组和默认角色。
+     - ``false``
    * - ``entraid.permission.fields``
      - 额外用作权限值的组/角色字段（逗号分隔）。组/角色的ID（GUID）始终作为权限使用，此处指定的字段（例如 ``mail``）的值将被追加添加。
      - ``mail``
@@ -196,7 +199,8 @@ Entra ID侧配置
 
 5. 添加以下权限：
 
-   - ``Group.Read.All`` - 获取用户组信息所需
+   - ``User.Read`` - 获取已登录用户的组成员关系（``/me/memberOf``）所需。创建应用注册时默认授予
+   - ``GroupMember.Read.All`` - 读取组名等组属性以及解析嵌套组所需
 
 6. 点击 **添加权限**
 
@@ -206,10 +210,15 @@ Entra ID侧配置
    管理员同意需要租户管理员权限。
 
 .. note::
+   也可以授予 ``Group.Read.All`` 或 ``Directory.Read.All`` 来代替 ``GroupMember.Read.All``\ ，
+   组属性的获取与嵌套组的解析同样可以正常工作。但 ``/me/memberOf`` 无法通过 ``Group.Read.All``
+   授权，因此无论采用哪种方式都需要 ``User.Read``\ 。
+
+.. note::
    |Fess| 在获取令牌时会请求 ``https://graph.microsoft.com/.default`` 作用域。
    15.8 及以后版本还会向授权端点发送 ``openid profile offline_access https://graph.microsoft.com/.default``\ ，以便针对同一组权限请求同意。
    这意味着将使用在应用注册中配置并已授予同意的所有访问权限。
-   因此，若要获取组信息，必须将上述 ``Group.Read.All`` 权限添加到应用注册中，并授予管理员同意。
+   因此，若要获取组信息，必须将上述权限添加到应用注册中，并授予管理员同意。
 
 需要获取的信息
 --------------
@@ -322,9 +331,18 @@ Entra ID侧配置
 无法获取组信息
 ~~~~~~~~~~~~~~
 
-- 验证是否已授予 ``Group.Read.All`` 权限
+- 验证是否已授予 ``User.Read`` 和 ``GroupMember.Read.All`` 权限
+  （``GroupMember.Read.All`` 可以用 ``Group.Read.All`` 或 ``Directory.Read.All`` 代替，
+  但 ``/me/memberOf`` 仍然需要 ``User.Read``\ ）
 - 验证是否已授予管理员同意
 - 检查用户是否在Entra ID中属于组
+- 如果无法解析嵌套的父组，日志中会输出 ``Not allowed to read the parent groups of ...`` 警告。
+  此时请授予 ``GroupMember.Read.All``
+- 使用默认值 ``entraid.require.membership=false`` 时，即使无法获取组信息也会继续登录。
+  此时用户的权限仅为 ``entraid.default.groups`` 和 ``entraid.default.roles``\ ，
+  本应可以查看的文档将不会出现在搜索结果中
+- 如果不希望用户在权限不完整的情况下进行搜索，请指定 ``entraid.require.membership=true``\ ，
+  此时此类登录将被拒绝
 
 调试设置
 --------

--- a/zh-cn/15.8/install/upgrade.rst
+++ b/zh-cn/15.8/install/upgrade.rst
@@ -508,6 +508,21 @@ Microsoft Entra ID 的「我的应用」）中的 |Fess| 磁贴发起的登录�
 因此即使站点看起来正常，也请确认该设置。15.8 不再循环，而是一次性失败。
 详细内容请参阅 :doc:`../config/sso-saml`\ 。
 
+若此前使用过 Microsoft Entra ID（Azure AD）
+-------------------------------------------
+
+自 15.8 起，向授权端点请求的响应模式默认值由 ``form_post`` 变更为 ``query``\ 。15.7 之前回调以
+跨站 POST 返回，而 |Fess| 的默认值 ``tomcat.sameSiteCookies = lax`` 不会随该请求发送会话
+Cookie，因此需要将其改为 ``tomcat.sameSiteCookies = none``\ 。如果仅为此才设置了 ``none``\ ，
+可以恢复为默认值。若要保持原有行为，请指定 ``entraid.response.mode=form_post`` 并保留
+``tomcat.sameSiteCookies = none``\ 。
+
+15.8 还新增了 ``entraid.require.membership``\ ，用于选择登录时无法从 Microsoft Graph 获取用户的
+组和角色信息时的处理方式。默认值 ``false`` 与 15.7 相同：输出警告日志并继续登录。但此时用户的
+权限仅为 ``entraid.default.groups`` 和 ``entraid.default.roles``\ ，本应可以查看的文档将不会
+出现在搜索结果中。指定 ``true`` 则拒绝此类登录。
+详细内容请参阅 :doc:`../config/sso-entraid`\ 。
+
 插件版本更新
 ------------------------
 


### PR DESCRIPTION
Depends on codelibs/fess#3254, which adds `entraid.require.membership`. Please merge that first — this documents the key and its default.

## `install/upgrade.rst` — a missing section

15.8 changed two things about Entra ID that a 15.7 deployment has to know about, and `upgrade.rst` mentioned neither in any language, although SPNEGO already had a section for its own 15.8 change. This adds an equivalent one, following that section's shape and depth:

- **The response mode now defaults to `query`** rather than `form_post`. Up to 15.7 the callback came back as a cross-site POST, and the shipped `tomcat.sameSiteCookies = lax` does not send the session cookie with such a request, so `none` was a required workaround. A deployment that set `none` only for that reason can restore the default; one that wants to keep `form_post` now has to say so explicitly.
- **`entraid.require.membership`** decides what a login does when Microsoft Graph does not return the user's groups and roles. The default restores the 15.7 outcome, and the section says plainly what that outcome costs — the user holds only the configured defaults, so documents they should be able to see are missing from their results.

## `config/sso-entraid.rst` — a permission list that was wrong

The API permission step asked only for `Group.Read.All`. The [Microsoft Graph reference for `GET /me/memberOf`](https://learn.microsoft.com/en-us/graph/api/user-list-memberof?view=graph-rest-1.0) does not list `Group.Read.All` at all:

| Permission type | Least privileged | Higher privileged |
| --- | --- | --- |
| Delegated (work or school account) | `User.Read` | `Directory.Read.All`, `Directory.ReadWrite.All`, `GroupMember.Read.All` |

This matters more in 15.8 than it did before, because `/me/memberOf` is the call whose failure `entraid.require.membership=true` turns into a refused login.

Checked against all three calls Fess actually makes:

| Call | Delegated permissions |
| --- | --- |
| `GET /me/memberOf` | `User.Read` (least), `Directory.Read.All`, `Directory.ReadWrite.All`, `GroupMember.Read.All` |
| `POST /groups/{id}/getMemberGroups` | `GroupMember.Read.All`, `Group.Read.All`, `Directory.Read.All`, `Group.ReadWrite.All`, `Directory.ReadWrite.All` |
| `GET /groups/{id}` | `Group-NestingSupport.ReadWrite.All` (least); higher includes `Group.Read.All` and `GroupMember.Read.All` |

So `Group.Read.All` is a perfectly valid permission for the two *group* calls — it simply does not authorise `/me/memberOf`. The list now names `User.Read` + `GroupMember.Read.All`, the single pair that covers all three, and a note keeps `Group.Read.All` and `Directory.Read.All` documented as valid substitutes for the group calls, so an existing deployment is not told its working setup is broken.

The authenticator's own warning — *"Grant the Entra ID application GroupMember.Read.All to resolve nested groups"* — is therefore not in conflict with the old docs; it was naming the least privileged option for a different call. The defect was that the docs listed one permission for three calls.

The troubleshooting section is extended to cover both settings of the new key and to name the warning that appears when the nested-group walk is denied.

## Verification

The repository's own Sphinx configuration cannot run on a current toolchain: `conf/conf.py` has an invalid `\u` escape under Python 3 and `conf/ext.py` is Python 2 (`print 'Not found conf.ini'`, `from ConfigParser import SafeConfigParser`). Both predate this change and are untouched here, so **the shipped build was not exercised**.

To get a genuine parse, each language's 15.8 tree was built with a minimal `conf.py` written outside the repository, supplying only the substitutions `conf/conf.ini` defines. All seven languages: `sphinx-build` exit 0, HTML produced for both touched files, and zero warnings attributable to either of them. Remaining warnings in the logs are pre-existing.

Also checked directly: `:doc:`../config/sso-entraid`` is the only `:doc:` target added and resolves in all seven; the options list-table is 9 rows x 3 cells everywhere, matching its `:widths:`; the new heading underlines match the title width computed by East Asian display width, as the surrounding headings do; and `git diff --name-only` confirms nothing outside `*/15.8/` changed.

## Confidence per language

- **ja, en** — high; hand-written, following each file's existing escaping and CJK/Latin spacing conventions rather than normalising them.
- **de, es, fr** — high; terminology matched to each file and phrasing modelled on that file's own SPNEGO section. Worth a native skim.
- **ko, zh-cn** — medium-high; terminology matched per file, existing punctuation conventions kept. No English left in any non-English file apart from configuration keys and Graph permission names.

## Known, not fixed here

`15.4` through `15.7` carry the same `Group.Read.All`-only instruction. Left alone to keep this change scoped to 15.8; happy to follow up if you would rather correct the older versions too.
