### PR TITLE
docs(ldap): document how authentication.admin.users is compared

### DIFF
--- a/de/15.8/config/ldap-integration.rst
+++ b/de/15.8/config/ldap-integration.rst
@@ -236,6 +236,35 @@ Steuert das Verhalten bei der Rollen- und Gruppenauflösung nach der Anmeldung.
      - ``-1``
      - Maximale Länge des Benutzernamens. ``-1`` bedeutet keine Einschränkung.
 
+Reservierte Administrator-Benutzernamen
+---------------------------------------
+
+Die in ``authentication.admin.users`` aufgeführten Namen reserviert |Fess| für sich selbst. Für SSO
+wirken sie als Sperrliste: ``SpnegoAuthenticator`` löst für einen übereinstimmenden Namen keine
+Anmeldeinformationen auf, und auch die Formularanmeldung führt einen solchen Namen nicht zu LDAP.
+
+Ein Verzeichnis unterscheidet bei einem Kontonamen nicht zwischen Groß- und Kleinschreibung --
+Active Directory stellt für jede Schreibweise ein Ticket aus. Ein exakter Vergleich lässt dasselbe
+Konto daher allein durch eine andere Schreibweise herein. ``authentication.admin.users.ignore.case``
+bestimmt, wie verglichen wird.
+
+.. list-table:: Vergleich reservierter Namen
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - Eigenschaft
+     - Standardwert
+     - Beschreibung
+   * - ``authentication.admin.users``
+     - ``admin``
+     - Reservierte Administrator-Benutzernamen, durch Kommas getrennt.
+   * - ``authentication.admin.users.ignore.case``
+     - ``auto``
+     - Wie die reservierten Namen verglichen werden. ``auto`` ignoriert die Groß- und Kleinschreibung nur, wenn ``ldap.provider.url`` gesetzt ist, andernfalls wird exakt verglichen. ``true`` und ``false`` legen es unmittelbar fest.
+
+.. note::
+   Ist ``ldap.provider.url`` gesetzt, ignoriert ``auto`` die Groß- und Kleinschreibung. Ein Verzeichniskonto, dessen Name sich von einem reservierten nur in der Schreibweise unterscheidet, kann sich dann nicht mehr anmelden und wird nicht mehr aus der Administrationsoberfläche in das Verzeichnis synchronisiert. Setzen Sie ``authentication.admin.users.ignore.case=false``, um weiterhin exakt zu vergleichen.
+
 Attributzuordnung
 -----------------
 

--- a/en/15.8/config/ldap-integration.rst
+++ b/en/15.8/config/ldap-integration.rst
@@ -235,6 +235,34 @@ Controls the behavior of role and group resolution after login.
      - ``-1``
      - Maximum length of usernames. ``-1`` means no limit.
 
+Reserved Admin User Names
+-------------------------
+
+The names listed in ``authentication.admin.users`` are reserved by |Fess| for itself. For SSO they act
+as a block list: ``SpnegoAuthenticator`` resolves no credential for a name that matches one, and form
+login does not take such a name to LDAP either.
+
+A directory does not distinguish case in an account name -- Active Directory issues a ticket for any
+casing of one -- so comparing the reserved names exactly lets the same account log in simply by
+changing the spelling. ``authentication.admin.users.ignore.case`` decides how they are compared.
+
+.. list-table:: Comparison of Reserved Names
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - Property
+     - Default
+     - Description
+   * - ``authentication.admin.users``
+     - ``admin``
+     - Reserved admin user names, separated by commas.
+   * - ``authentication.admin.users.ignore.case``
+     - ``auto``
+     - How the reserved names are compared. ``auto`` ignores case only when ``ldap.provider.url`` is set, and compares exactly when it is not. ``true`` and ``false`` decide it outright.
+
+.. note::
+   Where ``ldap.provider.url`` is set, ``auto`` ignores case. A directory account whose name differs from a reserved one only in case can then no longer log in, and is no longer synchronised to the directory from the admin UI. Set ``authentication.admin.users.ignore.case=false`` to keep comparing the names exactly.
+
 Attribute Mapping
 -----------------
 

--- a/en/15.8/config/properties.rst
+++ b/en/15.8/config/properties.rst
@@ -1420,6 +1420,9 @@ Permission
   * - authentication.admin.users
     - Admin users for authentication
     - admin
+  * - authentication.admin.users.ignore.case
+    - How authentication.admin.users is compared: auto, true or false. auto ignores case when ldap.provider.url is set
+    - auto
   * - authentication.admin.roles
     - Admin roles for authentication
     - admin

--- a/es/15.8/config/ldap-integration.rst
+++ b/es/15.8/config/ldap-integration.rst
@@ -232,6 +232,35 @@ Controla el comportamiento de la resolución de roles y grupos tras el inicio de
      - ``-1``
      - Longitud máxima del nombre de usuario. ``-1`` significa sin límite.
 
+Nombres de usuario administrador reservados
+-------------------------------------------
+
+Los nombres indicados en ``authentication.admin.users`` quedan reservados por |Fess| para sí mismo.
+En SSO actúan como lista de bloqueo: ``SpnegoAuthenticator`` no resuelve credenciales para un nombre
+que coincida, y el inicio de sesión por formulario tampoco lleva ese nombre a LDAP.
+
+Un directorio no distingue mayúsculas y minúsculas en un nombre de cuenta -- Active Directory emite
+un ticket para cualquier grafía --, de modo que comparar exactamente permite que la misma cuenta
+inicie sesión solo con cambiar la grafía. ``authentication.admin.users.ignore.case`` decide cómo se
+comparan.
+
+.. list-table:: Comparación de nombres reservados
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - Propiedad
+     - Valor predeterminado
+     - Descripción
+   * - ``authentication.admin.users``
+     - ``admin``
+     - Nombres de usuario administrador reservados, separados por comas.
+   * - ``authentication.admin.users.ignore.case``
+     - ``auto``
+     - Cómo se comparan los nombres reservados. ``auto`` ignora mayúsculas y minúsculas solo cuando ``ldap.provider.url`` está definido; si no lo está, compara exactamente. ``true`` y ``false`` lo deciden de forma explícita.
+
+.. note::
+   Cuando ``ldap.provider.url`` está definido, ``auto`` ignora mayúsculas y minúsculas. Una cuenta del directorio cuyo nombre difiera de uno reservado solo en mayúsculas y minúsculas deja de poder iniciar sesión y ya no se sincroniza con el directorio desde la interfaz de administración. Defina ``authentication.admin.users.ignore.case=false`` para seguir comparando de forma exacta.
+
 Mapeo de atributos
 --------------------
 

--- a/fr/15.8/config/ldap-integration.rst
+++ b/fr/15.8/config/ldap-integration.rst
@@ -236,6 +236,34 @@ Contrôle le comportement de la résolution des rôles/groupes après la connexi
      - ``-1``
      - Longueur maximale du nom d'utilisateur. ``-1`` signifie sans limite.
 
+Noms d'utilisateur administrateur réservés
+------------------------------------------
+
+Les noms énumérés dans ``authentication.admin.users`` sont réservés par |Fess| pour lui-même. Pour le
+SSO, ils forment une liste de blocage : ``SpnegoAuthenticator`` ne résout aucune identité pour un nom
+qui y correspond, et la connexion par formulaire ne dirige pas non plus un tel nom vers LDAP.
+
+Un annuaire ne distingue pas la casse dans un nom de compte -- Active Directory délivre un ticket
+pour n'importe quelle graphie --, si bien qu'une comparaison exacte laisse entrer le même compte par
+un simple changement de graphie. ``authentication.admin.users.ignore.case`` décide de la comparaison.
+
+.. list-table:: Comparaison des noms réservés
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - Propriété
+     - Valeur par défaut
+     - Description
+   * - ``authentication.admin.users``
+     - ``admin``
+     - Noms d'utilisateur administrateur réservés, séparés par des virgules.
+   * - ``authentication.admin.users.ignore.case``
+     - ``auto``
+     - Manière de comparer les noms réservés. ``auto`` ignore la casse uniquement lorsque ``ldap.provider.url`` est défini, et compare exactement sinon. ``true`` et ``false`` le décident explicitement.
+
+.. note::
+   Lorsque ``ldap.provider.url`` est défini, ``auto`` ignore la casse. Un compte de l'annuaire dont le nom ne diffère d'un nom réservé que par la casse ne peut alors plus se connecter et n'est plus synchronisé vers l'annuaire depuis l'interface d'administration. Définissez ``authentication.admin.users.ignore.case=false`` pour continuer à comparer exactement.
+
 Correspondance des attributs
 -----------------------------
 

--- a/ja/15.8/config/ldap-integration.rst
+++ b/ja/15.8/config/ldap-integration.rst
@@ -235,6 +235,33 @@ LDAP管理機能・動作設定
      - ``-1``
      - ユーザー名の最大長。\ ``-1`` は制限なしを意味します。
 
+予約された管理ユーザー名
+------------------------
+
+``authentication.admin.users`` に列挙した名前は |Fess| が自身のために予約します。SSOではブロックリストとして働き、
+一致した名前は ``SpnegoAuthenticator`` が資格情報を解決せず、フォームログインでもLDAP認証に回りません。
+
+ディレクトリはアカウント名の大文字・小文字を区別しません（Active Directoryはどの綴りでもチケットを発行します）。
+そのため比較を完全一致にしていると、同じアカウントが綴りを変えるだけでログインできてしまいます。
+``authentication.admin.users.ignore.case`` がこの比較方法を決めます。
+
+.. list-table:: 予約名の比較
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - プロパティ
+     - デフォルト値
+     - 説明
+   * - ``authentication.admin.users``
+     - ``admin``
+     - 予約する管理ユーザー名。カンマ区切りで指定します。
+   * - ``authentication.admin.users.ignore.case``
+     - ``auto``
+     - 予約名の比較方法。``auto`` は ``ldap.provider.url`` が設定されている場合のみ大文字・小文字を無視し、未設定なら完全一致で比較します。``true`` / ``false`` は明示的に固定します。
+
+.. note::
+   ``ldap.provider.url`` を設定した構成では ``auto`` は大文字・小文字を無視します。この場合、予約名と大文字・小文字だけが異なるディレクトリ上のアカウントはログインできなくなり、管理画面からディレクトリへ同期されなくなります。従来どおり完全一致で比較するには ``authentication.admin.users.ignore.case=false`` を設定してください。
+
 属性マッピング
 --------------
 

--- a/ko/15.8/config/ldap-integration.rst
+++ b/ko/15.8/config/ldap-integration.rst
@@ -235,6 +235,34 @@ LDAP 관리 기능·동작 설정
      - ``-1``
      - 사용자 이름의 최대 길이. ``-1`` 은 제한 없음을 의미합니다.
 
+예약된 관리자 사용자 이름
+-------------------------
+
+``authentication.admin.users`` 에 나열한 이름은 |Fess| 가 자체적으로 예약합니다. SSO에서는 차단 목록으로
+동작하여, 일치하는 이름에 대해 ``SpnegoAuthenticator`` 는 자격 증명을 해결하지 않으며 폼 로그인도 그 이름을
+LDAP로 보내지 않습니다.
+
+디렉터리는 계정 이름의 대소문자를 구분하지 않습니다. Active Directory는 어떤 표기에도 티켓을 발급하므로,
+정확히 비교하면 같은 계정이 표기만 바꾸어 로그인할 수 있습니다. ``authentication.admin.users.ignore.case``
+가 비교 방식을 결정합니다.
+
+.. list-table:: 예약된 이름의 비교
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - 속성
+     - 기본값
+     - 설명
+   * - ``authentication.admin.users``
+     - ``admin``
+     - 예약할 관리자 사용자 이름. 쉼표로 구분합니다.
+   * - ``authentication.admin.users.ignore.case``
+     - ``auto``
+     - 예약된 이름의 비교 방식. ``auto`` 는 ``ldap.provider.url`` 이 설정된 경우에만 대소문자를 무시하고, 설정되지 않았으면 정확히 비교합니다. ``true`` 와 ``false`` 는 명시적으로 고정합니다.
+
+.. note::
+   ``ldap.provider.url`` 이 설정된 구성에서 ``auto`` 는 대소문자를 무시합니다. 이때 예약된 이름과 대소문자만 다른 디렉터리 계정은 더 이상 로그인할 수 없으며, 관리 화면에서 디렉터리로 동기화되지도 않습니다. 이전처럼 정확히 비교하려면 ``authentication.admin.users.ignore.case=false`` 를 설정하십시오.
+
 속성 매핑
 ---------
 

--- a/zh-cn/15.8/config/ldap-integration.rst
+++ b/zh-cn/15.8/config/ldap-integration.rst
@@ -232,6 +232,32 @@ LDAP管理功能与行为设置
      - ``-1``
      - 用户名的最大长度。\ ``-1`` 表示无限制。
 
+保留的管理员用户名
+------------------
+
+``authentication.admin.users`` 中列出的名称由 |Fess| 为自身保留。在SSO中它们作为阻止列表：
+``SpnegoAuthenticator`` 不会为匹配的名称解析凭据，表单登录也不会将该名称交给LDAP。
+
+目录不区分账户名称的大小写——Active Directory 对任何写法都会签发票据——因此按完全一致比较时，
+同一账户只要改变大小写就能登录。``authentication.admin.users.ignore.case`` 决定比较方式。
+
+.. list-table:: 保留名称的比较
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - 属性
+     - 默认值
+     - 说明
+   * - ``authentication.admin.users``
+     - ``admin``
+     - 保留的管理员用户名，以逗号分隔。
+   * - ``authentication.admin.users.ignore.case``
+     - ``auto``
+     - 保留名称的比较方式。``auto`` 仅在设置了 ``ldap.provider.url`` 时忽略大小写，未设置时按完全一致比较。``true`` 与 ``false`` 直接指定。
+
+.. note::
+   在设置了 ``ldap.provider.url`` 的配置中，``auto`` 会忽略大小写。此时，目录中仅大小写与保留名称不同的账户将无法登录，也不再从管理界面同步到目录。若需按完全一致比较，请设置 ``authentication.admin.users.ignore.case=false``。
+
 属性映射
 --------
 


### PR DESCRIPTION
Documents `authentication.admin.users.ignore.case`, added by codelibs/fess#3316.

## Why

The names in `authentication.admin.users` are reserved by Fess for itself, and for SSO they act as a block list: `SpnegoAuthenticator` resolves no credential for a name that matches one, and form login does not take such a name to LDAP either. A directory does not distinguish case in an account name — Active Directory issues a ticket for any casing of one — so comparing exactly let the same account log in by changing the spelling.

15.8 lets `authentication.admin.users.ignore.case` decide the comparison. It ships as `auto`: case is ignored only where `ldap.provider.url` names a directory, and compared exactly where it does not, which is where the comparison cannot change any outcome anyway.

## Change

- `<lang>/15.8/config/ldap-integration.rst` (de, en, es, fr, ja, ko, zh-cn): a new "Reserved Admin User Names" section under the LDAP administration chapter, with a table for the two properties and a note on what changes for an installation that has a directory account whose name differs from a reserved one only in case — it stops being able to log in, and stops being synchronised to the directory from the admin UI. `authentication.admin.users.ignore.case=false` keeps the previous behaviour.
- `en/15.8/config/properties.rst`: the key in the permission table.
