### PR TITLE
docs(sso): correct three SPNEGO details found while verifying against AD

### DIFF
--- a/de/15.8/config/sso-spnego.rst
+++ b/de/15.8/config/sso-spnego.rst
@@ -148,10 +148,10 @@ Fügen Sie die folgenden Einstellungen zu ``app/WEB-INF/conf/system.properties``
      - Standard
    * - ``spnego.preauth.username``
      - AD-Verbindungsbenutzername
-     - (Erforderlich)
+     - (Erforderlich, sofern kein Keytab verwendet wird)
    * - ``spnego.preauth.password``
      - AD-Verbindungspasswort
-     - (Erforderlich)
+     - (Erforderlich, sofern kein Keytab verwendet wird)
    * - ``spnego.krb5.conf``
      - Pfad zur Kerberos-Konfigurationsdatei
      - ``krb5.conf``
@@ -228,6 +228,8 @@ Die folgenden Einstellungen können bei Bedarf hinzugefügt werden.
    ist dieser Wert ``false``. Ein Client, der kein Kerberos-Ticket erhalten kann und auf NTLM
    zurückfällt, kann sich dann nicht anmelden. Setzen Sie ``tomcat.secure=true`` in
    ``tomcat_config.properties``, damit |Fess| die Anfrage als über HTTPS eingegangen behandelt.
+   Diese Datei liegt in der ZIP-Distribution unter ``lib/classes/`` und in den DEB/RPM-Paketen
+   unter ``/etc/fess/``; nach einer Änderung muss |Fess| neu gestartet werden.
 
 .. warning::
    In |Fess| 15.8 wird eine Anmeldung standardmäßig abgelehnt, wenn sich die Realm des
@@ -291,6 +293,14 @@ Konfigurieren Sie LDAP-Einstellungen im |Fess|-Administrationsbereich unter "Sys
      - ``(&(objectClass=user)(sAMAccountName=%s))``
    * - memberOf-Attribut
      - ``memberOf``
+
+.. note::
+   |Fess| liest das Attribut ``memberOf`` des Benutzers nur eine Ebene tief, sodass verschachtelte
+   Gruppen (eine Gruppe als Mitglied einer anderen Gruppe) standardmäßig nicht aufgelöst werden.
+   Um verschachtelte AD-Gruppen abzubilden, setzen Sie unter „System“ → „Allgemein“ in der
+   Administrationsoberfläche den Gruppenfilter (``ldap.group.filter``) auf
+   ``(member:1.2.840.113556.1.4.1941:=%s)``. Die Auflösung läuft nach der Anmeldung asynchron,
+   daher enthält der Anmeldeeintrag im Audit-Log nur die zuvor aufgelösten Gruppen.
 
 Browser-Einstellungen
 =====================

--- a/en/15.8/config/sso-spnego.rst
+++ b/en/15.8/config/sso-spnego.rst
@@ -148,10 +148,10 @@ Add the following settings to ``app/WEB-INF/conf/system.properties``.
      - Default
    * - ``spnego.preauth.username``
      - AD connection username
-     - (Required)
+     - (Required unless a keytab is used)
    * - ``spnego.preauth.password``
      - AD connection password
-     - (Required)
+     - (Required unless a keytab is used)
    * - ``spnego.krb5.conf``
      - Kerberos configuration file path
      - ``krb5.conf``
@@ -226,7 +226,9 @@ The following settings can be added as needed.
    When TLS is terminated at a reverse proxy and the request is forwarded to |Fess| over HTTP,
    that value is ``false``, so a client that cannot obtain a Kerberos ticket and falls back to
    NTLM cannot log in. Set ``tomcat.secure=true`` in ``tomcat_config.properties`` to tell |Fess|
-   that the request arrived over HTTPS.
+   that the request arrived over HTTPS. That file lives in ``lib/classes/`` in the ZIP
+   distribution and in ``/etc/fess/`` in the DEB/RPM packages, and |Fess| must be restarted
+   after it is changed.
 
 .. warning::
    In |Fess| 15.8, a login is rejected by default when the realm of the client principal differs
@@ -286,6 +288,13 @@ Configure LDAP settings in the |Fess| admin panel under "System" -> "General".
      - ``(&(objectClass=user)(sAMAccountName=%s))``
    * - memberOf Attribute
      - ``memberOf``
+
+.. note::
+   |Fess| reads the ``memberOf`` attribute of the user one level deep, so nested groups (a group
+   that is a member of another group) are not expanded by default. To reflect AD nested groups,
+   set ``(member:1.2.840.113556.1.4.1941:=%s)`` as the Group Filter (``ldap.group.filter``) under
+   "System" → "General" in the administration UI. The expansion runs asynchronously after login,
+   so the login entry in the audit log records only the groups resolved before it completed.
 
 Browser Settings
 ================

--- a/es/15.8/config/sso-spnego.rst
+++ b/es/15.8/config/sso-spnego.rst
@@ -148,10 +148,10 @@ Agregue la siguiente configuración a ``app/WEB-INF/conf/system.properties``.
      - Por defecto
    * - ``spnego.preauth.username``
      - Nombre de usuario de conexión AD
-     - (Requerido)
+     - (Requerido salvo que se use un keytab)
    * - ``spnego.preauth.password``
      - Contraseña de conexión AD
-     - (Requerido)
+     - (Requerido salvo que se use un keytab)
    * - ``spnego.krb5.conf``
      - Ruta del archivo de configuración de Kerberos
      - ``krb5.conf``
@@ -226,7 +226,9 @@ Las siguientes configuraciones pueden agregarse según sea necesario.
    Si TLS se termina en un proxy inverso y la petición se reenvía a |Fess| por HTTP, ese valor es
    ``false``, por lo que un cliente que no puede obtener un tique de Kerberos y recurre a NTLM no
    puede iniciar sesión. Establezca ``tomcat.secure=true`` en ``tomcat_config.properties`` para
-   indicar a |Fess| que la petición llegó por HTTPS.
+   indicar a |Fess| que la petición llegó por HTTPS. Ese archivo se encuentra en ``lib/classes/``
+   en la distribución ZIP y en ``/etc/fess/`` en los paquetes DEB/RPM, y hay que reiniciar |Fess|
+   después de modificarlo.
 
 .. warning::
    En |Fess| 15.8, un inicio de sesión se rechaza de forma predeterminada cuando el reino del
@@ -289,6 +291,14 @@ Configure los ajustes LDAP en el panel de administración de |Fess| bajo "Sistem
      - ``(&(objectClass=user)(sAMAccountName=%s))``
    * - Atributo memberOf
      - ``memberOf``
+
+.. note::
+   |Fess| lee el atributo ``memberOf`` del usuario con un solo nivel de profundidad, por lo que los
+   grupos anidados (un grupo que es miembro de otro grupo) no se expanden de forma predeterminada.
+   Para reflejar los grupos anidados de AD, establezca ``(member:1.2.840.113556.1.4.1941:=%s)`` como
+   Filtro de grupo (``ldap.group.filter``) en «Sistema» → «General» de la interfaz de administración.
+   La expansión se ejecuta de forma asíncrona tras el inicio de sesión, por lo que la entrada de
+   inicio de sesión del registro de auditoría solo contiene los grupos resueltos hasta ese momento.
 
 Configuración del navegador
 ============================

--- a/fr/15.8/config/sso-spnego.rst
+++ b/fr/15.8/config/sso-spnego.rst
@@ -148,10 +148,10 @@ Ajoutez les paramètres suivants à ``app/WEB-INF/conf/system.properties``.
      - Valeur par défaut
    * - ``spnego.preauth.username``
      - Nom d'utilisateur de connexion AD
-     - (Requis)
+     - (Requis sauf si un keytab est utilisé)
    * - ``spnego.preauth.password``
      - Mot de passe de connexion AD
-     - (Requis)
+     - (Requis sauf si un keytab est utilisé)
    * - ``spnego.krb5.conf``
      - Chemin du fichier de configuration Kerberos
      - ``krb5.conf``
@@ -228,6 +228,8 @@ Les paramètres suivants peuvent être ajoutés si nécessaire.
    cette valeur est ``false`` : un client qui ne peut pas obtenir de ticket Kerberos et bascule
    vers NTLM ne peut donc pas se connecter. Définissez ``tomcat.secure=true`` dans
    ``tomcat_config.properties`` pour indiquer à |Fess| que la requête est arrivée en HTTPS.
+   Ce fichier se trouve dans ``lib/classes/`` pour la distribution ZIP et dans ``/etc/fess/`` pour
+   les paquets DEB/RPM ; |Fess| doit être redémarré après sa modification.
 
 .. warning::
    Dans |Fess| 15.8, une connexion est refusée par défaut lorsque le domaine Kerberos du principal
@@ -290,6 +292,15 @@ Configurez les paramètres LDAP dans le panneau d'administration de |Fess| sous 
      - ``(&(objectClass=user)(sAMAccountName=%s))``
    * - Attribut memberOf
      - ``memberOf``
+
+.. note::
+   |Fess| ne lit l'attribut ``memberOf`` de l'utilisateur que sur un seul niveau : les groupes
+   imbriqués (un groupe membre d'un autre groupe) ne sont donc pas développés par défaut. Pour
+   prendre en compte les groupes imbriqués d'AD, définissez le filtre de groupe
+   (``ldap.group.filter``) sur ``(member:1.2.840.113556.1.4.1941:=%s)`` dans « Système » →
+   « Général » de l'interface d'administration. Ce développement s'exécute de façon asynchrone
+   après la connexion : l'entrée de connexion du journal d'audit ne contient donc que les groupes
+   résolus avant son achèvement.
 
 Paramètres du navigateur
 ========================

--- a/ja/15.8/config/sso-spnego.rst
+++ b/ja/15.8/config/sso-spnego.rst
@@ -148,10 +148,10 @@ Kerberos設定ファイル
      - デフォルト値
    * - ``spnego.preauth.username``
      - AD接続用ユーザー名
-     - （必須）
+     - （keytabを使用しない場合は必須）
    * - ``spnego.preauth.password``
      - AD接続用パスワード
-     - （必須）
+     - （keytabを使用しない場合は必須）
    * - ``spnego.krb5.conf``
      - Kerberos設定ファイルパス
      - ``krb5.conf``
@@ -226,7 +226,8 @@ Kerberos設定ファイル
    TLSをリバースプロキシで終端して |Fess| へHTTPで転送している構成ではこの値が ``false`` になるため、
    Kerberosチケットを取得できずNTLMにフォールバックしたクライアントはログインできません。
    ``tomcat_config.properties`` で ``tomcat.secure=true`` を設定し、リクエストがHTTPS由来であることを
-   |Fess| に伝えてください。
+   |Fess| に伝えてください。このファイルはZIP版では ``lib/classes/`` 、DEB/RPM版では ``/etc/fess/`` に
+   配置されています。変更後は |Fess| の再起動が必要です。
 
 .. warning::
    |Fess| 15.8 では、クライアントのプリンシパルのレルムがサーバーのレルムと異なる場合、
@@ -285,6 +286,13 @@ Windows統合認証でログインしたユーザーのグループ情報を取�
      - ``(&(objectClass=user)(sAMAccountName=%s))``
    * - memberOf属性
      - ``memberOf``
+
+.. note::
+   |Fess| はユーザーの ``memberOf`` 属性を1段だけ読むため、既定では入れ子になったグループ
+   （グループのメンバーであるグループ）は展開されません。ADの入れ子グループを反映するには、
+   管理画面「システム」→「全般」の「グループフィルター」（ ``ldap.group.filter`` ）に
+   ``(member:1.2.840.113556.1.4.1941:=%s)`` を設定してください。この展開はログイン後に
+   非同期で実行されるため、監査ログのログイン行には展開前のグループだけが記録されます。
 
 ブラウザ設定
 ============

--- a/ko/15.8/config/sso-spnego.rst
+++ b/ko/15.8/config/sso-spnego.rst
@@ -148,10 +148,10 @@ Kerberos 설정 파일
      - 기본값
    * - ``spnego.preauth.username``
      - AD 접속용 사용자명
-     - (필수)
+     - (keytab을 사용하지 않는 경우 필수)
    * - ``spnego.preauth.password``
      - AD 접속용 비밀번호
-     - (필수)
+     - (keytab을 사용하지 않는 경우 필수)
    * - ``spnego.krb5.conf``
      - Kerberos 설정 파일 경로
      - ``krb5.conf``
@@ -226,7 +226,8 @@ Kerberos 설정 파일
    리버스 프록시에서 TLS를 종료하고 |Fess| 로 HTTP로 전달하는 구성에서는 이 값이 ``false`` 이므로,
    Kerberos 티켓을 받지 못해 NTLM으로 대체된 클라이언트는 로그인할 수 없습니다.
    ``tomcat_config.properties`` 에서 ``tomcat.secure=true`` 를 설정하여 요청이 HTTPS로 도착했음을
-   |Fess| 에 알려 주십시오.
+   |Fess| 에 알려 주십시오. 이 파일은 ZIP 버전에서는 ``lib/classes/`` , DEB/RPM 버전에서는
+   ``/etc/fess/`` 에 있으며, 변경 후에는 |Fess| 를 재시작해야 합니다.
 
 .. warning::
    |Fess| 15.8에서는 클라이언트 주체의 영역이 서버의 영역과 다르면 로그인이 기본적으로 거부됩니다.
@@ -285,6 +286,12 @@ Windows 통합 인증으로 로그인한 사용자의 그룹 정보를 취득하
      - ``(&(objectClass=user)(sAMAccountName=%s))``
    * - memberOf 속성
      - ``memberOf``
+
+.. note::
+   |Fess| 는 사용자의 ``memberOf`` 속성을 한 단계만 읽으므로 중첩된 그룹(다른 그룹의 멤버인 그룹)은
+   기본적으로 전개되지 않습니다. AD의 중첩 그룹을 반영하려면 관리 화면 「시스템」 → 「일반」의
+   「그룹 필터」( ``ldap.group.filter`` )에 ``(member:1.2.840.113556.1.4.1941:=%s)`` 를 설정하십시오.
+   이 전개는 로그인 후 비동기로 실행되므로 감사 로그의 로그인 항목에는 전개 이전의 그룹만 기록됩니다.
 
 브라우저 설정
 =============

--- a/zh-cn/15.8/config/sso-spnego.rst
+++ b/zh-cn/15.8/config/sso-spnego.rst
@@ -147,10 +147,10 @@ Kerberos配置文件
      - 默认值
    * - ``spnego.preauth.username``
      - AD连接用户名
-     - （必需）
+     - （不使用 keytab 时必需）
    * - ``spnego.preauth.password``
      - AD连接密码
-     - （必需）
+     - （不使用 keytab 时必需）
    * - ``spnego.krb5.conf``
      - Kerberos配置文件路径
      - ``krb5.conf``
@@ -224,6 +224,7 @@ Kerberos配置文件
    如果在反向代理上终止 TLS 并以 HTTP 转发到 |Fess| ，该值为 ``false`` ，
    因此无法获取 Kerberos 票据而回退到 NTLM 的客户端将无法登录。
    请在 ``tomcat_config.properties`` 中设置 ``tomcat.secure=true`` ，以告知 |Fess| 该请求来自 HTTPS。
+   该文件在 ZIP 版中位于 ``lib/classes/`` ，在 DEB/RPM 版中位于 ``/etc/fess/`` ，修改后需要重启 |Fess| 。
 
 .. warning::
    在 |Fess| 15.8 中，如果客户端主体的领域与服务器的领域不同，登录将默认被拒绝。
@@ -280,6 +281,12 @@ LDAP配置
      - ``(&(objectClass=user)(sAMAccountName=%s))``
    * - memberOf属性
      - ``memberOf``
+
+.. note::
+   |Fess| 只读取用户 ``memberOf`` 属性的一层，因此默认不会展开嵌套组（作为其他组成员的组）。
+   若要反映 AD 的嵌套组，请在管理界面「系统」→「常规」的「组过滤器」( ``ldap.group.filter`` )
+   中设置 ``(member:1.2.840.113556.1.4.1941:=%s)`` 。该展开在登录后异步执行，
+   因此审计日志的登录记录中只包含展开前的组。
 
 浏览器设置
 ==========


### PR DESCRIPTION
Three corrections to `config/sso-spnego.rst`, in all seven languages, found while verifying Windows Integrated Authentication end to end against an Active Directory domain (Samba AD DC, Kerberos realm with SPN, keytab and password paths, group- and role-based search permissions) with Fess 15.8.0-SNAPSHOT.

### 1. The required-settings table contradicted the note below it

The table listed `spnego.preauth.username` and `spnego.preauth.password` as required, while the note immediately below explained that leaving **both** empty is precisely how the server login module falls back to a keytab.

Both paths were exercised and both work:

- `spnego.preauth.*` absent + `auth_login.conf` with `useKeyTab=true` / `keyTab` / `principal` → SPNEGO login succeeds.
- `spnego.preauth.username=svc_fess` + `spnego.preauth.password=…` + the plain `spnego-server` module from the minimal example → SPNEGO login succeeds.

Getting it wrong is not silent: preauth empty *and* no keytab in `auth_login.conf` fails initialization with `IllegalArgumentException: Must specify a username and password or a keyTab.` on every login attempt.

The default column now states the condition rather than asserting "Required".

### 2. `tomcat_config.properties` had no location

The `tomcat.secure=true` note tells the reader to edit `tomcat_config.properties`, but that file is not in `app/WEB-INF/classes/` where everything else on the page goes. `config/sso-saml.rst` already spells out the ZIP and DEB/RPM locations; the same wording is now used here, together with the restart requirement.

(The setting itself was confirmed: with `spnego.allow.unsecure.basic=false` over plain HTTP the challenge is `WWW-Authenticate: Negotiate` only, and with `tomcat.secure=true` it becomes `Negotiate` plus `Basic realm="…"`.)

### 3. Nested AD groups were not mentioned

Fess reads the user's `memberOf` attribute one level deep. With `alice` in `sales` and `sales` a member of `all-staff`, `alice` did not inherit `all-staff` and could not see documents restricted to it. Setting the Group Filter (`ldap.group.filter`) to `(member:1.2.840.113556.1.4.1941:=%s)` — the AD in-chain matching rule — expanded it and the documents became visible.

Worth knowing for anyone reading the audit log: the expansion runs asynchronously after login, so the `LOGIN` entry lists only the directly resolved groups and a later `UPDATE_PERMISSION` entry carries the nested ones.

---

Local checks: `python -m unittest discover -s tools` (23 tests), `tools/check_headings.py` over the current versions, and `tools/update_eol.py --check` all pass.
