### PR TITLE
docs(sso): note the hardened SPNEGO defaults in the 15.8 upgrade guide

### DIFF
--- a/de/15.8/install/upgrade.rst
+++ b/de/15.8/install/upgrade.rst
@@ -505,6 +505,33 @@ Realms kommagetrennt in ``spnego.allowed.realms`` ein, entweder über die Verwal
 Benutzer, die sich bis 15.7 anmelden konnten, mit ``Kerberos realm is not allowed`` abgewiesen.
 Einzelheiten finden Sie unter :doc:`../config/sso-spnego`.
 
+Außerdem wurden in 15.8 die im Code hinterlegten Standardwerte von
+``spnego.allow.unsecure.basic`` und ``spnego.allow.localhost`` von ``true`` auf ``false``
+geändert. Eine Installation, in der diese Schlüssel in ``app/WEB-INF/conf/system.properties``
+fehlen, übernimmt mit dem Upgrade das strengere Verhalten. Insbesondere bietet die
+SPNEGO-Bibliothek bei ``spnego.allow.unsecure.basic=false`` die Basic-Authentifizierung nur noch
+für Anfragen an, bei denen ``HttpServletRequest#isSecure()`` ``true`` zurückgibt. Hinter einem
+Reverse-Proxy, der TLS terminiert und die Anfrage per HTTP weiterleitet, können sich Clients, die
+bisher auf die Basic-Authentifizierung zurückgefallen sind, dann nicht mehr anmelden. Setzen Sie
+in diesem Fall ``tomcat.secure=true`` in ``tomcat_config.properties``; Einzelheiten finden Sie
+unter :doc:`../config/sso-spnego`.
+
+.. warning::
+
+   Ein im Code hinterlegter Standardwert greift nur, solange der Schlüssel fehlt, und
+   „System" → „Allgemein" auf der Verwaltungsseite schreibt bei jedem Speichern sämtliche
+   ``spnego.*``-Schlüssel. In einer Installation, in der unter 15.7 auf dieser Seite jemals
+   „Aktualisieren" gedrückt wurde, sind daher weiterhin
+   ``spnego.allow.unsecure.basic=true`` und ``spnego.allow.localhost=true`` gespeichert. Das
+   Upgrade auf 15.8 härtet eine solche Installation nicht: Sie behält das freizügige Verhalten
+   stillschweigend bei, und 15.8 protokolliert beim Initialisieren von SPNEGO lediglich eine
+   Warnung in ``fess.log``. Öffnen Sie „System" → „Allgemein" (oder bearbeiten Sie
+   ``system.properties``) und schalten Sie beide Einstellungen bewusst ab.
+   ``spnego.allow.localhost=true`` ist dabei die gefährlichere der beiden Optionen: Die
+   SPNEGO-Bibliothek authentifiziert Anfragen vom selben Host dann als Betriebssystembenutzer des
+   Servers, ganz ohne Kerberos-Prüfung, was hinter einem Reverse-Proxy auf demselben Host unsicher
+   ist.
+
 Falls Sie SAML-Authentifizierung (SSO) genutzt haben
 ----------------------------------------------------
 

--- a/en/15.8/install/upgrade.rst
+++ b/en/15.8/install/upgrade.rst
@@ -499,6 +499,27 @@ from a trusted forest, list those realms in ``spnego.allowed.realms``, separated
 users who could log in up to 15.7 are rejected with ``Kerberos realm is not allowed``. For
 details, see :doc:`../config/sso-spnego`.
 
+The coded defaults of ``spnego.allow.unsecure.basic`` and ``spnego.allow.localhost`` also changed
+from ``true`` to ``false`` in 15.8. An installation where these keys are absent from
+``app/WEB-INF/conf/system.properties`` inherits the stricter behavior on upgrade. In particular,
+with ``spnego.allow.unsecure.basic=false`` the SPNEGO library only offers Basic authentication for
+requests where ``HttpServletRequest#isSecure()`` returns ``true``, so behind a reverse proxy that
+terminates TLS and forwards plain HTTP, clients that used to fall back to Basic authentication can
+no longer log in. Set ``tomcat.secure=true`` in ``tomcat_config.properties`` in that case; see
+:doc:`../config/sso-spnego` for details.
+
+.. warning::
+
+   A coded default only applies while the key is absent, and "System" → "General" in the admin UI
+   writes every ``spnego.*`` key each time you save. An installation that ever pressed Update on
+   that screen under 15.7 therefore still has ``spnego.allow.unsecure.basic=true`` and
+   ``spnego.allow.localhost=true`` stored, so upgrading to 15.8 does not harden it: the permissive
+   behavior is kept silently, and 15.8 only records a warning in ``fess.log`` when SPNEGO is
+   initialized. Open "System" → "General" in the admin UI (or edit ``system.properties``) and
+   turn both off deliberately. ``spnego.allow.localhost=true`` is the more dangerous of the two,
+   because the SPNEGO library then authenticates same-host requests as the server OS user with no
+   Kerberos verification at all, which is unsafe behind a same-host reverse proxy.
+
 If You Were Using SAML Authentication (SSO)
 -------------------------------------------
 

--- a/es/15.8/install/upgrade.rst
+++ b/es/15.8/install/upgrade.rst
@@ -508,6 +508,32 @@ usuarios que podían iniciar sesión hasta la versión 15.7 son rechazados con
 ``Kerberos realm is not allowed``. Consulte :doc:`../config/sso-spnego` para conocer más
 detalles.
 
+Además, en la versión 15.8 los valores predeterminados definidos en el código de
+``spnego.allow.unsecure.basic`` y ``spnego.allow.localhost`` cambiaron de ``true`` a ``false``.
+Una instalación en la que estas claves no estén presentes en
+``app/WEB-INF/conf/system.properties`` adopta el comportamiento más estricto al actualizar. En
+particular, con ``spnego.allow.unsecure.basic=false`` la biblioteca SPNEGO solo ofrece la
+autenticación básica en las peticiones en las que ``HttpServletRequest#isSecure()`` devuelve
+``true``, por lo que, detrás de un proxy inverso que termina TLS y reenvía la petición por HTTP,
+los clientes que antes recurrían a la autenticación básica ya no pueden iniciar sesión. En ese
+caso, establezca ``tomcat.secure=true`` en ``tomcat_config.properties``; consulte
+:doc:`../config/sso-spnego` para conocer más detalles.
+
+.. warning::
+
+   Un valor predeterminado definido en el código solo se aplica mientras la clave está ausente, y
+   "Sistema" → "General" de la pantalla de administración escribe todas las claves ``spnego.*``
+   cada vez que se guarda. Por lo tanto, una instalación en la que alguna vez se pulsó Actualizar
+   en esa pantalla con la versión 15.7 sigue teniendo almacenados
+   ``spnego.allow.unsecure.basic=true`` y ``spnego.allow.localhost=true``, y actualizar a 15.8 no
+   la refuerza: mantiene el comportamiento permisivo de forma silenciosa y 15.8 solo registra una
+   advertencia en ``fess.log`` al inicializar SPNEGO. Abra "Sistema" → "General" (o edite
+   ``system.properties``) y desactive ambas opciones de forma deliberada.
+   ``spnego.allow.localhost=true`` es la más peligrosa de las dos: la biblioteca SPNEGO autentica
+   las peticiones procedentes del mismo host como el usuario del sistema operativo del servidor,
+   sin ninguna verificación de Kerberos, lo que resulta inseguro detrás de un proxy inverso
+   situado en el mismo host.
+
 Si Utilizaba la Autenticación SAML (SSO)
 ----------------------------------------
 

--- a/fr/15.8/install/upgrade.rst
+++ b/fr/15.8/install/upgrade.rst
@@ -511,6 +511,31 @@ qui pouvaient se connecter jusqu'à la version 15.7 sont refusés avec
 ``Kerberos realm is not allowed``. Pour plus de détails, consultez
 :doc:`../config/sso-spnego`.
 
+Par ailleurs, en 15.8, les valeurs par défaut codées de ``spnego.allow.unsecure.basic`` et
+``spnego.allow.localhost`` sont passées de ``true`` à ``false``. Une installation dans laquelle
+ces clés sont absentes de ``app/WEB-INF/conf/system.properties`` adopte le comportement plus
+strict lors de la mise à niveau. En particulier, avec ``spnego.allow.unsecure.basic=false``, la
+bibliothèque SPNEGO ne propose l'authentification Basic que pour les requêtes dont
+``HttpServletRequest#isSecure()`` renvoie ``true`` : derrière un proxy inverse qui termine TLS et
+transmet la requête en HTTP, les clients qui basculaient jusqu'ici vers l'authentification Basic
+ne peuvent plus se connecter. Dans ce cas, définissez ``tomcat.secure=true`` dans
+``tomcat_config.properties`` ; pour plus de détails, consultez :doc:`../config/sso-spnego`.
+
+.. warning::
+
+   Une valeur par défaut codée ne s'applique que tant que la clé est absente, et
+   « Système » → « Général » de l'écran d'administration écrit toutes les clés ``spnego.*`` à
+   chaque enregistrement. Une installation sur laquelle « Mettre à jour » a été cliqué au moins
+   une fois depuis cet écran en 15.7 conserve donc ``spnego.allow.unsecure.basic=true`` et
+   ``spnego.allow.localhost=true``, et la mise à niveau vers la 15.8 ne la durcit pas : elle
+   conserve silencieusement le comportement permissif, et la 15.8 se contente de consigner un
+   avertissement dans ``fess.log`` lors de l'initialisation de SPNEGO. Ouvrez
+   « Système » → « Général » (ou modifiez ``system.properties``) et désactivez délibérément les
+   deux options. ``spnego.allow.localhost=true`` est la plus dangereuse des deux : la bibliothèque
+   SPNEGO authentifie alors les requêtes provenant du même hôte en tant qu'utilisateur du système
+   d'exploitation du serveur, sans aucune vérification Kerberos, ce qui n'est pas sûr derrière un
+   proxy inverse situé sur le même hôte.
+
 Si vous utilisiez l'authentification SAML (SSO)
 -----------------------------------------------
 

--- a/ja/15.8/install/upgrade.rst
+++ b/ja/15.8/install/upgrade.rst
@@ -495,6 +495,28 @@ SPNEGO ログインは拒否されます。AD のドメインツリーの子ド�
 ``Kerberos realm is not allowed`` として拒否されます。
 詳細は :doc:`../config/sso-spnego` を参照してください。
 
+また、15.8 では ``spnego.allow.unsecure.basic`` と ``spnego.allow.localhost`` のコード上の
+既定値が ``true`` から ``false`` へ変更されました。これらのキーが
+``app/WEB-INF/conf/system.properties`` に存在しない環境では、アップグレードによって
+より厳格な挙動が適用されます。特に ``spnego.allow.unsecure.basic=false`` では、SPNEGO ライブラリは
+``HttpServletRequest#isSecure()`` が ``true`` を返すリクエストにのみ Basic 認証を提示するため、
+TLS をリバースプロキシで終端して HTTP で転送している構成では、これまで Basic 認証へ
+フォールバックしていたクライアントがログインできなくなります。その場合は
+``tomcat_config.properties`` で ``tomcat.secure=true`` を設定してください。
+詳細は :doc:`../config/sso-spnego` を参照してください。
+
+.. warning::
+
+   コード上の既定値は、キーが存在しない場合にのみ適用されます。管理画面「システム」→「全般」は
+   保存のたびにすべての ``spnego.*`` キーを書き込むため、15.7 でこの画面から一度でも更新した環境には
+   ``spnego.allow.unsecure.basic=true`` と ``spnego.allow.localhost=true`` が保存されたままです。
+   この場合、15.8 へアップグレードしても設定は強化されず、緩い挙動が黙って引き継がれます。
+   15.8 は SPNEGO の初期化時に ``fess.log`` へ警告を出力するだけです。管理画面「システム」→「全般」
+   または ``system.properties`` で、両方を明示的に無効化してください。特に
+   ``spnego.allow.localhost=true`` は危険です。SPNEGO ライブラリが同一ホストからのリクエストを
+   Kerberos の検証なしにサーバーの OS ユーザーとして認証するため、同一ホスト上にリバースプロキシを
+   置く構成では安全ではありません。
+
 SAML 認証（SSO）を利用していた場合
 ----------------------------------
 

--- a/ko/15.8/install/upgrade.rst
+++ b/ko/15.8/install/upgrade.rst
@@ -494,6 +494,27 @@ AD 도메인 트리의 하위 도메인이나 신뢰 관계를 맺은 포리스�
 15.7까지 로그인할 수 있었던 사용자가 ``Kerberos realm is not allowed`` 로 거부됩니다.
 자세한 내용은 :doc:`../config/sso-spnego` 를 참조하십시오.
 
+또한 15.8에서는 ``spnego.allow.unsecure.basic`` 과 ``spnego.allow.localhost`` 의 코드상 기본값이
+``true`` 에서 ``false`` 로 변경되었습니다. 이 키들이 ``app/WEB-INF/conf/system.properties`` 에
+없는 환경에서는 업그레이드와 함께 더 엄격한 동작이 적용됩니다. 특히
+``spnego.allow.unsecure.basic=false`` 인 경우 SPNEGO 라이브러리는 ``HttpServletRequest#isSecure()``
+가 ``true`` 를 반환하는 요청에만 Basic 인증을 제공하므로, 리버스 프록시에서 TLS를 종료하고 HTTP로
+전달하는 구성에서는 지금까지 Basic 인증으로 대체하던 클라이언트가 로그인할 수 없게 됩니다.
+이 경우 ``tomcat_config.properties`` 에서 ``tomcat.secure=true`` 를 설정하십시오.
+자세한 내용은 :doc:`../config/sso-spnego` 를 참조하십시오.
+
+.. warning::
+
+   코드상의 기본값은 키가 없는 경우에만 적용되며, 관리 화면 「시스템」→「일반」은 저장할 때마다
+   모든 ``spnego.*`` 키를 기록합니다. 따라서 15.7에서 이 화면으로 한 번이라도 갱신한 환경에는
+   ``spnego.allow.unsecure.basic=true`` 와 ``spnego.allow.localhost=true`` 가 저장된 채로 남아
+   있으며, 15.8로 업그레이드해도 설정은 강화되지 않습니다. 느슨한 동작이 조용히 유지되고, 15.8은
+   SPNEGO 초기화 시 ``fess.log`` 에 경고를 기록할 뿐입니다. 관리 화면 「시스템」→「일반」 또는
+   ``system.properties`` 에서 두 가지를 모두 명시적으로 비활성화하십시오. 특히
+   ``spnego.allow.localhost=true`` 는 위험합니다. SPNEGO 라이브러리가 동일 호스트에서 온 요청을
+   Kerberos 검증 없이 서버의 OS 사용자로 인증하므로, 동일 호스트에 리버스 프록시를 두는 구성에서는
+   안전하지 않습니다.
+
 SAML 인증(SSO)을 사용하고 있었던 경우
 -------------------------------------
 

--- a/zh-cn/15.8/install/upgrade.rst
+++ b/zh-cn/15.8/install/upgrade.rst
@@ -489,6 +489,25 @@ Docker 版::
 这些领域。否则，在 15.7 之前能够登录的用户将因 ``Kerberos realm is not allowed`` 而被拒绝。
 详细内容请参阅 :doc:`../config/sso-spnego`\ 。
 
+此外，15.8 中 ``spnego.allow.unsecure.basic`` 与 ``spnego.allow.localhost`` 的代码默认值也从
+``true`` 改为了 ``false`` 。在 ``app/WEB-INF/conf/system.properties`` 中不存在这些键的环境中，
+升级后会自动采用更严格的行为。特别是当 ``spnego.allow.unsecure.basic=false`` 时，SPNEGO 库仅对
+``HttpServletRequest#isSecure()`` 返回 ``true`` 的请求提供 Basic 认证，
+因此在反向代理上终止 TLS 并以 HTTP 转发的环境中，此前回退到 Basic 认证的客户端将无法登录。
+此时请在 ``tomcat_config.properties`` 中设置 ``tomcat.secure=true`` 。
+详细内容请参阅 :doc:`../config/sso-spnego`\ 。
+
+.. warning::
+
+   代码默认值仅在该键不存在时才生效，而管理页面「系统」→「通用」每次保存都会写入所有
+   ``spnego.*`` 键。因此，在 15.7 中曾经在该页面上执行过更新的环境，仍然保存着
+   ``spnego.allow.unsecure.basic=true`` 与 ``spnego.allow.localhost=true`` ，
+   升级到 15.8 并不会使其变得更严格：宽松的行为会被静默沿用，15.8 只会在 SPNEGO 初始化时
+   向 ``fess.log`` 输出一条警告。请在管理页面「系统」→「通用」或 ``system.properties`` 中
+   有意识地关闭这两项。其中 ``spnego.allow.localhost=true`` 更为危险：SPNEGO 库会把来自同一
+   主机的请求以服务器的 OS 用户身份进行认证，完全不做 Kerberos 验证，在同一主机上部署反向
+   代理时并不安全。
+
 若此前使用过 SAML 认证（SSO）
 -----------------------------
 


### PR DESCRIPTION
## Summary

`<lang>/15.8/install/upgrade.rst` already covers the new cross-realm rejection under
"If You Were Using SPNEGO", but not the second SPNEGO behaviour change that lands in
the same release: the coded defaults of `spnego.allow.unsecure.basic` and
`spnego.allow.localhost` were flipped from `true` to `false`.

This extends that existing section (rather than adding a new top-level one) in all
seven languages that have the file.

## The two consequences documented

1. **Installations where the keys are absent from `app/WEB-INF/conf/system.properties`
   inherit the stricter behaviour on upgrade.** With `spnego.allow.unsecure.basic=false`
   the SPNEGO library only offers Basic authentication when
   `HttpServletRequest#isSecure()` returns `true`, so behind a reverse proxy that
   terminates TLS and forwards plain HTTP, clients that used to fall back to Basic can
   no longer log in. The remedy (`tomcat.secure=true` in `tomcat_config.properties`) is
   already explained on the 15.8 SPNEGO config page, so the new text links to
   `:doc:`../config/sso-spnego`` instead of repeating it.

2. **Installations that ever pressed Update on the admin "General" screen under 15.7 are
   NOT hardened by upgrading.** That screen writes every `spnego.*` key on every save, so
   `spnego.allow.unsecure.basic=true` and `spnego.allow.localhost=true` remain stored, and
   a coded default only applies while the key is absent. Those installations keep the
   permissive behaviour silently — 15.8 only emits a warning in the log at SPNEGO
   initialisation. Administrators should open the General screen (or edit
   `system.properties`) and turn both off deliberately. `spnego.allow.localhost=true` is
   the dangerous one: same-host requests are authenticated as the server OS user with no
   Kerberos verification at all, which is unsafe behind a same-host reverse proxy.

## Files

`de`, `en`, `es`, `fr`, `ja`, `ko`, `zh-cn` — `15.8/install/upgrade.rst` (7 files, insertions only).

## Verification

- Every `:doc:` target (`../config/sso-spnego`) resolves from `15.8/install/` in all seven languages.
- Each file parsed with `docutils` (`|Fess|` registered as a substitution, `:doc:`/`:ref:` as dummy
  roles): **0 messages before and 0 messages after** in all seven. Every new inline literal
  (`spnego.allow.localhost=true`, `HttpServletRequest#isSecure()`, `spnego.*`, `tomcat.secure=true`, …)
  parses as a real `literal` node, and the warning-admonition count goes 8 → 9 per file, i.e. exactly
  the one added.
- Terminology reused from each language's own `15.8/config/sso-spnego.rst`.
