### PR TITLE
docs(sso): the SAML single logout NameID is compared now

### DIFF
--- a/de/15.8/config/sso-saml.rst
+++ b/de/15.8/config/sso-saml.rst
@@ -369,13 +369,18 @@ Signatureinstellungen
    Wenn Single Logout konfiguriert ist (``saml.idp.single_logout_service.url``), setzen Sie unbedingt
    auch ``saml.security.want_messages_signed=true``.
    Solange die Option ``false`` ist, wird für eine an ``/sso/logout`` eingehende LogoutRequest keine
-   Signatur verlangt. Geprüft werden lediglich das XML-Schema, ``NotOnOrAfter`` (falls vorhanden),
-   ``Destination`` (falls vorhanden) und die Übereinstimmung des Issuers mit ``saml.idp.entityid``
-   (falls vorhanden); die NameID in der LogoutRequest wird nie mit dem angemeldeten Benutzer verglichen.
+   Signatur verlangt. Die SAML-Bibliothek prüft lediglich das XML-Schema, ``NotOnOrAfter`` (falls
+   vorhanden), ``Destination`` (falls vorhanden) und die Übereinstimmung des Issuers mit
+   ``saml.idp.entityid`` (falls vorhanden).
    Das Issuer-Element ist im SAML-Schema optional, sodass eine LogoutRequest, die es weglässt, nie mit
-   der Entity-ID des IdP verglichen wird. Ein Angreifer kann daher, ohne die Entity-ID des IdP zu
-   kennen, eine unsignierte LogoutRequest erzeugen und die Sitzung eines authentifizierten Benutzers
-   beenden, indem er diesen auf die entsprechende URL lockt.
+   der Entity-ID des IdP verglichen wird; der Absender muss also nichts über die Installation wissen.
+   Fess vergleicht zusätzlich die NameID in der LogoutRequest mit dem angemeldeten Benutzer und behält
+   die Sitzung bei, wenn beide nicht übereinstimmen. Eine LogoutRequest, die jemand anderen nennt,
+   beendet die Sitzung daher nicht mehr.
+   Es bleiben zwei Fälle: eine Sitzung, deren NameID der Absender bereits kennt -- beim
+   voreingestellten Format ``emailAddress`` kann das schlicht die E-Mail-Adresse des Benutzers sein --
+   und jede Sitzung, die nicht aus SAML stammt, etwa eine lokale oder LDAP-Anmeldung, bei der es keine
+   NameID zum Vergleichen gibt.
    Die Auswirkung ist eine erzwungene Abmeldung (Denial of Service), keine Kontoübernahme.
 
 Verschlüsselungseinstellungen

--- a/en/15.8/config/sso-saml.rst
+++ b/en/15.8/config/sso-saml.rst
@@ -365,12 +365,16 @@ Signature Settings
    When Single Logout is configured (``saml.idp.single_logout_service.url``), always set
    ``saml.security.want_messages_signed=true`` as well.
    While it is ``false``, no signature is required on a LogoutRequest received at ``/sso/logout``.
-   The only checks performed are the XML schema, ``NotOnOrAfter`` (if present), ``Destination``
-   (if present), and that the Issuer matches ``saml.idp.entityid`` (if present); the NameID in the
-   LogoutRequest is never compared against the logged-in user. The Issuer element is optional in the
-   SAML schema, so a LogoutRequest that omits it is never compared against the IdP entity ID. An
-   attacker, without needing to know the IdP entity ID, can therefore craft an unsigned LogoutRequest
-   and terminate an authenticated user's session by luring that user to the URL.
+   The only checks the SAML library performs are the XML schema, ``NotOnOrAfter`` (if present),
+   ``Destination`` (if present), and that the Issuer matches ``saml.idp.entityid`` (if present).
+   The Issuer element is optional in the SAML schema, so a LogoutRequest that omits it is never
+   compared against the IdP entity ID, and its sender therefore needs to know nothing about the
+   deployment.
+   Fess compares the NameID in the LogoutRequest with the user the session is logged in as and
+   keeps the session when they differ, so a request that names somebody else no longer ends it.
+   What remains is a session whose NameID the sender already knows -- with the default
+   ``emailAddress`` format that may simply be the user's email address -- and any session that did
+   not come from SAML, such as a local or LDAP login, which has no NameID to compare.
    The impact is a forced logout (denial of service), not account takeover.
 
 Encryption Settings

--- a/es/15.8/config/sso-saml.rst
+++ b/es/15.8/config/sso-saml.rst
@@ -369,13 +369,19 @@ Configuración de firma
    Cuando se configura el cierre de sesión único (``saml.idp.single_logout_service.url``), establezca
    siempre también ``saml.security.want_messages_signed=true``.
    Mientras sea ``false``, no se exige ninguna firma en una LogoutRequest recibida en ``/sso/logout``.
-   Las únicas comprobaciones que se realizan son el esquema XML, ``NotOnOrAfter`` (si está presente),
-   ``Destination`` (si está presente) y que el Issuer coincida con ``saml.idp.entityid`` (si está
-   presente); el NameID de la LogoutRequest nunca se compara con el usuario que ha iniciado sesión.
+   Las únicas comprobaciones que realiza la biblioteca SAML son el esquema XML, ``NotOnOrAfter`` (si
+   está presente), ``Destination`` (si está presente) y que el Issuer coincida con
+   ``saml.idp.entityid`` (si está presente).
    El elemento Issuer es opcional en el esquema SAML, por lo que una LogoutRequest que lo omita nunca
-   se compara con el identificador de entidad del IdP. Por tanto, un atacante, sin necesidad de conocer
-   el identificador de entidad del IdP, puede crear una LogoutRequest sin firmar y terminar la sesión
-   de un usuario autenticado atrayéndolo a esa URL.
+   se compara con el identificador de entidad del IdP; su remitente, por tanto, no necesita saber nada
+   sobre la instalación.
+   Fess compara además el NameID de la LogoutRequest con el usuario con el que se ha iniciado la
+   sesión y la mantiene cuando no coinciden, de modo que una solicitud que nombra a otra persona ya no
+   la termina.
+   Quedan dos casos: una sesión cuyo NameID ya conoce el remitente -- con el formato predeterminado
+   ``emailAddress`` puede ser sencillamente la dirección de correo del usuario -- y cualquier sesión
+   que no provenga de SAML, como un inicio de sesión local o LDAP, en la que no hay NameID que
+   comparar.
    El impacto es un cierre de sesión forzado (denegación de servicio), no una apropiación de la cuenta.
 
 Configuración de cifrado

--- a/fr/15.8/config/sso-saml.rst
+++ b/fr/15.8/config/sso-saml.rst
@@ -369,13 +369,18 @@ Paramètres de signature
    Lorsque la déconnexion unique est configurée (``saml.idp.single_logout_service.url``), définissez
    impérativement aussi ``saml.security.want_messages_signed=true``.
    Tant que ce paramètre vaut ``false``, aucune signature n'est exigée sur une LogoutRequest reçue sur
-   ``/sso/logout``. Les seules vérifications effectuées sont le schéma XML, ``NotOnOrAfter`` (s'il est
-   présent), ``Destination`` (s'il est présent) et la correspondance de l'Issuer avec
-   ``saml.idp.entityid`` (s'il est présent) ; le NameID de la LogoutRequest n'est jamais comparé à
-   l'utilisateur connecté. L'élément Issuer est optionnel dans le schéma SAML, si bien qu'une
-   LogoutRequest qui l'omet n'est jamais comparée à l'identifiant d'entité de l'IdP. Un attaquant peut
-   donc, sans avoir besoin de connaître l'identifiant d'entité de l'IdP, forger une LogoutRequest non
-   signée et mettre fin à la session d'un utilisateur authentifié en l'attirant vers cette URL.
+   ``/sso/logout``. Les seules vérifications effectuées par la bibliothèque SAML sont le schéma XML,
+   ``NotOnOrAfter`` (s'il est présent), ``Destination`` (s'il est présent) et la correspondance de
+   l'Issuer avec ``saml.idp.entityid`` (s'il est présent).
+   L'élément Issuer est optionnel dans le schéma SAML, si bien qu'une LogoutRequest qui l'omet n'est
+   jamais comparée à l'identifiant d'entité de l'IdP ; son expéditeur n'a donc besoin de rien savoir
+   de l'installation.
+   Fess compare en outre le NameID de la LogoutRequest avec l'utilisateur connecté et conserve la
+   session lorsqu'ils diffèrent : une requête qui nomme quelqu'un d'autre n'y met donc plus fin.
+   Il reste deux cas : une session dont l'expéditeur connaît déjà le NameID -- avec le format
+   ``emailAddress`` par défaut, il peut s'agir simplement de l'adresse e-mail de l'utilisateur -- et
+   toute session qui ne provient pas de SAML, comme une connexion locale ou LDAP, pour laquelle il n'y
+   a pas de NameID à comparer.
    L'impact est une déconnexion forcée (déni de service), et non une prise de contrôle du compte.
 
 Paramètres de chiffrement

--- a/ja/15.8/config/sso-saml.rst
+++ b/ja/15.8/config/sso-saml.rst
@@ -365,12 +365,15 @@ Keycloakのアカウントは既定で複数のレルムロールを持つため
    シングルログアウト（``saml.idp.single_logout_service.url``）を設定する場合は、
    ``saml.security.want_messages_signed=true`` を必ず併せて設定してください。
    ``false`` のままでは、``/sso/logout`` が受け取るLogoutRequestに署名が要求されません。
-   検証されるのはXMLスキーマ、``NotOnOrAfter``（存在する場合）、``Destination``（存在する場合）、
-   および Issuer が ``saml.idp.entityid`` と一致すること（存在する場合）だけで、
-   LogoutRequest内のNameIDがログイン中のユーザーと一致するかは検査されません。
+   SAMLライブラリが検証するのはXMLスキーマ、``NotOnOrAfter``（存在する場合）、``Destination``（存在する場合）、
+   および Issuer が ``saml.idp.entityid`` と一致すること（存在する場合）だけです。
    Issuer要素はSAMLのスキーマ上は省略可能であり、省略されたLogoutRequestではIdPのEntity IDとの
-   照合そのものが行われません。このため攻撃者はIdPのEntity IDを知らなくても、署名のないLogoutRequestを作成し、
-   そのURLをユーザーに踏ませることで認証済みセッションを終了させられます。
+   照合そのものが行われないため、送信者は配備について何も知らなくてもこのエンドポイントに到達できます。
+   Fessはこれに加えて、LogoutRequest内のNameIDをログイン中のユーザーと比較し、
+   一致しない場合はセッションを維持します。そのため他人を名指しするLogoutRequestではセッションは終了しません。
+   残るのは、送信者がNameIDを既に知っているセッション（既定の ``emailAddress`` 形式では
+   利用者のメールアドレスそのもののことがあります）と、ローカルログインやLDAPログインなど
+   SAML由来でないセッション（比較すべきNameIDがありません）の2つです。
    影響は強制ログアウト（サービス妨害）であり、アカウントの乗っ取りではありません。
 
 暗号化の設定

--- a/ko/15.8/config/sso-saml.rst
+++ b/ko/15.8/config/sso-saml.rst
@@ -364,12 +364,15 @@ Keycloak은 기본적으로 이러한 형태의 어서션을 보냅니다. 역�
    싱글 로그아웃（``saml.idp.single_logout_service.url``）을 설정하는 경우에는
    ``saml.security.want_messages_signed=true`` 도 반드시 함께 설정하십시오.
    ``false`` 인 상태에서는 ``/sso/logout`` 이 수신하는 LogoutRequest에 서명이 요구되지 않습니다.
-   검증되는 것은 XML 스키마, ``NotOnOrAfter``（존재하는 경우）, ``Destination``（존재하는 경우）,
-   그리고 Issuer가 ``saml.idp.entityid`` 와 일치하는지（존재하는 경우）뿐이며,
-   LogoutRequest 안의 NameID가 로그인 중인 사용자와 일치하는지는 검사하지 않습니다.
+   SAML 라이브러리가 검증하는 것은 XML 스키마, ``NotOnOrAfter``（존재하는 경우）, ``Destination``（존재하는 경우）,
+   그리고 Issuer가 ``saml.idp.entityid`` 와 일치하는지（존재하는 경우）뿐입니다.
    Issuer 요소는 SAML 스키마상 생략 가능하며, 생략된 LogoutRequest에서는 IdP의 Entity ID와의
-   대조 자체가 이루어지지 않습니다. 이 때문에 공격자는 IdP의 Entity ID를 몰라도 서명 없는
-   LogoutRequest를 만들어, 해당 URL로 사용자를 유도함으로써 인증된 세션을 종료시킬 수 있습니다.
+   대조 자체가 이루어지지 않으므로, 보낸 쪽은 해당 설치 환경에 대해 아무것도 알 필요가 없습니다.
+   Fess는 여기에 더해 LogoutRequest 안의 NameID를 로그인 중인 사용자와 비교하고, 일치하지 않으면
+   세션을 유지합니다. 따라서 다른 사람을 지목한 LogoutRequest로는 세션이 종료되지 않습니다.
+   남는 것은 보낸 쪽이 NameID를 이미 알고 있는 세션（기본 ``emailAddress`` 형식에서는 사용자의
+   이메일 주소 그 자체일 수 있습니다）과, 로컬 로그인이나 LDAP 로그인처럼 SAML에서 오지 않아
+   비교할 NameID가 없는 세션의 두 가지입니다.
    영향은 강제 로그아웃（서비스 거부）이며, 계정 탈취는 아닙니다.
 
 암호화 설정

--- a/zh-cn/15.8/config/sso-saml.rst
+++ b/zh-cn/15.8/config/sso-saml.rst
@@ -357,11 +357,14 @@ Keycloak 默认发送这种形式的断言：除非启用其角色映射器和�
    配置单点登出（``saml.idp.single_logout_service.url``）时，请务必同时设置\
    ``saml.security.want_messages_signed=true``\ 。
    若保持为\ ``false``\ ，则不会对\ ``/sso/logout``\ 收到的LogoutRequest要求签名。
-   此时仅校验XML架构、``NotOnOrAfter``\ （若存在）、``Destination``\ （若存在）以及Issuer是否与\
-   ``saml.idp.entityid``\ 一致（若存在）；LogoutRequest中的NameID从不与已登录用户进行比对。
-   Issuer元素在SAML架构中是可选的，省略该元素的LogoutRequest从不会与IdP的实体ID进行比对。
-   因此，攻击者无需知晓IdP的实体ID，即可构造未签名的LogoutRequest，
-   诱导用户访问该URL，从而终止已认证用户的会话。
+   此时SAML库仅校验XML架构、``NotOnOrAfter``\ （若存在）、``Destination``\ （若存在）以及Issuer是否与\
+   ``saml.idp.entityid``\ 一致（若存在）。
+   Issuer元素在SAML架构中是可选的，省略该元素的LogoutRequest从不会与IdP的实体ID进行比对，
+   因此发送方无需了解该部署的任何信息即可到达此端点。
+   Fess还会将LogoutRequest中的NameID与当前登录用户进行比对，不一致时保留会话，
+   因此指名他人的LogoutRequest不再会终止会话。
+   剩下的情形有两种：发送方已经知道其NameID的会话（在默认的\ ``emailAddress``\ 格式下，
+   这可能就是用户的邮箱地址），以及并非来自SAML的会话（例如本地登录或LDAP登录），此时没有可供比对的NameID。
    其影响是强制登出（拒绝服务），而不是账户接管。
 
 加密设置


### PR DESCRIPTION
Follows codelibs/fess#3262 and codelibs/fess#3300, both merged for 15.8.

## The problem

The Single Logout warning in `15.8/config/sso-saml.rst` says:

> the NameID in the LogoutRequest is never compared against the logged-in user

That was true when it was written. It is not true of 15.8: `SamlAuthenticator` now
compares the NameID a LogoutRequest carries with the user the session is logged in as,
and keeps the session when they differ. So the warning describes an exposure that is
wider than the one the release actually has.

All seven translations carry the same paragraph, so all seven are updated.

## What the warning says now

The conclusion is unchanged, because it is still right: `want_messages_signed=true` is
the real fix. What changed is the description of what happens while it is `false`.

Kept, because it is still true:

- no signature is required on a LogoutRequest received at `/sso/logout`
- the library checks only the XML schema, `NotOnOrAfter` (if present), `Destination`
  (if present), and the Issuer against `saml.idp.entityid` (if present)
- `Issuer` is optional in the SAML protocol schema, so a LogoutRequest that omits it is
  never compared against the entity ID — reaching the endpoint needs no knowledge of
  the deployment

Corrected:

- Fess compares the NameID with the session user and keeps the session on a mismatch, so
  a LogoutRequest that names somebody else no longer ends it

Added, since this is what an operator now needs to know is left:

- a session whose NameID the sender already knows — with the default `emailAddress`
  format that may simply be the user's email address
- any session that did not come from SAML, such as a local or LDAP login, which has no
  NameID to compare

The impact statement (forced logout, not account takeover) is unchanged.

## Verification

- `python tools/check_headings.py` over the versions `versions.json` calls current → passes
- `python -m unittest discover -s tools -p 'test_*.py'` → `Ran 23 tests ... OK`
- `python tools/update_eol.py --check` → passes
- All seven files parse under docutils with no new system messages
- Checked that no translation still asserts the NameID is not compared
