### PR TITLE
docs(sso): state that Entra ID form_post requires HTTPS

### DIFF
--- a/de/15.8/config/sso-entraid.rst
+++ b/de/15.8/config/sso-entraid.rst
@@ -142,9 +142,12 @@ Die folgenden Einstellungen können bei Bedarf hinzugefügt werden.
    Browserverlauf und den Zugriffsprotokollen vorgelagerter Proxys oder einer WAF. Allerdings wird
    der Callback dadurch zu einem websiteübergreifenden POST und erfordert
    ``tomcat.sameSiteCookies = none``. Ohne diese Einstellung wird das Sitzungscookie nicht
-   zurückgesendet und die Anmeldung schlägt fehl; die meisten Installationen sollten daher beim
-   Standardwert bleiben. Andere Werte werden mit einer Warnung ignoriert und ``query`` wird
-   verwendet.
+   zurückgesendet und die Anmeldung schlägt fehl. Browser akzeptieren ``none`` zudem nur bei einem
+   Cookie, das auch das Attribut ``Secure`` trägt; ``form_post`` setzt daher voraus, dass |Fess|
+   über HTTPS bereitgestellt wird. Über einfaches HTTP speichert der Browser das Sitzungscookie
+   überhaupt nicht und die Anmeldung schlägt weiterhin fehl. Die meisten Installationen sollten
+   daher beim Standardwert bleiben. Andere Werte werden mit einer Warnung ignoriert und ``query``
+   wird verwendet.
 
 .. warning::
 
@@ -338,7 +341,14 @@ Kann nach der Authentifizierung nicht zu Fess zurückkehren
 - Stellen Sie sicher, dass der Wert von ``entraid.reply.url`` genau mit der Azure Portal-Konfiguration übereinstimmt
 - Überprüfen Sie, ob das Protokoll (HTTP/HTTPS) übereinstimmt
 - Überprüfen Sie, ob die Umleitungs-URI mit ``/`` endet
-- Wenn ``entraid.response.mode`` auf ``form_post`` gesetzt ist, überprüfen Sie, ob ``tomcat.sameSiteCookies = none`` konfiguriert ist. Andernfalls wird das Sitzungscookie beim Callback nicht mitgesendet und die Anmeldeseite erscheint immer wieder
+- Wenn ``entraid.response.mode`` auf ``form_post`` gesetzt ist, prüfen Sie sowohl, ob
+  ``tomcat.sameSiteCookies = none`` konfiguriert ist, als auch, ob |Fess| über HTTPS bereitgestellt
+  wird. Beim ausgelieferten Standardwert ``lax`` sendet der Browser das Sitzungscookie nicht mit dem
+  websiteübergreifenden POST des Callbacks; mit ``none`` über einfaches HTTP speichert der Browser
+  dieses Cookie überhaupt nicht, da ``none`` das Attribut ``Secure`` voraussetzt. In beiden Fällen
+  schlägt die Anmeldung genau einmal fehl: Der Browser kehrt zur Anmeldeseite zurück und zeigt
+  "SSO-Anmeldevorgang fehlgeschlagen.", und im Protokoll erscheint eine Warnung mit dem Wortlaut
+  ``Failed to process SSO login: could not validate state``
 
 Authentifizierungsfehler treten auf
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/de/15.8/install/upgrade.rst
+++ b/de/15.8/install/upgrade.rst
@@ -565,7 +565,9 @@ zurückgegeben, und beim |Fess|-Standardwert ``tomcat.sameSiteCookies = lax`` wi
 Sitzungscookie dabei nicht mitgesendet, sodass ``tomcat.sameSiteCookies = none`` erforderlich
 war. Wenn Sie ``none`` nur aus diesem Grund gesetzt haben, können Sie zum Standardwert
 zurückkehren. Um das bisherige Verhalten beizubehalten, setzen Sie
-``entraid.response.mode=form_post`` und belassen ``tomcat.sameSiteCookies = none``.
+``entraid.response.mode=form_post`` und belassen ``tomcat.sameSiteCookies = none``. Browser
+akzeptieren ``none`` nur bei einem Cookie, das auch das Attribut ``Secure`` trägt; auch dieser Weg
+setzt daher voraus, dass |Fess| über HTTPS bereitgestellt wird.
 
 Ab 15.8 löst |Fess| außerdem die Gruppen- und Rollenmitgliedschaft des Benutzers im Hintergrund
 auf, nachdem die Anmeldung abgeschlossen ist, statt die Anmeldung auf Microsoft Graph warten zu

--- a/en/15.8/config/sso-entraid.rst
+++ b/en/15.8/config/sso-entraid.rst
@@ -138,8 +138,11 @@ The following settings can be added as needed.
    callback URL. ``form_post`` keeps the code out of the URL, and therefore out of browser history
    and the access logs of any front-end proxy or WAF, but it makes the callback a cross-site POST
    and requires ``tomcat.sameSiteCookies = none``. Without that setting the session cookie is not
-   sent back and login fails, so most deployments should keep the default. Any other value is
-   ignored with a warning and ``query`` is used.
+   sent back and login fails. Browsers also only accept ``none`` on a cookie that carries the
+   ``Secure`` attribute, so ``form_post`` additionally requires |Fess| to be served over HTTPS:
+   over plain HTTP the browser does not store the session cookie at all and login still fails.
+   Most deployments should therefore keep the default. Any other value is ignored with a warning
+   and ``query`` is used.
 
 .. warning::
 
@@ -329,7 +332,13 @@ Cannot Return to Fess After Authentication
 - Ensure the ``entraid.reply.url`` value exactly matches the Azure Portal configuration
 - Check that the protocol (HTTP/HTTPS) matches
 - Verify the Redirect URI ends with ``/``
-- If ``entraid.response.mode`` is set to ``form_post``, verify that ``tomcat.sameSiteCookies = none`` is configured. Without it, the session cookie is not sent with the callback and the sign-in screen keeps reappearing
+- If ``entraid.response.mode`` is set to ``form_post``, check both that
+  ``tomcat.sameSiteCookies = none`` is configured and that |Fess| is served over HTTPS. With the
+  shipped default ``lax`` the browser does not send the session cookie on the callback's
+  cross-site POST; with ``none`` over plain HTTP the browser does not store that cookie at all,
+  because ``none`` requires the ``Secure`` attribute. Either way the login fails once, on the
+  spot: the browser returns to the login page showing "SSO login process failed.", and a warning
+  reading ``Failed to process SSO login: could not validate state`` is written to the log
 
 Authentication Errors Occur
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/en/15.8/install/upgrade.rst
+++ b/en/15.8/install/upgrade.rst
@@ -549,6 +549,8 @@ and the |Fess| default ``tomcat.sameSiteCookies = lax`` does not send the sessio
 such a request, so ``tomcat.sameSiteCookies = none`` was required. If you set ``none`` only for
 that reason, you can restore the default. To keep the previous behaviour, set
 ``entraid.response.mode=form_post`` and leave ``tomcat.sameSiteCookies = none`` in place.
+Browsers only accept ``none`` on a cookie that also carries the ``Secure`` attribute, so that
+path requires |Fess| to be served over HTTPS as well.
 
 Starting with 15.8, |Fess| also resolves the user's group and role membership in the background
 after login completes, instead of blocking the login on Microsoft Graph. Until resolution

--- a/es/15.8/config/sso-entraid.rst
+++ b/es/15.8/config/sso-entraid.rst
@@ -142,8 +142,11 @@ Las siguientes configuraciones pueden agregarse según sea necesario.
    tanto, fuera del historial del navegador y de los registros de acceso de cualquier proxy
    frontal o WAF, pero convierte el callback en un POST entre sitios y requiere
    ``tomcat.sameSiteCookies = none``. Sin esa configuración, la cookie de sesión no se devuelve y
-   el inicio de sesión falla, por lo que la mayoría de las instalaciones deberían mantener el valor
-   por defecto. Cualquier otro valor se ignora con una advertencia y se utiliza ``query``.
+   el inicio de sesión falla. Además, los navegadores solo aceptan ``none`` en una cookie que
+   también tenga el atributo ``Secure``, por lo que ``form_post`` exige servir |Fess| mediante
+   HTTPS: sobre HTTP simple el navegador ni siquiera almacena la cookie de sesión y el inicio de
+   sesión sigue fallando. Por ello, la mayoría de las instalaciones deberían mantener el valor por
+   defecto. Cualquier otro valor se ignora con una advertencia y se utiliza ``query``.
 
 .. warning::
 
@@ -336,7 +339,14 @@ No se puede regresar a Fess después de la autenticación
 - Asegúrese de que el valor de ``entraid.reply.url`` coincida exactamente con la configuración del portal Azure
 - Verifique que el protocolo (HTTP/HTTPS) coincida
 - Verifique que la URI de redirección termine con ``/``
-- Si ``entraid.response.mode`` está establecido en ``form_post``, verifique que ``tomcat.sameSiteCookies = none`` esté configurado. De lo contrario, la cookie de sesión no se envía con el callback y la pantalla de inicio de sesión vuelve a aparecer una y otra vez
+- Si ``entraid.response.mode`` está establecido en ``form_post``, verifique tanto que
+  ``tomcat.sameSiteCookies = none`` esté configurado como que |Fess| se sirva mediante HTTPS. Con el
+  valor por defecto ``lax``, el navegador no envía la cookie de sesión en el POST entre sitios del
+  callback; con ``none`` sobre HTTP simple, el navegador no almacena esa cookie en absoluto, porque
+  ``none`` exige el atributo ``Secure``. En ambos casos el inicio de sesión falla una sola vez: el
+  navegador vuelve a la pantalla de inicio de sesión mostrando "Error en el proceso de inicio de
+  sesión SSO." y en el registro se escribe una advertencia con el texto
+  ``Failed to process SSO login: could not validate state``
 
 Ocurren errores de autenticación
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/es/15.8/install/upgrade.rst
+++ b/es/15.8/install/upgrade.rst
@@ -567,7 +567,9 @@ como un POST entre sitios, y con el valor por defecto de |Fess| ``tomcat.sameSit
 la cookie de sesión no se envía en esa petición, por lo que era necesario
 ``tomcat.sameSiteCookies = none``. Si estableció ``none`` únicamente por ese motivo, puede volver
 al valor por defecto. Para mantener el comportamiento anterior, establezca
-``entraid.response.mode=form_post`` y conserve ``tomcat.sameSiteCookies = none``.
+``entraid.response.mode=form_post`` y conserve ``tomcat.sameSiteCookies = none``. Los navegadores
+solo aceptan ``none`` en una cookie que además tenga el atributo ``Secure``, por lo que esa vía
+también exige servir |Fess| mediante HTTPS.
 
 A partir de la versión 15.8, |Fess| también resuelve la pertenencia a grupos y roles del usuario
 en segundo plano una vez completado el inicio de sesión, en lugar de bloquear el inicio de sesión

--- a/fr/15.8/config/sso-entraid.rst
+++ b/fr/15.8/config/sso-entraid.rst
@@ -142,7 +142,10 @@ Les paramètres suivants peuvent être ajoutés si nécessaire.
    l'URL de callback. ``form_post`` maintient le code hors de l'URL, et donc hors de l'historique
    du navigateur et des journaux d'accès des proxys frontaux ou d'un WAF, mais il transforme le
    callback en un POST inter-sites et nécessite ``tomcat.sameSiteCookies = none``. Sans ce
-   paramètre, le cookie de session n'est pas renvoyé et la connexion échoue : la plupart des
+   paramètre, le cookie de session n'est pas renvoyé et la connexion échoue. Les navigateurs
+   n'acceptent en outre ``none`` que sur un cookie portant également l'attribut ``Secure`` :
+   ``form_post`` impose donc de servir |Fess| en HTTPS. En HTTP simple, le navigateur n'enregistre
+   pas du tout le cookie de session et la connexion échoue malgré tout. La plupart des
    installations doivent donc conserver la valeur par défaut. Toute autre valeur est ignorée avec
    un avertissement et ``query`` est utilisé.
 
@@ -336,7 +339,14 @@ Impossible de revenir à Fess après l'authentification
 - Assurez-vous que la valeur de ``entraid.reply.url`` correspond exactement à la configuration du portail Azure
 - Vérifiez que le protocole (HTTP/HTTPS) correspond
 - Vérifiez que l'URI de redirection se termine par ``/``
-- Si ``entraid.response.mode`` est défini sur ``form_post``, vérifiez que ``tomcat.sameSiteCookies = none`` est configuré. Sinon, le cookie de session n'est pas renvoyé avec le callback et l'écran de connexion réapparaît sans cesse
+- Si ``entraid.response.mode`` est défini sur ``form_post``, vérifiez à la fois que
+  ``tomcat.sameSiteCookies = none`` est configuré et que |Fess| est servi en HTTPS. Avec la valeur
+  par défaut ``lax``, le navigateur n'envoie pas le cookie de session avec le POST inter-sites du
+  callback ; avec ``none`` en HTTP simple, le navigateur n'enregistre pas du tout ce cookie, car
+  ``none`` exige l'attribut ``Secure``. Dans les deux cas, la connexion échoue une seule fois : le
+  navigateur revient à la page de connexion en affichant "Le processus de connexion SSO a échoué."
+  et un avertissement indiquant ``Failed to process SSO login: could not validate state`` est écrit
+  dans le journal
 
 Des erreurs d'authentification se produisent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/fr/15.8/install/upgrade.rst
+++ b/fr/15.8/install/upgrade.rst
@@ -568,7 +568,9 @@ POST intersite, et la valeur par défaut de |Fess| ``tomcat.sameSiteCookies = la
 le cookie de session avec une telle requête ; ``tomcat.sameSiteCookies = none`` était donc
 nécessaire. Si vous aviez défini ``none`` uniquement pour cette raison, vous pouvez revenir à la
 valeur par défaut. Pour conserver le comportement précédent, définissez
-``entraid.response.mode=form_post`` et laissez ``tomcat.sameSiteCookies = none`` en place.
+``entraid.response.mode=form_post`` et laissez ``tomcat.sameSiteCookies = none`` en place. Les
+navigateurs n'acceptent ``none`` que sur un cookie portant également l'attribut ``Secure`` : cette
+voie impose donc elle aussi de servir |Fess| en HTTPS.
 
 À partir de la 15.8, |Fess| résout également l'appartenance aux groupes et rôles de l'utilisateur
 en arrière-plan une fois la connexion terminée, au lieu de bloquer la connexion en attendant

--- a/ja/15.8/config/sso-entraid.rst
+++ b/ja/15.8/config/sso-entraid.rst
@@ -137,6 +137,9 @@ Entra IDから取得した情報を設定します。
    フロントエンドのプロキシ・WAFのアクセスログにも残りません。
    ただし ``form_post`` はクロスサイトのPOSTになるため、``tomcat.sameSiteCookies = none`` が必要です。
    設定していない場合はセッションクッキーが送信されず、ログインに失敗します。
+   さらに ``none`` はブラウザが ``Secure`` 属性付きCookieに対してのみ受け入れるため、
+   ``form_post`` を使うには |Fess| をHTTPSで提供する必要があります。
+   HTTPのままでは、``none`` を設定してもブラウザがセッションCookie自体を保存しないため、やはりログインできません。
    通常は既定値のまま使用してください。
    ``query`` と ``form_post`` 以外を指定した場合は、警告を出力して ``query`` として扱います。
 
@@ -333,7 +336,13 @@ Entra ID認証では、Microsoft Graph APIを使用してユーザーが所属�
 - ``entraid.reply.url`` の値がAzure Portalの設定と完全に一致しているか確認してください
 - プロトコル（HTTP/HTTPS）が一致しているか確認してください
 - リダイレクトURIの末尾に ``/`` が含まれているか確認してください
-- ``entraid.response.mode`` に ``form_post`` を指定している場合は、``tomcat.sameSiteCookies = none`` が設定されているか確認してください。未設定の場合、コールバック時にセッションクッキーが送信されず、ログイン画面に戻る動作を繰り返します
+- ``entraid.response.mode`` に ``form_post`` を指定している場合は、``tomcat.sameSiteCookies = none``
+  が設定されているか、かつ |Fess| をHTTPSで提供しているかを確認してください。既定値の ``lax`` のままでは、
+  コールバックのクロスサイトPOSTにブラウザがセッションCookieを送信しません。``none`` を設定しても
+  HTTPのままでは、``none`` が ``Secure`` 属性を要求するためブラウザがそのCookie自体を保存しません。
+  いずれの場合もその場で1回だけログインに失敗し、ブラウザはログイン画面に戻って
+  「SSOログイン処理に失敗しました。」を表示します。ログには
+  ``Failed to process SSO login: could not validate state`` という警告が出力されます
 
 認証エラーが発生する
 ~~~~~~~~~~~~~~~~~~~~

--- a/ja/15.8/install/upgrade.rst
+++ b/ja/15.8/install/upgrade.rst
@@ -546,7 +546,8 @@ Microsoft Entra ID（Azure AD）を利用していた場合
 ``tomcat.sameSiteCookies = lax`` ではセッションクッキーが送信されず、\ ``none`` への変更が必要で
 した。この回避策のためだけに ``none`` を設定していた場合は、既定値に戻せます。従来どおり
 ``form_post`` を使う場合は ``entraid.response.mode=form_post`` を指定し、
-``tomcat.sameSiteCookies = none`` を維持してください。
+``tomcat.sameSiteCookies = none`` を維持してください。``none`` はブラウザーが ``Secure`` 属性付きの
+Cookie に対してのみ受け入れるため、この場合も |Fess| を HTTPS で提供する必要があります。
 
 また 15.8 からは、ログイン完了後にユーザーのグループ・ロール権限をバックグラウンドで解決するように
 なり、ログインがMicrosoft Graphの応答を待って止まることはなくなりました。解決が完了するまでの間、

--- a/ko/15.8/config/sso-entraid.rst
+++ b/ko/15.8/config/sso-entraid.rst
@@ -138,7 +138,10 @@ Entra ID에서 취득한 정보를 설정합니다.
    ``form_post`` 를 지정하면 인가 코드가 URL에 나타나지 않으므로 브라우저 기록이나 프런트엔드
    프록시・WAF의 액세스 로그에도 남지 않습니다. 다만 ``form_post`` 는 콜백이 크로스 사이트
    POST가 되므로 ``tomcat.sameSiteCookies = none`` 이 필요합니다. 설정하지 않으면 세션 쿠키가
-   전송되지 않아 로그인에 실패하므로, 대부분의 환경에서는 기본값 그대로 사용하십시오.
+   전송되지 않아 로그인에 실패합니다. 또한 브라우저는 ``Secure`` 속성이 함께 있는 쿠키에 대해서만
+   ``none`` 을 허용하므로, ``form_post`` 를 사용하려면 |Fess| 를 HTTPS로 제공해야 합니다.
+   일반 HTTP에서는 ``none`` 을 설정해도 브라우저가 세션 쿠키 자체를 저장하지 않아 역시 로그인할 수
+   없습니다. 따라서 대부분의 환경에서는 기본값 그대로 사용하십시오.
    그 외의 값을 지정한 경우에는 경고를 출력하고 ``query`` 로 처리합니다.
 
 .. warning::
@@ -333,7 +336,13 @@ Entra ID 인증에서는 Microsoft Graph API를 사용하여 사용자가 소속
 - ``entraid.reply.url`` 의 값이 Azure Portal의 설정과 완전히 일치하는지 확인하십시오
 - 프로토콜（HTTP/HTTPS）이 일치하는지 확인하십시오
 - 리다이렉트 URI의 끝에 ``/`` 가 포함되어 있는지 확인하십시오
-- ``entraid.response.mode`` 에 ``form_post`` 를 지정한 경우에는 ``tomcat.sameSiteCookies = none`` 이 설정되어 있는지 확인하십시오. 설정되어 있지 않으면 콜백 시 세션 쿠키가 전송되지 않아 로그인 화면으로 되돌아가는 동작이 반복됩니다
+- ``entraid.response.mode`` 에 ``form_post`` 를 지정한 경우에는 ``tomcat.sameSiteCookies = none``
+  이 설정되어 있는지, 그리고 |Fess| 를 HTTPS로 제공하고 있는지 확인하십시오. 기본값인 ``lax`` 에서는
+  콜백의 크로스 사이트 POST에 브라우저가 세션 쿠키를 전송하지 않습니다. ``none`` 을 설정하더라도 일반
+  HTTP에서는 ``none`` 이 ``Secure`` 속성을 요구하기 때문에 브라우저가 해당 쿠키 자체를 저장하지
+  않습니다. 어느 경우든 그 자리에서 한 번만 로그인에 실패하며, 브라우저는 로그인 화면으로 돌아가
+  "SSO 로그인 프로세스에 실패했습니다." 를 표시하고, 로그에는
+  ``Failed to process SSO login: could not validate state`` 경고가 출력됩니다
 
 인증 오류가 발생함
 ~~~~~~~~~~~~~~~~~~~~

--- a/ko/15.8/install/upgrade.rst
+++ b/ko/15.8/install/upgrade.rst
@@ -543,7 +543,8 @@ Microsoft Entra ID(Azure AD)를 사용하고 있었던 경우
 ``tomcat.sameSiteCookies = lax`` 에서는 세션 쿠키가 전송되지 않아 ``none`` 으로 변경해야
 했습니다. 이 회피책만을 위해 ``none`` 을 설정했다면 기본값으로 되돌릴 수 있습니다. 기존과 같이
 ``form_post`` 를 사용하려면 ``entraid.response.mode=form_post`` 를 지정하고
-``tomcat.sameSiteCookies = none`` 을 유지하십시오.
+``tomcat.sameSiteCookies = none`` 을 유지하십시오. 브라우저는 ``Secure`` 속성이 함께 있는 쿠키에
+대해서만 ``none`` 을 허용하므로, 이 경우에도 |Fess| 를 HTTPS로 제공해야 합니다.
 
 또한 15.8부터 |Fess| 는 로그인이 완료된 후 백그라운드에서 사용자의 그룹·역할 소속을 해결하며,
 로그인이 Microsoft Graph의 응답을 기다리다 멈추는 일은 없어졌습니다. 해결이 완료될 때까지, 또는

--- a/zh-cn/15.8/config/sso-entraid.rst
+++ b/zh-cn/15.8/config/sso-entraid.rst
@@ -134,7 +134,11 @@ Entra ID认证的工作原理
    使用默认值 ``query`` 时，授权码会包含在回调URL的查询字符串中。
    指定 ``form_post`` 后，授权码不会出现在URL中，因此也不会留在浏览器历史记录以及前端代理或WAF的访问日志中。
    但 ``form_post`` 会使回调成为跨站POST，因此需要 ``tomcat.sameSiteCookies = none``\ 。
-   未进行该设置时，会话Cookie不会被发送，登录将失败，因此大多数环境应保持默认值。
+   未进行该设置时，会话Cookie不会被发送，登录将失败。
+   此外，浏览器仅对同时带有 ``Secure`` 属性的Cookie接受 ``none``\ ，
+   因此使用 ``form_post`` 时必须通过HTTPS提供 |Fess| 。
+   在普通HTTP下，即使设置了 ``none``\ ，浏览器也根本不会保存会话Cookie，登录同样会失败。
+   因此大多数环境应保持默认值。
    指定其他值时，将输出警告并按 ``query`` 处理。
 
 .. warning::
@@ -324,7 +328,12 @@ Entra ID侧配置
 - 确保 ``entraid.reply.url`` 的值与Azure Portal配置完全匹配
 - 验证协议（HTTP/HTTPS）是否匹配
 - 验证重定向URI是否以 ``/`` 结尾
-- 如果将 ``entraid.response.mode`` 设置为 ``form_post``\ ，请确认已配置 ``tomcat.sameSiteCookies = none``\ 。否则回调时不会发送会话Cookie，会反复返回登录页面
+- 如果将 ``entraid.response.mode`` 设置为 ``form_post``\ ，请同时确认已配置
+  ``tomcat.sameSiteCookies = none``\ ，并且 |Fess| 通过 HTTPS 提供服务。使用默认值 ``lax`` 时，
+  浏览器不会在回调的跨站 POST 中发送会话 Cookie；设置为 ``none`` 但仍使用普通 HTTP 时，
+  由于 ``none`` 要求 ``Secure`` 属性，浏览器根本不会保存该 Cookie。
+  两种情况下登录都会当场失败一次，浏览器返回登录页面并显示“SSO登录处理失败。”，
+  日志中会输出 ``Failed to process SSO login: could not validate state`` 警告
 
 发生认证错误
 ~~~~~~~~~~~~

--- a/zh-cn/15.8/install/upgrade.rst
+++ b/zh-cn/15.8/install/upgrade.rst
@@ -534,7 +534,8 @@ Microsoft Entra ID 的「我的应用」）中的 |Fess| 磁贴发起的登录�
 跨站 POST 返回，而 |Fess| 的默认值 ``tomcat.sameSiteCookies = lax`` 不会随该请求发送会话
 Cookie，因此需要将其改为 ``tomcat.sameSiteCookies = none``\ 。如果仅为此才设置了 ``none``\ ，
 可以恢复为默认值。若要保持原有行为，请指定 ``entraid.response.mode=form_post`` 并保留
-``tomcat.sameSiteCookies = none``\ 。
+``tomcat.sameSiteCookies = none``\ 。浏览器仅对同时带有 ``Secure`` 属性的 Cookie 接受
+``none``\ ，因此这种方式同样要求通过 HTTPS 提供 |Fess| 。
 
 自 15.8 起，|Fess| 还会在登录完成后于后台解析用户所属的组和角色，而不再让登录等待 Microsoft
 Graph。在解析完成之前——或解析未能完全成功时——用户拥有的仅有其自身的用户级权限，以及在


### PR DESCRIPTION
## What

The 15.8 Entra ID pages tell you to set `tomcat.sameSiteCookies = none` when
`entraid.response.mode` is `form_post`, but never say that the workaround only
works over HTTPS. This adds that requirement and corrects how the failure is
described.

Touches `config/sso-entraid.rst` and `install/upgrade.rst` in all seven
languages (de, en, es, fr, ja, ko, zh-cn).

## Why

Testing 15.8 against a live tenant turned up two inaccuracies.

**The `none` workaround needs TLS.** With `tomcat.sameSiteCookies = none`, the
session cookie goes out as:

```
Set-Cookie: JSESSIONID=...; Path=/; HttpOnly; SameSite=None
```

There is no `Secure` attribute, and browsers reject a `SameSite=None` cookie
that does not carry one. Over plain HTTP the cookie is therefore never stored
at all, which is worse than leaving the default `lax` in place: instead of
only the cross-site callback losing the cookie, every request does. Either way
the login fails with `could not validate state`.

Worth noting that the server side is fine — replaying the same callback as a
POST with the session cookie attached completes the login normally, so the
only thing standing between `form_post` and a working setup is the cookie
attribute.

The SAML pages already carry this warning, in every language:

> Browsers only accept `none` on a cookie that also carries the `Secure`
> attribute, so Fess must be served over HTTPS.

This reuses that wording so the two SSO methods read the same way.

**The failure does not loop.** The troubleshooting entry said the sign-in
screen "keeps reappearing". It fails once, on the spot, and the browser lands
on the login page with an error. The revised entry names both the message the
user sees and the warning written to the log, matching how the SAML page
documents its equivalent failure.

## Verification

Built 15.8 from master and connected it to a real Entra ID tenant, then ran
the callback through a browser under `lax` and under `none`, and separately
replayed the callback POST with the session cookie attached to isolate the
server-side path from the cookie policy.

The changed reStructuredText was parsed with docutils to confirm the new
bullet continuations and inline literals render — including the CJK
languages, where a closing ``` `` ``` followed directly by a CJK character
would silently fall back to plain text.

## Notes

No behaviour change in Fess; documentation only. The default
`entraid.response.mode=query` is unaffected and needs no TLS-specific setup
beyond the usual production recommendation.
