### PR TITLE
docs(sso): describe the SAML session expiry warning

### DIFF
--- a/de/15.8/config/sso-saml.rst
+++ b/de/15.8/config/sso-saml.rst
@@ -433,6 +433,7 @@ Ein Wert von null oder kleiner würde die AuthnRequest-ID verwerfen, bevor eine 
 .. note::
    Pro Sitzung werden höchstens 10 unbeantwortete AuthnRequests aufbewahrt; wird dieses Limit überschritten, werden die ältesten verworfen.
    Dies ermöglicht es, Anmeldungen gleichzeitig aus mehreren Tabs zu starten, und lässt sich nicht über eine ``saml.``-Einstellung ändern.
+   Wird das Limit mit einem Wert von null oder weniger überschrieben, werden stattdessen 10 verwendet und eine Warnung protokolliert.
 
 Konfigurationsbeispiele
 =======================
@@ -507,9 +508,22 @@ Kann nach der Authentifizierung nicht zu Fess zurückkehren
   Meldung „SSO-Anmeldevorgang fehlgeschlagen." zurück, und im Protokoll erscheint eine Warnung, die
   mit ``Received a SAML response with no matching AuthnRequest ID in the session`` beginnt.
   Setzen Sie in diesem Fall ``tomcat.sameSiteCookies = none`` (``SameSite=None`` erfordert HTTPS)
-- Wenn die Anmeldeseite des IdP so lange offen war, dass ``saml.request.id.ttl`` (Standard 3600
-  Sekunden) abgelaufen ist, wurde die gespeicherte AuthnRequest-ID bereits verworfen, und dieselbe
-  Warnung wird protokolliert. Starten Sie in diesem Fall die Anmeldung erneut.
+- Wenn die Anmeldung am IdP zu lange gedauert hat, ist die AuthnRequest-ID nicht mehr vorhanden,
+  sobald die Assertion zurückkommt; die Anmeldung schlägt einmalig fehl und muss neu gestartet
+  werden. Welche Warnung erscheint, zeigt, was abgelaufen ist: Eine Warnung, die mit
+  ``Received a SAML response after the session it belongs to had expired`` beginnt, bedeutet, dass
+  der Servlet-Container die gesamte Sitzung verworfen hat; eine Warnung, die
+  ``pending AuthnRequest ID(s) of the session had expired`` enthält, bedeutet, dass die Sitzung noch
+  besteht und lediglich ``saml.request.id.ttl`` abgelaufen ist. Beide werden nur protokolliert, wenn
+  der Browser sein Sitzungs-Cookie mitgesendet hat, und genau das unterscheidet sie vom
+  SameSite-Fall oben
+- |Fess| setzt in ``app/WEB-INF/web.xml`` kein ``session-timeout``, sodass der Standardwert des
+  Servlet-Containers von 30 Minuten gilt; er ist kürzer als die 3600 Sekunden von
+  ``saml.request.id.ttl``. Die Sitzung wird also samt der darin gehaltenen AuthnRequest-ID zuerst
+  verworfen: Ein höherer Wert für ``saml.request.id.ttl`` allein verlängert nicht die Zeit, die
+  Benutzer für die Anmeldung am IdP haben. Erhöhen Sie dafür auch den Sitzungs-Timeout. Die Warnung
+  zu ``saml.request.id.ttl`` erscheint daher nur dort, wo die TTL kürzer als der Sitzungs-Timeout
+  eingestellt ist
 
 .. note::
    In 15.7 leitete |Fess| in derselben Situation immer wieder zum IdP weiter, sodass die Anmeldung in

--- a/en/15.8/config/sso-saml.rst
+++ b/en/15.8/config/sso-saml.rst
@@ -429,6 +429,7 @@ A value of zero or less would discard the AuthnRequest ID before a login could r
 .. note::
    At most 10 unanswered AuthnRequests are kept per session; when the cap is exceeded the oldest are discarded.
    This exists so that logins can be started from several tabs at once, and it cannot be changed with a ``saml.`` setting.
+   If it is overridden with a value of zero or less, 10 is used instead and a warning is logged.
 
 Configuration Examples
 ======================
@@ -502,9 +503,19 @@ Cannot return to Fess after authentication
   browser returns to the login page showing "SSO login process failed.", and a warning beginning with
   ``Received a SAML response with no matching AuthnRequest ID in the session`` is written to the log.
   Set ``tomcat.sameSiteCookies = none`` in that case (``SameSite=None`` requires HTTPS)
-- If the IdP login page took long enough for ``saml.request.id.ttl`` (default 3600 seconds) to
-  elapse, the recorded AuthnRequest ID has already been discarded and the same warning is logged.
-  In that case, start the login again.
+- If the login took too long at the IdP, the AuthnRequest ID is no longer there when the assertion
+  comes back, so the login fails once and has to be started again. Which warning appears says what
+  ran out: one beginning with ``Received a SAML response after the session it belongs to had
+  expired`` means the servlet container discarded the whole session, while one containing
+  ``pending AuthnRequest ID(s) of the session had expired`` means the session is still alive and
+  only ``saml.request.id.ttl`` elapsed. Both are written only when the browser did send its session
+  cookie, which is what separates them from the SameSite case above
+- |Fess| leaves ``session-timeout`` unset in ``app/WEB-INF/web.xml``, so the servlet container's
+  default of 30 minutes applies and is shorter than the 3600 seconds of ``saml.request.id.ttl``. The
+  session, and with it the AuthnRequest ID it holds, is discarded first, so raising
+  ``saml.request.id.ttl`` on its own does not give users longer to finish logging in at the IdP:
+  raise the session timeout as well. The ``saml.request.id.ttl`` warning is therefore only seen
+  where the TTL is set shorter than the session timeout
 
 .. note::
    In 15.7 the same situation caused |Fess| to redirect to the IdP again and again, looping the login.

--- a/es/15.8/config/sso-saml.rst
+++ b/es/15.8/config/sso-saml.rst
@@ -434,6 +434,7 @@ Un valor igual o menor que cero descartaría el identificador de la AuthnRequest
 .. note::
    Como máximo se conservan 10 AuthnRequest sin respuesta por sesión; al superar ese límite, se descartan las más antiguas.
    Esto existe para permitir iniciar sesiones desde varias pestañas a la vez, y no se puede cambiar con ningún ajuste ``saml.``.
+   Si el límite se sobrescribe con un valor de cero o menos, se usan 10 en su lugar y se registra una advertencia.
 
 Ejemplos de configuración
 =========================
@@ -509,9 +510,21 @@ No se puede regresar a Fess después de la autenticación
   registro se escribe una advertencia que empieza por
   ``Received a SAML response with no matching AuthnRequest ID in the session``.
   En ese caso, configure ``tomcat.sameSiteCookies = none`` (``SameSite=None`` requiere HTTPS)
-- Si la página de inicio de sesión del IdP tardó tanto que ``saml.request.id.ttl`` (3600 segundos
-  por defecto) expiró, el identificador de AuthnRequest registrado ya se ha descartado y se registra
-  la misma advertencia. En ese caso, inicie sesión de nuevo
+- Si el inicio de sesión tardó demasiado en el IdP, el identificador de AuthnRequest ya no está
+  disponible cuando llega la aserción, por lo que el inicio de sesión falla una sola vez y hay que
+  empezarlo de nuevo. La advertencia que aparece indica qué caducó: una que empieza por
+  ``Received a SAML response after the session it belongs to had expired`` significa que el
+  contenedor de servlets descartó la sesión entera, mientras que una que contiene
+  ``pending AuthnRequest ID(s) of the session had expired`` significa que la sesión sigue activa y
+  que solo expiró ``saml.request.id.ttl``. Ambas se registran únicamente cuando el navegador sí
+  envió su cookie de sesión, que es lo que las distingue del caso SameSite anterior
+- |Fess| no define ``session-timeout`` en ``app/WEB-INF/web.xml``, por lo que se aplica el valor
+  predeterminado del contenedor de servlets, 30 minutos, más corto que los 3600 segundos de
+  ``saml.request.id.ttl``. La sesión, y con ella el identificador de AuthnRequest que guarda, se
+  descarta antes: aumentar solo ``saml.request.id.ttl`` no da a los usuarios más tiempo para
+  completar el inicio de sesión en el IdP, así que amplíe también el tiempo de espera de la sesión.
+  Por eso la advertencia de ``saml.request.id.ttl`` solo aparece donde el TTL se ha configurado por
+  debajo del tiempo de espera de la sesión
 
 .. note::
    En 15.7, la misma situación hacía que |Fess| redirigiera una y otra vez al IdP, dejando el inicio de

--- a/fr/15.8/config/sso-saml.rst
+++ b/fr/15.8/config/sso-saml.rst
@@ -434,6 +434,7 @@ Une valeur nulle ou négative écarterait l'identifiant de l'AuthnRequest avant 
 .. note::
    Au maximum 10 AuthnRequest restées sans réponse sont conservées par session ; lorsque cette limite est dépassée, les plus anciennes sont écartées.
    Cela permet de démarrer des connexions depuis plusieurs onglets à la fois, et ne peut pas être modifié par un paramètre ``saml.``.
+   Si la limite est remplacée par une valeur inférieure ou égale à zéro, la valeur 10 est utilisée à la place et un avertissement est consigné.
 
 Exemples de configuration
 =========================
@@ -509,9 +510,21 @@ Impossible de retourner à Fess après l'authentification
   et un avertissement commençant par
   ``Received a SAML response with no matching AuthnRequest ID in the session`` est écrit dans le
   journal. Dans ce cas, définissez ``tomcat.sameSiteCookies = none`` (``SameSite=None`` nécessite HTTPS)
-- Si la page de connexion de l'IdP a pris tellement de temps que ``saml.request.id.ttl`` (3600
-  secondes par défaut) a expiré, l'identifiant d'AuthnRequest enregistré a déjà été écarté et le
-  même avertissement est consigné. Dans ce cas, recommencez la connexion
+- Si la connexion a pris trop de temps chez l'IdP, l'identifiant d'AuthnRequest n'est plus présent
+  lorsque l'assertion revient : la connexion échoue une seule fois et doit être recommencée.
+  L'avertissement consigné indique ce qui a expiré : celui qui commence par
+  ``Received a SAML response after the session it belongs to had expired`` signifie que le conteneur
+  de servlets a supprimé la session entière, tandis que celui qui contient
+  ``pending AuthnRequest ID(s) of the session had expired`` signifie que la session est toujours
+  active et que seul ``saml.request.id.ttl`` a expiré. Les deux ne sont écrits que si le navigateur
+  a bien envoyé son cookie de session, ce qui les distingue du cas SameSite ci-dessus
+- |Fess| ne définit pas ``session-timeout`` dans ``app/WEB-INF/web.xml`` ; la valeur par défaut du
+  conteneur de servlets, 30 minutes, s'applique donc, et elle est plus courte que les 3600 secondes
+  de ``saml.request.id.ttl``. La session, et avec elle l'identifiant d'AuthnRequest qu'elle
+  conserve, est écartée en premier : augmenter uniquement ``saml.request.id.ttl`` ne laisse pas plus
+  de temps aux utilisateurs pour terminer la connexion chez l'IdP, il faut aussi allonger le délai
+  d'expiration de session. L'avertissement relatif à ``saml.request.id.ttl`` n'apparaît donc que
+  lorsque la TTL est réglée en dessous de ce délai
 
 .. note::
    En 15.7, la même situation faisait rediriger |Fess| encore et encore vers l'IdP, mettant la connexion

--- a/ja/15.8/config/sso-saml.rst
+++ b/ja/15.8/config/sso-saml.rst
@@ -438,6 +438,7 @@ IdPから返されたSAMLレスポンスは、記録されたIDと対応付け�
 .. note::
    1つのセッションで保持できる応答待ちのAuthnRequestは最大10件で、上限を超えると古いものから破棄されます。
    これは複数のタブから同時にログインを開始できるようにするためのもので、``saml.`` で始まる設定では変更できません。
+   上限に0以下の値を指定して上書きした場合は、代わりに10が使われ、警告が出力されます。
 
 設定例
 ======
@@ -512,9 +513,20 @@ IdPから返されたSAMLレスポンスは、記録されたIDと対応付け�
   ``Received a SAML response with no matching AuthnRequest ID in the session``
   で始まる警告が出力されます。この場合は ``tomcat.sameSiteCookies = none`` を設定してください
   （``SameSite=None`` はHTTPSが必須です）
-- IdPのログイン画面で時間がかかり ``saml.request.id.ttl``（既定3600秒）を過ぎた場合も、
-  記録されたAuthnRequestのIDが破棄されているため同じ警告が出力されます。
-  この場合はログインをやり直してください
+- IdPでのログインに時間がかかった場合、アサーションが戻ってきた時点でAuthnRequestのIDは残っていないため、
+  その場で1回だけログインに失敗します。この場合はログインをやり直してください。
+  何が期限切れになったのかは、出力される警告で見分けられます。
+  ``Received a SAML response after the session it belongs to had expired`` で始まる警告は、
+  サーブレットコンテナがセッションごと破棄したことを表します。
+  ``pending AuthnRequest ID(s) of the session had expired`` を含む警告は、セッションは生きたままで
+  ``saml.request.id.ttl`` だけが経過したことを表します。どちらもブラウザがセッションCookieを
+  送信できている場合にのみ出力され、その点が上記のSameSiteのケースとの違いです
+- |Fess| は ``app/WEB-INF/web.xml`` で ``session-timeout`` を指定していないため、
+  サーブレットコンテナの既定値である30分が適用されます。これは ``saml.request.id.ttl`` の3600秒より短く、
+  セッションが先に破棄されて、保持していたAuthnRequestのIDも一緒に失われます。
+  このため ``saml.request.id.ttl`` だけを大きくしても、IdPでログインを完了するまでの猶予は延びません。
+  猶予を延ばしたい場合は、セッションタイムアウトも合わせて延長してください。
+  ``saml.request.id.ttl`` の警告が出力されるのは、TTLをセッションタイムアウトより短く設定した場合だけです
 
 .. note::
    15.7 では同じ状況でIdPへの再リダイレクトが繰り返され、ログインがループしていました。

--- a/ko/15.8/config/sso-saml.rst
+++ b/ko/15.8/config/sso-saml.rst
@@ -437,6 +437,7 @@ IdP 로그인 화면을 열어둔 채로 방치하는 등의 이유로 유효 �
 .. note::
    하나의 세션에서 보관할 수 있는 응답 대기 중인 AuthnRequest는 최대 10건이며, 상한을 초과하면 오래된 것부터 폐기됩니다.
    이는 여러 탭에서 동시에 로그인을 시작할 수 있도록 하기 위한 것으로, ``saml.`` 로 시작하는 설정으로는 변경할 수 없습니다.
+   상한을 0 이하의 값으로 덮어쓴 경우에는 대신 10이 사용되며 경고가 출력됩니다.
 
 설정 예
 =======
@@ -511,9 +512,19 @@ IdP 로그인 화면을 열어둔 채로 방치하는 등의 이유로 유효 �
   ``Received a SAML response with no matching AuthnRequest ID in the session``
   으로 시작하는 경고가 출력됩니다. 이 경우
   ``tomcat.sameSiteCookies = none`` 을 설정하십시오 (``SameSite=None`` 은 HTTPS가 필요합니다)
-- IdP 로그인 화면에서 시간이 오래 걸려 ``saml.request.id.ttl`` (기본값 3600초)가 경과한 경우에도
-  기록된 AuthnRequest의 ID가 이미 폐기되어 있어 같은 경고가 출력됩니다.
-  이 경우에는 로그인을 다시 시작하십시오
+- IdP에서 로그인에 시간이 오래 걸리면 어설션이 돌아온 시점에 AuthnRequest의 ID가 남아 있지 않으므로
+  그 자리에서 한 번만 로그인에 실패합니다. 이 경우에는 로그인을 다시 시작하십시오.
+  무엇이 만료되었는지는 출력되는 경고로 구분할 수 있습니다.
+  ``Received a SAML response after the session it belongs to had expired`` 로 시작하는 경고는
+  서블릿 컨테이너가 세션 자체를 폐기했음을 뜻합니다.
+  ``pending AuthnRequest ID(s) of the session had expired`` 를 포함하는 경고는 세션은 살아 있고
+  ``saml.request.id.ttl`` 만 경과했음을 뜻합니다. 두 경고 모두 브라우저가 세션 쿠키를 보낸 경우에만
+  출력되며, 이 점이 위의 SameSite 사례와 다릅니다
+- |Fess| 는 ``app/WEB-INF/web.xml`` 에 ``session-timeout`` 을 지정하지 않으므로 서블릿 컨테이너의
+  기본값인 30분이 적용됩니다. 이는 ``saml.request.id.ttl`` 의 3600초보다 짧아, 세션이 먼저 폐기되면서
+  세션이 보관하던 AuthnRequest의 ID도 함께 사라집니다. 따라서 ``saml.request.id.ttl`` 만 늘려도
+  사용자가 IdP에서 로그인을 마칠 수 있는 시간은 늘어나지 않으므로, 세션 타임아웃도 함께 늘리십시오.
+  ``saml.request.id.ttl`` 경고는 TTL을 세션 타임아웃보다 짧게 설정한 경우에만 출력됩니다
 
 .. note::
    15.7에서는 같은 상황에서 IdP로의 재리다이렉트가 반복되어 로그인이 루프에 빠졌습니다.

--- a/zh-cn/15.8/config/sso-saml.rst
+++ b/zh-cn/15.8/config/sso-saml.rst
@@ -425,6 +425,7 @@ IdP返回的SAML响应会根据记录的ID进行校验。
 .. note::
    每个会话最多保留10个未收到响应的AuthnRequest，超出上限后将丢弃最旧的。
    这是为了支持同时从多个标签页发起登录，且无法通过\ ``saml.``\ 开头的设置进行更改。
+   如果将上限覆盖为0或更小的值，则会改用10并输出警告。
 
 配置示例
 ========
@@ -498,8 +499,16 @@ IdP返回的SAML响应会根据记录的ID进行校验。
   浏览器会返回登录页面并显示"SSO登录处理失败。"，日志中会输出以\
   ``Received a SAML response with no matching AuthnRequest ID in the session``\ 开头的警告。
   此时请设置\ ``tomcat.sameSiteCookies = none``\ （``SameSite=None``\ 需要HTTPS）
-- 如果IdP登录页面耗时过长，导致\ ``saml.request.id.ttl``\ （默认3600秒）超时，记录的AuthnRequest ID
-  也会被丢弃，从而输出相同的警告。此时请重新开始登录
+- 如果在IdP上的登录耗时过长，断言返回时AuthnRequest ID已经不存在，登录会当场只失败一次，需要重新开始登录。
+  输出哪条警告可以判断是什么超时了：以\
+  ``Received a SAML response after the session it belongs to had expired``\ 开头的警告表示
+  Servlet容器已经丢弃了整个会话；包含\ ``pending AuthnRequest ID(s) of the session had expired``\
+  的警告表示会话仍然存在，只是\ ``saml.request.id.ttl``\ 超时。
+  这两条警告都只在浏览器确实发送了会话Cookie时输出，这一点与上面的SameSite情形不同
+- |Fess| 未在\ ``app/WEB-INF/web.xml``\ 中设置\ ``session-timeout``\ ，因此采用Servlet容器的默认值30分钟。
+  该值短于\ ``saml.request.id.ttl``\ 的3600秒，会话及其保存的AuthnRequest ID会先被丢弃，
+  因此仅调大\ ``saml.request.id.ttl``\ 并不能延长用户在IdP完成登录的时间，还需要同时延长会话超时时间。
+  也正因如此，只有把TTL设置得比会话超时更短时，才会看到\ ``saml.request.id.ttl``\ 的警告
 
 .. note::
    在15.7中，同样的情况会导致\ |Fess|\ 反复重定向到IdP，使登录陷入循环。


### PR DESCRIPTION
Follows codelibs/fess#3271, which splits the SAML "unmatched response" warning into three.

## Why the page was wrong

The troubleshooting list said that when `saml.request.id.ttl` elapses, "the same warning is
logged" as the SameSite case. That was true, but only by accident — and #3271 changes it.

The reason is an ordering that was documented nowhere:

| clock | value |
|---|---|
| `saml.request.id.ttl` | 3600 s (1 hour) |
| servlet container session timeout | **30 minutes** (`web.xml` sets no `session-timeout`) |

The session is discarded — AuthnRequest IDs and all — about half an hour *before* any ID can
reach its TTL. So a slow login never reached the TTL warning; it fell through to the SameSite
one, sending an operator whose cookie settings were already correct off to change them.

## What changed

- The "same warning" bullet is replaced with a description of which of the three warnings appears
  and what each one means. The two expiry warnings are both written only when the browser did send
  its session cookie, which is what separates them from the SameSite case above.
- **The constraint operators actually need**: raising `saml.request.id.ttl` on its own does not give
  users longer to finish logging in at the IdP, because the session timeout is the shorter of the
  two. The session timeout has to be raised as well. This was not stated anywhere before.
- One sentence beside the per-session AuthnRequest cap the page already documents, noting that a
  value of zero or less falls back to 10 with a warning (codelibs/fess#3270). Worded as "if it is
  overridden with…" rather than naming the DI channel, so the page does not start documenting a
  configuration path it deliberately omits.

The SameSite bullet itself is untouched — the three cases now read as a set.

Applied to en, ja, de, es, fr, ko and zh-cn, each written in its own register rather than
translated from the English, reusing the terminology already present in each file
(`サーブレットコンテナ`, `Servlet-Container`, `conteneur de servlets`, `Servlet容器`, …).

## Verification

Built with Sphinx in a throwaway project containing the seven changed files (a full site build
needs `rst2pdf` and `sphinxjp.themes.basicstrap`, which are not installed). Build succeeded; the
only warnings are `unknown document` for `:doc:` targets absent from the stripped-down project.
The rendered HTML was checked in all seven languages: every inline literal closes correctly, the
English literal that wraps across a line renders as one code span, and the zh-cn `\ ` escapes
produce no stray backslashes.
