### PR TITLE
docs: document the crawl.order configuration parameter

### DIFF
--- a/de/15.9/config/crawler-basic.rst
+++ b/de/15.9/config/crawler-basic.rst
@@ -319,12 +319,13 @@ Gibt die Häufigkeit der Crawl-Ausführung an.
 Crawl-Reihenfolge
 -----------------
 
-Durch Setzen von ``crawl.order`` in den Konfigurationsparametern einer Crawl-Konfiguration
+Durch Setzen von ``config.crawl.order`` in den Konfigurationsparametern einer Crawl-Konfiguration
 wird die Reihenfolge geändert, in der URLs aus der Warteschlange entnommen werden. Der Wert
 ist einer der folgenden Komponentennamen.
 
 .. list-table::
    :header-rows: 1
+   :widths: 30 70
 
    * - Wert
      - Abrufreihenfolge
@@ -339,9 +340,14 @@ ist einer der folgenden Komponentennamen.
    * - ``weightFirstUrlQueueOrder``
      - Nur nach absteigendem Gewicht
 
+Die Gewichte sind standardmäßig einheitlich, sofern kein benutzerdefinierter
+``UrlQueueWeigher`` installiert ist; daher hat ``weightFirstUrlQueueOrder`` standardmäßig
+keine Wirkung, und ``sequentialUrlQueueOrder`` sortiert in der Praxis nach
+Entdeckungsreihenfolge.
+
 ::
 
-    crawl.order=depthFirstUrlQueueOrder
+    config.crawl.order=depthFirstUrlQueueOrder
 
 ``depthFirstUrlQueueOrder`` ist keine strikte Tiefensuche. Der Crawler ruft einen Stapel von
 URLs ab und arbeitet ihn vollständig ab, bevor er den nächsten abruft. Tiefere URLs, die
@@ -351,7 +357,7 @@ Ein nicht auflösbarer Komponentenname wird als Warnung protokolliert, und die
 Standardreihenfolge wird verwendet.
 
 .. note::
-   Die Werte ``sequential`` und ``random`` aus früheren Versionen funktionieren weiterhin.
+   Die Werte ``config.crawl.order=sequential`` und ``config.crawl.order=random`` aus früheren Versionen funktionieren weiterhin.
 
 Konfiguration der Dateigröße
 ====================

--- a/de/15.9/config/crawler-basic.rst
+++ b/de/15.9/config/crawler-basic.rst
@@ -338,12 +338,15 @@ ist einer der folgenden Komponentennamen.
    * - ``newestFirstUrlQueueOrder``
      - Zuletzt entdeckte URLs zuerst
    * - ``weightFirstUrlQueueOrder``
-     - Nur nach absteigendem Gewicht
+     - Nur nach absteigendem Gewicht; Gleichstände überlässt sie der Suchmaschine
 
 Die Gewichte sind standardmäßig einheitlich, sofern kein benutzerdefinierter
-``UrlQueueWeigher`` installiert ist; daher hat ``weightFirstUrlQueueOrder`` standardmäßig
-keine Wirkung, und ``sequentialUrlQueueOrder`` sortiert in der Praxis nach
-Entdeckungsreihenfolge.
+``UrlQueueWeigher`` installiert ist; alle Einträge sind dann gleichauf und
+``sequentialUrlQueueOrder`` sortiert in der Praxis nach Entdeckungsreihenfolge. Das Gewicht ist
+ihr primärer Sortierschlüssel, sodass ein Weigher die Abrufreihenfolge ändert, ohne dass
+``config.crawl.order`` überhaupt gesetzt werden muss. ``weightFirstUrlQueueOrder``
+unterscheidet sich nur bei Einträgen mit gleichem Gewicht: Sie ist für einen großen,
+gewichteten Rückstand gedacht, bei dem allein das Gewicht entscheiden soll.
 
 ::
 
@@ -351,7 +354,9 @@ Entdeckungsreihenfolge.
 
 ``depthFirstUrlQueueOrder`` ist keine strikte Tiefensuche. Der Crawler ruft einen Stapel von
 URLs ab und arbeitet ihn vollständig ab, bevor er den nächsten abruft. Tiefere URLs, die
-während der Abarbeitung gefunden werden, warten daher auf den nächsten Stapel.
+während der Abarbeitung gefunden werden, warten daher auf den nächsten Stapel. Bei einem
+Crawl, dessen gesamte Warteschlange in einen Stapel passt, wird daher unabhängig von der
+gewählten Reihenfolge Ebene für Ebene abgearbeitet.
 
 Ein nicht auflösbarer Komponentenname wird als Warnung protokolliert, und die
 Standardreihenfolge wird verwendet.

--- a/de/15.9/config/crawler-basic.rst
+++ b/de/15.9/config/crawler-basic.rst
@@ -316,6 +316,43 @@ Gibt die Häufigkeit der Crawl-Ausführung an.
     # Oder im Scheduler konfigurieren
     0 2 * * *  # Täglich um 2 Uhr morgens
 
+Crawl-Reihenfolge
+-----------------
+
+Durch Setzen von ``crawl.order`` in den Konfigurationsparametern einer Crawl-Konfiguration
+wird die Reihenfolge geändert, in der URLs aus der Warteschlange entnommen werden. Der Wert
+ist einer der folgenden Komponentennamen.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Wert
+     - Abrufreihenfolge
+   * - ``sequentialUrlQueueOrder``
+     - Nach absteigendem Gewicht, dann nach Entdeckungsreihenfolge (Standard)
+   * - ``randomUrlQueueOrder``
+     - Zufällig, mit einem pro Sitzung festen Seed
+   * - ``depthFirstUrlQueueOrder``
+     - Tiefste URLs zuerst
+   * - ``newestFirstUrlQueueOrder``
+     - Zuletzt entdeckte URLs zuerst
+   * - ``weightFirstUrlQueueOrder``
+     - Nur nach absteigendem Gewicht
+
+::
+
+    crawl.order=depthFirstUrlQueueOrder
+
+``depthFirstUrlQueueOrder`` ist keine strikte Tiefensuche. Der Crawler ruft einen Stapel von
+URLs ab und arbeitet ihn vollständig ab, bevor er den nächsten abruft. Tiefere URLs, die
+während der Abarbeitung gefunden werden, warten daher auf den nächsten Stapel.
+
+Ein nicht auflösbarer Komponentenname wird als Warnung protokolliert, und die
+Standardreihenfolge wird verwendet.
+
+.. note::
+   Die Werte ``sequential`` und ``random`` aus früheren Versionen funktionieren weiterhin.
+
 Konfiguration der Dateigröße
 ====================
 

--- a/en/15.9/config/crawler-basic.rst
+++ b/en/15.9/config/crawler-basic.rst
@@ -314,6 +314,42 @@ Specifies the frequency of crawl execution.
     # Or set in scheduler
     0 2 * * *  # Daily at 2 AM
 
+Crawl Order
+-----------
+
+Setting ``crawl.order`` in the configuration parameters of a crawling config changes the
+order in which URLs are taken from the queue. The value is one of the following component
+names.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Value
+     - Fetch order
+   * - ``sequentialUrlQueueOrder``
+     - By descending weight, then by discovery order (default)
+   * - ``randomUrlQueueOrder``
+     - Random, with a seed fixed per session
+   * - ``depthFirstUrlQueueOrder``
+     - Deepest URLs first
+   * - ``newestFirstUrlQueueOrder``
+     - Most recently discovered URLs first
+   * - ``weightFirstUrlQueueOrder``
+     - By descending weight only
+
+::
+
+    crawl.order=depthFirstUrlQueueOrder
+
+``depthFirstUrlQueueOrder`` is not a strict depth-first search. The crawler fetches a batch
+of URLs and consumes it before fetching the next one, so deeper URLs found while a batch is
+being consumed wait for the following batch.
+
+An unresolvable component name is logged as a warning and the default order is used.
+
+.. note::
+   The ``sequential`` and ``random`` values from earlier versions still work.
+
 File Size Configuration
 =======================
 

--- a/en/15.9/config/crawler-basic.rst
+++ b/en/15.9/config/crawler-basic.rst
@@ -317,12 +317,13 @@ Specifies the frequency of crawl execution.
 Crawl Order
 -----------
 
-Setting ``crawl.order`` in the configuration parameters of a crawling config changes the
+Setting ``config.crawl.order`` in the configuration parameters of a crawling config changes the
 order in which URLs are taken from the queue. The value is one of the following component
 names.
 
 .. list-table::
    :header-rows: 1
+   :widths: 30 70
 
    * - Value
      - Fetch order
@@ -337,9 +338,13 @@ names.
    * - ``weightFirstUrlQueueOrder``
      - By descending weight only
 
+Weights are uniform unless a custom ``UrlQueueWeigher`` is installed, so
+``weightFirstUrlQueueOrder`` has no effect by default and ``sequentialUrlQueueOrder`` is, in
+practice, ordered by discovery order.
+
 ::
 
-    crawl.order=depthFirstUrlQueueOrder
+    config.crawl.order=depthFirstUrlQueueOrder
 
 ``depthFirstUrlQueueOrder`` is not a strict depth-first search. The crawler fetches a batch
 of URLs and consumes it before fetching the next one, so deeper URLs found while a batch is
@@ -348,7 +353,7 @@ being consumed wait for the following batch.
 An unresolvable component name is logged as a warning and the default order is used.
 
 .. note::
-   The ``sequential`` and ``random`` values from earlier versions still work.
+   The ``config.crawl.order=sequential`` and ``config.crawl.order=random`` values from earlier versions still work.
 
 File Size Configuration
 =======================

--- a/en/15.9/config/crawler-basic.rst
+++ b/en/15.9/config/crawler-basic.rst
@@ -336,11 +336,14 @@ names.
    * - ``newestFirstUrlQueueOrder``
      - Most recently discovered URLs first
    * - ``weightFirstUrlQueueOrder``
-     - By descending weight only
+     - By descending weight only, leaving ties to the search engine
 
-Weights are uniform unless a custom ``UrlQueueWeigher`` is installed, so
-``weightFirstUrlQueueOrder`` has no effect by default and ``sequentialUrlQueueOrder`` is, in
-practice, ordered by discovery order.
+Weights are uniform unless a custom ``UrlQueueWeigher`` is installed, so out of the box every
+entry ties and ``sequentialUrlQueueOrder`` is, in practice, ordered by discovery order. Weight
+is its primary sort key, so installing a weigher changes the fetch order without setting
+``config.crawl.order`` at all. ``weightFirstUrlQueueOrder`` differs only in what happens
+between entries of equal weight: choose it for a large weighted backlog where only the weight
+should decide what is crawled next.
 
 ::
 
@@ -348,7 +351,8 @@ practice, ordered by discovery order.
 
 ``depthFirstUrlQueueOrder`` is not a strict depth-first search. The crawler fetches a batch
 of URLs and consumes it before fetching the next one, so deeper URLs found while a batch is
-being consumed wait for the following batch.
+being consumed wait for the following batch. A crawl small enough for its whole queue to fit
+in one batch therefore proceeds level by level whichever order is selected.
 
 An unresolvable component name is logged as a warning and the default order is used.
 

--- a/es/15.9/config/crawler-basic.rst
+++ b/es/15.9/config/crawler-basic.rst
@@ -318,6 +318,43 @@ Especifique la frecuencia de ejecución del rastreo.
     # O configure en el programador
     0 2 * * *  # Todos los días a las 2 AM
 
+Orden de Rastreo
+----------------
+
+Al establecer ``crawl.order`` en los parámetros de configuración de una configuración de
+rastreo se cambia el orden en que se toman las URL de la cola. El valor es uno de los
+siguientes nombres de componente.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Valor
+     - Orden de obtención
+   * - ``sequentialUrlQueueOrder``
+     - Por peso descendente, luego por orden de descubrimiento (predeterminado)
+   * - ``randomUrlQueueOrder``
+     - Aleatorio, con una semilla fija por sesión
+   * - ``depthFirstUrlQueueOrder``
+     - URL más profundas primero
+   * - ``newestFirstUrlQueueOrder``
+     - URL descubiertas más recientemente primero
+   * - ``weightFirstUrlQueueOrder``
+     - Solo por peso descendente
+
+::
+
+    crawl.order=depthFirstUrlQueueOrder
+
+``depthFirstUrlQueueOrder`` no es una búsqueda en profundidad estricta. El rastreador obtiene
+un lote de URL y lo consume antes de obtener el siguiente, por lo que las URL más profundas
+encontradas mientras se consume un lote esperan al siguiente lote.
+
+Un nombre de componente que no se puede resolver se registra como advertencia y se utiliza el
+orden predeterminado.
+
+.. note::
+   Los valores ``sequential`` y ``random`` de versiones anteriores siguen funcionando.
+
 Configuración de Tamaño de Archivo
 ===================================
 

--- a/es/15.9/config/crawler-basic.rst
+++ b/es/15.9/config/crawler-basic.rst
@@ -340,12 +340,15 @@ siguientes nombres de componente.
    * - ``newestFirstUrlQueueOrder``
      - URL descubiertas más recientemente primero
    * - ``weightFirstUrlQueueOrder``
-     - Solo por peso descendente
+     - Solo por peso descendente, dejando los empates al motor de búsqueda
 
 Los pesos son uniformes de forma predeterminada a menos que se instale un
-``UrlQueueWeigher`` personalizado, por lo que ``weightFirstUrlQueueOrder`` no tiene efecto de
-forma predeterminada y ``sequentialUrlQueueOrder`` se ordena, en la práctica, por orden de
-descubrimiento.
+``UrlQueueWeigher`` personalizado, por lo que todas las entradas empatan y
+``sequentialUrlQueueOrder`` se ordena, en la práctica, por orden de descubrimiento. El peso es
+su clave de ordenación principal, de modo que instalar un weigher cambia el orden de obtención
+sin necesidad de establecer ``config.crawl.order``. ``weightFirstUrlQueueOrder`` solo difiere
+en el tratamiento de las entradas con el mismo peso: elíjalo para una cola grande y ponderada
+en la que solo el peso deba decidir qué se rastrea a continuación.
 
 ::
 
@@ -353,7 +356,8 @@ descubrimiento.
 
 ``depthFirstUrlQueueOrder`` no es una búsqueda en profundidad estricta. El rastreador obtiene
 un lote de URL y lo consume antes de obtener el siguiente, por lo que las URL más profundas
-encontradas mientras se consume un lote esperan al siguiente lote.
+encontradas mientras se consume un lote esperan al siguiente lote. Por tanto, un rastreo cuya
+cola completa cabe en un solo lote avanza nivel por nivel sea cual sea el orden seleccionado.
 
 Un nombre de componente que no se puede resolver se registra como advertencia y se utiliza el
 orden predeterminado.

--- a/es/15.9/config/crawler-basic.rst
+++ b/es/15.9/config/crawler-basic.rst
@@ -321,12 +321,13 @@ Especifique la frecuencia de ejecución del rastreo.
 Orden de Rastreo
 ----------------
 
-Al establecer ``crawl.order`` en los parámetros de configuración de una configuración de
+Al establecer ``config.crawl.order`` en los parámetros de configuración de una configuración de
 rastreo se cambia el orden en que se toman las URL de la cola. El valor es uno de los
 siguientes nombres de componente.
 
 .. list-table::
    :header-rows: 1
+   :widths: 30 70
 
    * - Valor
      - Orden de obtención
@@ -341,9 +342,14 @@ siguientes nombres de componente.
    * - ``weightFirstUrlQueueOrder``
      - Solo por peso descendente
 
+Los pesos son uniformes de forma predeterminada a menos que se instale un
+``UrlQueueWeigher`` personalizado, por lo que ``weightFirstUrlQueueOrder`` no tiene efecto de
+forma predeterminada y ``sequentialUrlQueueOrder`` se ordena, en la práctica, por orden de
+descubrimiento.
+
 ::
 
-    crawl.order=depthFirstUrlQueueOrder
+    config.crawl.order=depthFirstUrlQueueOrder
 
 ``depthFirstUrlQueueOrder`` no es una búsqueda en profundidad estricta. El rastreador obtiene
 un lote de URL y lo consume antes de obtener el siguiente, por lo que las URL más profundas
@@ -353,7 +359,7 @@ Un nombre de componente que no se puede resolver se registra como advertencia y 
 orden predeterminado.
 
 .. note::
-   Los valores ``sequential`` y ``random`` de versiones anteriores siguen funcionando.
+   Los valores ``config.crawl.order=sequential`` y ``config.crawl.order=random`` de versiones anteriores siguen funcionando.
 
 Configuración de Tamaño de Archivo
 ===================================

--- a/fr/15.9/config/crawler-basic.rst
+++ b/fr/15.9/config/crawler-basic.rst
@@ -318,6 +318,43 @@ Spécifie la fréquence d'exécution de l'indexation.
     # Ou configuré dans le planificateur
     0 2 * * *  # Tous les jours à 2h du matin
 
+Ordre d'indexation
+------------------
+
+Définir ``crawl.order`` dans les paramètres de configuration d'une configuration
+d'indexation modifie l'ordre dans lequel les URL sont extraites de la file d'attente. La
+valeur est l'un des noms de composant suivants.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Valeur
+     - Ordre de récupération
+   * - ``sequentialUrlQueueOrder``
+     - Par poids décroissant, puis par ordre de découverte (par défaut)
+   * - ``randomUrlQueueOrder``
+     - Aléatoire, avec une graine fixe par session
+   * - ``depthFirstUrlQueueOrder``
+     - URL les plus profondes en premier
+   * - ``newestFirstUrlQueueOrder``
+     - URL découvertes le plus récemment en premier
+   * - ``weightFirstUrlQueueOrder``
+     - Par poids décroissant uniquement
+
+::
+
+    crawl.order=depthFirstUrlQueueOrder
+
+``depthFirstUrlQueueOrder`` n'est pas un parcours en profondeur strict. Le crawler récupère
+un lot d'URL et le traite entièrement avant d'en récupérer un autre ; les URL plus profondes
+découvertes pendant le traitement attendent donc le lot suivant.
+
+Un nom de composant introuvable est journalisé comme avertissement et l'ordre par défaut est
+utilisé.
+
+.. note::
+   Les valeurs ``sequential`` et ``random`` des versions précédentes fonctionnent toujours.
+
 Configuration de la taille des fichiers
 ====================
 

--- a/fr/15.9/config/crawler-basic.rst
+++ b/fr/15.9/config/crawler-basic.rst
@@ -340,11 +340,14 @@ valeur est l'un des noms de composant suivants.
    * - ``newestFirstUrlQueueOrder``
      - URL découvertes le plus récemment en premier
    * - ``weightFirstUrlQueueOrder``
-     - Par poids décroissant uniquement
+     - Par poids décroissant uniquement, les égalités étant laissées au moteur de recherche
 
 Les poids sont uniformes par défaut, sauf si un ``UrlQueueWeigher`` personnalisé est
-installé ; ``weightFirstUrlQueueOrder`` n'a donc aucun effet par défaut, et
-``sequentialUrlQueueOrder`` s'ordonne en pratique par ordre de découverte.
+installé ; toutes les entrées sont alors à égalité et ``sequentialUrlQueueOrder`` s'ordonne en
+pratique par ordre de découverte. Le poids en est la clé de tri principale : installer un
+weigher modifie l'ordre de récupération sans même définir ``config.crawl.order``.
+``weightFirstUrlQueueOrder`` ne diffère que sur les entrées de poids égal ; choisissez-le pour
+un grand arriéré pondéré où seul le poids doit décider de la suite.
 
 ::
 
@@ -352,7 +355,8 @@ installé ; ``weightFirstUrlQueueOrder`` n'a donc aucun effet par défaut, et
 
 ``depthFirstUrlQueueOrder`` n'est pas un parcours en profondeur strict. Le crawler récupère
 un lot d'URL et le traite entièrement avant d'en récupérer un autre ; les URL plus profondes
-découvertes pendant le traitement attendent donc le lot suivant.
+découvertes pendant le traitement attendent donc le lot suivant. Un crawl dont toute la file
+tient dans un seul lot progresse donc niveau par niveau, quel que soit l'ordre choisi.
 
 Un nom de composant introuvable est journalisé comme avertissement et l'ordre par défaut est
 utilisé.

--- a/fr/15.9/config/crawler-basic.rst
+++ b/fr/15.9/config/crawler-basic.rst
@@ -321,12 +321,13 @@ Spécifie la fréquence d'exécution de l'indexation.
 Ordre d'indexation
 ------------------
 
-Définir ``crawl.order`` dans les paramètres de configuration d'une configuration
+Définir ``config.crawl.order`` dans les paramètres de configuration d'une configuration
 d'indexation modifie l'ordre dans lequel les URL sont extraites de la file d'attente. La
 valeur est l'un des noms de composant suivants.
 
 .. list-table::
    :header-rows: 1
+   :widths: 30 70
 
    * - Valeur
      - Ordre de récupération
@@ -341,9 +342,13 @@ valeur est l'un des noms de composant suivants.
    * - ``weightFirstUrlQueueOrder``
      - Par poids décroissant uniquement
 
+Les poids sont uniformes par défaut, sauf si un ``UrlQueueWeigher`` personnalisé est
+installé ; ``weightFirstUrlQueueOrder`` n'a donc aucun effet par défaut, et
+``sequentialUrlQueueOrder`` s'ordonne en pratique par ordre de découverte.
+
 ::
 
-    crawl.order=depthFirstUrlQueueOrder
+    config.crawl.order=depthFirstUrlQueueOrder
 
 ``depthFirstUrlQueueOrder`` n'est pas un parcours en profondeur strict. Le crawler récupère
 un lot d'URL et le traite entièrement avant d'en récupérer un autre ; les URL plus profondes
@@ -353,7 +358,7 @@ Un nom de composant introuvable est journalisé comme avertissement et l'ordre p
 utilisé.
 
 .. note::
-   Les valeurs ``sequential`` et ``random`` des versions précédentes fonctionnent toujours.
+   Les valeurs ``config.crawl.order=sequential`` et ``config.crawl.order=random`` des versions précédentes fonctionnent toujours.
 
 Configuration de la taille des fichiers
 ====================

--- a/ja/15.9/config/crawler-basic.rst
+++ b/ja/15.9/config/crawler-basic.rst
@@ -319,6 +319,41 @@ URLパターンによる制限
     # または、スケジューラーで設定
     0 2 * * *  # 毎日午前2時
 
+クロール順序
+------------
+
+クロール設定の設定パラメーターに ``crawl.order`` を指定すると、キューから URL を取り出す順序を
+変更できます。値には以下のコンポーネント名を指定します。
+
+.. list-table::
+   :header-rows: 1
+
+   * - 値
+     - 取り出す順序
+   * - ``sequentialUrlQueueOrder``
+     - 重み降順、次に発見順（既定値）
+   * - ``randomUrlQueueOrder``
+     - ランダム（シードはセッションごとに固定）
+   * - ``depthFirstUrlQueueOrder``
+     - 深い階層から先に取り出す
+   * - ``newestFirstUrlQueueOrder``
+     - 後から見つかった URL を先に取り出す
+   * - ``weightFirstUrlQueueOrder``
+     - 重み降順のみ
+
+::
+
+    crawl.order=depthFirstUrlQueueOrder
+
+``depthFirstUrlQueueOrder`` は厳密な深さ優先探索ではありません。クローラーは URL をまとめて
+取り出し、そのバッチを処理し終えてから次のバッチを取り出すため、処理中に見つかったより深い
+URL は次のバッチに回ります。
+
+解決できないコンポーネント名を指定した場合は警告をログに出力し、既定の順序で動作します。
+
+.. note::
+   以前のバージョンの ``sequential`` と ``random`` はそのまま指定できます。
+
 ファイルサイズの設定
 ====================
 

--- a/ja/15.9/config/crawler-basic.rst
+++ b/ja/15.9/config/crawler-basic.rst
@@ -322,11 +322,12 @@ URLパターンによる制限
 クロール順序
 ------------
 
-クロール設定の設定パラメーターに ``crawl.order`` を指定すると、キューから URL を取り出す順序を
+クロール設定の設定パラメーターに ``config.crawl.order`` を指定すると、キューから URL を取り出す順序を
 変更できます。値には以下のコンポーネント名を指定します。
 
 .. list-table::
    :header-rows: 1
+   :widths: 30 70
 
    * - 値
      - 取り出す順序
@@ -341,9 +342,13 @@ URLパターンによる制限
    * - ``weightFirstUrlQueueOrder``
      - 重み降順のみ
 
+既定では重みは一律のため、カスタムの ``UrlQueueWeigher`` を導入しない限り
+``weightFirstUrlQueueOrder`` は効果を持たず、``sequentialUrlQueueOrder`` は実質的に
+発見順での取り出しになります。
+
 ::
 
-    crawl.order=depthFirstUrlQueueOrder
+    config.crawl.order=depthFirstUrlQueueOrder
 
 ``depthFirstUrlQueueOrder`` は厳密な深さ優先探索ではありません。クローラーは URL をまとめて
 取り出し、そのバッチを処理し終えてから次のバッチを取り出すため、処理中に見つかったより深い
@@ -352,7 +357,7 @@ URL は次のバッチに回ります。
 解決できないコンポーネント名を指定した場合は警告をログに出力し、既定の順序で動作します。
 
 .. note::
-   以前のバージョンの ``sequential`` と ``random`` はそのまま指定できます。
+   以前のバージョンの ``config.crawl.order=sequential`` と ``config.crawl.order=random`` はそのまま指定できます。
 
 ファイルサイズの設定
 ====================

--- a/ja/15.9/config/crawler-basic.rst
+++ b/ja/15.9/config/crawler-basic.rst
@@ -340,11 +340,14 @@ URLパターンによる制限
    * - ``newestFirstUrlQueueOrder``
      - 後から見つかった URL を先に取り出す
    * - ``weightFirstUrlQueueOrder``
-     - 重み降順のみ
+     - 重み降順のみ（同じ重みの並びは検索エンジンに任せる）
 
-既定では重みは一律のため、カスタムの ``UrlQueueWeigher`` を導入しない限り
-``weightFirstUrlQueueOrder`` は効果を持たず、``sequentialUrlQueueOrder`` は実質的に
-発見順での取り出しになります。
+既定では重みは一律のため、カスタムの ``UrlQueueWeigher`` を導入しない限りすべてが同じ重みになり、
+``sequentialUrlQueueOrder`` は実質的に発見順での取り出しになります。
+``sequentialUrlQueueOrder`` は重みを第一のソートキーとしているため、weigher を導入すれば
+``config.crawl.order`` を設定しなくても取り出し順が変わります。
+``weightFirstUrlQueueOrder`` との違いは同じ重みの場合の扱いだけで、重み付けされた大量のキューに対して
+重みだけで次を決めたい場合に選択します。
 
 ::
 
@@ -352,7 +355,8 @@ URLパターンによる制限
 
 ``depthFirstUrlQueueOrder`` は厳密な深さ優先探索ではありません。クローラーは URL をまとめて
 取り出し、そのバッチを処理し終えてから次のバッチを取り出すため、処理中に見つかったより深い
-URL は次のバッチに回ります。
+URL は次のバッチに回ります。キュー全体が 1 つのバッチに収まる規模のクロールでは、どの順序を
+指定しても階層ごとの取り出しになります。
 
 解決できないコンポーネント名を指定した場合は警告をログに出力し、既定の順序で動作します。
 

--- a/ko/15.9/config/crawler-basic.rst
+++ b/ko/15.9/config/crawler-basic.rst
@@ -338,11 +338,14 @@ URL 패턴에 의한 제한
    * - ``newestFirstUrlQueueOrder``
      - 가장 최근에 발견된 URL 먼저
    * - ``weightFirstUrlQueueOrder``
-     - 가중치 내림차순만
+     - 가중치 내림차순만 (동점은 검색 엔진에 맡김)
 
-기본적으로 가중치는 균일하므로, 사용자 지정 ``UrlQueueWeigher``\ 를 설치하지 않는 한
-``weightFirstUrlQueueOrder``\ 는 효과가 없으며, ``sequentialUrlQueueOrder``\ 는 사실상
-발견 순서로 동작합니다.
+기본적으로 가중치는 균일하므로, 사용자 지정 ``UrlQueueWeigher``\ 를 설치하지 않는 한 모든 항목이
+동점이 되어 ``sequentialUrlQueueOrder``\ 는 사실상 발견 순서로 동작합니다.
+``sequentialUrlQueueOrder``\ 는 가중치를 첫 번째 정렬 키로 사용하므로, weigher를 설치하면
+``config.crawl.order``\ 를 설정하지 않아도 가져오는 순서가 바뀝니다.
+``weightFirstUrlQueueOrder``\ 와의 차이는 동점 항목의 처리뿐이며, 가중치가 부여된 대량의 큐에서
+가중치만으로 다음 대상을 정하고 싶을 때 선택합니다.
 
 ::
 
@@ -350,6 +353,7 @@ URL 패턴에 의한 제한
 
 ``depthFirstUrlQueueOrder``\ 는 엄밀한 깊이 우선 탐색이 아닙니다. 크롤러는 URL을 일괄로 가져와
 모두 처리한 후 다음 일괄을 가져오므로, 처리 중에 발견된 더 깊은 URL은 다음 일괄로 넘어갑니다.
+전체 큐가 한 일괄에 들어갈 정도의 크롤링에서는 어떤 순서를 지정하더라도 계층별로 가져옵니다.
 
 확인할 수 없는 컴포넌트 이름을 지정하면 경고를 로그에 출력하고 기본 순서로 동작합니다.
 

--- a/ko/15.9/config/crawler-basic.rst
+++ b/ko/15.9/config/crawler-basic.rst
@@ -317,6 +317,40 @@ URL 패턴에 의한 제한
     # 또는 스케줄러에서 설정
     0 2 * * *  # 매일 오전 2시
 
+크롤링 순서
+------------
+
+크롤링 설정의 설정 파라미터에 ``crawl.order``\ 를 지정하면 큐에서 URL을 꺼내는 순서를 변경할 수
+있습니다. 값에는 다음 컴포넌트 이름을 지정합니다.
+
+.. list-table::
+   :header-rows: 1
+
+   * - 값
+     - 가져오는 순서
+   * - ``sequentialUrlQueueOrder``
+     - 가중치 내림차순, 그 다음 발견 순서 (기본값)
+   * - ``randomUrlQueueOrder``
+     - 무작위 (시드는 세션별로 고정)
+   * - ``depthFirstUrlQueueOrder``
+     - 가장 깊은 URL 먼저
+   * - ``newestFirstUrlQueueOrder``
+     - 가장 최근에 발견된 URL 먼저
+   * - ``weightFirstUrlQueueOrder``
+     - 가중치 내림차순만
+
+::
+
+    crawl.order=depthFirstUrlQueueOrder
+
+``depthFirstUrlQueueOrder``\ 는 엄밀한 깊이 우선 탐색이 아닙니다. 크롤러는 URL을 일괄로 가져와
+모두 처리한 후 다음 일괄을 가져오므로, 처리 중에 발견된 더 깊은 URL은 다음 일괄로 넘어갑니다.
+
+확인할 수 없는 컴포넌트 이름을 지정하면 경고를 로그에 출력하고 기본 순서로 동작합니다.
+
+.. note::
+   이전 버전의 ``sequential`` 및 ``random`` 값도 그대로 사용할 수 있습니다.
+
 파일 크기 설정
 ====================
 

--- a/ko/15.9/config/crawler-basic.rst
+++ b/ko/15.9/config/crawler-basic.rst
@@ -320,11 +320,12 @@ URL 패턴에 의한 제한
 크롤링 순서
 ------------
 
-크롤링 설정의 설정 파라미터에 ``crawl.order``\ 를 지정하면 큐에서 URL을 꺼내는 순서를 변경할 수
+크롤링 설정의 설정 파라미터에 ``config.crawl.order``\ 를 지정하면 큐에서 URL을 꺼내는 순서를 변경할 수
 있습니다. 값에는 다음 컴포넌트 이름을 지정합니다.
 
 .. list-table::
    :header-rows: 1
+   :widths: 30 70
 
    * - 값
      - 가져오는 순서
@@ -339,9 +340,13 @@ URL 패턴에 의한 제한
    * - ``weightFirstUrlQueueOrder``
      - 가중치 내림차순만
 
+기본적으로 가중치는 균일하므로, 사용자 지정 ``UrlQueueWeigher``\ 를 설치하지 않는 한
+``weightFirstUrlQueueOrder``\ 는 효과가 없으며, ``sequentialUrlQueueOrder``\ 는 사실상
+발견 순서로 동작합니다.
+
 ::
 
-    crawl.order=depthFirstUrlQueueOrder
+    config.crawl.order=depthFirstUrlQueueOrder
 
 ``depthFirstUrlQueueOrder``\ 는 엄밀한 깊이 우선 탐색이 아닙니다. 크롤러는 URL을 일괄로 가져와
 모두 처리한 후 다음 일괄을 가져오므로, 처리 중에 발견된 더 깊은 URL은 다음 일괄로 넘어갑니다.
@@ -349,7 +354,7 @@ URL 패턴에 의한 제한
 확인할 수 없는 컴포넌트 이름을 지정하면 경고를 로그에 출력하고 기본 순서로 동작합니다.
 
 .. note::
-   이전 버전의 ``sequential`` 및 ``random`` 값도 그대로 사용할 수 있습니다.
+   이전 버전의 ``config.crawl.order=sequential`` 및 ``config.crawl.order=random`` 값도 그대로 사용할 수 있습니다.
 
 파일 크기 설정
 ====================

--- a/zh-cn/15.9/config/crawler-basic.rst
+++ b/zh-cn/15.9/config/crawler-basic.rst
@@ -337,18 +337,20 @@ URL模式限制
    * - ``newestFirstUrlQueueOrder``
      - 最近发现的 URL 优先
    * - ``weightFirstUrlQueueOrder``
-     - 仅按权重降序
+     - 仅按权重降序，同分时交由搜索引擎决定
 
-默认情况下权重是统一的，除非安装了自定义的 ``UrlQueueWeigher``，因此
-``weightFirstUrlQueueOrder`` 默认不起作用，``sequentialUrlQueueOrder`` 实际上按发现顺序
-排序。
+默认情况下权重是统一的，除非安装了自定义的 ``UrlQueueWeigher``，因此所有条目都同分，
+``sequentialUrlQueueOrder`` 实际上按发现顺序排序。由于权重是它的第一排序键，安装 weigher 后，
+即使不设置 ``config.crawl.order`` 取出顺序也会改变。``weightFirstUrlQueueOrder`` 的差别仅在于
+同分条目的处理：当队列中积压了大量已加权的 URL、且希望只由权重决定下一个抓取对象时选用它。
 
 ::
 
     config.crawl.order=depthFirstUrlQueueOrder
 
 ``depthFirstUrlQueueOrder`` 并非严格的深度优先搜索。爬虫会批量取出 URL 并处理完毕后再取下一批，
-因此处理过程中发现的更深的 URL 会推迟到下一批。
+因此处理过程中发现的更深的 URL 会推迟到下一批。如果整个队列都能装进一批，那么无论选择哪种
+顺序，爬取都会按层级逐层进行。
 
 指定无法解析的组件名称时会记录警告日志，并使用默认顺序。
 

--- a/zh-cn/15.9/config/crawler-basic.rst
+++ b/zh-cn/15.9/config/crawler-basic.rst
@@ -316,6 +316,40 @@ URL模式限制
     # 或在调度器中设置
     0 2 * * *  # 每天凌晨2点
 
+爬取顺序
+--------
+
+在爬取配置的配置参数中指定 ``crawl.order``，可以更改从队列中取出 URL 的顺序。值为以下组件名称
+之一。
+
+.. list-table::
+   :header-rows: 1
+
+   * - 值
+     - 取出顺序
+   * - ``sequentialUrlQueueOrder``
+     - 权重降序，然后按发现顺序（默认）
+   * - ``randomUrlQueueOrder``
+     - 随机（种子按会话固定）
+   * - ``depthFirstUrlQueueOrder``
+     - 最深的 URL 优先
+   * - ``newestFirstUrlQueueOrder``
+     - 最近发现的 URL 优先
+   * - ``weightFirstUrlQueueOrder``
+     - 仅按权重降序
+
+::
+
+    crawl.order=depthFirstUrlQueueOrder
+
+``depthFirstUrlQueueOrder`` 并非严格的深度优先搜索。爬虫会批量取出 URL 并处理完毕后再取下一批，
+因此处理过程中发现的更深的 URL 会推迟到下一批。
+
+指定无法解析的组件名称时会记录警告日志，并使用默认顺序。
+
+.. note::
+   早期版本的 ``sequential`` 和 ``random`` 值仍然有效。
+
 文件大小配置
 ====================
 

--- a/zh-cn/15.9/config/crawler-basic.rst
+++ b/zh-cn/15.9/config/crawler-basic.rst
@@ -319,11 +319,12 @@ URL模式限制
 爬取顺序
 --------
 
-在爬取配置的配置参数中指定 ``crawl.order``，可以更改从队列中取出 URL 的顺序。值为以下组件名称
+在爬取配置的配置参数中指定 ``config.crawl.order``，可以更改从队列中取出 URL 的顺序。值为以下组件名称
 之一。
 
 .. list-table::
    :header-rows: 1
+   :widths: 30 70
 
    * - 值
      - 取出顺序
@@ -338,9 +339,13 @@ URL模式限制
    * - ``weightFirstUrlQueueOrder``
      - 仅按权重降序
 
+默认情况下权重是统一的，除非安装了自定义的 ``UrlQueueWeigher``，因此
+``weightFirstUrlQueueOrder`` 默认不起作用，``sequentialUrlQueueOrder`` 实际上按发现顺序
+排序。
+
 ::
 
-    crawl.order=depthFirstUrlQueueOrder
+    config.crawl.order=depthFirstUrlQueueOrder
 
 ``depthFirstUrlQueueOrder`` 并非严格的深度优先搜索。爬虫会批量取出 URL 并处理完毕后再取下一批，
 因此处理过程中发现的更深的 URL 会推迟到下一批。
@@ -348,7 +353,7 @@ URL模式限制
 指定无法解析的组件名称时会记录警告日志，并使用默认顺序。
 
 .. note::
-   早期版本的 ``sequential`` 和 ``random`` 值仍然有效。
+   早期版本的 ``config.crawl.order=sequential`` 和 ``config.crawl.order=random`` 值仍然有效。
 
 文件大小配置
 ====================


### PR DESCRIPTION
`crawl.order` has shipped for some time but was never documented in any language. It now names a `UrlQueueOrder` component, so this documents it in the 15.9 tree for all seven languages.

Added to the "Basic Configuration Items" section of `config/crawler-basic.rst`, between "Crawl Interval" and "File Size Configuration":

- a table of the five built-in component names and the order each produces
- an example using the full parameter name, `config.crawl.order=depthFirstUrlQueueOrder`
- the caveat that depth-first is bounded by the polling batch rather than being a strict traversal, including the case that surprises people: when the whole queue fits in one batch, every order proceeds level by level
- what separates the two weight-based orders. Weight is already the default order's primary sort key, so installing a `UrlQueueWeigher` changes the fetch order without setting `config.crawl.order` at all; `weightFirstUrlQueueOrder` differs only between entries of equal weight, and earns its place on a large weighted backlog where only the weight should decide what comes next
- warning-and-fallback behavior for an unresolvable name
- a note that the older `sequential` and `random` values still resolve

The full parameter name matters: `ParameterUtil` strips the `config.` prefix before building the map, so `crawl.order=...` is ignored with no diagnostic at all — verified on a live crawl.

Only the `15.9` tree is touched; `versions.json` marks it as `development`.

Verified with standalone docutils rather than a Sphinx build — `conf/conf.py:228` contains an invalid `\u` escape in a non-raw string, so the module raises `SyntaxError` on Python 3 before any RST is parsed. That is a pre-existing problem unrelated to this change and worth a separate fix, since it currently blocks local HTML builds for every language. The parse was run before and after the edit in all seven languages; the message counts are unchanged.
