### PR TITLE
docs: drop the storage:// crawl protocol from the 15.9 file config API

### DIFF
--- a/de/15.9/api/admin/api-admin-fileconfig.rst
+++ b/de/15.9/api/admin/api-admin-fileconfig.rst
@@ -394,9 +394,7 @@ Für ``paths`` können folgende Protokolle verwendet werden (die unterstützten 
      - ``smb1://server/share/path``
    * - FTP
      - ``ftp://server/path``
-   * - S3-kompatibler Objektspeicher (z. B. MinIO)
-     - ``storage://bucket/path``
-   * - Amazon S3
+   * - Amazon S3 / S3-kompatibler Objektspeicher (z. B. MinIO)
      - ``s3://bucket/path``
    * - Google Cloud Storage
      - ``gcs://bucket/path``

--- a/en/15.9/api/admin/api-admin-fileconfig.rst
+++ b/en/15.9/api/admin/api-admin-fileconfig.rst
@@ -394,9 +394,7 @@ The following protocols can be used in ``paths`` (the supported protocols can be
      - ``smb1://server/share/path``
    * - FTP
      - ``ftp://server/path``
-   * - S3-compatible object storage (MinIO, etc.)
-     - ``storage://bucket/path``
-   * - Amazon S3
+   * - Amazon S3 / S3-compatible object storage (MinIO, etc.)
      - ``s3://bucket/path``
    * - Google Cloud Storage
      - ``gcs://bucket/path``

--- a/es/15.9/api/admin/api-admin-fileconfig.rst
+++ b/es/15.9/api/admin/api-admin-fileconfig.rst
@@ -396,9 +396,7 @@ En ``paths`` se pueden utilizar los siguientes protocolos (los protocolos dispon
      - ``smb1://server/share/path``
    * - FTP
      - ``ftp://server/path``
-   * - Almacenamiento de objetos compatible con S3 (MinIO, etc.)
-     - ``storage://bucket/path``
-   * - Amazon S3
+   * - Amazon S3 / Almacenamiento de objetos compatible con S3 (MinIO, etc.)
      - ``s3://bucket/path``
    * - Google Cloud Storage
      - ``gcs://bucket/path``

--- a/fr/15.9/api/admin/api-admin-fileconfig.rst
+++ b/fr/15.9/api/admin/api-admin-fileconfig.rst
@@ -395,9 +395,7 @@ Le champ ``paths`` accepte les protocoles suivants (la liste des protocoles pris
      - ``smb1://server/share/path``
    * - FTP
      - ``ftp://server/path``
-   * - Stockage objet compatible S3 (MinIO, etc.)
-     - ``storage://bucket/path``
-   * - Amazon S3
+   * - Amazon S3 / Stockage objet compatible S3 (MinIO, etc.)
      - ``s3://bucket/path``
    * - Google Cloud Storage
      - ``gcs://bucket/path``

--- a/ja/15.9/api/admin/api-admin-fileconfig.rst
+++ b/ja/15.9/api/admin/api-admin-fileconfig.rst
@@ -394,9 +394,7 @@ FileConfig APIは、|Fess| のファイルクロール設定を管理するた�
      - ``smb1://server/share/path``
    * - FTP
      - ``ftp://server/path``
-   * - S3互換オブジェクトストレージ（MinIO等）
-     - ``storage://bucket/path``
-   * - Amazon S3
+   * - Amazon S3／S3互換オブジェクトストレージ（MinIO等）
      - ``s3://bucket/path``
    * - Google Cloud Storage
      - ``gcs://bucket/path``

--- a/ko/15.9/api/admin/api-admin-fileconfig.rst
+++ b/ko/15.9/api/admin/api-admin-fileconfig.rst
@@ -394,9 +394,7 @@ FileConfig API는 |Fess| 의 파일 크롤링 설정을 관리하기 위한 API�
      - ``smb1://server/share/path``
    * - FTP
      - ``ftp://server/path``
-   * - S3 호환 오브젝트 스토리지 (MinIO 등)
-     - ``storage://bucket/path``
-   * - Amazon S3
+   * - Amazon S3 / S3 호환 오브젝트 스토리지 (MinIO 등)
      - ``s3://bucket/path``
    * - Google Cloud Storage
      - ``gcs://bucket/path``

--- a/zh-cn/15.9/api/admin/api-admin-fileconfig.rst
+++ b/zh-cn/15.9/api/admin/api-admin-fileconfig.rst
@@ -394,9 +394,7 @@ FileConfig API是用于管理 |Fess| 文件爬虫设置的API。
      - ``smb1://server/share/path``
    * - FTP
      - ``ftp://server/path``
-   * - S3兼容对象存储（MinIO等）
-     - ``storage://bucket/path``
-   * - Amazon S3
+   * - Amazon S3／S3兼容对象存储（MinIO等）
      - ``s3://bucket/path``
    * - Google Cloud Storage
      - ``gcs://bucket/path``


### PR DESCRIPTION
## Summary

Removes the `storage://` row from the file crawl path table in the 15.9 file config API reference, across all seven languages.

The MinIO-based `storage:` client is removed in codelibs/fess-crawler#190 in favor of `s3:`, which supports S3-compatible object storage through its `endpoint` parameter.

## Change

The separate row is merged into the Amazon S3 row so the S3-compatible case stays documented:

```
- * - S3-compatible object storage (MinIO, etc.)
-   - ``storage://bucket/path``
- * - Amazon S3
+ * - Amazon S3 / S3-compatible object storage (MinIO, etc.)
    - ``s3://bucket/path``
```

Applied to `de`, `en`, `es`, `fr`, `ja`, `ko` and `zh-cn`, each with its own translated label.

## Scope

Only the 15.9 tree is touched. Earlier version trees describe releases where `storage://` still worked and are left as they are.

This was the only occurrence of `storage://` in the 15.9 documentation — the file crawl guide (`fileconfig-guide.rst`) already listed just `file:/`, `smb://`, `ftp://`, `s3://` and `gcs://`, so no change was needed there.

The admin storage page documentation (`storage-guide.rst`) is unaffected: that feature uses `S3StorageClient` and `GcsStorageClient` on the AWS and Google SDKs, not the MinIO SDK, and continues to work against MinIO servers as an S3-compatible endpoint.
