### PR TITLE
docs: restore the missing accents in the Spanish pages

### DIFF
--- a/es/15.9/config/datastore/ds-database.rst
+++ b/es/15.9/config/datastore/ds-database.rst
@@ -2,13 +2,13 @@
 Conector de Base de Datos (Búsqueda en Bases de Datos)
 ======================================================
 
-Descripcion General
+Descripción General
 ===================
 
 El conector de base de datos permite registrar en el índice de |Fess| los registros de bases de datos relacionales compatibles con JDBC (MySQL, PostgreSQL, Oracle, SQL Server, etc.), haciendo posible la búsqueda en bases de datos (búsqueda de texto completo sobre el contenido de la base de datos). Cada columna obtenida mediante una sentencia SELECT se asigna a un campo de búsqueda durante el registro.
 
 El conector de base de datos proporciona funcionalidad para obtener datos de bases de datos
-relacionales compatibles con JDBC y registrarlos en el indice de |Fess|.
+relacionales compatibles con JDBC y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-db``.
 
@@ -30,18 +30,18 @@ Requisitos Previos
 1. Se requiere instalar el plugin ``fess-ds-db``
 2. Se requiere el controlador JDBC correspondiente a la base de datos de destino
 3. Se requiere acceso de lectura a la base de datos
-4. Para grandes volumenes de datos, es importante un diseno de consultas apropiado
+4. Para grandes volúmenes de datos, es importante un diseño de consultas apropiado
 
-Instalacion del Plugin
+Instalación del Plugin
 ----------------------
 
-Metodo 1: Instalar desde la consola de administracion
+Método 1: Instalar desde la consola de administración
 
 1. Abrir "Sistema" -> "Plugins"
 2. Subir el archivo JAR
 3. Reiniciar |Fess|
 
-Metodo 2: Colocar el archivo JAR directamente
+Método 2: Colocar el archivo JAR directamente
 
 ::
 
@@ -53,12 +53,12 @@ Metodo 2: Colocar el archivo JAR directamente
     # o bien
     cp fess-ds-db-X.X.X.jar /usr/share/fess/app/WEB-INF/plugin/
 
-Instalacion del Controlador JDBC
+Instalación del Controlador JDBC
 ---------------------------------
 
-El controlador JDBC no se incluye en el plugin. Obtenga por separado el controlador correspondiente a su base de datos y coloquelo usted mismo.
+El controlador JDBC no se incluye en el plugin. Obtenga por separado el controlador correspondiente a su base de datos y colóquelo usted mismo.
 
-El rastreo del almacen de datos se ejecuta en el proceso del rastreador, por lo que el controlador debe estar en el **classpath del proceso del rastreador**. Sirve cualquiera de estos directorios:
+El rastreo del almacén de datos se ejecuta en el proceso del rastreador, por lo que el controlador debe estar en el **classpath del proceso del rastreador**. Sirve cualquiera de estos directorios:
 
 - ``app/WEB-INF/lib/``
 - ``app/WEB-INF/env/crawler/lib/``
@@ -70,18 +70,18 @@ El rastreo del almacen de datos se ejecuta en el proceso del rastreador, por lo 
     # o bien
     cp mysql-connector-j-9.x.x.jar /usr/share/fess/app/WEB-INF/lib/
 
-Despues de colocar el controlador JDBC, reinicie |Fess| para cargarlo.
+Después de colocar el controlador JDBC, reinicie |Fess| para cargarlo.
 
 .. note::
    Cuando falta el controlador, el rastreo falla con el mensaje
    ``The JDBC driver ... is not on the crawler classpath.``
 
-Metodo de Configuracion
+Método de Configuración
 =======================
 
-Configure desde la consola de administracion en "Rastreador" -> "Almacen de Datos" -> "Crear Nuevo".
+Configure desde la consola de administración en "Rastreador" -> "Almacén de Datos" -> "Crear Nuevo".
 
-Configuracion Basica
+Configuración Básica
 --------------------
 
 .. list-table::
@@ -89,7 +89,7 @@ Configuracion Basica
    :widths: 25 75
 
    * - Elemento
-     - Ejemplo de Configuracion
+     - Ejemplo de Configuración
    * - Nombre
      - Products Database
    * - Nombre del Manejador
@@ -97,7 +97,7 @@ Configuracion Basica
    * - Habilitado
      - Activado
 
-Configuracion de Parametros
+Configuración de Parámetros
 ----------------------------
 
 Ejemplo MySQL/MariaDB:
@@ -120,22 +120,22 @@ Ejemplo PostgreSQL:
     password=your_password
     sql=SELECT id, title, content, url, updated_at FROM articles WHERE deleted = false
 
-Lista de Parametros
+Lista de Parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 20 10 70
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``driver``
      - Si
      - Nombre de la clase del controlador JDBC (si no se especifica, se produce ``DataStoreException``)
    * - ``url``
      - Si
-     - URL de conexion JDBC (obligatorio para la conexion)
+     - URL de conexión JDBC (obligatorio para la conexión)
    * - ``sql``
      - Si
      - Consulta SQL para obtener datos (si no se especifica, se produce ``DataStoreException``)
@@ -144,25 +144,25 @@ Lista de Parametros
      - Nombre de usuario de la base de datos
    * - ``password``
      - No
-     - Contrasena de la base de datos
+     - Contraseña de la base de datos
    * - ``fetch_size``
      - No
-     - Tamano de recuperacion JDBC. ``MIN_VALUE`` indica a MySQL que lea el conjunto de resultados fila a fila; otros controladores rechazan los valores negativos y el rastreo continua con el valor predeterminado del controlador tras emitir una advertencia. Los valores negativos o no numericos se notifican y se ignoran
+     - Tamaño de recuperación JDBC. ``MIN_VALUE`` indica a MySQL que lea el conjunto de resultados fila a fila; otros controladores rechazan los valores negativos y el rastreo continúa con el valor predeterminado del controlador tras emitir una advertencia. Los valores negativos o no numéricos se notifican y se ignoran
    * - ``query_timeout``
      - No
-     - Tiempo de espera de la consulta en segundos. ``0`` significa sin limite (el valor predeterminado de JDBC). Si el parametro no se especifica, no se establece ningun tiempo de espera
+     - Tiempo de espera de la consulta en segundos. ``0`` significa sin límite (el valor predeterminado de JDBC). Si el parámetro no se especifica, no se establece ningún tiempo de espera
    * - ``default_mimetype``
      - No
      - Tipo MIME predeterminado utilizado al extraer contenido de columnas BLOB o binarias
    * - ``column_label.mimetype``
      - No
-     - Nombre de la columna que contiene el tipo MIME utilizado para la extraccion de columnas BLOB o binarias (ej. ``column_label.mimetype=content_type``)
+     - Nombre de la columna que contiene el tipo MIME utilizado para la extracción de columnas BLOB o binarias (ej. ``column_label.mimetype=content_type``)
    * - ``column_label.filename``
      - No
-     - Nombre de la columna que contiene el nombre de archivo utilizado para la extraccion de columnas BLOB o binarias (el tipo MIME se infiere a partir de la extension)
+     - Nombre de la columna que contiene el nombre de archivo utilizado para la extracción de columnas BLOB o binarias (el tipo MIME se infiere a partir de la extensión)
    * - ``info.*``
      - No
-     - Propiedades adicionales de conexion JDBC (ej. ``info.ssl=true``). La clave sin el prefijo ``info.`` se pasa al controlador JDBC
+     - Propiedades adicionales de conexión JDBC (ej. ``info.ssl=true``). La clave sin el prefijo ``info.`` se pasa al controlador JDBC
    * - ``readInterval``
      - No
      - Retardo en milisegundos entre el procesamiento de cada fila. Predeterminado: 0
@@ -176,10 +176,10 @@ Lista de Parametros
    llamada bloqueada dentro del controlador. Establezca ``query_timeout`` para las consultas
    que puedan tardar mucho.
 
-Configuracion de Script
+Configuración de Script
 ------------------------
 
-Mapee los nombres de columnas SQL a campos del indice:
+Mapee los nombres de columnas SQL a campos del índice:
 
 ::
 
@@ -191,26 +191,26 @@ Mapee los nombres de columnas SQL a campos del indice:
 Campos disponibles:
 
 - ``<nombre_columna>`` - Columnas de resultado de la consulta SQL (se accede directamente por el nombre de la etiqueta de columna; no se usa prefijo como ``data.``)
-- ``crawlingConfig`` - la configuracion del almacen de datos
-- ``crawlingContext`` - el contexto del rastreo; ``crawlingContext.doc`` contiene el documento que se esta construyendo
+- ``crawlingConfig`` - la configuración del almacén de datos
+- ``crawlingContext`` - el contexto del rastreo; ``crawlingContext.doc`` contiene el documento que se está construyendo
 
 .. note::
-   Los nombres de columna deben coincidir con la etiqueta de columna (alias) de la clausula ``SELECT``.
-   Cuando se usen funciones de agregacion o expresiones, asigne un alias explicito con ``AS``
+   Los nombres de columna deben coincidir con la etiqueta de columna (alias) de la cláusula ``SELECT``.
+   Cuando se usen funciones de agregación o expresiones, asigne un alias explícito con ``AS``
    (ej. ``COUNT(*) AS total``).
 
 .. note::
-   El uso de mayusculas y minusculas en las etiquetas de columna varia segun la base de datos.
-   PostgreSQL convierte a minusculas los identificadores sin comillas, H2 los convierte a
-   mayusculas y MySQL los devuelve tal como se declararon. Un nombre que no se resuelve deja el
-   campo sin asignar en lugar de generar un error, asi que asigne un alias explicito con ``AS``
+   El uso de mayúsculas y minúsculas en las etiquetas de columna varía según la base de datos.
+   PostgreSQL convierte a minúsculas los identificadores sin comillas, H2 los convierte a
+   mayúsculas y MySQL los devuelve tal como se declararon. Un nombre que no se resuelve deja el
+   campo sin asignar en lugar de generar un error, así que asigne un alias explícito con ``AS``
    cuando la portabilidad sea importante.
 
 .. warning::
-   Los scripts pueden referenciar **todo el mapa de parametros del almacen de datos**, no solo
+   Los scripts pueden referenciar **todo el mapa de parámetros del almacén de datos**, no solo
    las columnas de resultado de la consulta SQL. ``driver``, ``url``, ``username``, ``password``
    y ``sql`` son visibles como variables con el mismo nombre, por lo que una columna puede
-   quedar ocultada de forma involuntaria, o el valor de un parametro puede aparecer donde se
+   quedar ocultada de forma involuntaria, o el valor de un parámetro puede aparecer donde se
    esperaba una columna inexistente. Cuando existen ambos, prevalece el valor de la columna.
 
 Carga de Datos BLOB o Binarios
@@ -220,11 +220,11 @@ Las columnas binarias (BLOB, ``BYTEA``, arrays de bytes y flujos binarios) se pr
 mediante el extractor de contenido (el mismo que se usa en el rastreo de archivos) y se
 incorporan como texto.
 
-CLOB, NCLOB y los flujos de caracteres **no** pasan por ningun extractor. Se leen tal cual
-como texto, y las indicaciones de tipo MIME descritas a continuacion no se les aplican.
+CLOB, NCLOB y los flujos de caracteres **no** pasan por ningún extractor. Se leen tal cual
+como texto, y las indicaciones de tipo MIME descritas a continuación no se les aplican.
 
 Las columnas de tipo array se convierten en sus elementos unidos por espacios. Los valores
-NULL se convierten en cadenas vacias.
+NULL se convierten en cadenas vacías.
 
 .. note::
    Que una columna BLOB llegue como ``java.sql.Blob`` o como array de bytes lo decide el
@@ -232,33 +232,33 @@ NULL se convierten en cadenas vacias.
    misma manera.
 
 .. note::
-   CLOB y NCLOB se leen enteros en memoria, sin limite de tamano. Para columnas de texto muy
+   CLOB y NCLOB se leen enteros en memoria, sin límite de tamaño. Para columnas de texto muy
    grandes, considere truncarlas en el SQL con ``SUBSTRING`` o similar. La ruta que pasa por
-   el extractor si respeta la longitud maxima de contenido del rastreador.
+   el extractor si respeta la longitud máxima de contenido del rastreador.
 
 Para extraer correctamente el texto de datos BLOB o flujos binarios, es necesario
-determinar el tipo de dato (tipo MIME). La determinacion sigue el siguiente orden de
+determinar el tipo de dato (tipo MIME). La determinación sigue el siguiente orden de
 prioridad:
 
 1. ``column_label.mimetype=<nombre_columna>`` - Usa el valor de la columna indicada como tipo MIME
-2. ``column_label.filename=<nombre_columna>`` - Trata el valor de la columna indicada como nombre de archivo e infiere el tipo MIME a partir de la extension
-3. ``default_mimetype`` - Tipo MIME predeterminado usado cuando no se puede determinar con los metodos anteriores
+2. ``column_label.filename=<nombre_columna>`` - Trata el valor de la columna indicada como nombre de archivo e infiere el tipo MIME a partir de la extensión
+3. ``default_mimetype`` - Tipo MIME predeterminado usado cuando no se puede determinar con los métodos anteriores
 
-Ejemplo (extraccion del BLOB de la columna ``file_data`` usando el tipo MIME de la columna ``content_type``):
+Ejemplo (extracción del BLOB de la columna ``file_data`` usando el tipo MIME de la columna ``content_type``):
 
 ::
 
     sql=SELECT id, title, file_data, content_type FROM documents
     column_label.mimetype=content_type
 
-Diseno de Consultas SQL
+Diseño de Consultas SQL
 ========================
 
 Consultas Eficientes
 ---------------------
 
 Al manejar grandes cantidades de datos, el rendimiento de la consulta es importante.
-La consulta SQL se envia tal cual a la base de datos (no se realiza enlace de parametros):
+La consulta SQL se envía tal cual a la base de datos (no se realiza enlace de parámetros):
 
 ::
 
@@ -270,7 +270,7 @@ La consulta SQL se envia tal cual a la base de datos (no se realiza enlace de pa
 Rastreo Incremental
 --------------------
 
-Metodo para obtener solo registros actualizados:
+Método para obtener solo registros actualizados:
 
 ::
 
@@ -291,7 +291,7 @@ Metodo para obtener solo registros actualizados:
    datos dejan entonces de eliminarse también del índice, así que ejecute periódicamente
    un rastreo completo.
 
-Generacion de URLs
+Generación de URLs
 -------------------
 
 Las URLs de documentos se generan en el script:
@@ -309,15 +309,15 @@ Las URLs de documentos se generan en el script:
 
 .. warning::
    ``url=url`` solo hace lo que parece cuando el resultado de ``SELECT`` tiene una columna
-   etiquetada como ``url``. Si no existe esa columna, el parametro del almacen de datos con el
-   mismo nombre, es decir, la **URL de conexion JDBC**, se convierte en la URL del documento.
-   Asigne un alias a la columna, como en ``SELECT page_url AS url``, o indiquela en el script,
+   etiquetada como ``url``. Si no existe esa columna, el parámetro del almacén de datos con el
+   mismo nombre, es decir, la **URL de conexión JDBC**, se convierte en la URL del documento.
+   Asigne un alias a la columna, como en ``SELECT page_url AS url``, o indíquela en el script,
    como en ``url=page_url``.
 
 Soporte de Caracteres Multibyte
 ================================
 
-Al manejar datos con caracteres multibyte como japones u otros idiomas:
+Al manejar datos con caracteres multibyte como japonés u otros idiomas:
 
 MySQL
 -----
@@ -338,45 +338,45 @@ PostgreSQL normalmente usa UTF-8 de forma predeterminada. Si es necesario:
 Seguridad
 =========
 
-Proteccion de Credenciales de Base de Datos
+Protección de Credenciales de Base de Datos
 --------------------------------------------
 
 .. warning::
-   Escribir contrasenas directamente en archivos de configuracion es un riesgo de seguridad.
+   Escribir contraseñas directamente en archivos de configuración es un riesgo de seguridad.
 
-Metodos recomendados:
+Métodos recomendados:
 
-1. Aprovechar el cifrado automatico
+1. Aprovechar el cifrado automático
 
-   El valor de un parametro cuyo nombre coincide con ``app.encrypt.property.pattern``
+   El valor de un parámetro cuyo nombre coincide con ``app.encrypt.property.pattern``
    (predeterminado ``.*password|.*key|.*token|.*secret``) se cifra al guardarlo desde la
-   consola de administracion y se almacena con el prefijo ``{cipher}``. ``password`` coincide
-   con ese patron, por lo que no se almacena en texto plano cuando se establece desde la
-   consola de administracion.
+   consola de administración y se almacena con el prefijo ``{cipher}``. ``password`` coincide
+   con ese patrón, por lo que no se almacena en texto plano cuando se establece desde la
+   consola de administración.
 
 2. Usar variables de entorno
 
    Una variable de entorno cuyo nombre empieza por ``FESS_ENV_`` se expande dentro de un
-   parametro del almacen de datos como ``${nombre de la variable}``:
+   parámetro del almacén de datos como ``${nombre de la variable}``:
 
    ::
 
        password=${FESS_ENV_DB_PASSWORD}
 
-   Que nombres se expanden lo controla ``crawler.data.env.param.key.pattern``
+   Qué nombres se expanden lo controla ``crawler.data.env.param.key.pattern``
    (predeterminado ``^FESS_ENV_.*``).
 
 3. Usar usuarios de solo lectura
 
 .. note::
    Subir ``org.codelibs.fess.ds`` a DEBUG no expone las credenciales: los valores de los
-   parametros que coinciden con ``app.encrypt.property.pattern``, y las credenciales incrustadas
+   parámetros que coinciden con ``app.encrypt.property.pattern``, y las credenciales incrustadas
    en la URL JDBC, se enmascaran en el registro.
 
-Principio de Minimo Privilegio
+Principio de Mínimo Privilegio
 --------------------------------
 
-Otorgue solo los permisos minimos necesarios al usuario de la base de datos:
+Otorgue solo los permisos mínimos necesarios al usuario de la base de datos:
 
 ::
 
@@ -387,10 +387,10 @@ Otorgue solo los permisos minimos necesarios al usuario de la base de datos:
 Ejemplos de Uso
 ===============
 
-Busqueda de Catalogo de Productos
+Búsqueda de Catálogo de Productos
 -----------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -409,10 +409,10 @@ Script:
     content=description + " Categoria: " + category + " Precio: " + price + " EUR"
     lastModified=updated_at
 
-Articulos de Base de Conocimientos
+Artículos de Base de Conocimientos
 -------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -434,38 +434,38 @@ Script:
     created=created_at
     lastModified=updated_at
 
-Solucion de Problemas
+Solución de Problemas
 ======================
 
-Cuando un rastreo falla, el mensaje del registro identifica que paso ha fallado.
+Cuando un rastreo falla, el mensaje del registro identifica qué paso ha fallado.
 
 Controlador JDBC No Encontrado
 --------------------------------
 
-**Sintoma**: ``The JDBC driver ... is not on the crawler classpath.``
+**Síntoma**: ``The JDBC driver ... is not on the crawler classpath.``
 
-**Solucion**:
+**Solución**:
 
-1. Verifique que el controlador JDBC este colocado en ``app/WEB-INF/lib/`` o ``app/WEB-INF/env/crawler/lib/``
+1. Verifique que el controlador JDBC esté colocado en ``app/WEB-INF/lib/`` o ``app/WEB-INF/env/crawler/lib/``
 2. Verifique que el nombre de clase indicado en ``driver`` sea correcto
 3. Reinicie |Fess|
 
-Error de Conexion
+Error de Conexión
 ------------------
 
-**Sintoma**: ``Failed to connect to <URL>.``
+**Síntoma**: ``Failed to connect to <URL>.``
 
 **Verifique**:
 
-1. La base de datos esta en ejecucion
-2. El nombre del host y numero de puerto son correctos
-3. El nombre de usuario y contrasena son correctos
-4. Configuracion del firewall
+1. La base de datos está en ejecución
+2. El nombre del host y número de puerto son correctos
+3. El nombre de usuario y contraseña son correctos
+4. Configuración del firewall
 
 Error de Consulta
 ------------------
 
-**Sintoma**: ``Failed to execute the query.``
+**Síntoma**: ``Failed to execute the query.``
 
 **Verifique**:
 
@@ -473,12 +473,12 @@ Error de Consulta
 2. Verifique que los nombres de columna sean correctos
 3. Verifique que los nombres de tabla sean correctos
 
-Parametros Faltantes
+Parámetros Faltantes
 ---------------------
 
-**Sintoma**: ``The driver parameter is required.``, ``The url parameter is required.`` o ``The sql parameter is required.``
+**Síntoma**: ``The driver parameter is required.``, ``The url parameter is required.`` o ``The sql parameter is required.``
 
-Falta un parametro obligatorio. Revise el campo de parametros.
+Falta un parámetro obligatorio. Revise el campo de parámetros.
 
 Solo Fallan Algunas Filas
 --------------------------
@@ -487,19 +487,19 @@ Una fila que falla no detiene el rastreo; queda registrada en "Sistema" -> "URL 
 Se usa la URL del documento cuando los scripts la generaron, y
 ``datastore://<id de la configuracion del almacen de datos>/<numero de fila>`` cuando no.
 
-Los Documentos No Aparecen en los Resultados de Busqueda
+Los Documentos No Aparecen en los Resultados de Búsqueda
 ---------------------------------------------------------
 
 1. Verifique que los scripts establezcan ``url``, ``title`` y ``content``
-2. Verifique que el uso de mayusculas y minusculas de las etiquetas de columna coincida con el que usan los scripts (vease "Configuracion de Script")
-3. Revise el numero de documentos en el registro del trabajo de rastreo
+2. Verifique que el uso de mayúsculas y minúsculas de las etiquetas de columna coincida con el que usan los scripts (véase "Configuración de Script")
+3. Revise el número de documentos en el registro del trabajo de rastreo
 
-Informacion de Referencia
+Información de Referencia
 ==========================
 
-- :doc:`ds-overview` - Descripcion General de Conectores de Almacen de Datos
+- :doc:`ds-overview` - Descripción General de Conectores de Almacén de Datos
 - :doc:`ds-csv` - Conector CSV
 - :doc:`ds-json` - Conector JSON
-- :doc:`../../admin/dataconfig-guide` - Guia de Configuracion de Almacen de Datos
+- :doc:`../../admin/dataconfig-guide` - Guía de Configuración de Almacén de Datos
 - :doc:`../crawler-basic`
 - :doc:`../search-basic`

--- a/es/15.9/config/datastore/ds-git.rst
+++ b/es/15.9/config/datastore/ds-git.rst
@@ -2,20 +2,20 @@
 Conector Git
 ==================================
 
-Descripcion general
+Descripción general
 ===================
 
 El conector Git proporciona la funcionalidad para obtener archivos de repositorios Git
-y registrarlos en el indice de |Fess|.
+y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-git``.
 
 Repositorios compatibles
 ========================
 
-- GitHub (publico/privado)
-- GitLab (publico/privado)
-- Bitbucket (publico/privado)
+- GitHub (público/privado)
+- GitLab (público/privado)
+- Bitbucket (público/privado)
 - Repositorios Git locales
 - Otros servicios de alojamiento Git
 
@@ -23,22 +23,22 @@ Requisitos previos
 ==================
 
 1. Es necesario instalar el plugin
-2. Para repositorios privados, se requieren credenciales de autenticacion
+2. Para repositorios privados, se requieren credenciales de autenticación
 3. Se necesita acceso de lectura al repositorio
 
-Instalacion del plugin
+Instalación del plugin
 ----------------------
 
-Instale desde la pantalla de administracion en "Sistema" -> "Plugins".
+Instale desde la pantalla de administración en "Sistema" -> "Plugins".
 
-O consulte :doc:`../../admin/plugin-guide` para mas detalles.
+O consulte :doc:`../../admin/plugin-guide` para más detalles.
 
-Configuracion
+Configuración
 =============
 
-Configure desde la pantalla de administracion en "Crawler" -> "Data Store" -> "Crear nuevo".
+Configure desde la pantalla de administración en "Crawler" -> "Data Store" -> "Crear nuevo".
 
-Configuracion basica
+Configuración básica
 --------------------
 
 .. list-table::
@@ -54,10 +54,10 @@ Configuracion basica
    * - Habilitado
      - Activado
 
-Configuracion de parametros
+Configuración de parámetros
 ---------------------------
 
-Ejemplo de repositorio publico:
+Ejemplo de repositorio público:
 
 ::
 
@@ -66,7 +66,7 @@ Ejemplo de repositorio publico:
     extractors=text/.*:textExtractor,application/xml:textExtractor,application/javascript:textExtractor,
     prev_commit_id=
 
-Ejemplo de repositorio privado (con autenticacion):
+Ejemplo de repositorio privado (con autenticación):
 
 ::
 
@@ -75,37 +75,37 @@ Ejemplo de repositorio privado (con autenticacion):
     extractors=text/.*:textExtractor,application/xml:textExtractor,
     prev_commit_id=
 
-Lista de parametros
+Lista de parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``uri``
      - Si
      - URI del repositorio Git (para clonar)
    * - ``base_url``
      - No
-     - URL base para visualizacion de archivos. Si no se configura, las URL estaran vacias y la eliminacion automatica de archivos borrados estara desactivada
+     - URL base para visualización de archivos. Si no se configura, las URL estarán vacías y la eliminación automática de archivos borrados estará desactivada
    * - ``username``
      - No
-     - Nombre de usuario para autenticacion Git. Se usa con ``password`` como alternativa a incluir credenciales en la URI
+     - Nombre de usuario para autenticación Git. Se usa con ``password`` como alternativa a incluir credenciales en la URI
    * - ``password``
      - No
-     - Contrasena o token para autenticacion Git. Se usa con ``username``
+     - Contraseña o token para autenticación Git. Se usa con ``username``
    * - ``extractors``
      - No
-     - Configuracion de extractores por tipo MIME
+     - Configuración de extractores por tipo MIME
    * - ``default_extractor``
      - No
-     - Extractor de respaldo cuando ningun patron MIME coincide (predeterminado: ``tikaExtractor``)
+     - Extractor de respaldo cuando ningún patrón MIME coincide (predeterminado: ``tikaExtractor``)
    * - ``prev_commit_id``
      - No
-     - ID del commit anterior (para crawl diferencial). Se actualiza automaticamente despues de un crawl exitoso
+     - ID del commit anterior (para crawl diferencial). Se actualiza automáticamente después de un crawl exitoso
    * - ``commit_id``
      - No
      - ID de commit objetivo (predeterminado: HEAD). Se puede especificar rama o etiqueta
@@ -114,16 +114,16 @@ Lista de parametros
      - Git ref specs (predeterminado: ``+refs/heads/*:refs/heads/*``)
    * - ``repository_path``
      - No
-     - Ruta del repositorio local. Si no se configura, se crea un directorio temporal que se elimina despues del crawl
+     - Ruta del repositorio local. Si no se configura, se crea un directorio temporal que se elimina después del crawl
    * - ``include_pattern``
      - No
-     - Filtro de inclusion de rutas de archivo (regex)
+     - Filtro de inclusión de rutas de archivo (regex)
    * - ``exclude_pattern``
      - No
-     - Filtro de exclusion de rutas de archivo (regex)
+     - Filtro de exclusión de rutas de archivo (regex)
    * - ``max_size``
      - No
-     - Tamano maximo de archivo para indexar en bytes (predeterminado: ``10000000``)
+     - Tamaño máximo de archivo para indexar en bytes (predeterminado: ``10000000``)
    * - ``cache_threshold``
      - No
      - Umbral en bytes para cambiar entre buffering en memoria y disco (predeterminado: ``1000000``)
@@ -131,7 +131,7 @@ Lista de parametros
      - No
      - Intervalo de procesamiento entre cada archivo (en milisegundos, predeterminado: ``0``)
 
-Configuracion de scripts
+Configuración de scripts
 ------------------------
 
 ::
@@ -156,7 +156,7 @@ Campos disponibles
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``url``
      - URL del archivo
    * - ``path``
@@ -168,17 +168,17 @@ Campos disponibles
    * - ``contentLength``
      - Longitud del contenido
    * - ``timestamp``
-     - Fecha y hora de ultima modificacion
+     - Fecha y hora de última modificación
    * - ``mimetype``
      - Tipo MIME del archivo
    * - ``author``
-     - Informacion del ultimo autor del commit (PersonIdent)
+     - Información del último autor del commit (PersonIdent)
    * - ``committer``
-     - Informacion del committer (PersonIdent). Puede diferir del autor
+     - Información del committer (PersonIdent). Puede diferir del autor
    * - ``uri``
      - URI del repositorio Git
 
-Autenticacion en repositorios Git
+Autenticación en repositorios Git
 =================================
 
 GitHub Personal Access Token
@@ -222,10 +222,10 @@ En GitLab User Settings -> Access Tokens:
 
     uri=https://username:YOUR_GITLAB_TOKEN@gitlab.com/company/repo.git
 
-Autenticacion con nombre de usuario y contrasena
+Autenticación con nombre de usuario y contraseña
 -------------------------------------------------
 
-En lugar de incluir credenciales en la URI, tambien puede especificar credenciales usando los parametros ``username`` y ``password``:
+En lugar de incluir credenciales en la URI, también puede especificar credenciales usando los parámetros ``username`` y ``password``:
 
 ::
 
@@ -233,18 +233,18 @@ En lugar de incluir credenciales en la URI, tambien puede especificar credencial
     username=your_username
     password=YOUR_PERSONAL_ACCESS_TOKEN
 
-Las credenciales se usan solo cuando tanto ``username`` como ``password`` estan especificados.
+Las credenciales se usan solo cuando tanto ``username`` como ``password`` están especificados.
 
 .. note::
-   El conector Git admite unicamente autenticacion HTTP/HTTPS (nombre de usuario y contrasena, o un token de acceso). La autenticacion con clave SSH (URI con formato ``git@...``) no esta soportada. Utilice una URI con formato HTTPS.
+   El conector Git admite únicamente autenticación HTTP/HTTPS (nombre de usuario y contraseña, o un token de acceso). La autenticación con clave SSH (URI con formato ``git@...``) no está soportada. Utilice una URI con formato HTTPS.
 
-Configuracion de extractores
+Configuración de extractores
 ============================
 
 Extractores por tipo MIME
 -------------------------
 
-Especifique extractores por tipo de archivo con el parametro ``extractors``:
+Especifique extractores por tipo de archivo con el parámetro ``extractors``:
 
 ::
 
@@ -272,7 +272,7 @@ Todos los archivos
 
     extractors=.*:tikaExtractor,
 
-Solo tipos de archivo especificos
+Solo tipos de archivo específicos
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
@@ -283,10 +283,10 @@ Solo tipos de archivo especificos
 Crawl diferencial
 =================
 
-Crawl solo de cambios desde el ultimo commit
+Crawl solo de cambios desde el último commit
 --------------------------------------------
 
-Despues del primer crawl, configure ``prev_commit_id`` con el ID del commit anterior:
+Después del primer crawl, configure ``prev_commit_id`` con el ID del commit anterior:
 
 ::
 
@@ -295,26 +295,26 @@ Despues del primer crawl, configure ``prev_commit_id`` con el ID del commit ante
     prev_commit_id=a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0
 
 .. note::
-   ``prev_commit_id`` se actualiza automaticamente al ultimo ID de commit despues de un crawl exitoso.
-   Dejelo vacio para el crawl inicial para procesar todos los archivos; los crawls posteriores solo procesaran los cambios.
+   ``prev_commit_id`` se actualiza automáticamente al último ID de commit después de un crawl exitoso.
+   Déjelo vacío para el crawl inicial para procesar todos los archivos; los crawls posteriores solo procesarán los cambios.
 
 Procesamiento de archivos eliminados
 ------------------------------------
 
 Cuando ``base_url`` está configurado, los archivos detectados como eliminados a través de Git DiffEntry (``ChangeType.DELETE``) se eliminan automáticamente del índice.
 
-Cuando un archivo es renombrado (``ChangeType.RENAME``), el documento en la ruta antigua se elimina del indice y el archivo en la nueva ruta se reindexiza.
+Cuando un archivo es renombrado (``ChangeType.RENAME``), el documento en la ruta antigua se elimina del índice y el archivo en la nueva ruta se reindexiza.
 
 .. note::
-   La eliminacion automatica de archivos eliminados solo es efectiva cuando ``base_url`` esta configurado. Si ``base_url`` no esta configurado, la URL del documento estara vacia y la eliminacion no se realizara.
+   La eliminación automática de archivos eliminados solo es efectiva cuando ``base_url`` está configurado. Si ``base_url`` no está configurado, la URL del documento estará vacía y la eliminación no se realizará.
 
 Ejemplos de uso
 ===============
 
-Repositorio publico de GitHub
+Repositorio público de GitHub
 -----------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -337,7 +337,7 @@ Script:
 Repositorio privado de GitHub
 -----------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -360,7 +360,7 @@ Script:
 GitLab (self-hosted)
 --------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -383,7 +383,7 @@ Script:
 Solo documentos (archivos Markdown)
 -----------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -402,7 +402,7 @@ Script:
         last_modified=timestamp
     }
 
-Solo directorios especificos
+Solo directorios específicos
 ----------------------------
 
 Filtrado con script:
@@ -417,13 +417,13 @@ Filtrado con script:
         mimetype=mimetype
     }
 
-Solucion de problemas
+Solución de problemas
 =====================
 
-Error de autenticacion
+Error de autenticación
 ----------------------
 
-**Sintoma**: ``Authentication failed`` o ``Not authorized``
+**Síntoma**: ``Authentication failed`` o ``Not authorized``
 
 **Verificaciones**:
 
@@ -439,12 +439,12 @@ Error de autenticacion
        # Incorrecto
        uri=https://github.com/company/repo.git?token=...
 
-4. Verificar la fecha de expiracion del token
+4. Verificar la fecha de expiración del token
 
 Repositorio no encontrado
 -------------------------
 
-**Sintoma**: ``Repository not found``
+**Síntoma**: ``Repository not found``
 
 **Verificaciones**:
 
@@ -456,23 +456,23 @@ Repositorio no encontrado
 No se pueden obtener archivos
 -----------------------------
 
-**Sintoma**: El crawl tiene exito pero hay 0 archivos
+**Síntoma**: El crawl tiene éxito pero hay 0 archivos
 
 **Verificaciones**:
 
-1. Verificar que la configuracion de ``extractors`` sea apropiada
+1. Verificar que la configuración de ``extractors`` sea apropiada
 2. Confirmar que existen archivos en el repositorio
-3. Verificar que la configuracion del script sea correcta
+3. Verificar que la configuración del script sea correcta
 4. Confirmar que existen archivos en la rama objetivo
 
 Error de tipo MIME
 ------------------
 
-**Sintoma**: Ciertos archivos no se procesan
+**Síntoma**: Ciertos archivos no se procesan
 
-**Solucion**:
+**Solución**:
 
-Ajustar la configuracion de extractores:
+Ajustar la configuración de extractores:
 
 ::
 
@@ -485,16 +485,16 @@ Ajustar la configuracion de extractores:
 Repositorio grande
 ------------------
 
-**Sintoma**: El crawl toma mucho tiempo o hay memoria insuficiente
+**Síntoma**: El crawl toma mucho tiempo o hay memoria insuficiente
 
-**Solucion**:
+**Solución**:
 
 1. Limitar archivos objetivo con ``extractors``
-2. Filtrar solo directorios especificos con script
+2. Filtrar solo directorios específicos con script
 3. Usar crawl diferencial (configurar ``prev_commit_id``)
 4. Ajustar el intervalo de crawl
 
-Especificacion de rama
+Especificación de rama
 ----------------------
 
 Para rastrear una rama diferente a la predeterminada, especifique el nombre de la rama o etiqueta usando el parámetro ``commit_id``:
@@ -505,10 +505,10 @@ Para rastrear una rama diferente a la predeterminada, especifique el nombre de l
     base_url=https://github.com/company/repo/blob/develop/
     commit_id=develop
 
-Generacion de URL
+Generación de URL
 =================
 
-Patrones de configuracion de base_url
+Patrones de configuración de base_url
 -------------------------------------
 
 **GitHub**:
@@ -529,9 +529,9 @@ Patrones de configuracion de base_url
 
     base_url=https://bitbucket.org/user/repo/src/master/
 
-La URL se genera concatenando directamente ``base_url`` con la ruta del archivo (sin insertar ningun separador). Por lo tanto, ``base_url`` debe terminar con una barra diagonal ``/``.
+La URL se genera concatenando directamente ``base_url`` con la ruta del archivo (sin insertar ningún separador). Por lo tanto, ``base_url`` debe terminar con una barra diagonal ``/``.
 
-Generacion de URL en script
+Generación de URL en script
 ---------------------------
 
 ::
@@ -548,11 +548,11 @@ O con URL personalizada:
     title=name
     content=content
 
-Informacion de referencia
+Información de referencia
 =========================
 
-- :doc:`ds-overview` - Descripcion general de conectores de Data Store
+- :doc:`ds-overview` - Descripción general de conectores de Data Store
 - :doc:`ds-database` - Conector de base de datos
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de Data Store
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de Data Store
 - `GitHub Personal Access Tokens <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
 - `GitLab Personal Access Tokens <https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html>`_

--- a/es/15.9/config/datastore/ds-slack.rst
+++ b/es/15.9/config/datastore/ds-slack.rst
@@ -2,45 +2,45 @@
 Conector de Slack
 ==================================
 
-Vision General
+Visión General
 ==============
 
 El conector de Slack proporciona funcionalidad para obtener mensajes de canales del espacio de trabajo de Slack
-y registrarlos en el indice de |Fess|.
+y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-slack``.
 
 Contenido Soportado
 ===================
 
-- Mensajes de canales publicos
+- Mensajes de canales públicos
 - Mensajes de canales privados
 - Archivos adjuntos (opcional)
 
 Requisitos Previos
 ==================
 
-1. Se requiere la instalacion del plugin
-2. Se requiere la creacion de una Slack App y configuracion de permisos
-3. Se requiere la obtencion del OAuth Access Token
+1. Se requiere la instalación del plugin
+2. Se requiere la creación de una Slack App y configuración de permisos
+3. Se requiere la obtención del OAuth Access Token
 
-Instalacion del Plugin
+Instalación del Plugin
 ----------------------
 
-Instale desde "Sistema" -> "Plugins" en la pantalla de administracion:
+Instale desde "Sistema" -> "Plugins" en la pantalla de administración:
 
 1. Descargue ``fess-ds-slack-X.X.X.jar`` desde Maven Central
-2. Cargue e instale desde la pantalla de gestion de plugins
+2. Cargue e instale desde la pantalla de gestión de plugins
 3. Reinicie |Fess|
 
-O consulte :doc:`../../admin/plugin-guide` para mas detalles.
+O consulte :doc:`../../admin/plugin-guide` para más detalles.
 
-Metodo de Configuracion
+Método de Configuración
 =======================
 
-Configure desde la pantalla de administracion en "Rastreador" -> "Almacen de datos" -> "Nuevo".
+Configure desde la pantalla de administración en "Rastreador" -> "Almacén de datos" -> "Nuevo".
 
-Configuracion Basica
+Configuración Básica
 --------------------
 
 .. list-table::
@@ -56,7 +56,7 @@ Configuracion Basica
    * - Habilitado
      - Activado
 
-Configuracion de Parametros
+Configuración de Parámetros
 ---------------------------
 
 ::
@@ -66,16 +66,16 @@ Configuracion de Parametros
     file_crawl=false
     include_private=false
 
-Lista de Parametros
+Lista de Parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
 
-   * - Parametro
+   * - Parámetro
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``token``
      - Si
      - OAuth Access Token de la Slack App
@@ -84,7 +84,7 @@ Lista de Parametros
      - Canales a rastrear (separados por comas, o ``*all``). Si no se especifica, se obtienen todos los canales (mismo comportamiento que ``*all``)
    * - ``file_crawl``
      - No
-     - Rastrear archivos tambien (predeterminado: ``false``)
+     - Rastrear archivos también (predeterminado: ``false``)
    * - ``include_private``
      - No
      - Incluir canales privados (predeterminado: ``false``)
@@ -137,7 +137,7 @@ Lista de Parametros
      - No
      - Número máximo de entradas en el caché de información de canales (predeterminado: ``10000``)
 
-Configuracion de Script
+Configuración de Script
 -----------------------
 
 ::
@@ -157,7 +157,7 @@ Campos Disponibles
    :widths: 30 70
 
    * - Campo
-     - Descripcion
+     - Descripción
    * - ``message.title``
      - Título (cadena vacía para mensajes, nombre y título del archivo para entradas de archivo)
    * - ``message.text``
@@ -165,15 +165,15 @@ Campos Disponibles
    * - ``message.user``
      - Nombre para mostrar del remitente del mensaje (si no está configurado, se resuelve en el orden de nombre real, nombre de usuario y luego ID de usuario)
    * - ``message.channel``
-     - Nombre del canal donde se envio el mensaje
+     - Nombre del canal donde se envió el mensaje
    * - ``message.timestamp``
-     - Fecha/hora de envio del mensaje
+     - Fecha/hora de envío del mensaje
    * - ``message.permalink``
      - Enlace permanente del mensaje
    * - ``message.attachments``
-     - Informacion de respaldo de archivos adjuntos
+     - Información de respaldo de archivos adjuntos
 
-Configuracion de Slack App
+Configuración de Slack App
 ==========================
 
 1. Crear Slack App
@@ -183,21 +183,21 @@ Acceda a https://api.slack.com/apps:
 
 1. Haga clic en "Create New App"
 2. Seleccione "From scratch"
-3. Ingrese el nombre de la aplicacion (ej: Fess Crawler)
+3. Ingrese el nombre de la aplicación (ej: Fess Crawler)
 4. Seleccione el espacio de trabajo
 5. Haga clic en "Create App"
 
 2. Configurar OAuth & Permissions
 ---------------------------------
 
-En el menu "OAuth & Permissions":
+En el menú "OAuth & Permissions":
 
 **Agregue a Bot Token Scopes**:
 
-Para solo canales publicos:
+Para solo canales públicos:
 
-- ``channels:history`` - Lectura de mensajes de canales publicos
-- ``channels:read`` - Lectura de informacion de canales publicos
+- ``channels:history`` - Lectura de mensajes de canales públicos
+- ``channels:read`` - Lectura de información de canales públicos
 - ``users:read`` - Lectura de información de usuario (requerido para resolución de nombre para mostrar)
 
 Para incluir canales privados (``include_private=true``):
@@ -205,17 +205,17 @@ Para incluir canales privados (``include_private=true``):
 - ``channels:history``
 - ``channels:read``
 - ``groups:history`` - Lectura de mensajes de canales privados
-- ``groups:read`` - Lectura de informacion de canales privados
+- ``groups:read`` - Lectura de información de canales privados
 - ``users:read``
 
-Para rastrear archivos tambien (``file_crawl=true``):
+Para rastrear archivos también (``file_crawl=true``):
 
 - ``files:read`` - Lectura de contenido de archivos
 
-3. Instalar la Aplicacion
+3. Instalar la Aplicación
 -------------------------
 
-En el menu "Install App":
+En el menú "Install App":
 
 1. Haga clic en "Install to Workspace"
 2. Verifique los permisos y haga clic en "Permitir"
@@ -223,7 +223,7 @@ En el menu "Install App":
 
 .. note::
    Normalmente se usa el Bot User OAuth Token que comienza con ``xoxb-``,
-   pero tambien se puede usar el User OAuth Token que comienza con ``xoxp-`` en los parametros.
+   pero también se puede usar el User OAuth Token que comienza con ``xoxp-`` en los parámetros.
 
 4. Agregar a Canales
 --------------------
@@ -232,17 +232,17 @@ Agregue la App a los canales que desea rastrear:
 
 1. Abra el canal en Slack
 2. Haga clic en el nombre del canal
-3. Seleccione la pestana "Integraciones"
-4. Haga clic en "Agregar una aplicacion"
-5. Agregue la aplicacion creada
+3. Seleccione la pestaña "Integraciones"
+4. Haga clic en "Agregar una aplicación"
+5. Agregue la aplicación creada
 
 Ejemplos de Uso
 ===============
 
-Rastrear Canales Especificos
+Rastrear Canales Específicos
 ----------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -265,7 +265,7 @@ Script:
 Rastrear Todos los Canales
 --------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -286,7 +286,7 @@ Script:
 Rastrear Incluyendo Canales Privados
 ------------------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -308,7 +308,7 @@ Script:
 Rastrear Incluyendo Archivos
 -----------------------------
 
-Parametros:
+Parámetros:
 
 ::
 
@@ -326,7 +326,7 @@ Script:
     created=message.timestamp
     url=message.permalink
 
-Incluir Informacion Detallada de Mensajes
+Incluir Información Detallada de Mensajes
 -------------------------------------------
 
 Script:
@@ -340,13 +340,13 @@ Script:
     timestamp=message.timestamp
     url=message.permalink
 
-Solucion de Problemas
+Solución de Problemas
 =====================
 
-Error de Autenticacion
+Error de Autenticación
 ----------------------
 
-**Sintoma**: ``invalid_auth`` o ``not_authed``
+**Síntoma**: ``invalid_auth`` o ``not_authed``
 
 **Verificar**:
 
@@ -356,48 +356,48 @@ Error de Autenticacion
    - Bot User OAuth Token: comienza con ``xoxb-``
    - User OAuth Token: comienza con ``xoxp-``
 
-3. Verificar que la aplicacion este instalada en el espacio de trabajo
+3. Verificar que la aplicación esté instalada en el espacio de trabajo
 4. Verificar que se hayan otorgado los permisos necesarios
 
 Canal No Encontrado
 -------------------
 
-**Sintoma**: ``channel_not_found``
+**Síntoma**: ``channel_not_found``
 
 **Verificar**:
 
 1. Verificar que el nombre del canal sea correcto (sin #)
-2. Verificar que la aplicacion este agregada al canal
+2. Verificar que la aplicación esté agregada al canal
 3. Para canales privados, establecer ``include_private=true``
-4. Verificar que el canal exista y no este archivado
+4. Verificar que el canal exista y no esté archivado
 
 No se Pueden Obtener Mensajes
 -----------------------------
 
-**Sintoma**: El rastreo tiene exito pero hay 0 mensajes
+**Síntoma**: El rastreo tiene éxito pero hay 0 mensajes
 
 **Verificar**:
 
-1. Verificar que se hayan otorgado los ambitos necesarios:
+1. Verificar que se hayan otorgado los ámbitos necesarios:
 
    - ``channels:history``
    - ``channels:read``
    - Para canales privados: ``groups:history``, ``groups:read``
 
 2. Verificar que existan mensajes en el canal
-3. Verificar que la aplicacion este agregada al canal
-4. Verificar que la Slack App este habilitada
+3. Verificar que la aplicación esté agregada al canal
+4. Verificar que la Slack App esté habilitada
 
 Error de Permisos Insuficientes
 --------------------------------
 
-**Sintoma**: ``missing_scope``
+**Síntoma**: ``missing_scope``
 
-**Solucion**:
+**Solución**:
 
-1. Agregar los ambitos necesarios en la configuracion de la Slack App:
+1. Agregar los ámbitos necesarios en la configuración de la Slack App:
 
-   **Canales Publicos**:
+   **Canales Públicos**:
 
    - ``channels:history``
    - ``channels:read``
@@ -411,46 +411,46 @@ Error de Permisos Insuficientes
 
    - ``files:read``
 
-2. Reinstalar la aplicacion
+2. Reinstalar la aplicación
 3. Reiniciar |Fess|
 
 No se Pueden Rastrear Archivos
 -------------------------------
 
-**Sintoma**: No se obtienen archivos aunque ``file_crawl=true``
+**Síntoma**: No se obtienen archivos aunque ``file_crawl=true``
 
 **Verificar**:
 
-1. Verificar que se haya otorgado el ambito ``files:read``
+1. Verificar que se haya otorgado el ámbito ``files:read``
 2. Verificar que realmente se hayan publicado archivos en el canal
 3. Verificar los permisos de acceso a los archivos
 
-Limite de Tasa de API
+Límite de Tasa de API
 ---------------------
 
-**Sintoma**: ``rate_limited``
+**Síntoma**: ``rate_limited``
 
-**Solucion**:
+**Solución**:
 
 1. Aumentar el intervalo de rastreo
-2. Reducir el numero de canales
-3. Dividir en multiples almacenes de datos y distribuir la programacion
+2. Reducir el número de canales
+3. Dividir en múltiples almacenes de datos y distribuir la programación
 
-Limites de la API de Slack:
+Límites de la API de Slack:
 
-- Metodos de nivel 3: 50+ solicitudes/minuto
-- Metodos de nivel 4: 100+ solicitudes/minuto
+- Métodos de nivel 3: 50+ solicitudes/minuto
+- Métodos de nivel 4: 100+ solicitudes/minuto
 
 Gran Volumen de Mensajes
 -------------------------
 
-**Sintoma**: El rastreo tarda mucho tiempo o se agota el tiempo de espera
+**Síntoma**: El rastreo tarda mucho tiempo o se agota el tiempo de espera
 
-**Solucion**:
+**Solución**:
 
-1. Dividir los canales y configurar multiples almacenes de datos
-2. Distribuir la programacion de rastreo
-3. Considerar una configuracion para excluir mensajes antiguos
+1. Dividir los canales y configurar múltiples almacenes de datos
+2. Distribuir la programación de rastreo
+3. Considerar una configuración para excluir mensajes antiguos
 
 Ejemplos Avanzados de Script
 ==============================
@@ -477,11 +477,11 @@ Formato del nombre del canal:
     created=message.timestamp
     url=message.permalink
 
-Informacion de Referencia
+Información de Referencia
 =========================
 
-- :doc:`ds-overview` - Vision general de conectores de almacen de datos
+- :doc:`ds-overview` - Visión general de conectores de almacén de datos
 - :doc:`ds-atlassian` - Conector de Atlassian
-- :doc:`../../admin/dataconfig-guide` - Guia de configuracion de almacen de datos
+- :doc:`../../admin/dataconfig-guide` - Guía de configuración de almacén de datos
 - `Slack API Documentation <https://api.slack.com/>`_
 - `Slack Bot Token Scopes <https://api.slack.com/scopes>`_

--- a/es/15.9/config/llm-gemini.rst
+++ b/es/15.9/config/llm-gemini.rst
@@ -2,37 +2,37 @@
 Configuración de Google Gemini (Búsqueda IA / RAG)
 ===================================================
 
-Descripcion general
+Descripción general
 ===================
 
 Esta página explica cómo configurar el plugin ``fess-llm-gemini`` para que |Fess| pueda usar Google Gemini en su **modo de búsqueda IA (RAG: Retrieval-Augmented Generation)** — respondiendo preguntas en lenguaje natural a partir de su índice de búsqueda empresarial con fuentes citadas. |Fess| llama a la API de Google AI (Generative Language API) para ejecutar RAG sobre sus documentos rastreados con modelos Gemini.
 
-Google Gemini es un modelo de lenguaje grande (LLM) de ultima generacion proporcionado por Google.
+Google Gemini es un modelo de lenguaje grande (LLM) de última generación proporcionado por Google.
 |Fess| puede implementar la funcionalidad de modo de búsqueda IA con el modelo Gemini utilizando Google AI API (Generative Language API).
 
-Al usar Gemini, es posible generar respuestas de alta calidad aprovechando la ultima tecnologia de IA de Google.
+Al usar Gemini, es posible generar respuestas de alta calidad aprovechando la última tecnología de IA de Google.
 
-Caracteristicas principales
+Características principales
 ---------------------------
 
-- **Soporte multimodal**: Capaz de procesar no solo texto sino tambien imagenes
+- **Soporte multimodal**: Capaz de procesar no solo texto sino también imágenes
 - **Contexto largo**: Ventana de contexto larga que puede procesar grandes cantidades de documentos a la vez
-- **Eficiencia de costos**: El modelo Flash es rapido y de bajo costo
-- **Integracion con Google**: Facil integracion con servicios de Google Cloud
+- **Eficiencia de costos**: El modelo Flash es rápido y de bajo costo
+- **Integración con Google**: Fácil integración con servicios de Google Cloud
 
 Modelos compatibles
 -------------------
 
 Principales modelos disponibles en Gemini:
 
-- ``gemini-3.1-flash-lite-preview`` - Modelo rapido ligero y de bajo costo (predeterminado)
-- ``gemini-3-flash-preview`` - Modelo Flash estandar
+- ``gemini-3.1-flash-lite-preview`` - Modelo rápido ligero y de bajo costo (predeterminado)
+- ``gemini-3-flash-preview`` - Modelo Flash estándar
 - ``gemini-3.1-pro`` / ``gemini-3-pro`` - Modelos de alto razonamiento
-- ``gemini-2.5-flash`` - Modelo rapido version estable
-- ``gemini-2.5-pro`` - Modelo de alto razonamiento version estable
+- ``gemini-2.5-flash`` - Modelo rápido versión estable
+- ``gemini-2.5-pro`` - Modelo de alto razonamiento versión estable
 
 .. note::
-   Para la informacion mas reciente sobre modelos disponibles, consulte `Google AI for Developers <https://ai.google.dev/models/gemini>`__.
+   Para la información más reciente sobre modelos disponibles, consulte `Google AI for Developers <https://ai.google.dev/models/gemini>`__.
 
 Requisitos previos
 ==================
@@ -43,7 +43,7 @@ Antes de usar Gemini, prepare lo siguiente.
 2. **Acceso a Google AI Studio**: Acceda a `https://aistudio.google.com/ <https://aistudio.google.com/>`__
 3. **Clave API**: Genere una clave API en Google AI Studio
 
-Obtencion de clave API
+Obtención de clave API
 ----------------------
 
 1. Acceda a `Google AI Studio <https://aistudio.google.com/>`__
@@ -53,20 +53,20 @@ Obtencion de clave API
 5. Guarde la clave API generada de forma segura
 
 .. warning::
-   La clave API es informacion confidencial. Tenga en cuenta lo siguiente:
+   La clave API es información confidencial. Tenga en cuenta lo siguiente:
 
    - No la commita en sistemas de control de versiones
    - No la imprima en logs
-   - Administrela con variables de entorno o archivos de configuracion seguros
+   - Adminístrela con variables de entorno o archivos de configuración seguros
 
-Instalacion del plugin
+Instalación del plugin
 ======================
 
-La funcionalidad de integracion con Gemini se proporciona como plugin ``fess-llm-gemini``.
+La funcionalidad de integración con Gemini se proporciona como plugin ``fess-llm-gemini``.
 Para usar Gemini es necesario instalar el plugin.
 
 1. Descargue `fess-llm-gemini-15.9.0.jar`
-2. Coloquelo en el directorio ``app/WEB-INF/plugin/`` de |Fess|
+2. Colóquelo en el directorio ``app/WEB-INF/plugin/`` de |Fess|
 3. Reinicie |Fess|
 
 ::
@@ -75,32 +75,32 @@ Para usar Gemini es necesario instalar el plugin.
     cp fess-llm-gemini-15.9.0.jar /path/to/fess/app/WEB-INF/plugin/
 
 .. note::
-   La version del plugin debe coincidir con la version de |Fess|.
+   La versión del plugin debe coincidir con la versión de |Fess|.
 
-Configuracion basica
+Configuración básica
 ====================
 
-La habilitacion de la funcionalidad de modo de búsqueda IA y la configuracion especifica de Gemini se realizan en ``fess_config.properties``, y la seleccion del proveedor LLM (``rag.llm.name``) se realiza en la pantalla de administracion o en ``system.properties``.
+La habilitación de la funcionalidad de modo de búsqueda IA y la configuración específica de Gemini se realizan en ``fess_config.properties``, y la selección del proveedor LLM (``rag.llm.name``) se realiza en la pantalla de administración o en ``system.properties``.
 
-Configuracion de fess_config.properties
+Configuración de fess_config.properties
 ----------------------------------------
 
-Agregue la configuracion de habilitacion de la funcionalidad de modo de búsqueda IA en ``app/WEB-INF/conf/fess_config.properties``.
+Agregue la configuración de habilitación de la funcionalidad de modo de búsqueda IA en ``app/WEB-INF/conf/fess_config.properties``.
 
 ::
 
     # Habilitar la funcionalidad de modo de búsqueda IA
     rag.chat.enabled=true
 
-Configuracion del proveedor LLM
+Configuración del proveedor LLM
 --------------------------------
 
-La seleccion del proveedor LLM (``rag.llm.name``) se configura en la pantalla de administracion (Administracion > Sistema > General) o en ``system.properties``. La configuracion especifica de Gemini se realiza en ``fess_config.properties``.
+La selección del proveedor LLM (``rag.llm.name``) se configura en la pantalla de administración (Administración > Sistema > General) o en ``system.properties``. La configuración específica de Gemini se realiza en ``fess_config.properties``.
 
-Configuracion minima
+Configuración mínima
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``system.properties`` (tambien configurable en Administracion > Sistema > General):
+``system.properties`` (también configurable en Administración > Sistema > General):
 
 ::
 
@@ -120,10 +120,10 @@ Configuracion minima
     # Modelo a usar
     rag.llm.gemini.model=gemini-3.1-flash-lite-preview
 
-Configuracion recomendada (entorno de produccion)
+Configuración recomendada (entorno de producción)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``system.properties`` (tambien configurable en Administracion > Sistema > General):
+``system.properties`` (también configurable en Administración > Sistema > General):
 
 ::
 
@@ -149,17 +149,17 @@ Configuracion recomendada (entorno de produccion)
     # Configuracion de timeout
     rag.llm.gemini.timeout=60000
 
-Elementos de configuracion
+Elementos de configuración
 ==========================
 
-Todos los elementos de configuracion disponibles para el cliente de Gemini. Todos se configuran en ``fess_config.properties``.
+Todos los elementos de configuración disponibles para el cliente de Gemini. Todos se configuran en ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
    * - ``rag.llm.gemini.api.key``
      - Clave API de Google AI (debe configurarse para usar la API de Gemini)
@@ -174,68 +174,68 @@ Todos los elementos de configuracion disponibles para el cliente de Gemini. Todo
      - Timeout de solicitud (milisegundos)
      - ``60000``
    * - ``rag.llm.gemini.availability.check.interval``
-     - Intervalo de verificacion de disponibilidad (segundos)
+     - Intervalo de verificación de disponibilidad (segundos)
      - ``60``
    * - ``rag.llm.gemini.max.concurrent.requests``
-     - Numero maximo de solicitudes simultaneas
+     - Número máximo de solicitudes simultáneas
      - ``5``
    * - ``rag.llm.gemini.chat.evaluation.max.relevant.docs``
-     - Numero maximo de documentos relevantes en la evaluacion
+     - Número máximo de documentos relevantes en la evaluación
      - ``3``
    * - ``rag.llm.gemini.chat.evaluation.description.max.chars``
-     - Numero maximo de caracteres para la descripcion del documento en la evaluacion
+     - Número máximo de caracteres para la descripción del documento en la evaluación
      - ``500``
    * - ``rag.llm.gemini.concurrency.wait.timeout``
-     - Tiempo de espera de solicitudes simultaneas (milisegundos)
+     - Tiempo de espera de solicitudes simultáneas (milisegundos)
      - ``30000``
    * - ``rag.llm.gemini.history.max.chars``
-     - Numero maximo de caracteres del historial de chat
+     - Número máximo de caracteres del historial de chat
      - ``10000``
    * - ``rag.llm.gemini.intent.history.max.messages``
-     - Numero maximo de mensajes del historial para la determinacion de intencion
+     - Número máximo de mensajes del historial para la determinación de intención
      - ``10``
    * - ``rag.llm.gemini.intent.history.max.chars``
-     - Numero maximo de caracteres del historial para la determinacion de intencion
+     - Número máximo de caracteres del historial para la determinación de intención
      - ``5000``
    * - ``rag.llm.gemini.history.assistant.max.chars``
-     - Numero maximo de caracteres del historial del asistente
+     - Número máximo de caracteres del historial del asistente
      - ``1000``
    * - ``rag.llm.gemini.history.assistant.summary.max.chars``
-     - Numero maximo de caracteres del resumen del historial del asistente
+     - Número máximo de caracteres del resumen del historial del asistente
      - ``1000``
    * - ``rag.llm.gemini.retry.max``
-     - Numero maximo de reintentos HTTP (en errores ``429`` y de la familia ``5xx``)
+     - Número máximo de reintentos HTTP (en errores ``429`` y de la familia ``5xx``)
      - ``10``
    * - ``rag.llm.gemini.retry.base.delay.ms``
      - Retardo base del backoff exponencial (milisegundos)
      - ``2000``
 
-Metodo de autenticacion
+Método de autenticación
 =======================
 
-La clave API se envia mediante el encabezado HTTP ``x-goog-api-key`` (metodo recomendado por Google).
-Ya no se anade a la URL como parametro de consulta ``?key=...`` como anteriormente, por lo que la clave API no queda registrada en los logs de acceso.
+La clave API se envía mediante el encabezado HTTP ``x-goog-api-key`` (método recomendado por Google).
+Ya no se añade a la URL como parámetro de consulta ``?key=...`` como anteriormente, por lo que la clave API no queda registrada en los logs de acceso.
 
 Comportamiento de reintentos
 ============================
 
-Las solicitudes a la API de Gemini se reintentan automaticamente para los siguientes codigos de estado HTTP:
+Las solicitudes a la API de Gemini se reintentan automáticamente para los siguientes códigos de estado HTTP:
 
-- ``429`` Resource Exhausted (cuota superada / limite de tasa)
+- ``429`` Resource Exhausted (cuota superada / límite de tasa)
 - ``500`` Internal Server Error
 - ``503`` Service Unavailable
 - ``504`` Gateway Timeout
 
 Durante los reintentos se aplica un backoff exponencial (valor base ``rag.llm.gemini.retry.base.delay.ms`` milisegundos, hasta ``rag.llm.gemini.retry.max`` intentos, con jitter de +/-20%).
-En las solicitudes de streaming, solo la conexion inicial es objeto de reintentos; los errores que ocurren despues de comenzar a recibir el cuerpo de la respuesta se propagan inmediatamente.
+En las solicitudes de streaming, solo la conexión inicial es objeto de reintentos; los errores que ocurren después de comenzar a recibir el cuerpo de la respuesta se propagan inmediatamente.
 
-Configuracion por tipo de prompt
+Configuración por tipo de prompt
 =================================
 
-En |Fess|, se pueden configurar los parametros del LLM en detalle por tipo de prompt.
-La configuracion por tipo de prompt se escribe en ``fess_config.properties``.
+En |Fess|, se pueden configurar los parámetros del LLM en detalle por tipo de prompt.
+La configuración por tipo de prompt se escribe en ``fess_config.properties``.
 
-Formato de configuracion
+Formato de configuración
 ------------------------
 
 ::
@@ -253,32 +253,32 @@ Tipos de prompt disponibles
    :widths: 20 80
 
    * - Tipo de prompt
-     - Descripcion
+     - Descripción
    * - ``intent``
-     - Prompt para determinar la intencion del usuario
+     - Prompt para determinar la intención del usuario
    * - ``evaluation``
      - Prompt para evaluar la relevancia de los documentos
    * - ``unclear``
-     - Prompt para cuando la pregunta no esta clara
+     - Prompt para cuando la pregunta no está clara
    * - ``noresults``
-     - Prompt para cuando no hay resultados de busqueda
+     - Prompt para cuando no hay resultados de búsqueda
    * - ``docnotfound``
      - Prompt para cuando no se encuentra el documento
    * - ``answer``
-     - Prompt de generacion de respuesta
+     - Prompt de generación de respuesta
    * - ``summary``
-     - Prompt de generacion de resumen
+     - Prompt de generación de resumen
    * - ``faq``
-     - Prompt de generacion de FAQ
+     - Prompt de generación de FAQ
    * - ``direct``
      - Prompt de respuesta directa
    * - ``queryregeneration``
-     - Prompt de regeneracion de consulta
+     - Prompt de regeneración de consulta
 
 Valores predeterminados por tipo de prompt
 -------------------------------------------
 
-Valores predeterminados para cada tipo de prompt. Estos valores se utilizan cuando no se configuran explicitamente.
+Valores predeterminados para cada tipo de prompt. Estos valores se utilizan cuando no se configuran explícitamente.
 
 .. list-table::
    :header-rows: 1
@@ -329,7 +329,7 @@ Valores predeterminados para cada tipo de prompt. Estos valores se utilizan cuan
      - ``256``
      - ``0``
 
-Ejemplo de configuracion
+Ejemplo de configuración
 ------------------------
 
 ::
@@ -350,16 +350,16 @@ Ejemplo de configuracion
     rag.llm.gemini.faq.context.max.chars=10000
 
 .. note::
-   El valor predeterminado de ``context.max.chars`` varia segun el tipo de prompt.
+   El valor predeterminado de ``context.max.chars`` varía según el tipo de prompt.
    ``answer`` y ``summary`` son 16000, ``faq`` es 10000, y otros tipos de prompt son 10000.
 
 Soporte de modelo de pensamiento
 ==================================
 
 Gemini soporta modelos de pensamiento (Thinking Model).
-Al usar un modelo de pensamiento, el modelo ejecuta un proceso de razonamiento interno antes de generar una respuesta, lo que permite generar respuestas con mayor precision.
+Al usar un modelo de pensamiento, el modelo ejecuta un proceso de razonamiento interno antes de generar una respuesta, lo que permite generar respuestas con mayor precisión.
 
-El presupuesto de pensamiento se configura por tipo de prompt en ``fess_config.properties``. |Fess| convierte automaticamente el valor entero (numero de tokens) de ``rag.llm.gemini.{promptType}.thinking.budget`` al campo de API apropiado en funcion de la generacion del modelo resuelta en el momento de la solicitud.
+El presupuesto de pensamiento se configura por tipo de prompt en ``fess_config.properties``. |Fess| convierte automáticamente el valor entero (número de tokens) de ``rag.llm.gemini.{promptType}.thinking.budget`` al campo de API apropiado en función de la generación del modelo resuelta en el momento de la solicitud.
 
 ::
 
@@ -369,10 +369,10 @@ El presupuesto de pensamiento se configura por tipo de prompt en ``fess_config.p
     # Configuracion del presupuesto de pensamiento para generacion de resumenes
     rag.llm.gemini.summary.thinking.budget=1024
 
-Mapeo segun la generacion del modelo
+Mapeo según la generación del modelo
 ------------------------------------
 
-- **Gemini 2.x** (por ejemplo, ``gemini-2.5-flash``): el valor entero configurado se envia tal cual como ``thinkingConfig.thinkingBudget``. Si se especifica ``0``, el pensamiento se desactiva por completo.
+- **Gemini 2.x** (por ejemplo, ``gemini-2.5-flash``): el valor entero configurado se envía tal cual como ``thinkingConfig.thinkingBudget``. Si se especifica ``0``, el pensamiento se desactiva por completo.
 - **Gemini 3.x** (por ejemplo, ``gemini-3.1-flash-lite-preview``): el valor entero se agrupa en los valores enumerados de ``thinkingConfig.thinkingLevel`` (``MINIMAL`` / ``LOW`` / ``MEDIUM`` / ``HIGH``) antes de enviarse.
 
 El mapeo de buckets para Gemini 3.x es el siguiente:
@@ -396,31 +396,31 @@ El mapeo de buckets para Gemini 3.x es el siguiente:
 
 .. note::
    Gemini 3.x siempre consume una cantidad fija de tokens de pensamiento en cualquier bucket (incluso con ``thinkingLevel=MINIMAL`` puede consumir varios cientos de tokens).
-   Por este motivo, |Fess| anade automaticamente un margen adicional (1024 tokens) al ``maxOutputTokens`` predeterminado cuando se utiliza un modelo Gemini 3.x, evitando el truncado de la respuesta por ``finishReason=MAX_TOKENS``.
-   En Gemini 2.x, ``thinkingBudget=0`` desactiva el pensamiento en si, por lo que no se anade margen adicional.
+   Por este motivo, |Fess| añade automáticamente un margen adicional (1024 tokens) al ``maxOutputTokens`` predeterminado cuando se utiliza un modelo Gemini 3.x, evitando el truncado de la respuesta por ``finishReason=MAX_TOKENS``.
+   En Gemini 2.x, ``thinkingBudget=0`` desactiva el pensamiento en sí, por lo que no se añade margen adicional.
 
 .. note::
    Al configurar un presupuesto de pensamiento mayor, el tiempo de respuesta puede aumentar.
-   Configure un valor apropiado segun el uso.
+   Configure un valor apropiado según el uso.
 
-Configuracion via opciones JVM
+Configuración vía opciones JVM
 ==============================
 
-Por razones de seguridad, se recomienda configurar las claves de API a traves del
-entorno de ejecucion (opciones JVM) en lugar de archivos versionados.
+Por razones de seguridad, se recomienda configurar las claves de API a través del
+entorno de ejecución (opciones JVM) en lugar de archivos versionados.
 
 Entorno Docker
 --------------
 
 El repositorio oficial `docker-fess <https://github.com/codelibs/docker-fess>`__
-incluye un overlay Gemini (``compose-gemini.yaml``). Pasos minimos:
+incluye un overlay Gemini (``compose-gemini.yaml``). Pasos mínimos:
 
 ::
 
     export GEMINI_API_KEY="AIzaSy..."
     docker compose -f compose.yaml -f compose-opensearch3.yaml -f compose-gemini.yaml up -d
 
-Contenido de ``compose-gemini.yaml`` (referencia para una configuracion equivalente):
+Contenido de ``compose-gemini.yaml`` (referencia para una configuración equivalente):
 
 .. code-block:: yaml
 
@@ -432,12 +432,12 @@ Contenido de ``compose-gemini.yaml`` (referencia para una configuracion equivale
 
 Notas:
 
-- ``FESS_PLUGINS=fess-llm-gemini:15.9.0`` hace que el ``run.sh`` del contenedor descargue e instale automaticamente el plugin en ``app/WEB-INF/plugin/``
+- ``FESS_PLUGINS=fess-llm-gemini:15.9.0`` hace que el ``run.sh`` del contenedor descargue e instale automáticamente el plugin en ``app/WEB-INF/plugin/``
 - ``-Dfess.config.rag.chat.enabled=true`` habilita el modo IA
 - ``-Dfess.config.rag.llm.gemini.api.key=...`` define la clave API, ``-Dfess.config.rag.llm.gemini.model=...`` selecciona el modelo
-- ``-Dfess.system.rag.llm.name=gemini`` solo actua como valor inicial por defecto antes de que se persista un valor en OpenSearch. Despues del inicio el ajuste tambien puede modificarse desde Administracion > Sistema > General (seccion RAG)
+- ``-Dfess.system.rag.llm.name=gemini`` solo actúa como valor inicial por defecto antes de que se persista un valor en OpenSearch. Después del inicio el ajuste también puede modificarse desde Administración > Sistema > General (sección RAG)
 
-Si el acceso a Internet pasa por un proxy, especifique la configuracion ``http.proxy.*`` de |Fess| a traves de ``FESS_JAVA_OPTS`` (consulte la seccion "Uso a traves de proxy HTTP" mas adelante).
+Si el acceso a Internet pasa por un proxy, especifique la configuración ``http.proxy.*`` de |Fess| a través de ``FESS_JAVA_OPTS`` (consulte la sección "Uso a través de proxy HTTP" más adelante).
 
 Entorno systemd
 ---------------
@@ -448,29 +448,29 @@ Agregue a ``FESS_JAVA_OPTS`` en ``/etc/sysconfig/fess`` (o ``/etc/default/fess``
 
     FESS_JAVA_OPTS="-Dfess.config.rag.chat.enabled=true -Dfess.config.rag.llm.gemini.api.key=AIzaSy... -Dfess.system.rag.llm.name=gemini"
 
-Uso a traves de proxy HTTP
+Uso a través de proxy HTTP
 ==========================
 
-El cliente de Gemini comparte la configuracion de proxy HTTP comun de |Fess|. Especifique las siguientes propiedades en ``fess_config.properties``.
+El cliente de Gemini comparte la configuración de proxy HTTP común de |Fess|. Especifique las siguientes propiedades en ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
    * - ``http.proxy.host``
-     - Nombre del host del proxy (si esta vacio, no se usa proxy)
+     - Nombre del host del proxy (si está vacío, no se usa proxy)
      - ``""``
    * - ``http.proxy.port``
-     - Numero de puerto del proxy
+     - Número de puerto del proxy
      - ``8080``
    * - ``http.proxy.username``
-     - Nombre de usuario para autenticacion del proxy (opcional; al especificarlo se habilita la autenticacion Basic)
+     - Nombre de usuario para autenticación del proxy (opcional; al especificarlo se habilita la autenticación Basic)
      - ``""``
    * - ``http.proxy.password``
-     - Contrasena para autenticacion del proxy
+     - Contraseña para autenticación del proxy
      - ``""``
 
 En entornos Docker, especifique en ``FESS_JAVA_OPTS`` de la siguiente forma::
@@ -479,23 +479,23 @@ En entornos Docker, especifique en ``FESS_JAVA_OPTS`` de la siguiente forma::
     -Dfess.config.http.proxy.port=8080
 
 .. note::
-   Esta configuracion tambien afecta el acceso HTTP de todo |Fess|, incluido el crawler.
+   Esta configuración también afecta el acceso HTTP de todo |Fess|, incluido el crawler.
    Las propiedades de sistema Java tradicionales (como ``-Dhttps.proxyHost``) no son consultadas por el cliente de Gemini.
 
-Uso a traves de Vertex AI
+Uso a través de Vertex AI
 =========================
 
-Si esta usando Google Cloud Platform, tambien puede usar Gemini a traves de Vertex AI.
-Al usar Vertex AI, el endpoint de la API y el metodo de autenticacion son diferentes.
+Si está usando Google Cloud Platform, también puede usar Gemini a través de Vertex AI.
+Al usar Vertex AI, el endpoint de la API y el método de autenticación son diferentes.
 
 .. note::
    El |Fess| actual utiliza Google AI API (generativelanguage.googleapis.com).
-   Si se requiere el uso a traves de Vertex AI, puede ser necesaria una implementacion personalizada.
+   Si se requiere el uso a través de Vertex AI, puede ser necesaria una implementación personalizada.
 
-Guia de seleccion de modelos
+Guía de selección de modelos
 ============================
 
-Guia para la seleccion de modelos segun el proposito de uso.
+Guía para la selección de modelos según el propósito de uso.
 
 .. list-table::
    :header-rows: 1
@@ -506,45 +506,45 @@ Guia para la seleccion de modelos segun el proposito de uso.
      - Calidad
      - Uso
    * - ``gemini-3.1-flash-lite-preview``
-     - Rapido
+     - Rápido
      - Alta
      - Ligero y de bajo costo (predeterminado, admite ``thinkingLevel=MINIMAL``)
    * - ``gemini-3-flash-preview``
-     - Rapido
-     - Maxima
+     - Rápido
+     - Máxima
      - Uso general (admite ``thinkingLevel=MINIMAL``)
    * - ``gemini-3.1-pro`` / ``gemini-3-pro``
      - Medio
-     - Maxima
-     - Razonamiento complejo (no admite ``MINIMAL``; minimo ``LOW``)
+     - Máxima
+     - Razonamiento complejo (no admite ``MINIMAL``; mínimo ``LOW``)
    * - ``gemini-2.5-flash``
-     - Rapido
+     - Rápido
      - Alta
-     - Version estable, enfasis en costos
+     - Versión estable, énfasis en costos
    * - ``gemini-2.5-pro``
      - Medio
      - Alta
-     - Version estable, contexto largo
+     - Versión estable, contexto largo
 
 Ventana de contexto
 -------------------
 
 Los modelos Gemini soportan ventanas de contexto muy largas:
 
-- **Gemini 3 Flash / 2.5 Flash**: Hasta 1 millon de tokens
-- **Gemini 3.1 Pro / 2.5 Pro**: Hasta 1 millon de tokens (3.1 Pro) / 2 millones de tokens (2.5 Pro)
+- **Gemini 3 Flash / 2.5 Flash**: Hasta 1 millón de tokens
+- **Gemini 3.1 Pro / 2.5 Pro**: Hasta 1 millón de tokens (3.1 Pro) / 2 millones de tokens (2.5 Pro)
 
-Aprovechando esta caracteristica, puede incluir mas resultados de busqueda en el contexto.
+Aprovechando esta característica, puede incluir más resultados de búsqueda en el contexto.
 
 ::
 
     # Incluir mas documentos en el contexto (configurar en fess_config.properties)
     rag.llm.gemini.answer.context.max.chars=20000
 
-Estimacion de costos
+Estimación de costos
 --------------------
 
-La API de Google AI cobra segun el uso (con cuota gratuita disponible).
+La API de Google AI cobra según el uso (con cuota gratuita disponible).
 
 .. list-table::
    :header-rows: 1
@@ -567,12 +567,12 @@ La API de Google AI cobra segun el uso (con cuota gratuita disponible).
      - $5.00
 
 .. note::
-   Para los precios mas recientes e informacion sobre la cuota gratuita, consulte `Google AI Pricing <https://ai.google.dev/pricing>`__.
+   Para los precios más recientes e información sobre la cuota gratuita, consulte `Google AI Pricing <https://ai.google.dev/pricing>`__.
 
-Control de solicitudes simultaneas
+Control de solicitudes simultáneas
 ====================================
 
-En |Fess|, se puede controlar el numero de solicitudes simultaneas a Gemini.
+En |Fess|, se puede controlar el número de solicitudes simultáneas a Gemini.
 Configure la siguiente propiedad en ``fess_config.properties``.
 
 ::
@@ -580,72 +580,72 @@ Configure la siguiente propiedad en ``fess_config.properties``.
     # Numero maximo de solicitudes simultaneas (predeterminado: 5)
     rag.llm.gemini.max.concurrent.requests=5
 
-Esta configuracion permite prevenir solicitudes excesivas a la API de Google AI y evitar errores de limite de tasa.
+Esta configuración permite prevenir solicitudes excesivas a la API de Google AI y evitar errores de límite de tasa.
 
-Limites de la cuota gratuita (referencia)
+Límites de la cuota gratuita (referencia)
 -----------------------------------------
 
 La API de Google AI tiene una cuota gratuita, pero con las siguientes limitaciones:
 
 - Solicitudes/minuto: 15 RPM
-- Tokens/minuto: 1 millon TPM
-- Solicitudes/dia: 1,500 RPD
+- Tokens/minuto: 1 millón TPM
+- Solicitudes/día: 1,500 RPD
 
 Se recomienda configurar ``rag.llm.gemini.max.concurrent.requests`` a un valor bajo cuando se usa la cuota gratuita.
 
-Solucion de problemas
+Solución de problemas
 =====================
 
-Error de autenticacion
+Error de autenticación
 ----------------------
 
-**Sintoma**: Errores relacionados con la clave API
+**Síntoma**: Errores relacionados con la clave API
 
 **Verificaciones**:
 
-1. Verificar que la clave API este configurada correctamente
-2. Confirmar que la clave API sea valida en Google AI Studio
+1. Verificar que la clave API esté configurada correctamente
+2. Confirmar que la clave API sea válida en Google AI Studio
 3. Confirmar que la clave API tenga los permisos necesarios
-4. Verificar que la API este habilitada en el proyecto
+4. Verificar que la API esté habilitada en el proyecto
 
-Error de limite de tasa
+Error de límite de tasa
 -----------------------
 
-**Sintoma**: Error "429 Resource has been exhausted"
+**Síntoma**: Error "429 Resource has been exhausted"
 
-**Solucion**:
+**Solución**:
 
-1. Reducir el numero de solicitudes simultaneas en ``fess_config.properties``::
+1. Reducir el número de solicitudes simultáneas en ``fess_config.properties``::
 
     rag.llm.gemini.max.concurrent.requests=3
 
 2. Esperar unos minutos y reintentar
 3. Solicitar aumento de cuota si es necesario
 
-Restriccion de region
+Restricción de región
 ---------------------
 
-**Sintoma**: Error de que el servicio no esta disponible
+**Síntoma**: Error de que el servicio no está disponible
 
 **Verificaciones**:
 
-La API de Google AI solo esta disponible en ciertas regiones.
-Consulte la documentacion de Google para las regiones soportadas.
+La API de Google AI solo está disponible en ciertas regiones.
+Consulte la documentación de Google para las regiones soportadas.
 
 Timeout
 -------
 
-**Sintoma**: Las solicitudes tienen timeout
+**Síntoma**: Las solicitudes tienen timeout
 
-**Solucion**:
+**Solución**:
 
 1. Extender el tiempo de timeout::
 
     rag.llm.gemini.timeout=120000
 
-2. Considerar usar el modelo Flash (mas rapido)
+2. Considerar usar el modelo Flash (más rápido)
 
-Configuracion de depuracion
+Configuración de depuración
 ---------------------------
 
 Para investigar problemas, puede ajustar el nivel de log de |Fess| para obtener logs detallados relacionados con Gemini.
@@ -661,19 +661,19 @@ Notas de seguridad
 
 Al usar la API de Google AI, tenga en cuenta los siguientes aspectos de seguridad.
 
-1. **Privacidad de datos**: El contenido de los resultados de busqueda se envia a los servidores de Google
-2. **Gestion de claves API**: La filtracion de claves puede llevar a uso no autorizado
-3. **Cumplimiento**: Si incluye datos confidenciales, verifique las politicas de su organizacion
-4. **Terminos de uso**: Cumpla con los terminos de uso y la Politica de Uso Aceptable de Google
+1. **Privacidad de datos**: El contenido de los resultados de búsqueda se envía a los servidores de Google
+2. **Gestión de claves API**: La filtración de claves puede llevar a uso no autorizado
+3. **Cumplimiento**: Si incluye datos confidenciales, verifique las políticas de su organización
+4. **Términos de uso**: Cumpla con los términos de uso y la Política de Uso Aceptable de Google
 
-Informacion de referencia
+Información de referencia
 =========================
 
 - `Google AI for Developers <https://ai.google.dev/>`__
 - `Google AI Studio <https://aistudio.google.com/>`__
 - `Gemini API Documentation <https://ai.google.dev/docs>`__
 - `Google AI Pricing <https://ai.google.dev/pricing>`__
-- :doc:`llm-overview` - Descripcion general de integracion LLM
+- :doc:`llm-overview` - Descripción general de integración LLM
 - :doc:`rag-chat` - Detalles de la funcionalidad de modo de búsqueda IA
 - :doc:`rank-fusion` - Búsqueda híbrida: combina búsqueda por palabras clave y búsqueda semántica (vectorial)
 - :doc:`../user/chat-search` - Uso del modo de búsqueda IA (guía para el usuario final)

--- a/es/15.9/config/llm-openai.rst
+++ b/es/15.9/config/llm-openai.rst
@@ -2,7 +2,7 @@
 Configuración de OpenAI (Búsqueda IA / RAG)
 ===========================================
 
-Descripcion general
+Descripción general
 ===================
 
 Esta página explica cómo configurar el plugin ``fess-llm-openai`` para que |Fess| pueda usar OpenAI en su **modo de búsqueda IA (RAG: Retrieval-Augmented Generation)** — respondiendo preguntas en lenguaje natural a partir de su índice de búsqueda empresarial con fuentes citadas. |Fess| llama a la API de OpenAI para ejecutar RAG sobre sus documentos rastreados con modelos GPT.
@@ -10,33 +10,33 @@ Esta página explica cómo configurar el plugin ``fess-llm-openai`` para que |Fe
 OpenAI es un servicio en la nube que proporciona modelos de lenguaje grandes (LLM) de alto rendimiento, comenzando con GPT-4.
 |Fess| puede utilizar la API de OpenAI para implementar la funcionalidad de modo de búsqueda IA.
 
-Al usar OpenAI, es posible generar respuestas de alta calidad con modelos de IA de ultima generacion.
+Al usar OpenAI, es posible generar respuestas de alta calidad con modelos de IA de última generación.
 
-Caracteristicas principales
+Características principales
 ---------------------------
 
-- **Respuestas de alta calidad**: Generacion de respuestas de alta precision con modelos GPT de ultima generacion
-- **Escalabilidad**: Facil escalado al ser un servicio en la nube
-- **Mejora continua**: El rendimiento mejora con actualizaciones periodicas de modelos
-- **Funcionalidad rica**: Compatible con diversas tareas como generacion de texto, resumen, traduccion
+- **Respuestas de alta calidad**: Generación de respuestas de alta precisión con modelos GPT de última generación
+- **Escalabilidad**: Fácil escalado al ser un servicio en la nube
+- **Mejora continua**: El rendimiento mejora con actualizaciones periódicas de modelos
+- **Funcionalidad rica**: Compatible con diversas tareas como generación de texto, resumen, traducción
 
 Modelos compatibles
 -------------------
 
 Principales modelos disponibles en OpenAI:
 
-- ``gpt-5`` - Ultimo modelo de alto rendimiento
-- ``gpt-5-mini`` - Version ligera de GPT-5 (buena relacion costo-rendimiento)
+- ``gpt-5`` - Último modelo de alto rendimiento
+- ``gpt-5-mini`` - Versión ligera de GPT-5 (buena relación costo-rendimiento)
 - ``gpt-4o`` - Modelo multimodal de alto rendimiento
-- ``gpt-4o-mini`` - Version ligera de GPT-4o
+- ``gpt-4o-mini`` - Versión ligera de GPT-4o
 - ``o3-mini`` - Modelo ligero especializado en razonamiento
-- ``o4-mini`` - Modelo ligero de proxima generacion especializado en razonamiento
+- ``o4-mini`` - Modelo ligero de próxima generación especializado en razonamiento
 
 .. note::
-   Para la informacion mas reciente sobre modelos disponibles, consulte `OpenAI Models <https://platform.openai.com/docs/models>`__.
+   Para la información más reciente sobre modelos disponibles, consulte `OpenAI Models <https://platform.openai.com/docs/models>`__.
 
 .. note::
-   Al usar modelos de la serie o1/o3/o4 o de la serie gpt-5, |Fess| utiliza automaticamente el parametro ``max_completion_tokens`` de la API de OpenAI. No se requieren cambios de configuracion.
+   Al usar modelos de la serie o1/o3/o4 o de la serie gpt-5, |Fess| utiliza automáticamente el parámetro ``max_completion_tokens`` de la API de OpenAI. No se requieren cambios de configuración.
 
 Requisitos previos
 ==================
@@ -45,51 +45,51 @@ Antes de usar OpenAI, prepare lo siguiente.
 
 1. **Cuenta de OpenAI**: Cree una cuenta en `https://platform.openai.com/ <https://platform.openai.com/>`__
 2. **Clave API**: Genere una clave API en el dashboard de OpenAI
-3. **Configuracion de facturacion**: Configure la informacion de facturacion ya que el uso de la API genera cargos
+3. **Configuración de facturación**: Configure la información de facturación ya que el uso de la API genera cargos
 
-Obtencion de clave API
+Obtención de clave API
 ----------------------
 
-1. Inicie sesion en `OpenAI Platform <https://platform.openai.com/>`__
-2. Navegue a la seccion "API keys"
+1. Inicie sesión en `OpenAI Platform <https://platform.openai.com/>`__
+2. Navegue a la sección "API keys"
 3. Haga clic en "Create new secret key"
-4. Ingrese un nombre para la clave y creela
+4. Ingrese un nombre para la clave y créela
 5. Guarde la clave mostrada de forma segura (solo se muestra una vez)
 
 .. warning::
-   La clave API es informacion confidencial. Tenga en cuenta lo siguiente:
+   La clave API es información confidencial. Tenga en cuenta lo siguiente:
 
    - No la commita en sistemas de control de versiones
    - No la imprima en logs
-   - Administrela con variables de entorno o archivos de configuracion seguros
+   - Adminístrela con variables de entorno o archivos de configuración seguros
 
-Instalacion del plugin
+Instalación del plugin
 ======================
 
-La funcionalidad de integracion con OpenAI se proporciona como plugin. Para usarla es necesario instalar el plugin ``fess-llm-openai``.
+La funcionalidad de integración con OpenAI se proporciona como plugin. Para usarla es necesario instalar el plugin ``fess-llm-openai``.
 
 1. Descargue `fess-llm-openai-15.9.0.jar`
-2. Coloque el archivo JAR en el directorio ``app/WEB-INF/plugin/`` del directorio de instalacion de |Fess|::
+2. Coloque el archivo JAR en el directorio ``app/WEB-INF/plugin/`` del directorio de instalación de |Fess|::
 
     cp fess-llm-openai-15.9.0.jar /path/to/fess/app/WEB-INF/plugin/
 
 3. Reinicie |Fess|
 
 .. note::
-   La version del plugin debe coincidir con la version de |Fess|.
+   La versión del plugin debe coincidir con la versión de |Fess|.
 
-Configuracion basica
+Configuración básica
 ====================
 
-Los elementos de configuracion se dividen en los siguientes dos archivos segun su uso.
+Los elementos de configuración se dividen en los siguientes dos archivos según su uso.
 
-- ``app/WEB-INF/conf/fess_config.properties`` - Configuracion del nucleo de |Fess| y configuracion especifica del proveedor LLM
-- ``system.properties`` / Pantalla de administracion (Administracion > Sistema > General) - Seleccion del proveedor LLM (``rag.llm.name``)
+- ``app/WEB-INF/conf/fess_config.properties`` - Configuración del núcleo de |Fess| y configuración específica del proveedor LLM
+- ``system.properties`` / Pantalla de administración (Administración > Sistema > General) - Selección del proveedor LLM (``rag.llm.name``)
 
-Configuracion minima
+Configuración mínima
 --------------------
 
-``system.properties`` (tambien configurable en Administracion > Sistema > General):
+``system.properties`` (también configurable en Administración > Sistema > General):
 
 ::
 
@@ -109,10 +109,10 @@ Configuracion minima
     # Modelo a usar
     rag.llm.openai.model=gpt-5-mini
 
-Configuracion recomendada (entorno de produccion)
+Configuración recomendada (entorno de producción)
 -------------------------------------------------
 
-``system.properties`` (tambien configurable en Administracion > Sistema > General):
+``system.properties`` (también configurable en Administración > Sistema > General):
 
 ::
 
@@ -141,19 +141,19 @@ Configuracion recomendada (entorno de produccion)
     # Limite de solicitudes simultaneas
     rag.llm.openai.max.concurrent.requests=5
 
-Elementos de configuracion
+Elementos de configuración
 ==========================
 
-Todos los elementos de configuracion disponibles para el cliente de OpenAI. Excepto ``rag.llm.name``, todos se configuran en ``fess_config.properties``.
+Todos los elementos de configuración disponibles para el cliente de OpenAI. Excepto ``rag.llm.name``, todos se configuran en ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 35 15 15
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
-     - Lugar de configuracion
+     - Lugar de configuración
    * - ``rag.llm.name``
      - Nombre del proveedor LLM (especificar ``openai``)
      - ``ollama``
@@ -175,19 +175,19 @@ Todos los elementos de configuracion disponibles para el cliente de OpenAI. Exce
      - ``120000``
      - fess_config.properties
    * - ``rag.llm.openai.availability.check.interval``
-     - Intervalo de verificacion de disponibilidad (segundos)
+     - Intervalo de verificación de disponibilidad (segundos)
      - ``60``
      - fess_config.properties
    * - ``rag.llm.openai.max.concurrent.requests``
-     - Numero maximo de solicitudes simultaneas
+     - Número máximo de solicitudes simultáneas
      - ``5``
      - fess_config.properties
    * - ``rag.llm.openai.chat.evaluation.max.relevant.docs``
-     - Numero maximo de documentos relevantes en la evaluacion
+     - Número máximo de documentos relevantes en la evaluación
      - ``3``
      - fess_config.properties
    * - ``rag.llm.openai.concurrency.wait.timeout``
-     - Timeout de espera de solicitudes simultaneas (ms)
+     - Timeout de espera de solicitudes simultáneas (ms)
      - ``30000``
      - fess_config.properties
    * - ``rag.llm.openai.reasoning.token.multiplier``
@@ -195,7 +195,7 @@ Todos los elementos de configuracion disponibles para el cliente de OpenAI. Exce
      - ``4``
      - fess_config.properties
    * - ``rag.llm.openai.retry.max``
-     - Numero maximo de reintentos HTTP (en errores ``429`` y de la familia ``5xx``)
+     - Número máximo de reintentos HTTP (en errores ``429`` y de la familia ``5xx``)
      - ``10``
      - fess_config.properties
    * - ``rag.llm.openai.retry.base.delay.ms``
@@ -203,51 +203,51 @@ Todos los elementos de configuracion disponibles para el cliente de OpenAI. Exce
      - ``2000``
      - fess_config.properties
    * - ``rag.llm.openai.stream.include.usage``
-     - Envia ``stream_options.include_usage=true`` durante el streaming para recibir la informacion de tokens utilizados en el chunk final
+     - Envía ``stream_options.include_usage=true`` durante el streaming para recibir la información de tokens utilizados en el chunk final
      - ``true``
      - fess_config.properties
    * - ``rag.llm.openai.history.max.chars``
-     - Maximo de caracteres para historial de conversacion
+     - Máximo de caracteres para historial de conversación
      - ``8000``
      - fess_config.properties
    * - ``rag.llm.openai.intent.history.max.messages``
-     - Maximo de mensajes de historial para deteccion de intencion
+     - Máximo de mensajes de historial para detección de intención
      - ``8``
      - fess_config.properties
    * - ``rag.llm.openai.intent.history.max.chars``
-     - Maximo de caracteres de historial para deteccion de intencion
+     - Máximo de caracteres de historial para detección de intención
      - ``4000``
      - fess_config.properties
    * - ``rag.llm.openai.history.assistant.max.chars``
-     - Maximo de caracteres para mensajes del asistente
+     - Máximo de caracteres para mensajes del asistente
      - ``800``
      - fess_config.properties
    * - ``rag.llm.openai.history.assistant.summary.max.chars``
-     - Maximo de caracteres para resumen del asistente
+     - Máximo de caracteres para resumen del asistente
      - ``800``
      - fess_config.properties
    * - ``rag.llm.openai.chat.evaluation.description.max.chars``
-     - Maximo de caracteres para descripcion de documentos en evaluacion
+     - Máximo de caracteres para descripción de documentos en evaluación
      - ``500``
      - fess_config.properties
    * - ``rag.chat.enabled``
-     - Habilitacion de la funcionalidad de modo de búsqueda IA
+     - Habilitación de la funcionalidad de modo de búsqueda IA
      - ``false``
      - fess_config.properties
 
-Configuracion por tipo de prompt
+Configuración por tipo de prompt
 =================================
 
-En |Fess|, se pueden configurar parametros individuales para cada tipo de prompt. La configuracion se realiza en ``fess_config.properties``.
+En |Fess|, se pueden configurar parámetros individuales para cada tipo de prompt. La configuración se realiza en ``fess_config.properties``.
 
-Patron de configuracion
+Patrón de configuración
 ------------------------
 
-La configuracion por tipo de prompt se especifica con el siguiente patron:
+La configuración por tipo de prompt se especifica con el siguiente patrón:
 
-- ``rag.llm.openai.{promptType}.temperature`` - Aleatoriedad de generacion (0.0 a 2.0). Se ignora para modelos de inferencia (serie o1/o3/o4/gpt-5)
-- ``rag.llm.openai.{promptType}.max.tokens`` - Numero maximo de tokens
-- ``rag.llm.openai.{promptType}.context.max.chars`` - Numero maximo de caracteres del contexto (predeterminado: ``16000`` para answer/summary, ``10000`` para otros)
+- ``rag.llm.openai.{promptType}.temperature`` - Aleatoriedad de generación (0.0 a 2.0). Se ignora para modelos de inferencia (serie o1/o3/o4/gpt-5)
+- ``rag.llm.openai.{promptType}.max.tokens`` - Número máximo de tokens
+- ``rag.llm.openai.{promptType}.context.max.chars`` - Número máximo de caracteres del contexto (predeterminado: ``16000`` para answer/summary, ``10000`` para otros)
 
 Tipos de prompt
 ---------------
@@ -259,32 +259,32 @@ Tipos de prompt disponibles:
    :widths: 20 80
 
    * - Tipo de prompt
-     - Descripcion
+     - Descripción
    * - ``intent``
-     - Prompt para determinar la intencion del usuario
+     - Prompt para determinar la intención del usuario
    * - ``evaluation``
-     - Prompt para evaluar la relevancia de los resultados de busqueda
+     - Prompt para evaluar la relevancia de los resultados de búsqueda
    * - ``unclear``
      - Prompt de respuesta para consultas no claras
    * - ``noresults``
-     - Prompt de respuesta cuando no hay resultados de busqueda
+     - Prompt de respuesta cuando no hay resultados de búsqueda
    * - ``docnotfound``
      - Prompt de respuesta cuando no se encuentra el documento
    * - ``answer``
      - Prompt para generar respuestas
    * - ``summary``
-     - Prompt para generar resumenes
+     - Prompt para generar resúmenes
    * - ``faq``
      - Prompt para generar FAQ
    * - ``direct``
      - Prompt para respuesta directa
    * - ``queryregeneration``
-     - Prompt de regeneracion de consultas
+     - Prompt de regeneración de consultas
 
 Valores predeterminados
 -----------------------
 
-Valores predeterminados para cada tipo de prompt. La configuracion de temperature se ignora para modelos de inferencia (serie o1/o3/o4/gpt-5).
+Valores predeterminados para cada tipo de prompt. La configuración de temperature se ignora para modelos de inferencia (serie o1/o3/o4/gpt-5).
 
 .. list-table::
    :header-rows: 1
@@ -297,11 +297,11 @@ Valores predeterminados para cada tipo de prompt. La configuracion de temperatur
    * - ``intent``
      - 0.1
      - 256
-     - Deteccion de intencion determinista
+     - Detección de intención determinista
    * - ``evaluation``
      - 0.1
      - 256
-     - Evaluacion de relevancia determinista
+     - Evaluación de relevancia determinista
    * - ``unclear``
      - 0.7
      - 512
@@ -325,17 +325,17 @@ Valores predeterminados para cada tipo de prompt. La configuracion de temperatur
    * - ``answer``
      - 0.5
      - 2048
-     - Generacion de respuesta principal
+     - Generación de respuesta principal
    * - ``summary``
      - 0.3
      - 2048
-     - Generacion de resumen
+     - Generación de resumen
    * - ``queryregeneration``
      - 0.3
      - 256
-     - Regeneracion de consultas
+     - Regeneración de consultas
 
-Ejemplo de configuracion
+Ejemplo de configuración
 ------------------------
 
 ::
@@ -355,40 +355,40 @@ Ejemplo de configuracion
 Comportamiento de reintentos
 ============================
 
-Las solicitudes a la API de OpenAI se reintentan automaticamente para los siguientes codigos de estado HTTP:
+Las solicitudes a la API de OpenAI se reintentan automáticamente para los siguientes códigos de estado HTTP:
 
-- ``429`` Too Many Requests (limite de tasa)
+- ``429`` Too Many Requests (límite de tasa)
 - ``500`` Internal Server Error
-- ``502`` Bad Gateway (OpenAI puede devolverlo cuando el upstream esta sobrecargado)
+- ``502`` Bad Gateway (OpenAI puede devolverlo cuando el upstream está sobrecargado)
 - ``503`` Service Unavailable
 - ``504`` Gateway Timeout
 
 Durante los reintentos se aplica un backoff exponencial (valor base ``rag.llm.openai.retry.base.delay.ms`` milisegundos, hasta ``rag.llm.openai.retry.max`` intentos, con jitter de +/-20%).
-Si el servidor devuelve un encabezado ``Retry-After`` (segundos enteros, limitado a ``600`` segundos como maximo), ese valor tiene prioridad sobre el backoff exponencial. Esto sigue la guia oficial de OpenAI.
+Si el servidor devuelve un encabezado ``Retry-After`` (segundos enteros, limitado a ``600`` segundos como máximo), ese valor tiene prioridad sobre el backoff exponencial. Esto sigue la guía oficial de OpenAI.
 
-Tenga en cuenta que las ``IOException`` (timeouts de conexion, reset de socket, fallos de DNS) no se reintentan, ya que la solicitud podria haber llegado al servidor y un reintento podria provocar un cobro doble.
-En las solicitudes de streaming, solo la conexion inicial es objeto de reintentos; los errores que ocurren despues de comenzar a recibir el cuerpo de la respuesta se propagan inmediatamente.
+Tenga en cuenta que las ``IOException`` (timeouts de conexión, reset de socket, fallos de DNS) no se reintentan, ya que la solicitud podría haber llegado al servidor y un reintento podría provocar un cobro doble.
+En las solicitudes de streaming, solo la conexión inicial es objeto de reintentos; los errores que ocurren después de comenzar a recibir el cuerpo de la respuesta se propagan inmediatamente.
 
 .. note::
-   Con la configuracion predeterminada (maximo 10 intentos, base 2 segundos), en el peor caso la suma de los 9 backoffs es ``2 + 4 + 8 + ... + 512 = aproximadamente 1022 segundos (aproximadamente 17 minutos)``. Si ``Retry-After`` (maximo 600 segundos) se devuelve en cada intento, el peor caso puede llegar a ``9 x 600 segundos = 90 minutos``. Si desea controlar la latencia de forma mas estricta, reduzca ``rag.llm.openai.retry.max``.
+   Con la configuración predeterminada (máximo 10 intentos, base 2 segundos), en el peor caso la suma de los 9 backoffs es ``2 + 4 + 8 + ... + 512 = aproximadamente 1022 segundos (aproximadamente 17 minutos)``. Si ``Retry-After`` (máximo 600 segundos) se devuelve en cada intento, el peor caso puede llegar a ``9 x 600 segundos = 90 minutos``. Si desea controlar la latencia de forma más estricta, reduzca ``rag.llm.openai.retry.max``.
 
-Streaming e informacion de uso
+Streaming e información de uso
 ==============================
 
-Por defecto, se incluye ``stream_options.include_usage=true`` en las solicitudes y, en el chunk SSE final de la respuesta de streaming, se recibe el objeto ``usage`` (que incluye ``completion_tokens_details.reasoning_tokens`` para los modelos de inferencia y ``prompt_tokens_details.cached_tokens`` cuando se utiliza la cache de prompts).
+Por defecto, se incluye ``stream_options.include_usage=true`` en las solicitudes y, en el chunk SSE final de la respuesta de streaming, se recibe el objeto ``usage`` (que incluye ``completion_tokens_details.reasoning_tokens`` para los modelos de inferencia y ``prompt_tokens_details.cached_tokens`` cuando se utiliza la caché de prompts).
 
-Si utiliza un backend que no admite el campo ``stream_options.include_usage`` (como vLLM o gateways compatibles con Azure OpenAI), desactivelo de la siguiente forma::
+Si utiliza un backend que no admite el campo ``stream_options.include_usage`` (como vLLM o gateways compatibles con Azure OpenAI), desactívelo de la siguiente forma::
 
     rag.llm.openai.stream.include.usage=false
 
-Salida de logs y deteccion de anomalias
+Salida de logs y detección de anomalías
 =======================================
 
-El cliente de OpenAI emite los siguientes logs estructurados, que permiten supervisar el uso de tokens y las anomalias de respuesta sin necesidad de habilitar el nivel ``DEBUG``.
+El cliente de OpenAI emite los siguientes logs estructurados, que permiten supervisar el uso de tokens y las anomalías de respuesta sin necesidad de habilitar el nivel ``DEBUG``.
 
-- ``[LLM:OPENAI] Stream completed.`` (INFO) - Al finalizar la respuesta de streaming, emite el numero de chunks, el tiempo hasta el primer chunk y la informacion de uso de tokens
-- ``[LLM:OPENAI] Chat response received.`` (INFO) - Al finalizar la respuesta no-streaming, emite informacion equivalente
-- ``[LLM:OPENAI] Chat finished abnormally`` / ``Stream finished abnormally`` (WARN) - Cuando ``finish_reason`` es distinto de ``stop`` (``length``: truncado por max_tokens, ``content_filter``: moderacion, ``tool_calls`` / ``function_call``: invocacion de herramientas no esperada por configuracion erronea, etc.)
+- ``[LLM:OPENAI] Stream completed.`` (INFO) - Al finalizar la respuesta de streaming, emite el número de chunks, el tiempo hasta el primer chunk y la información de uso de tokens
+- ``[LLM:OPENAI] Chat response received.`` (INFO) - Al finalizar la respuesta no-streaming, emite información equivalente
+- ``[LLM:OPENAI] Chat finished abnormally`` / ``Stream finished abnormally`` (WARN) - Cuando ``finish_reason`` es distinto de ``stop`` (``length``: truncado por max_tokens, ``content_filter``: moderación, ``tool_calls`` / ``function_call``: invocación de herramientas no esperada por configuración errónea, etc.)
 - ``[LLM:OPENAI] Stream refusal.`` (WARN) - Cuando se devuelve ``delta.refusal`` con salida estructurada
 
 Estos logs WARN pueden utilizarse para ajustar ``max_tokens``, auditar filtros de contenido y detectar configuraciones incorrectas de ``extra_params``.
@@ -396,46 +396,46 @@ Estos logs WARN pueden utilizarse para ajustar ``max_tokens``, auditar filtros d
 Enmascaramiento de credenciales en URLs registradas
 ---------------------------------------------------
 
-Las URLs emitidas en los logs se enmascaran automaticamente sustituyendo por ``***`` los parametros de consulta que contienen credenciales (``api_key``, ``apikey``, ``api-key``, ``key``, ``token``, ``access_token``, ``access-token``; sin distinguir mayusculas y minusculas).
+Las URLs emitidas en los logs se enmascaran automáticamente sustituyendo por ``***`` los parámetros de consulta que contienen credenciales (``api_key``, ``apikey``, ``api-key``, ``key``, ``token``, ``access_token``, ``access-token``; sin distinguir mayúsculas y minúsculas).
 
-El endpoint oficial de OpenAI (``https://api.openai.com``) se autentica mediante el encabezado ``Authorization: Bearer``, por lo que la URL no contiene credenciales. No obstante, este enmascaramiento evita que la clave API se filtre en los logs incluso cuando ``rag.llm.openai.api.url`` apunta a un proxy personalizado que acepta credenciales como parametro de consulta (algunas implementaciones de Azure, gateways vLLM, etc.).
+El endpoint oficial de OpenAI (``https://api.openai.com``) se autentica mediante el encabezado ``Authorization: Bearer``, por lo que la URL no contiene credenciales. No obstante, este enmascaramiento evita que la clave API se filtre en los logs incluso cuando ``rag.llm.openai.api.url`` apunta a un proxy personalizado que acepta credenciales como parámetro de consulta (algunas implementaciones de Azure, gateways vLLM, etc.).
 
 Soporte de modelos de inferencia
 =================================
 
-Cuando se usan modelos de inferencia de las series o1/o3/o4 o de la serie gpt-5, |Fess| utiliza automaticamente el parametro ``max_completion_tokens`` de la API de OpenAI en lugar de ``max_tokens``. No se requieren cambios adicionales de configuracion.
+Cuando se usan modelos de inferencia de las series o1/o3/o4 o de la serie gpt-5, |Fess| utiliza automáticamente el parámetro ``max_completion_tokens`` de la API de OpenAI en lugar de ``max_tokens``. No se requieren cambios adicionales de configuración.
 
 .. note::
-   Los modelos de inferencia (serie o1/o3/o4/gpt-5) ignoran la configuracion de ``temperature`` y usan un valor fijo (1). Ademas, al usar modelos de inferencia, el ``max_tokens`` predeterminado se multiplica por ``reasoning.token.multiplier`` (predeterminado: 4).
+   Los modelos de inferencia (serie o1/o3/o4/gpt-5) ignoran la configuración de ``temperature`` y usan un valor fijo (1). Además, al usar modelos de inferencia, el ``max_tokens`` predeterminado se multiplica por ``reasoning.token.multiplier`` (predeterminado: 4).
 
-Parametros adicionales para modelos de inferencia
+Parámetros adicionales para modelos de inferencia
 --------------------------------------------------
 
-Al usar modelos de inferencia, se pueden configurar los siguientes parametros adicionales en ``fess_config.properties``:
+Al usar modelos de inferencia, se pueden configurar los siguientes parámetros adicionales en ``fess_config.properties``:
 
 .. list-table::
    :header-rows: 1
    :widths: 40 40 20
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
    * - ``rag.llm.openai.{promptType}.reasoning.effort``
-     - Configuracion de reasoning effort para modelos serie o (``low``, ``medium``, ``high``)
+     - Configuración de reasoning effort para modelos serie o (``low``, ``medium``, ``high``)
      - ``low`` (intent/evaluation/docnotfound/unclear/noresults/queryregeneration), no configurado (otros)
    * - ``rag.llm.openai.{promptType}.top.p``
-     - Umbral de probabilidad para la seleccion de tokens (0.0 a 1.0)
+     - Umbral de probabilidad para la selección de tokens (0.0 a 1.0)
      - (no configurado)
    * - ``rag.llm.openai.{promptType}.frequency.penalty``
-     - Penalizacion de frecuencia (-2.0 a 2.0)
+     - Penalización de frecuencia (-2.0 a 2.0)
      - (no configurado)
    * - ``rag.llm.openai.{promptType}.presence.penalty``
-     - Penalizacion de presencia (-2.0 a 2.0)
+     - Penalización de presencia (-2.0 a 2.0)
      - (no configurado)
 
 ``{promptType}`` puede ser ``intent``, ``evaluation``, ``answer``, ``summary``, etc.
 
-Ejemplo de configuracion
+Ejemplo de configuración
 ------------------------
 
 ::
@@ -449,24 +449,24 @@ Ejemplo de configuracion
     rag.llm.openai.answer.top.p=0.9
     rag.llm.openai.answer.frequency.penalty=0.5
 
-Configuracion via opciones JVM
+Configuración vía opciones JVM
 ==============================
 
-Por razones de seguridad, se recomienda configurar las claves de API a traves del
-entorno de ejecucion (opciones JVM) en lugar de archivos versionados.
+Por razones de seguridad, se recomienda configurar las claves de API a través del
+entorno de ejecución (opciones JVM) en lugar de archivos versionados.
 
 Entorno Docker
 --------------
 
 El repositorio oficial `docker-fess <https://github.com/codelibs/docker-fess>`__
-incluye un overlay OpenAI (``compose-openai.yaml``). Pasos minimos:
+incluye un overlay OpenAI (``compose-openai.yaml``). Pasos mínimos:
 
 ::
 
     export OPENAI_API_KEY="sk-..."
     docker compose -f compose.yaml -f compose-opensearch3.yaml -f compose-openai.yaml up -d
 
-Contenido de ``compose-openai.yaml`` (referencia para una configuracion equivalente):
+Contenido de ``compose-openai.yaml`` (referencia para una configuración equivalente):
 
 .. code-block:: yaml
 
@@ -478,12 +478,12 @@ Contenido de ``compose-openai.yaml`` (referencia para una configuracion equivale
 
 Notas:
 
-- ``FESS_PLUGINS=fess-llm-openai:15.9.0`` hace que el ``run.sh`` del contenedor descargue e instale automaticamente el plugin en ``app/WEB-INF/plugin/``
+- ``FESS_PLUGINS=fess-llm-openai:15.9.0`` hace que el ``run.sh`` del contenedor descargue e instale automáticamente el plugin en ``app/WEB-INF/plugin/``
 - ``-Dfess.config.rag.chat.enabled=true`` habilita el modo IA
 - ``-Dfess.config.rag.llm.openai.api.key=...`` define la clave API, ``-Dfess.config.rag.llm.openai.model=...`` selecciona el modelo
-- ``-Dfess.system.rag.llm.name=openai`` solo actua como valor inicial por defecto antes de que se persista un valor en OpenSearch. Despues del inicio el ajuste tambien puede modificarse desde Administracion > Sistema > General (seccion RAG)
+- ``-Dfess.system.rag.llm.name=openai`` solo actúa como valor inicial por defecto antes de que se persista un valor en OpenSearch. Después del inicio el ajuste también puede modificarse desde Administración > Sistema > General (sección RAG)
 
-Si el acceso a Internet pasa por un proxy, especifique la configuracion ``http.proxy.*`` de |Fess| a traves de ``FESS_JAVA_OPTS`` (consulte la seccion "Uso a traves de proxy HTTP" mas adelante).
+Si el acceso a Internet pasa por un proxy, especifique la configuración ``http.proxy.*`` de |Fess| a través de ``FESS_JAVA_OPTS`` (consulte la sección "Uso a través de proxy HTTP" más adelante).
 
 Entorno systemd
 ---------------
@@ -494,29 +494,29 @@ Agregue a ``FESS_JAVA_OPTS`` en ``/etc/sysconfig/fess`` (o ``/etc/default/fess``
 
     FESS_JAVA_OPTS="-Dfess.config.rag.chat.enabled=true -Dfess.config.rag.llm.openai.api.key=sk-... -Dfess.system.rag.llm.name=openai"
 
-Uso a traves de proxy HTTP
+Uso a través de proxy HTTP
 ==========================
 
-El cliente de OpenAI comparte la configuracion de proxy HTTP comun de |Fess|. Especifique las siguientes propiedades en ``fess_config.properties``.
+El cliente de OpenAI comparte la configuración de proxy HTTP común de |Fess|. Especifique las siguientes propiedades en ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
    * - ``http.proxy.host``
-     - Nombre del host del proxy (si esta vacio, no se usa proxy)
+     - Nombre del host del proxy (si está vacío, no se usa proxy)
      - ``""``
    * - ``http.proxy.port``
-     - Numero de puerto del proxy
+     - Número de puerto del proxy
      - ``8080``
    * - ``http.proxy.username``
-     - Nombre de usuario para autenticacion del proxy (opcional; al especificarlo se habilita la autenticacion Basic)
+     - Nombre de usuario para autenticación del proxy (opcional; al especificarlo se habilita la autenticación Basic)
      - ``""``
    * - ``http.proxy.password``
-     - Contrasena para autenticacion del proxy
+     - Contraseña para autenticación del proxy
      - ``""``
 
 En entornos Docker, especifique en ``FESS_JAVA_OPTS`` de la siguiente forma::
@@ -525,13 +525,13 @@ En entornos Docker, especifique en ``FESS_JAVA_OPTS`` de la siguiente forma::
     -Dfess.config.http.proxy.port=8080
 
 .. note::
-   Esta configuracion tambien afecta el acceso HTTP de todo |Fess|, incluido el crawler.
+   Esta configuración también afecta el acceso HTTP de todo |Fess|, incluido el crawler.
    Las propiedades de sistema Java tradicionales (como ``-Dhttps.proxyHost``) no son consultadas por el cliente de OpenAI.
 
 Uso de Azure OpenAI
 ===================
 
-Para usar modelos de OpenAI a traves de Microsoft Azure, cambie el endpoint de la API.
+Para usar modelos de OpenAI a través de Microsoft Azure, cambie el endpoint de la API.
 
 ::
 
@@ -546,12 +546,12 @@ Para usar modelos de OpenAI a traves de Microsoft Azure, cambie el endpoint de l
 
 .. note::
    Al usar Azure OpenAI, el formato de solicitud de la API puede diferir ligeramente.
-   Consulte la documentacion de Azure OpenAI para mas detalles.
+   Consulte la documentación de Azure OpenAI para más detalles.
 
-Guia de seleccion de modelos
+Guía de selección de modelos
 ============================
 
-Guia para la seleccion de modelos segun el proposito de uso.
+Guía para la selección de modelos según el propósito de uso.
 
 .. list-table::
    :header-rows: 1
@@ -571,69 +571,69 @@ Guia para la seleccion de modelos segun el proposito de uso.
      - Uso con prioridad en costos
    * - ``gpt-5``
      - Alto
-     - Maxima
+     - Máxima
      - Razonamiento complejo, cuando se requiere alta calidad
    * - ``gpt-4o``
      - Medio-Alto
-     - Maxima
+     - Máxima
      - Cuando se requiere soporte multimodal
    * - ``o3-mini`` / ``o4-mini``
      - Medio
-     - Maxima
-     - Tareas de razonamiento como matematicas y programacion
+     - Máxima
+     - Tareas de razonamiento como matemáticas y programación
 
-Estimacion de costos
+Estimación de costos
 --------------------
 
-La API de OpenAI cobra segun el uso.
+La API de OpenAI cobra según el uso.
 
 .. note::
-   Para los precios mas recientes, consulte `OpenAI Pricing <https://openai.com/pricing>`__.
+   Para los precios más recientes, consulte `OpenAI Pricing <https://openai.com/pricing>`__.
 
-Control de solicitudes simultaneas
+Control de solicitudes simultáneas
 ====================================
 
-En |Fess|, el numero de solicitudes simultaneas a la API de OpenAI se puede controlar con ``rag.llm.openai.max.concurrent.requests`` en ``fess_config.properties``. El valor predeterminado es ``5``.
+En |Fess|, el número de solicitudes simultáneas a la API de OpenAI se puede controlar con ``rag.llm.openai.max.concurrent.requests`` en ``fess_config.properties``. El valor predeterminado es ``5``.
 
 ::
 
     # Configurar el numero maximo de solicitudes simultaneas
     rag.llm.openai.max.concurrent.requests=5
 
-Esta configuracion permite prevenir solicitudes excesivas a la API de OpenAI y evitar errores de limite de tasa.
+Esta configuración permite prevenir solicitudes excesivas a la API de OpenAI y evitar errores de límite de tasa.
 
-Limites por nivel de OpenAI
+Límites por nivel de OpenAI
 ---------------------------
 
-Los limites del lado de la API varian segun el nivel de la cuenta de OpenAI:
+Los límites del lado de la API varían según el nivel de la cuenta de OpenAI:
 
 - **Free**: 3 RPM (solicitudes/minuto)
 - **Tier 1**: 500 RPM
 - **Tier 2**: 5,000 RPM
-- **Tier 3+**: Limites aun mayores
+- **Tier 3+**: Límites aún mayores
 
-Ajuste ``rag.llm.openai.max.concurrent.requests`` apropiadamente segun el nivel de la cuenta de OpenAI.
+Ajuste ``rag.llm.openai.max.concurrent.requests`` apropiadamente según el nivel de la cuenta de OpenAI.
 
-Solucion de problemas
+Solución de problemas
 =====================
 
-Error de autenticacion
+Error de autenticación
 ----------------------
 
-**Sintoma**: Error "401 Unauthorized"
+**Síntoma**: Error "401 Unauthorized"
 
 **Verificaciones**:
 
-1. Verificar que la clave API este configurada correctamente
-2. Confirmar que la clave API sea valida (verificar en el dashboard de OpenAI)
+1. Verificar que la clave API esté configurada correctamente
+2. Confirmar que la clave API sea válida (verificar en el dashboard de OpenAI)
 3. Confirmar que la clave API tenga los permisos necesarios
 
-Error de limite de tasa
+Error de límite de tasa
 -----------------------
 
-**Sintoma**: Error "429 Too Many Requests"
+**Síntoma**: Error "429 Too Many Requests"
 
-**Solucion**:
+**Solución**:
 
 1. Reducir el valor de ``rag.llm.openai.max.concurrent.requests``::
 
@@ -644,27 +644,27 @@ Error de limite de tasa
 Cuota excedida
 --------------
 
-**Sintoma**: Error "You exceeded your current quota"
+**Síntoma**: Error "You exceeded your current quota"
 
-**Solucion**:
+**Solución**:
 
 1. Verificar el uso en el dashboard de OpenAI
-2. Revisar la configuracion de facturacion y aumentar el limite si es necesario
+2. Revisar la configuración de facturación y aumentar el límite si es necesario
 
 Timeout
 -------
 
-**Sintoma**: Las solicitudes tienen timeout
+**Síntoma**: Las solicitudes tienen timeout
 
-**Solucion**:
+**Solución**:
 
 1. Extender el tiempo de timeout::
 
     rag.llm.openai.timeout=180000
 
-2. Considerar usar un modelo mas rapido (como gpt-5-mini)
+2. Considerar usar un modelo más rápido (como gpt-5-mini)
 
-Configuracion de depuracion
+Configuración de depuración
 ---------------------------
 
 Para investigar problemas, puede ajustar el nivel de log de |Fess| para obtener logs detallados relacionados con OpenAI.
@@ -680,18 +680,18 @@ Notas de seguridad
 
 Al usar la API de OpenAI, tenga en cuenta los siguientes aspectos de seguridad.
 
-1. **Privacidad de datos**: El contenido de los resultados de busqueda se envia a los servidores de OpenAI
-2. **Gestion de claves API**: La filtracion de claves puede llevar a uso no autorizado
-3. **Cumplimiento**: Si incluye datos confidenciales, verifique las politicas de su organizacion
-4. **Politica de uso**: Cumpla con los terminos de servicio de OpenAI
+1. **Privacidad de datos**: El contenido de los resultados de búsqueda se envía a los servidores de OpenAI
+2. **Gestión de claves API**: La filtración de claves puede llevar a uso no autorizado
+3. **Cumplimiento**: Si incluye datos confidenciales, verifique las políticas de su organización
+4. **Política de uso**: Cumpla con los términos de servicio de OpenAI
 
-Informacion de referencia
+Información de referencia
 =========================
 
 - `OpenAI Platform <https://platform.openai.com/>`__
 - `OpenAI API Reference <https://platform.openai.com/docs/api-reference>`__
 - `OpenAI Pricing <https://openai.com/pricing>`__
-- :doc:`llm-overview` - Descripcion general de integracion LLM
+- :doc:`llm-overview` - Descripción general de integración LLM
 - :doc:`rag-chat` - Detalles de la funcionalidad de modo de búsqueda IA
 - :doc:`rank-fusion` - Búsqueda híbrida: combina búsqueda por palabras clave y búsqueda semántica (vectorial)
 - :doc:`../user/chat-search` - Uso del modo de búsqueda IA (guía para el usuario final)

--- a/es/15.9/config/rag-chat.rst
+++ b/es/15.9/config/rag-chat.rst
@@ -1,54 +1,54 @@
 ==========================
-Configuracion de la funcionalidad de modo de búsqueda IA
+Configuración de la funcionalidad de modo de búsqueda IA
 ==========================
 
-Descripcion general
+Descripción general
 ===================
 
-El modo de búsqueda IA (RAG: Retrieval-Augmented Generation) es una funcionalidad que extiende los resultados de busqueda de |Fess| con LLM (Modelo de Lenguaje Grande),
-proporcionando informacion en formato de dialogo. Los usuarios pueden hacer preguntas en lenguaje natural
-y obtener respuestas detalladas basadas en los resultados de busqueda.
+El modo de búsqueda IA (RAG: Retrieval-Augmented Generation) es una funcionalidad que extiende los resultados de búsqueda de |Fess| con LLM (Modelo de Lenguaje Grande),
+proporcionando información en formato de diálogo. Los usuarios pueden hacer preguntas en lenguaje natural
+y obtener respuestas detalladas basadas en los resultados de búsqueda.
 
 En |Fess| 15.9, la funcionalidad LLM ha sido separada como plugins ``fess-llm-*``.
-La configuracion del nucleo y la configuracion especifica del proveedor LLM se realizan en ``fess_config.properties``,
-y la seleccion del proveedor LLM (``rag.llm.name``) se realiza desde ``system.properties`` o la pantalla de administracion.
+La configuración del núcleo y la configuración específica del proveedor LLM se realizan en ``fess_config.properties``,
+y la selección del proveedor LLM (``rag.llm.name``) se realiza desde ``system.properties`` o la pantalla de administración.
 
-Pipeline de recuperacion
+Pipeline de recuperación
 ========================
 
-El modo de búsqueda IA obtiene sus documentos de origen a traves del pipeline estandar de busqueda de |Fess| (rank fusion), con el control de acceso basado en roles y etiquetas habitual de |Fess|. Por defecto se usa busqueda por palabras clave (BM25); el LLM no realiza por si mismo la busqueda, el ranking ni el embedding de los documentos.
+El modo de búsqueda IA obtiene sus documentos de origen a través del pipeline estándar de búsqueda de |Fess| (rank fusión), con el control de acceso basado en roles y etiquetas habitual de |Fess|. Por defecto se usa búsqueda por palabras clave (BM25); el LLM no realiza por sí mismo la búsqueda, el ranking ni el embedding de los documentos.
 
 Los dos tipos de solicitud ejecutan pipelines ligeramente distintos:
 
-- ``POST /api/v2/chat/stream`` (usado por la interfaz web) ejecuta el flujo completo: **analisis de intencion → busqueda → evaluacion de relevancia por el LLM → obtencion de contenido → generacion de la respuesta** (en streaming).
-- ``POST /api/v2/chat`` (sin streaming) ejecuta un flujo mas corto: **analisis de intencion → busqueda → generacion de la respuesta** (sin fase de evaluacion de relevancia ni una fase independiente de obtencion de contenido).
+- ``POST /api/v2/chat/stream`` (usado por la interfaz web) ejecuta el flujo completo: **análisis de intención → búsqueda → evaluación de relevancia por el LLM → obtención de contenido → generación de la respuesta** (en streaming).
+- ``POST /api/v2/chat`` (sin streaming) ejecuta un flujo más corto: **análisis de intención → búsqueda → generación de la respuesta** (sin fase de evaluación de relevancia ni una fase independiente de obtención de contenido).
 
-En el flujo de streaming, una llamada adicional al LLM **evalua los resultados de busqueda** y conserva unicamente los documentos que considera relevantes antes de generar la respuesta.
+En el flujo de streaming, una llamada adicional al LLM **evalúa los resultados de búsqueda** y conserva únicamente los documentos que considera relevantes antes de generar la respuesta.
 
-Como funciona el modo de búsqueda IA
+Cómo funciona el modo de búsqueda IA
 ========================
 
-El modo de búsqueda IA opera con el siguiente flujo de multiples etapas.
+El modo de búsqueda IA opera con el siguiente flujo de múltiples etapas.
 
-1. **Fase de analisis de intencion**: Analiza la pregunta del usuario y extrae las palabras clave mas adecuadas para la busqueda
-2. **Fase de busqueda**: Busca documentos usando el motor de busqueda de |Fess| con las palabras clave extraidas
-3. **Fallback de regeneracion de consulta**: Cuando no se encuentran resultados, el LLM regenera la consulta y reintenta
-4. **Fase de evaluacion**: Evalua la relevancia de los resultados de busqueda y selecciona los documentos mas apropiados
-5. **Fase de generacion**: El LLM genera una respuesta basada en los documentos seleccionados
-6. **Fase de salida**: Devuelve la respuesta y la informacion de fuentes al usuario (con renderizado Markdown)
+1. **Fase de análisis de intención**: Analiza la pregunta del usuario y extrae las palabras clave más adecuadas para la búsqueda
+2. **Fase de búsqueda**: Busca documentos usando el motor de búsqueda de |Fess| con las palabras clave extraídas
+3. **Fallback de regeneración de consulta**: Cuando no se encuentran resultados, el LLM regenera la consulta y reintenta
+4. **Fase de evaluación**: Evalúa la relevancia de los resultados de búsqueda y selecciona los documentos más apropiados
+5. **Fase de generación**: El LLM genera una respuesta basada en los documentos seleccionados
+6. **Fase de salida**: Devuelve la respuesta y la información de fuentes al usuario (con renderizado Markdown)
 
-Este flujo permite respuestas de alta calidad con comprension del contexto, superiores a la simple busqueda por palabras clave.
-La regeneracion de consultas mejora la cobertura de respuestas cuando la consulta de busqueda inicial no es optima.
+Este flujo permite respuestas de alta calidad con comprensión del contexto, superiores a la simple búsqueda por palabras clave.
+La regeneración de consultas mejora la cobertura de respuestas cuando la consulta de búsqueda inicial no es óptima.
 
-Configuracion basica
+Configuración básica
 ====================
 
-La configuracion de la funcionalidad de modo de búsqueda IA se divide en configuracion del nucleo y configuracion del proveedor.
+La configuración de la funcionalidad de modo de búsqueda IA se divide en configuración del núcleo y configuración del proveedor.
 
-Configuracion del nucleo (fess_config.properties)
+Configuración del núcleo (fess_config.properties)
 --------------------------------------------------
 
-Configuracion basica para habilitar la funcionalidad de modo de búsqueda IA.
+Configuración básica para habilitar la funcionalidad de modo de búsqueda IA.
 Se configura en ``app/WEB-INF/conf/fess_config.properties``.
 
 ::
@@ -56,14 +56,14 @@ Se configura en ``app/WEB-INF/conf/fess_config.properties``.
     # Habilitar la funcionalidad de modo de búsqueda IA
     rag.chat.enabled=true
 
-Configuracion del proveedor (system.properties / pantalla de administracion)
+Configuración del proveedor (system.properties / pantalla de administración)
 -----------------------------------------------------------------------------
 
-La seleccion del proveedor LLM se realiza en la pantalla de administracion o en las propiedades del sistema.
+La selección del proveedor LLM se realiza en la pantalla de administración o en las propiedades del sistema.
 
-**Al configurar desde la pantalla de administracion**:
+**Al configurar desde la pantalla de administración**:
 
-Seleccione el proveedor LLM a usar en la pantalla de configuracion de Administracion > Sistema > General.
+Seleccione el proveedor LLM a usar en la pantalla de configuración de Administración > Sistema > General.
 
 **Al configurar en system.properties**:
 
@@ -72,18 +72,18 @@ Seleccione el proveedor LLM a usar en la pantalla de configuracion de Administra
     # Seleccionar el proveedor LLM (ollama, openai, gemini)
     rag.llm.name=ollama
 
-Para la configuracion detallada del proveedor LLM, consulte lo siguiente:
+Para la configuración detallada del proveedor LLM, consulte lo siguiente:
 
-- :doc:`llm-ollama` - Configuracion de Ollama
-- :doc:`llm-openai` - Configuracion de OpenAI
-- :doc:`llm-gemini` - Configuracion de Google Gemini
+- :doc:`llm-ollama` - Configuración de Ollama
+- :doc:`llm-openai` - Configuración de OpenAI
+- :doc:`llm-gemini` - Configuración de Google Gemini
 
-Referencia rapida de rutas de configuracion
+Referencia rápida de rutas de configuración
 ===========================================
 
-En |Fess| 15.9 los parametros estan divididos en dos familias: la familia FessConfig
+En |Fess| 15.9 los parámetros están divididos en dos familias: la familia FessConfig
 (``fess_config.properties``) y la familia SystemProperty (``system.properties``,
-persistida en OpenSearch). Las rutas de configuracion difieren; no las mezcle.
+persistida en OpenSearch). Las rutas de configuración difieren; no las mezcle.
 
 .. list-table::
    :header-rows: 1
@@ -91,7 +91,7 @@ persistida en OpenSearch). Las rutas de configuracion difieren; no las mezcle.
 
    * - Propiedad
      - Familia
-     - Paso via Docker / opciones JVM
+     - Paso vía Docker / opciones JVM
      - UI Admin
    * - ``rag.chat.enabled``
      - FessConfig
@@ -100,7 +100,7 @@ persistida en OpenSearch). Las rutas de configuracion difieren; no las mezcle.
    * - ``rag.llm.name``
      - SystemProperty
      - ``-Dfess.system.rag.llm.name=gemini`` (solo como valor inicial por defecto)
-     - Si (Configuracion general)
+     - Si (Configuración general)
    * - ``rag.llm.gemini.api.key``
      - FessConfig
      - ``-Dfess.config.rag.llm.gemini.api.key=...``
@@ -125,83 +125,83 @@ persistida en OpenSearch). Las rutas de configuracion difieren; no las mezcle.
 .. note::
 
    ``rag.llm.type`` es el nombre de propiedad heredado de |Fess| 15.5 y anteriores.
-   En 15.9 y posteriores se renombro a ``rag.llm.name``; los valores escritos bajo
+   En 15.9 y posteriores se renombró a ``rag.llm.name``; los valores escritos bajo
    ``rag.llm.type`` no se leen.
 
-Lista de configuracion del nucleo
+Lista de configuración del núcleo
 ==================================
 
-Lista de configuraciones del nucleo que se pueden configurar en ``fess_config.properties``.
+Lista de configuraciones del núcleo que se pueden configurar en ``fess_config.properties``.
 
 .. list-table::
    :header-rows: 1
    :widths: 40 40 20
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
    * - ``rag.chat.enabled``
      - Habilitar la funcionalidad de modo de búsqueda IA
      - ``false``
    * - ``rag.chat.context.max.documents``
-     - Numero maximo de documentos a incluir en el contexto
+     - Número máximo de documentos a incluir en el contexto
      - ``5``
    * - ``rag.chat.session.timeout.minutes``
-     - Tiempo de timeout de sesion (minutos)
+     - Tiempo de timeout de sesión (minutos)
      - ``30``
    * - ``rag.chat.session.max.size``
-     - Numero maximo de sesiones que se pueden mantener simultaneamente
+     - Número máximo de sesiones que se pueden mantener simultáneamente
      - ``10000``
    * - ``rag.chat.history.max.messages``
-     - Numero maximo de mensajes a mantener en el historial de conversacion
+     - Número máximo de mensajes a mantener en el historial de conversación
      - ``30``
    * - ``rag.chat.content.fields``
      - Campos a obtener de los documentos
      - ``title,url,content,doc_id,content_title,content_description``
    * - ``rag.chat.message.max.length``
-     - Numero maximo de caracteres del mensaje del usuario. Este valor se lee como System Property; el elemento en ``fess_config.properties`` no se utiliza. Configurelo mediante System Properties o ``-Dfess.system.rag.chat.message.max.length``.
+     - Número máximo de caracteres del mensaje del usuario. Este valor se lee como System Property; el elemento en ``fess_config.properties`` no se utiliza. Configúrelo mediante System Properties o ``-Dfess.system.rag.chat.message.max.length``.
      - ``4000``
    * - ``rag.chat.highlight.fragment.size``
-     - Tamano del fragmento de resaltado de busqueda
+     - Tamaño del fragmento de resaltado de búsqueda
      - ``500``
    * - ``rag.chat.highlight.number.of.fragments``
-     - Numero de fragmentos de resaltado de busqueda
+     - Número de fragmentos de resaltado de búsqueda
      - ``3``
    * - ``rag.chat.content.fulltext.max.length``
-     - Umbral por encima del cual los documentos (segun ``content_length``) usan pasajes resaltados en lugar del texto completo en el contexto de la respuesta
+     - Umbral por encima del cual los documentos (según ``content_length``) usan pasajes resaltados en lugar del texto completo en el contexto de la respuesta
      - ``3000``
    * - ``rag.chat.answer.highlight.fragment.size``
-     - Tamano del fragmento de resaltado al extraer pasajes de documentos grandes para el contexto de la respuesta
+     - Tamaño del fragmento de resaltado al extraer pasajes de documentos grandes para el contexto de la respuesta
      - ``1000``
    * - ``rag.chat.answer.highlight.number.of.fragments``
-     - Numero de fragmentos de resaltado al extraer pasajes de documentos grandes para el contexto de la respuesta
+     - Número de fragmentos de resaltado al extraer pasajes de documentos grandes para el contexto de la respuesta
      - ``5``
    * - ``rag.chat.history.assistant.content``
      - Tipo de contenido a incluir en el historial del asistente ( ``full`` / ``smart_summary`` / ``source_titles`` / ``source_titles_and_urls`` / ``truncated`` / ``none`` )
      - ``smart_summary``
    * - ``rag.chat.history.titles.max.count``
-     - Numero maximo de titulos de documentos referenciados que se conservan por turno en el modo ``smart_summary``
+     - Número máximo de títulos de documentos referenciados que se conservan por turno en el modo ``smart_summary``
      - ``5``
 
-Parametros de generacion
+Parámetros de generación
 ========================
 
-En |Fess| 15.9, los parametros de generacion (numero maximo de tokens, temperature, etc.) se configuran por proveedor
-y por tipo de prompt. Estas configuraciones se gestionan como configuracion de cada plugin ``fess-llm-*``,
-no como configuracion del nucleo.
+En |Fess| 15.9, los parámetros de generación (número máximo de tokens, temperature, etc.) se configuran por proveedor
+y por tipo de prompt. Estas configuraciones se gestionan como configuración de cada plugin ``fess-llm-*``,
+no como configuración del núcleo.
 
-Para los detalles, consulte la documentacion de cada proveedor:
+Para los detalles, consulte la documentación de cada proveedor:
 
-- :doc:`llm-ollama` - Configuracion de parametros de generacion de Ollama
-- :doc:`llm-openai` - Configuracion de parametros de generacion de OpenAI
-- :doc:`llm-gemini` - Configuracion de parametros de generacion de Google Gemini
+- :doc:`llm-ollama` - Configuración de parámetros de generación de Ollama
+- :doc:`llm-openai` - Configuración de parámetros de generación de OpenAI
+- :doc:`llm-gemini` - Configuración de parámetros de generación de Google Gemini
 
-Configuracion de contexto
+Configuración de contexto
 ==========================
 
-Configuracion del contexto pasado al LLM desde los resultados de busqueda.
+Configuración del contexto pasado al LLM desde los resultados de búsqueda.
 
-Configuracion del nucleo
+Configuración del núcleo
 ------------------------
 
 Las siguientes configuraciones se realizan en ``fess_config.properties``.
@@ -211,99 +211,99 @@ Las siguientes configuraciones se realizan en ``fess_config.properties``.
    :widths: 35 45 20
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
    * - ``rag.chat.context.max.documents``
-     - Numero maximo de documentos a incluir en el contexto
+     - Número máximo de documentos a incluir en el contexto
      - ``5``
    * - ``rag.chat.content.fields``
      - Campos a obtener de los documentos
      - ``title,url,content,doc_id,content_title,content_description``
 
-Configuracion especifica del proveedor
+Configuración específica del proveedor
 ---------------------------------------
 
 Las siguientes configuraciones se realizan en ``fess_config.properties`` por proveedor.
 
-- ``rag.llm.{provider}.{promptType}.context.max.chars`` - Numero maximo de caracteres del contexto
-- ``rag.llm.{provider}.chat.evaluation.max.relevant.docs`` - Numero maximo de documentos relevantes a seleccionar en la fase de evaluacion
+- ``rag.llm.{provider}.{promptType}.context.max.chars`` - Número máximo de caracteres del contexto
+- ``rag.llm.{provider}.chat.evaluation.max.relevant.docs`` - Número máximo de documentos relevantes a seleccionar en la fase de evaluación
 
 En ``{provider}`` va el nombre del proveedor como ``ollama``, ``openai``, ``gemini``, etc.
 En ``{promptType}`` va el tipo de prompt como ``intent``, ``evaluation``, ``answer``, ``summary``, ``faq``, ``queryregeneration``, ``unclear``, ``noresults``, ``docnotfound``, ``direct``, etc.
-Los tipos de prompt soportados estan definidos en la implementacion ``*LlmClient`` de cada plugin.
+Los tipos de prompt soportados están definidos en la implementación ``*LlmClient`` de cada plugin.
 
-Para los detalles, consulte la documentacion de cada proveedor.
+Para los detalles, consulte la documentación de cada proveedor.
 
 Campos de contenido
 -------------------
 
 Campos que pueden especificarse en ``rag.chat.content.fields``:
 
-- ``title`` - Titulo del documento
+- ``title`` - Título del documento
 - ``url`` - URL del documento
 - ``content`` - Cuerpo del documento
 - ``doc_id`` - ID del documento
-- ``content_title`` - Titulo del contenido
-- ``content_description`` - Descripcion del contenido
+- ``content_title`` - Título del contenido
+- ``content_description`` - Descripción del contenido
 
 Prompt del sistema
 ==================
 
-En |Fess| 15.9, los prompts del sistema estan definidos en el DI XML (``fess_llm++.xml``) de cada plugin ``fess-llm-*``,
+En |Fess| 15.9, los prompts del sistema están definidos en el DI XML (``fess_llm++.xml``) de cada plugin ``fess-llm-*``,
 no en archivos de propiedades.
 
-Personalizacion de prompts
+Personalización de prompts
 --------------------------
 
 Para personalizar los prompts del sistema, anule el ``fess_llm++.xml`` dentro del JAR del plugin.
 
 1. Obtenga ``fess_llm++.xml`` del archivo JAR del plugin en uso
 2. Realice los cambios necesarios
-3. Coloquelo en el lugar apropiado bajo ``app/WEB-INF/`` para anularlo
+3. Colóquelo en el lugar apropiado bajo ``app/WEB-INF/`` para anularlo
 
-Para cada tipo de prompt (analisis de intencion, evaluacion, generacion), estan definidos diferentes
-prompts del sistema, optimizados segun el uso.
+Para cada tipo de prompt (análisis de intención, evaluación, generación), están definidos diferentes
+prompts del sistema, optimizados según el uso.
 
-Para los detalles, consulte la documentacion de cada proveedor:
+Para los detalles, consulte la documentación de cada proveedor:
 
-- :doc:`llm-ollama` - Configuracion de prompts de Ollama
-- :doc:`llm-openai` - Configuracion de prompts de OpenAI
-- :doc:`llm-gemini` - Configuracion de prompts de Google Gemini
+- :doc:`llm-ollama` - Configuración de prompts de Ollama
+- :doc:`llm-openai` - Configuración de prompts de OpenAI
+- :doc:`llm-gemini` - Configuración de prompts de Google Gemini
 
-Gestion de sesiones
+Gestión de sesiones
 ===================
 
-Configuracion relacionada con la gestion de sesiones de chat.
+Configuración relacionada con la gestión de sesiones de chat.
 
 .. list-table::
    :header-rows: 1
    :widths: 35 45 20
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
    * - ``rag.chat.session.timeout.minutes``
-     - Tiempo de timeout de sesion (minutos)
+     - Tiempo de timeout de sesión (minutos)
      - ``30``
    * - ``rag.chat.session.max.size``
-     - Numero maximo de sesiones que se pueden mantener simultaneamente
+     - Número máximo de sesiones que se pueden mantener simultáneamente
      - ``10000``
    * - ``rag.chat.history.max.messages``
-     - Numero maximo de mensajes a mantener en el historial de conversacion
+     - Número máximo de mensajes a mantener en el historial de conversación
      - ``30``
 
 Comportamiento de sesiones
 --------------------------
 
-- Cuando un usuario inicia un nuevo chat, se crea una nueva sesion
-- El historial de conversacion se guarda en la sesion, permitiendo dialogo con contexto mantenido
-- Las sesiones se eliminan automaticamente despues del tiempo de timeout
-- Cuando el historial de conversacion excede el numero maximo de mensajes, los mensajes antiguos se eliminan
+- Cuando un usuario inicia un nuevo chat, se crea una nueva sesión
+- El historial de conversación se guarda en la sesión, permitiendo diálogo con contexto mantenido
+- Las sesiones se eliminan automáticamente después del tiempo de timeout
+- Cuando el historial de conversación excede el número máximo de mensajes, los mensajes antiguos se eliminan
 
 Control de concurrencia
 =======================
 
-El numero de solicitudes simultaneas al LLM se controla por proveedor en ``fess_config.properties``.
+El número de solicitudes simultáneas al LLM se controla por proveedor en ``fess_config.properties``.
 
 ::
 
@@ -318,67 +318,67 @@ El numero de solicitudes simultaneas al LLM se controla por proveedor en ``fess_
 Consideraciones del control de concurrencia
 --------------------------------------------
 
-- Configure tambien teniendo en cuenta los limites de tasa del lado del proveedor LLM
-- En entornos de alta carga, se recomienda configurar valores mas pequenos
-- Cuando se alcanza el limite del numero de solicitudes simultaneas, las solicitudes entran en cola y se procesan en orden
+- Configure también teniendo en cuenta los límites de tasa del lado del proveedor LLM
+- En entornos de alta carga, se recomienda configurar valores más pequeños
+- Cuando se alcanza el límite del número de solicitudes simultáneas, las solicitudes entran en cola y se procesan en orden
 - Si la espera para adquirir un permiso supera ``concurrency.wait.timeout``, la solicitud falla con un error de timeout
 
-Modo de historial de conversacion
+Modo de historial de conversación
 ==================================
 
-``rag.chat.history.assistant.content`` controla como se almacenan las respuestas del asistente en el historial de conversacion.
+``rag.chat.history.assistant.content`` controla como se almacenan las respuestas del asistente en el historial de conversación.
 
 .. list-table::
    :header-rows: 1
    :widths: 25 75
 
    * - Modo
-     - Descripcion
+     - Descripción
    * - ``smart_summary``
-     - (Predeterminado) Omite el cuerpo de la respuesta del asistente y conserva, por turno, unicamente la consulta de busqueda pasada y los titulos de los documentos referenciados (hasta ``rag.chat.history.titles.max.count`` elementos)
+     - (Predeterminado) Omite el cuerpo de la respuesta del asistente y conserva, por turno, únicamente la consulta de búsqueda pasada y los títulos de los documentos referenciados (hasta ``rag.chat.history.titles.max.count`` elementos)
    * - ``full``
      - Preserva la respuesta completa tal cual
    * - ``source_titles``
-     - Preserva solo los titulos de las fuentes
+     - Preserva solo los títulos de las fuentes
    * - ``source_titles_and_urls``
-     - Preserva los titulos y URLs de las fuentes
+     - Preserva los títulos y URLs de las fuentes
    * - ``truncated``
-     - Trunca la respuesta al limite maximo de caracteres
+     - Trunca la respuesta al límite máximo de caracteres
    * - ``none``
      - No preserva el historial
 
 .. note::
 
-   En el modo ``smart_summary``, el cuerpo de la respuesta se reemplaza por la consulta de busqueda y los titulos referenciados, preservando el contexto de forma eficiente y reduciendo el uso de tokens.
-   Los pares de mensajes de usuario y asistente se agrupan como turnos y se empaquetan optimamente dentro de un presupuesto de caracteres.
-   Los limites maximos de caracteres para el historial y el resumen, asi como el control por plugin, son gestionados por la implementacion ``LlmClient`` de cada plugin ``fess-llm-*``.
+   En el modo ``smart_summary``, el cuerpo de la respuesta se reemplaza por la consulta de búsqueda y los títulos referenciados, preservando el contexto de forma eficiente y reduciendo el uso de tokens.
+   Los pares de mensajes de usuario y asistente se agrupan como turnos y se empaquetan óptimamente dentro de un presupuesto de caracteres.
+   Los límites máximos de caracteres para el historial y el resumen, así como el control por plugin, son gestionados por la implementación ``LlmClient`` de cada plugin ``fess-llm-*``.
 
-Regeneracion de consulta
+Regeneración de consulta
 ========================
 
-Cuando no se encuentran resultados de busqueda o no se identifican resultados relevantes, el LLM regenera automaticamente la consulta y reintenta la busqueda.
+Cuando no se encuentran resultados de búsqueda o no se identifican resultados relevantes, el LLM regenera automáticamente la consulta y reintenta la búsqueda.
 
-- Con cero resultados de busqueda: Regeneracion de consulta con razon ``no_results``
-- Cuando no se encuentran documentos relevantes: Regeneracion de consulta con razon ``no_relevant_results``
-- Recurre a la consulta original si la regeneracion falla
+- Con cero resultados de búsqueda: Regeneración de consulta con razón ``no_results``
+- Cuando no se encuentran documentos relevantes: Regeneración de consulta con razón ``no_relevant_results``
+- Recurre a la consulta original si la regeneración falla
 
-Esta funcionalidad esta habilitada por defecto e integrada en los flujos RAG sincronos y de streaming.
-Los prompts de regeneracion de consulta se definen en cada plugin ``fess-llm-*``.
+Esta funcionalidad está habilitada por defecto e integrada en los flujos RAG síncronos y de streaming.
+Los prompts de regeneración de consulta se definen en cada plugin ``fess-llm-*``.
 
 Renderizado Markdown
 ====================
 
-Las respuestas del modo de busqueda IA se renderizan en formato Markdown.
+Las respuestas del modo de búsqueda IA se renderizan en formato Markdown.
 
 - Las respuestas del LLM se analizan como Markdown y se convierten a HTML
 - El HTML convertido se sanitiza, permitiendo solo etiquetas y atributos seguros
-- Soporta encabezados, listas, bloques de codigo, tablas, enlaces y otras sintaxis Markdown
+- Soporta encabezados, listas, bloques de código, tablas, enlaces y otras sintaxis Markdown
 - Del lado del cliente se usa ``marked.js`` y ``DOMPurify``; del lado del servidor se usa el sanitizador OWASP
 
 Uso de la API
 =============
 
-La funcionalidad de modo de busqueda IA esta disponible a traves de la API REST (v2).
+La funcionalidad de modo de búsqueda IA está disponible a través de la API REST (v2).
 La URL base es ``http://<nombre del servidor>/api/v2/``.
 
 La Chat API proporciona los siguientes tres endpoints:
@@ -388,22 +388,22 @@ La Chat API proporciona los siguientes tres endpoints:
    :widths: 45 55
 
    * - Endpoint
-     - Descripcion
+     - Descripción
    * - ``POST /api/v2/chat``
      - Completado RAG por lotes (sin streaming)
    * - ``POST /api/v2/chat/stream``
      - Streaming de completado RAG (Server-Sent Events)
    * - ``DELETE /api/v2/chat/sessions/{session_id}``
-     - Borrar el historial de conversacion de una sesion
+     - Borrar el historial de conversación de una sesión
 
-Las solicitudes se envian con cuerpo JSON usando ``Content-Type: application/json``.
+Las solicitudes se envían con cuerpo JSON usando ``Content-Type: application/json``.
 Las solicitudes que modifican el estado (``POST`` / ``DELETE``) requieren el token CSRF (cabecera ``X-Fess-CSRF-Token``).
-Las respuestas se almacenan en el sobre comun ``response``.
+Las respuestas se almacenan en el sobre común ``response``.
 
 .. note::
 
-   Los endpoints de parametros de formulario de la familia ``/api/v1/chat`` disponibles en |Fess| 15.5 y anteriores han sido eliminados.
-   En la version 15.9, utilice la API basada en JSON de ``/api/v2/``.
+   Los endpoints de parámetros de formulario de la familia ``/api/v1/chat`` disponibles en |Fess| 15.5 y anteriores han sido eliminados.
+   En la versión 15.9, utilice la API basada en JSON de ``/api/v2/``.
 
 API sin streaming
 -----------------
@@ -418,19 +418,19 @@ Cuerpo de la solicitud (JSON):
 
    * - Campo
      - Requerido
-     - Descripcion
+     - Descripción
    * - ``message``
      - Si
      - Mensaje del usuario
    * - ``session_id``
      - No
-     - ID de sesion (para continuar la conversacion). Si se omite, el servidor lo crea y lo devuelve en la respuesta
+     - ID de sesión (para continuar la conversación). Si se omite, el servidor lo crea y lo devuelve en la respuesta
    * - ``fields``
      - No
-     - Campos de filtro opcionales para el paso de recuperacion (objeto)
+     - Campos de filtro opcionales para el paso de recuperación (objeto)
    * - ``fields.label``
      - No
-     - Filtro de busqueda por etiqueta
+     - Filtro de búsqueda por etiqueta
    * - ``extra_queries``
      - No
      - Expresiones de consulta adicionales para filtros de faceta
@@ -452,11 +452,11 @@ Ejemplo de respuesta:
       "response": {
         "status": 0,
         "session_id": "abc123",
-        "content": "El metodo de instalacion de Fess es...",
+        "content": "El método de instalación de Fess es...",
         "sources": [
           {
             "rank": 1,
-            "title": "Guia de instalacion",
+            "title": "Guía de instalación",
             "url": "https://...",
             "doc_id": "...",
             "snippet": "..."
@@ -482,7 +482,7 @@ Ejemplo de solicitud:
          -H "X-Fess-CSRF-Token: <token>" \
          -H "Accept: text/event-stream" \
          --no-buffer \
-         -d '{"message":"Por favor explicame las caracteristicas de Fess"}'
+         -d '{"message":"Por favor explicame las características de Fess"}'
 
 Eventos SSE:
 
@@ -491,7 +491,7 @@ Eventos SSE:
    :widths: 20 80
 
    * - Evento
-     - Descripcion (payload)
+     - Descripción (payload)
    * - ``phase``
      - Inicio/fin de fase de procesamiento (``{ phase, status, message?, keywords?, hit_count?, ... }``). Fases: ``intent``, ``search``, ``evaluate``, ``fetch``, ``answer``
    * - ``chunk``
@@ -499,102 +499,102 @@ Eventos SSE:
    * - ``retry``
      - Notificado cuando se reintenta una solicitud al LLM (``{ phase, operation, attempt, max_attempts, sleep_ms, cause? }``)
    * - ``waiting``
-     - Progreso de una fase de larga duracion, como la espera para adquirir un permiso de concurrencia (``{ phase, reason, elapsed_ms, timeout_ms }``)
+     - Progreso de una fase de larga duración, como la espera para adquirir un permiso de concurrencia (``{ phase, reason, elapsed_ms, timeout_ms }``)
    * - ``fallback``
-     - Notificado cuando la consulta se regenera por cero resultados u otras causas (``{ phase, reason, original_query?, new_query? }``, razon: ``no_results`` o ``no_relevant_results``)
+     - Notificado cuando la consulta se regenera por cero resultados u otras causas (``{ phase, reason, original_query?, new_query? }``, razón: ``no_results`` o ``no_relevant_results``)
    * - ``warning``
      - Notificado al producirse una advertencia recuperable (``{ phase, code, detail? }``, por ejemplo agotamiento de tokens en modelos de razonamiento)
    * - ``sources``
-     - Informacion de documentos de referencia (``{ sources: [...] }``)
+     - Información de documentos de referencia (``{ sources: [...] }``)
    * - ``done``
      - Procesamiento completado (``{ session_id, html_content? }``). ``html_content`` contiene el string HTML renderizado desde Markdown
    * - ``error``
-     - Fallo terminal a mitad del stream (``{ phase?, message, error_code }``). Cubre timeout, longitud de contexto excedida, modelo no encontrado, respuesta invalida y errores de conexion
+     - Fallo terminal a mitad del stream (``{ phase?, message, error_code }``). Cubre timeout, longitud de contexto excedida, modelo no encontrado, respuesta inválida y errores de conexión
 
-Borrar una sesion
+Borrar una sesión
 -----------------
 
 Endpoint: ``DELETE /api/v2/chat/sessions/{session_id}``
 
-Borra el historial de conversacion de la sesion especificada. Devuelve ``cleared: true`` si tiene exito.
+Borra el historial de conversación de la sesión especificada. Devuelve ``cleared: true`` si tiene éxito.
 
-Para la documentacion completa de la API (autenticacion, CSRF, limites de tasa, codigos HTTP), consulte :doc:`../api/api-chat`.
+Para la documentación completa de la API (autenticación, CSRF, límites de tasa, códigos HTTP), consulte :doc:`../api/api-chat`.
 
 Interfaz web
 ============
 
-En la interfaz web de |Fess|, puede usar la funcionalidad de modo de búsqueda IA desde la pantalla de busqueda.
+En la interfaz web de |Fess|, puede usar la funcionalidad de modo de búsqueda IA desde la pantalla de búsqueda.
 
 Iniciar chat
 ------------
 
-1. Acceda a la pantalla de busqueda de |Fess|
+1. Acceda a la pantalla de búsqueda de |Fess|
 2. Haga clic en el icono de chat
-3. Se mostrara el panel de chat
+3. Se mostrará el panel de chat
 
 Usar chat
 ---------
 
 1. Ingrese una pregunta en el cuadro de texto
-2. Haga clic en el boton de enviar o presione la tecla Enter
-3. Se mostrara la respuesta del asistente de IA
+2. Haga clic en el botón de enviar o presione la tecla Enter
+3. Se mostrará la respuesta del asistente de IA
 4. La respuesta incluye enlaces a las fuentes de referencia
 
-Continuar conversacion
+Continuar conversación
 ----------------------
 
-- Puede continuar la conversacion dentro de la misma sesion de chat
+- Puede continuar la conversación dentro de la misma sesión de chat
 - Las respuestas consideran el contexto de las preguntas anteriores
-- Hacer clic en "Nuevo chat" reinicia la sesion
+- Hacer clic en "Nuevo chat" reinicia la sesión
 
-Solucion de problemas
+Solución de problemas
 =====================
 
-El boton del modo IA no aparece en la pantalla de busqueda
+El botón del modo IA no aparece en la pantalla de búsqueda
 ----------------------------------------------------------
 
-**Sintoma**: El boton del modo IA no aparece en el encabezado de los resultados
-de busqueda y al acceder a ``/chat`` se redirige a la pagina principal.
+**Síntoma**: El botón del modo IA no aparece en el encabezado de los resultados
+de búsqueda y al acceder a ``/chat`` se redirige a la página principal.
 
-**Lista de verificacion**: revise los siguientes puntos en orden.
+**Lista de verificación**: revise los siguientes puntos en orden.
 
-1. ¿Esta ``rag.chat.enabled=true`` configurado?
+1. ¿Está ``rag.chat.enabled=true`` configurado?
 
-   - Docker: ¿``-Dfess.config.rag.chat.enabled=true`` esta incluido en ``FESS_JAVA_OPTS``?
-   - Instalacion por paquete: ¿esta escrito en ``app/WEB-INF/conf/fess_config.properties``?
+   - Docker: ¿``-Dfess.config.rag.chat.enabled=true`` está incluido en ``FESS_JAVA_OPTS``?
+   - Instalación por paquete: ¿está escrito en ``app/WEB-INF/conf/fess_config.properties``?
 
-2. ¿Esta instalado el plugin ``fess-llm-*`` correspondiente?
+2. ¿Está instalado el plugin ``fess-llm-*`` correspondiente?
 
    - Docker: ``FESS_PLUGINS=fess-llm-gemini:15.9.0`` (o ``fess-llm-openai`` / ``fess-llm-ollama``) debe estar definido
-   - Instalacion por paquete: el JAR debe estar en ``app/WEB-INF/plugin/``
+   - Instalación por paquete: el JAR debe estar en ``app/WEB-INF/plugin/``
    - El log de inicio debe incluir ``Installing fess-llm-XXX-15.9.0.jar``
 
 3. ¿Coincide ``rag.llm.name`` con un plugin instalado?
 
-   - El valor por defecto es ``ollama``. Si solo el plugin Gemini esta instalado, debe definir explicitamente ``gemini`` (igualmente ``openai`` para el plugin OpenAI)
-   - Metodo (a): editar ``rag.llm.name`` desde Administracion > Sistema > General (seccion RAG) y guardar
-   - Metodo (b): incluir ``-Dfess.system.rag.llm.name=gemini`` en ``FESS_JAVA_OPTS`` al inicio. Solo actua como valor inicial por defecto antes de que se persista un valor en OpenSearch
+   - El valor por defecto es ``ollama``. Si solo el plugin Gemini está instalado, debe definir explícitamente ``gemini`` (igualmente ``openai`` para el plugin OpenAI)
+   - Método (a): editar ``rag.llm.name`` desde Administración > Sistema > General (sección RAG) y guardar
+   - Método (b): incluir ``-Dfess.system.rag.llm.name=gemini`` en ``FESS_JAVA_OPTS`` al inicio. Solo actúa como valor inicial por defecto antes de que se persista un valor en OpenSearch
 
 4. ¿Aparece repetidamente un WARN como ``[LLM] LlmClient not found. componentName=ollamaLlmClient`` en el log?
 
-   - Sintoma tipico cuando ``rag.llm.name`` sigue siendo ``ollama`` pero el plugin Ollama no esta instalado
+   - Síntoma típico cuando ``rag.llm.name`` sigue siendo ``ollama`` pero el plugin Ollama no está instalado
    - Definir ``rag.llm.name`` al proveedor realmente usado lo resuelve
-   - De forma similar, ``componentName=geminiLlmClient`` indica que ``rag.llm.name=gemini`` esta definido pero el plugin ``fess-llm-gemini`` no esta instalado
+   - De forma similar, ``componentName=geminiLlmClient`` indica que ``rag.llm.name=gemini`` está definido pero el plugin ``fess-llm-gemini`` no está instalado
 
-5. ¿Esta configurada la clave de API especifica del proveedor?
+5. ¿Está configurada la clave de API específica del proveedor?
 
-   - Si ``rag.llm.gemini.api.key`` / ``rag.llm.openai.api.key`` esta vacia, ``checkAvailabilityNow`` devuelve ``false`` y el modo IA queda desactivado
+   - Si ``rag.llm.gemini.api.key`` / ``rag.llm.openai.api.key`` está vacía, ``checkAvailabilityNow`` devuelve ``false`` y el modo IA queda desactivado
    - Activar DEBUG en ``org.codelibs.fess.llm.gemini`` en ``log4j2.xml`` muestra mensajes como ``[LLM:GEMINI] Gemini is not available. apiKey is blank``
 
 6. ¿Puede el host de Fess alcanzar al proveedor LLM?
 
    - Para APIs cloud (Gemini / OpenAI), el contenedor debe tener acceso saliente a Internet
-   - Si se requiere un proxy, configure ``http.proxy.host`` / ``http.proxy.port`` (y opcionalmente ``http.proxy.username`` / ``http.proxy.password``) en ``fess_config.properties``. En entornos Docker, agregue ``-Dfess.config.http.proxy.host=... -Dfess.config.http.proxy.port=...`` a ``FESS_JAVA_OPTS`` (desde |Fess| 15.9, los clientes LLM utilizan la configuracion de proxy comun de |Fess|)
+   - Si se requiere un proxy, configure ``http.proxy.host`` / ``http.proxy.port`` (y opcionalmente ``http.proxy.username`` / ``http.proxy.password``) en ``fess_config.properties``. En entornos Docker, agregue ``-Dfess.config.http.proxy.host=... -Dfess.config.http.proxy.port=...`` a ``FESS_JAVA_OPTS`` (desde |Fess| 15.9, los clientes LLM utilizan la configuración de proxy común de |Fess|)
 
 .. note::
 
-   La pagina "General" no expone una casilla para ``rag.chat.enabled`` (por diseño).
-   Es una propiedad de la familia FessConfig y solo puede definirse a traves de
+   La página "General" no expone una casilla para ``rag.chat.enabled`` (por diseño).
+   Es una propiedad de la familia FessConfig y solo puede definirse a través de
    ``fess_config.properties`` o ``-Dfess.config.rag.chat.enabled=true``.
 
 El modo de búsqueda IA no se habilita
@@ -602,10 +602,10 @@ El modo de búsqueda IA no se habilita
 
 **Verificaciones**:
 
-1. Si ``rag.chat.enabled=true`` esta configurado
-2. Si el proveedor LLM esta configurado correctamente en ``rag.llm.name``
-3. Si el plugin ``fess-llm-*`` correspondiente esta instalado
-4. Si es posible la conexion al proveedor LLM
+1. Si ``rag.chat.enabled=true`` está configurado
+2. Si el proveedor LLM está configurado correctamente en ``rag.llm.name``
+3. Si el plugin ``fess-llm-*`` correspondiente está instalado
+4. Si es posible la conexión al proveedor LLM
 
 Baja calidad de respuestas
 --------------------------
@@ -615,15 +615,15 @@ Baja calidad de respuestas
 1. Usar un modelo LLM de mayor rendimiento
 2. Aumentar ``rag.chat.context.max.documents``
 3. Personalizar los prompts del sistema en el DI XML
-4. Ajustar la configuracion de temperature especifica del proveedor (consulte la documentacion de cada plugin ``fess-llm-*``)
+4. Ajustar la configuración de temperature específica del proveedor (consulte la documentación de cada plugin ``fess-llm-*``)
 
 Respuestas lentas
 -----------------
 
 **Mejoras**:
 
-1. Usar un modelo LLM mas rapido (ej: Gemini Flash)
-2. Reducir la configuracion de max.tokens especifica del proveedor (consulte la documentacion de cada plugin ``fess-llm-*``)
+1. Usar un modelo LLM más rápido (ej: Gemini Flash)
+2. Reducir la configuración de max.tokens específica del proveedor (consulte la documentación de cada plugin ``fess-llm-*``)
 3. Reducir ``rag.chat.context.max.documents``
 
 Sesiones no se mantienen
@@ -631,11 +631,11 @@ Sesiones no se mantienen
 
 **Verificaciones**:
 
-1. Si el sessionId se esta enviando correctamente del lado del cliente
-2. Configuracion de ``rag.chat.session.timeout.minutes``
+1. Si el sessionId se está enviando correctamente del lado del cliente
+2. Configuración de ``rag.chat.session.timeout.minutes``
 3. Capacidad del almacenamiento de sesiones
 
-Configuracion de depuracion
+Configuración de depuración
 ---------------------------
 
 Para investigar problemas, puede ajustar el nivel de log para obtener logs detallados.
@@ -649,19 +649,19 @@ Para investigar problemas, puede ajustar el nivel de log para obtener logs detal
     <Logger name="org.codelibs.fess.chat" level="DEBUG"/>
 
 Los mensajes de log usan el prefijo ``[RAG]``, con subprefijos como ``[RAG:INTENT]``, ``[RAG:EVAL]`` y ``[RAG:ANSWER]`` para cada fase.
-A nivel INFO, se emiten logs de finalizacion de chat (tiempo transcurrido, cantidad de fuentes). A nivel DEBUG, se emiten detalles de uso de tokens, control de concurrencia y empaquetado del historial.
+A nivel INFO, se emiten logs de finalización de chat (tiempo transcurrido, cantidad de fuentes). A nivel DEBUG, se emiten detalles de uso de tokens, control de concurrencia y empaquetado del historial.
 
-Registro de busqueda y tipo de acceso
+Registro de búsqueda y tipo de acceso
 --------------------------------------
 
-Las busquedas a traves del modo de busqueda IA se registran con el nombre del proveedor LLM (por ejemplo, ``ollama``, ``openai``, ``gemini``) como tipo de acceso en los registros de busqueda. Esto permite distinguir las busquedas del modo IA de las busquedas web o API regulares en los analisis.
+Las búsquedas a través del modo de búsqueda IA se registran con el nombre del proveedor LLM (por ejemplo, ``ollama``, ``openai``, ``gemini``) como tipo de acceso en los registros de búsqueda. Esto permite distinguir las búsquedas del modo IA de las búsquedas web o API regulares en los análisis.
 
-Informacion de referencia
+Información de referencia
 =========================
 
-- :doc:`llm-overview` - Descripcion general de integracion LLM
-- :doc:`llm-ollama` - Configuracion de Ollama
-- :doc:`llm-openai` - Configuracion de OpenAI
-- :doc:`llm-gemini` - Configuracion de Google Gemini
+- :doc:`llm-overview` - Descripción general de integración LLM
+- :doc:`llm-ollama` - Configuración de Ollama
+- :doc:`llm-openai` - Configuración de OpenAI
+- :doc:`llm-gemini` - Configuración de Google Gemini
 - :doc:`../api/api-chat` - Referencia de Chat API
-- :doc:`../user/chat-search` - Guia de busqueda con chat para usuarios finales
+- :doc:`../user/chat-search` - Guía de búsqueda con chat para usuarios finales

--- a/es/15.9/config/rate-limiting.rst
+++ b/es/15.9/config/rate-limiting.rst
@@ -1,25 +1,25 @@
 ==================================
-Configuracion de limite de tasa
+Configuración de límite de tasa
 ==================================
 
-Descripcion general
+Descripción general
 ===================
 
-|Fess| tiene una funcionalidad de limite de tasa para mantener la estabilidad y el rendimiento del sistema.
-Esta funcionalidad protege el sistema de solicitudes excesivas y permite una distribucion justa de recursos.
+|Fess| tiene una funcionalidad de límite de tasa para mantener la estabilidad y el rendimiento del sistema.
+Esta funcionalidad protege el sistema de solicitudes excesivas y permite una distribución justa de recursos.
 
-El limite de tasa se aplica en los siguientes escenarios:
+El límite de tasa se aplica en los siguientes escenarios:
 
-- Todas las solicitudes HTTP, incluyendo API de busqueda, API de modo de búsqueda IA y pantallas de administracion (``RateLimitFilter``)
-- Solicitudes del crawler (controladas por la configuracion de crawl)
+- Todas las solicitudes HTTP, incluyendo API de búsqueda, API de modo de búsqueda IA y pantallas de administración (``RateLimitFilter``)
+- Solicitudes del crawler (controladas por la configuración de crawl)
 
-Limitacion de tasa de solicitudes HTTP
+Limitación de tasa de solicitudes HTTP
 =======================================
 
-Puede limitar el numero de solicitudes HTTP a |Fess| por direccion IP.
-Esta limitacion se aplica a todas las solicitudes HTTP, incluyendo la API de busqueda, la API de modo de búsqueda IA, las pantallas de administracion, etc.
+Puede limitar el número de solicitudes HTTP a |Fess| por dirección IP.
+Esta limitación se aplica a todas las solicitudes HTTP, incluyendo la API de búsqueda, la API de modo de búsqueda IA, las pantallas de administración, etc.
 
-Configuracion
+Configuración
 -------------
 
 ``app/WEB-INF/classes/fess_config.properties``:
@@ -38,38 +38,38 @@ Configuracion
 Comportamiento
 --------------
 
-- Las solicitudes que excedan el limite de tasa devuelven HTTP 429 (Too Many Requests)
+- Las solicitudes que excedan el límite de tasa devuelven HTTP 429 (Too Many Requests)
 - Las solicitudes de IPs incluidas en la lista de bloqueo devuelven HTTP 403 (Forbidden)
-- El limite se aplica por direccion IP
-- La ventana se inicia con la primera solicitud de cada IP y el contador se reinicia despues de que expire el periodo de ventana (metodo de ventana fija)
-- Cuando se excede el limite, la IP se bloquea durante el periodo definido en ``rate.limit.block.duration.ms``
+- El límite se aplica por dirección IP
+- La ventana se inicia con la primera solicitud de cada IP y el contador se reinicia después de que expire el período de ventana (método de ventana fija)
+- Cuando se excede el límite, la IP se bloquea durante el período definido en ``rate.limit.block.duration.ms``
 
-Limite de tasa del modo de búsqueda IA
+Límite de tasa del modo de búsqueda IA
 ==========================
 
-La funcionalidad de modo de búsqueda IA tiene un limite de tasa para controlar los costos y el consumo de recursos de la API de LLM.
-El modo de búsqueda IA tiene la limitacion de tasa de solicitudes HTTP descrita anteriormente, ademas de configuraciones de limite de tasa especificas del modo de búsqueda IA.
+La funcionalidad de modo de búsqueda IA tiene un límite de tasa para controlar los costos y el consumo de recursos de la API de LLM.
+El modo de búsqueda IA tiene la limitación de tasa de solicitudes HTTP descrita anteriormente, además de configuraciones de límite de tasa específicas del modo de búsqueda IA.
 
-Para la configuracion especifica del limite de tasa del modo de búsqueda IA, consulte :doc:`rag-chat`.
+Para la configuración específica del límite de tasa del modo de búsqueda IA, consulte :doc:`rag-chat`.
 
 .. note::
-   El limite de tasa del modo de búsqueda IA se aplica por separado del limite de tasa del proveedor LLM.
-   Considere ambos limites al configurar.
+   El límite de tasa del modo de búsqueda IA se aplica por separado del límite de tasa del proveedor LLM.
+   Considere ambos límites al configurar.
 
-Limite de tasa del crawler
+Límite de tasa del crawler
 ==========================
 
 Puede configurar el intervalo entre solicitudes para evitar que el crawler sobrecargue los sitios objetivo.
 
-Configuracion de crawl web
+Configuración de crawl web
 --------------------------
 
-Configure lo siguiente en "Crawler" -> "Web" en la pantalla de administracion:
+Configure lo siguiente en "Crawler" -> "Web" en la pantalla de administración:
 
 - **Intervalo de solicitudes**: Tiempo de espera entre solicitudes (milisegundos)
-- **Numero de hilos**: Numero de hilos de crawl paralelos
+- **Número de hilos**: Número de hilos de crawl paralelos
 
-Configuracion recomendada:
+Configuración recomendada:
 
 ::
 
@@ -101,7 +101,7 @@ Al establecerlo en ``true``, se deshabilita el manejo de robots.txt, incluyendo 
     # Ignorar robots.txt (predeterminado: false)
     crawler.ignore.robots.txt=false
 
-Todas las opciones de configuracion de limite de tasa
+Todas las opciones de configuración de límite de tasa
 =====================================================
 
 Todas las propiedades configurables en ``app/WEB-INF/classes/fess_config.properties``.
@@ -111,51 +111,51 @@ Todas las propiedades configurables en ``app/WEB-INF/classes/fess_config.propert
    :widths: 35 45 20
 
    * - Propiedad
-     - Descripcion
+     - Descripción
      - Predeterminado
    * - ``rate.limit.enabled``
-     - Habilitar limite de tasa
+     - Habilitar límite de tasa
      - ``false``
    * - ``rate.limit.requests.per.window``
-     - Numero maximo de solicitudes por ventana
+     - Número máximo de solicitudes por ventana
      - ``100``
    * - ``rate.limit.window.ms``
-     - Tamano de ventana (milisegundos)
+     - Tamaño de ventana (milisegundos)
      - ``60000``
    * - ``rate.limit.block.duration.ms``
-     - Periodo de bloqueo de IP cuando se excede el limite (milisegundos)
+     - Período de bloqueo de IP cuando se excede el límite (milisegundos)
      - ``300000``
    * - ``rate.limit.retry.after.seconds``
      - Valor del encabezado Retry-After (segundos)
      - ``60``
    * - ``rate.limit.whitelist.ips``
-     - Direcciones IP excluidas del limite de tasa (separadas por comas)
+     - Direcciones IP excluidas del límite de tasa (separadas por comas)
      - ``127.0.0.1,::1``
    * - ``rate.limit.blocked.ips``
      - Direcciones IP a bloquear (separadas por comas)
-     - (vacio)
+     - (vacío)
    * - ``rate.limit.trusted.proxies``
      - IPs de proxies confiables (para obtener X-Forwarded-For/X-Real-IP)
      - ``127.0.0.1,::1``
    * - ``rate.limit.cleanup.interval``
-     - Intervalo de limpieza (numero de solicitudes, reservado)
+     - Intervalo de limpieza (número de solicitudes, reservado)
      - ``1000``
 
 .. note::
-   ``rate.limit.cleanup.interval`` es una configuracion reservada para uso futuro.
-   En la implementacion actual, los contadores de solicitudes y la informacion de IPs bloqueadas
-   se limpian automaticamente en funcion de la expiracion de la cache interna
+   ``rate.limit.cleanup.interval`` es una configuración reservada para uso futuro.
+   En la implementación actual, los contadores de solicitudes y la información de IPs bloqueadas
+   se limpian automáticamente en función de la expiración de la caché interna
    (``rate.limit.window.ms`` y ``rate.limit.block.duration.ms``),
    por lo que este valor no se utiliza.
 
-Configuracion avanzada de limite de tasa
+Configuración avanzada de límite de tasa
 ========================================
 
-Limite de tasa personalizado
+Límite de tasa personalizado
 ----------------------------
 
-Para aplicar una logica de limite de tasa diferente basada en condiciones especificas,
-se requiere una implementacion de componente personalizado.
+Para aplicar una lógica de límite de tasa diferente basada en condiciones específicas,
+se requiere una implementación de componente personalizado.
 
 ::
 
@@ -167,10 +167,10 @@ se requiere una implementacion de componente personalizado.
         }
     }
 
-Configuracion de exclusion
+Configuración de exclusión
 ==========================
 
-Puede excluir direcciones IP especificas del limite de tasa o bloquearlas.
+Puede excluir direcciones IP específicas del límite de tasa o bloquearlas.
 
 ::
 
@@ -184,60 +184,60 @@ Puede excluir direcciones IP especificas del limite de tasa o bloquearlas.
     rate.limit.trusted.proxies=127.0.0.1,::1
 
 .. note::
-   Si esta usando un proxy inverso, configure la direccion IP del proxy en ``rate.limit.trusted.proxies``.
+   Si está usando un proxy inverso, configure la dirección IP del proxy en ``rate.limit.trusted.proxies``.
    Solo se obtendrá la IP del cliente de los encabezados X-Forwarded-For y X-Real-IP
    cuando la solicitud provenga de un proxy confiable.
 
 Monitoreo y alertas
 ===================
 
-Configuracion para monitorear el estado del limite de tasa:
+Configuración para monitorear el estado del límite de tasa:
 
 Salida de logs
 --------------
 
-Cuando se aplica el limite de tasa, se registra en el log:
+Cuando se aplica el límite de tasa, se registra en el log:
 
 ::
 
     <Logger name="org.codelibs.fess.helper.RateLimitHelper" level="INFO"/>
 
-Solucion de problemas
+Solución de problemas
 =====================
 
-Solicitudes legitimas son bloqueadas
+Solicitudes legítimas son bloqueadas
 ------------------------------------
 
-**Causa**: Valor de limite demasiado estricto
+**Causa**: Valor de límite demasiado estricto
 
-**Solucion**:
+**Solución**:
 
 1. Aumentar ``rate.limit.requests.per.window``
-2. Agregar IPs especificas a la lista blanca (``rate.limit.whitelist.ips``)
-3. Ajustar el tamano de la ventana (``rate.limit.window.ms``)
+2. Agregar IPs específicas a la lista blanca (``rate.limit.whitelist.ips``)
+3. Ajustar el tamaño de la ventana (``rate.limit.window.ms``)
 
-Limite de tasa no funciona
+Límite de tasa no funciona
 --------------------------
 
-**Causa**: Configuracion no reflejada correctamente
+**Causa**: Configuración no reflejada correctamente
 
 **Verificaciones**:
 
-1. Si ``rate.limit.enabled=true`` esta configurado
-2. Si el archivo de configuracion se esta leyendo correctamente
+1. Si ``rate.limit.enabled=true`` está configurado
+2. Si el archivo de configuración se está leyendo correctamente
 3. Si |Fess| fue reiniciado
 
 Impacto en el rendimiento
 -------------------------
 
-Si la verificacion del limite de tasa afecta el rendimiento:
+Si la verificación del límite de tasa afecta el rendimiento:
 
-1. Utilizar la lista blanca para omitir la verificacion de IPs confiables
-2. Deshabilitar el limite de tasa (``rate.limit.enabled=false``)
+1. Utilizar la lista blanca para omitir la verificación de IPs confiables
+2. Deshabilitar el límite de tasa (``rate.limit.enabled=false``)
 
-Informacion de referencia
+Información de referencia
 =========================
 
-- :doc:`rag-chat` - Configuracion de la funcionalidad de modo de búsqueda IA
-- :doc:`../admin/webconfig-guide` - Guia de configuracion de crawl web
-- :doc:`../api/api-overview` - Descripcion general de API
+- :doc:`rag-chat` - Configuración de la funcionalidad de modo de búsqueda IA
+- :doc:`../admin/webconfig-guide` - Guía de configuración de crawl web
+- :doc:`../api/api-overview` - Descripción general de API


### PR DESCRIPTION
> Stacked on #509, because that PR also touches `es/.../ds-database.rst`. This PR's diff is against it.

## Summary

Seven Spanish pages had lost most of their accents. The damage is partial rather
than stylistic - the same page reads `Búsqueda` in its title and `Descripcion`
two lines later, `índice` in one paragraph and `indice` in the next. It is a
defect, not a house style.

Share of non-blank lines carrying an accented character (`áéíóúüñ`, upper case,
`¿¡`):

| Page | Before | After |
|---|---|---|
| `config/datastore/ds-git.rst` | 0.005 | 0.195 |
| `config/datastore/ds-database.rst` | 0.017 | 0.271 |
| `config/llm-openai.rst` | 0.021 | 0.310 |
| `config/llm-gemini.rst` | 0.022 | 0.290 |
| `config/rag-chat.rst` | 0.040 | 0.386 |
| `config/datastore/ds-slack.rst` | 0.042 | 0.260 |
| `config/rate-limiting.rst` | 0.052 | 0.378 |

Measured the same way, the other 140 pages of `es/15.9` run from 0.057 to 0.694
with a median of 0.296, and the only one below 0.09 is `admin/index.rst`, which
is almost entirely a toctree. These seven were the outliers.

(`ds-database.rst` starts at 0.017 rather than near zero only because the text
#509 adds to it is already accented.)

## How the spellings were chosen

Not by guessing. Every accented word in the **healthy Spanish pages of this
repository** was collected and keyed by its unaccented form. A mapping was kept
only where exactly one accented form existed *and* the unaccented form is not
itself a Spanish word - 597 substitutions.

Two orthographic rules were applied on top: no Spanish word ends in an unaccented
`-cion` or `-sion`, and the plurals `-ciones` / `-siones` correctly carry none.

The remaining rare inflected forms and homographs were resolved one at a time
against their context: future and conditional (`estaran` → `estarán`,
`eliminarian` → `eliminarían`), preterite (`elimino` → `eliminó`, `inicio` →
`inició` where it is the verb and not the noun), imperative with an enclitic
pronoun (`coloquelo` → `colóquelo`, `Administrela` → `Adminístrela`), and
adjectives (`explicito` → `explícito`, `matematicas` → `matemáticas`).

## Homographs left alone

- `que`, `como`, `cuando`, `donde`, `cual` stay unaccented as relatives and
  conjunctions. Only genuine interrogatives were accented: `identifica qué paso
  ha fallado`, and the heading `Cómo funciona`.
- `esta` / `este` stay unaccented as demonstratives; only verb forms became
  `está` / `esté`.
- `si` stays unaccented as the conditional.
- `solo` stays unaccented, per current RAE.
- `envio` was split by meaning: `envió` (verb) at one site, `envío` (noun) at
  another.

**One bulk substitution was wrong and was reverted.** `Mejora continua`
translates "Continuous Improvement", so the adjective is correct there and the
verb `continúa` is not.

## Scope

Prose only, and 15.9 only.

- **1,079 protected fragments** - every literal block body, inline `` `` `` span,
  URL and `|Fess|` substitution - were extracted from both revisions and compared:
  all byte-identical.
- The diff is **782 insertions against 782 deletions**, so no line was added,
  removed or reflowed.
- Section title underlines are unaffected: an accent does not change a character
  count. `tools/check_headings.py` passes over the versions `versions.json` calls
  current, as do the `tools` unit tests and `update_eol.py --check`.

Spanish text inside code blocks was deliberately left as it is - for example the
curl payload in `rag-chat.rst` still reads `explicame como instalar Fess`, and
the placeholder `` `datastore://<id de la configuracion...>` `` in
`ds-database.rst` keeps its spelling because it sits inside an inline literal.

## Not addressed

- `ds-git.rst` uses `reindexiza`, which is not standard Spanish (`se reindexa`
  would be). Not an accent problem, so out of scope here.
- `llm-openai.rst` and `llm-gemini.rst` use `commita` as a verb.
- Four pre-existing "title underline too short" warnings (rag-chat, rate-limiting)
  are present identically before and after this change.
