### PR TITLE
docs(sso): say what a directory role name needs from Microsoft Graph

### DIFF
--- a/de/15.8/config/sso-entraid.rst
+++ b/de/15.8/config/sso-entraid.rst
@@ -235,6 +235,13 @@ Konfigurieren der API-Berechtigungen
    ist.
 
 .. note::
+   Die oben genannten Berechtigungen decken den ``displayName`` einer Verzeichnisrolle nicht ab:
+   Microsoft Graph gibt ihn als null zurück. ``displayName`` in ``entraid.permission.fields``
+   bewirkt daher für eine Verzeichnisrolle nichts, und nur die ID (GUID) der Rolle wird zu einer
+   Berechtigung. Um Rollennamen als Berechtigungswerte zu verwenden, erteilen Sie zusätzlich
+   ``RoleManagement.Read.Directory`` (oder ``Directory.Read.All``).
+
+.. note::
    |Fess| fordert beim Token-Abruf den Scope ``https://graph.microsoft.com/.default`` an.
    Ab 15.8 wird zusätzlich ``openid profile offline_access https://graph.microsoft.com/.default`` an den Autorisierungsendpunkt gesendet, sodass die Zustimmung für denselben Umfang eingeholt wird.
    Das bedeutet, dass alle in der App-Registrierung konfigurierten und genehmigten Zugriffsberechtigungen verwendet werden.

--- a/en/15.8/config/sso-entraid.rst
+++ b/en/15.8/config/sso-entraid.rst
@@ -229,6 +229,13 @@ Configuring API Permissions
    required in either case.
 
 .. note::
+   The permissions above do not cover the ``displayName`` of a directory role: Microsoft Graph
+   returns it as null. Naming ``displayName`` in ``entraid.permission.fields`` therefore adds
+   nothing for a directory role, and only the role's ID (GUID) becomes a permission. To use role
+   names as permission values, also grant ``RoleManagement.Read.Directory`` (or
+   ``Directory.Read.All``).
+
+.. note::
    |Fess| requests the ``https://graph.microsoft.com/.default`` scope when acquiring a token, and from 15.8 it also sends ``openid profile offline_access https://graph.microsoft.com/.default`` to the authorization endpoint so that consent is requested for the same set. This means that all access permissions configured and consented to on the app registration are used. Therefore, to retrieve group information, you must add the permissions above to the app registration and grant administrator consent.
 
 Information to Obtain

--- a/es/15.8/config/sso-entraid.rst
+++ b/es/15.8/config/sso-entraid.rst
@@ -233,6 +233,13 @@ Configurar permisos de API
    ``Group.Read.All``, por lo que ``User.Read`` es necesario en cualquier caso.
 
 .. note::
+   Los permisos anteriores no cubren el ``displayName`` de un rol de directorio: Microsoft Graph
+   lo devuelve como null. Por lo tanto, indicar ``displayName`` en ``entraid.permission.fields``
+   no aporta nada para un rol de directorio y solo el ID (GUID) del rol se convierte en un
+   permiso. Para usar los nombres de rol como valores de permiso, conceda además
+   ``RoleManagement.Read.Directory`` (o ``Directory.Read.All``).
+
+.. note::
    |Fess| solicita el ámbito ``https://graph.microsoft.com/.default`` al adquirir un token.
    Desde la versión 15.8, también se envía ``openid profile offline_access https://graph.microsoft.com/.default`` al endpoint de autorización, de modo que el consentimiento se solicita para el mismo conjunto.
    Esto significa que se utilizan todos los permisos de acceso configurados y para los que se ha dado consentimiento en el registro de la aplicación.

--- a/fr/15.8/config/sso-entraid.rst
+++ b/fr/15.8/config/sso-entraid.rst
@@ -235,6 +235,14 @@ Configuration des autorisations d'API
    ``Group.Read.All``, si bien que ``User.Read`` reste nécessaire dans tous les cas.
 
 .. note::
+   Les autorisations ci-dessus ne couvrent pas le ``displayName`` d'un rôle d'annuaire :
+   Microsoft Graph le renvoie à null. Indiquer ``displayName`` dans
+   ``entraid.permission.fields`` n'apporte donc rien pour un rôle d'annuaire, et seul
+   l'identifiant (GUID) du rôle devient une autorisation. Pour utiliser les noms de rôle comme
+   valeurs d'autorisation, accordez également ``RoleManagement.Read.Directory`` (ou
+   ``Directory.Read.All``).
+
+.. note::
    |Fess| demande le scope ``https://graph.microsoft.com/.default`` lors de l'acquisition d'un jeton.
    Depuis la version 15.8, ``openid profile offline_access https://graph.microsoft.com/.default`` est également envoyé au point de terminaison d'autorisation, afin que le consentement soit demandé pour le même ensemble.
    Cela signifie que toutes les autorisations d'accès configurées et consenties sur l'inscription d'application sont utilisées.

--- a/ja/15.8/config/sso-entraid.rst
+++ b/ja/15.8/config/sso-entraid.rst
@@ -228,6 +228,13 @@ APIアクセス許可の設定
    いずれの場合も ``User.Read`` は必要です。
 
 .. note::
+   上記のアクセス許可では、ディレクトリロールの ``displayName`` はMicrosoft Graphから返されません。
+   そのため、\ ``entraid.permission.fields`` に ``displayName`` を指定しても、
+   ディレクトリロールから権限になるのはロールのID（GUID）だけです。
+   ロール名を権限値として使用する場合は、\ ``RoleManagement.Read.Directory``
+   （または ``Directory.Read.All``\ ）も付与してください。
+
+.. note::
    |Fess| はトークン取得時に ``https://graph.microsoft.com/.default`` スコープを要求します。
    15.8 以降は、認可エンドポイントにも ``openid profile offline_access https://graph.microsoft.com/.default``
    を要求し、同じ範囲の同意を求めます。

--- a/ko/15.8/config/sso-entraid.rst
+++ b/ko/15.8/config/sso-entraid.rst
@@ -228,6 +228,12 @@ API 접근 권한 설정
    ``Group.Read.All`` 로는 인가되지 않으므로 어느 경우에도 ``User.Read`` 는 필요합니다.
 
 .. note::
+   위의 접근 권한으로는 디렉터리 역할의 ``displayName`` 을 Microsoft Graph가 반환하지 않습니다.
+   따라서 ``entraid.permission.fields`` 에 ``displayName`` 을 지정해도 디렉터리 역할에서
+   권한이 되는 것은 역할의 ID（GUID）뿐입니다. 역할 이름을 권한 값으로 사용하려면
+   ``RoleManagement.Read.Directory``\ （또는 ``Directory.Read.All``\ ）도 부여하십시오.
+
+.. note::
    |Fess| 는 토큰 취득 시 ``https://graph.microsoft.com/.default`` 스코프를 요청합니다.
    15.8 이상에서는 인가 엔드포인트에도 ``openid profile offline_access https://graph.microsoft.com/.default``
    를 요청하여 동일한 범위의 동의를 요구합니다.

--- a/zh-cn/15.8/config/sso-entraid.rst
+++ b/zh-cn/15.8/config/sso-entraid.rst
@@ -224,6 +224,12 @@ Entra ID侧配置
    授权，因此无论采用哪种方式都需要 ``User.Read``\ 。
 
 .. note::
+   上述权限不包含目录角色的 ``displayName``\ ，Microsoft Graph 会将其返回为 null。
+   因此，即使在 ``entraid.permission.fields`` 中指定 ``displayName``\ ，
+   目录角色也只有角色的 ID（GUID）会成为权限。
+   若要将角色名称用作权限值，请同时授予 ``RoleManagement.Read.Directory``\ （或 ``Directory.Read.All``\ ）。
+
+.. note::
    |Fess| 在获取令牌时会请求 ``https://graph.microsoft.com/.default`` 作用域。
    15.8 及以后版本还会向授权端点发送 ``openid profile offline_access https://graph.microsoft.com/.default``\ ，以便针对同一组权限请求同意。
    这意味着将使用在应用注册中配置并已授予同意的所有访问权限。


### PR DESCRIPTION
## Problem

`entraid.permission.fields` is described as naming **group/role** fields, and the guidance
under it tells the reader to add `displayName` because security groups carry no `mail`.

Applied to a directory role, that does nothing.

With the permissions this page asks for — `User.Read` plus `GroupMember.Read.All`, or the
`Group.Read.All` / `Directory.Read.All` substitutes named in the note above it — Microsoft Graph
answers `/me/memberOf` with `displayName` **null** for a `#microsoft.graph.directoryRole` entry:

```
member={roleTemplateId=…, @odata.type=#microsoft.graph.directoryRole,
        displayName=null, description=null, id=…}
```

So a directory role only ever contributes its GUID as a permission — and it does so silently,
because a permission field that is absent is not an error. An administrator who grants access by
role name sees the documented setting have no effect and no message anywhere.

## What fixes it

Granting `RoleManagement.Read.Directory`, or `Directory.Read.All`, makes Graph return the name:

```
member={roleTemplateId=…, @odata.type=#microsoft.graph.directoryRole,
        displayName=Global Administrator, …}
```

and the role's `displayName` becomes a permission value, so a document scoped to
`{role}Global Administrator` becomes visible to members of that role.

## Verification

Checked against a live tenant on 15.8, with a document scoped to the role's name and another to
the role's GUID:

| Delegated permissions | role permissions resolved | name-scoped document |
|---|---|---|
| `User.Read` + `Group.Read.All` | GUID only | not visible |
| `User.Read` + `Group.Read.All` + `RoleManagement.Read.Directory` | GUID + `Global Administrator` | visible |
| `User.Read` + `Directory.Read.All` | GUID + `Global Administrator` | visible |

## Change

One note, where the permissions are listed, in all seven languages. No behaviour claim outside
what the table above measured.
