### PR TITLE
docs: document Google Workspace connector 15.9 behaviour changes in all seven languages

### DIFF
--- a/de/15.9/config/datastore/ds-gsuite.rst
+++ b/de/15.9/config/datastore/ds-gsuite.rst
@@ -9,11 +9,79 @@ Der Google Workspace-Konnektor bietet die Funktionalität, Dateien aus Google Dr
 
 Für diese Funktion ist das Plugin ``fess-ds-gsuite`` erforderlich.
 
+Änderungen in 15.9
+==================
+
+Der Konnektor wurde in |Fess| 15.9 grundlegend überarbeitet. Lesen Sie diesen Abschnitt,
+bevor Sie eine bestehende Datenspeicher-Konfiguration aktualisieren.
+
+.. warning::
+
+   ``crawl_target`` hat jetzt den Standardwert ``shared_drives``, und jeder Wert außer
+   ``legacy`` setzt ``impersonate_user`` voraus. Eine unverändert aktualisierte
+   Konfiguration **schlägt daher beim Start mit einer ``DataStoreException`` fehl**,
+   statt zu laufen.
+
+   Das ist beabsichtigt: Das bisherige Verhalten erreichte nur die Dateien, die
+   ausdrücklich für das Dienstkonto freigegeben waren, sodass die Alternative ein Crawl
+   wäre, der stillschweigend nichts indiziert. Setzen Sie entweder ``impersonate_user``
+   auf ein Domain-Administratorkonto, oder setzen Sie ``crawl_target=legacy``, um das
+   bisherige Verhalten beizubehalten.
+
+Verhaltensänderungen
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Änderung
+     - Erforderliche Maßnahme
+   * - ``crawl_target`` hat den Standardwert ``shared_drives`` und setzt ``impersonate_user`` voraus
+     - Setzen Sie ``impersonate_user`` oder ``crawl_target=legacy``. Andernfalls schlägt der Crawl beim Start fehl.
+   * - Der Standard-OAuth-Bereich wurde von ``https://www.googleapis.com/auth/drive`` auf ``https://www.googleapis.com/auth/drive.readonly`` eingeschränkt
+     - Aktualisieren Sie den Eintrag für die Domain-weite Delegierung in der Google Workspace Admin-Konsole, da dieser die Bereiche ausdrücklich auflistet.
+   * - ``crawl_target=users`` und ``crawl_target=both`` benötigen zusätzlich ``https://www.googleapis.com/auth/admin.directory.user.readonly``
+     - Fügen Sie den Bereich sowohl dem Parameter ``scopes`` als auch dem Delegierungseintrag hinzu. Dies wird beim Start geprüft.
+   * - Die indizierte URL ist jetzt ``webViewLink`` (der im Browser zu öffnende Link) statt des Download-Links
+     - Führen Sie einen vollständigen erneuten Crawl durch, um die neuen URLs zu übernehmen.
+   * - ``default_permissions`` ist jetzt ein Rückfallwert, keine Ergänzung
+     - Ein Dokument mit auflösbarer ACL erhält nur diese ACL, nicht mehr die Vereinigung aus ACL und ``default_permissions``. Das Ergebnis ist strikt restriktiver.
+   * - Eine reine Link-Freigabe vergibt keine Suchrolle mehr
+     - Eine ``domain``- oder ``anyone``-Berechtigung mit ``allowFileDiscovery=false`` bedeutet "jeder, der über den Link verfügt"; Drive selbst macht solche Dateien ebenfalls nicht über die Suche auffindbar.
+   * - Ein Dokument, dessen ACL nichts ergibt, wird übersprungen, statt ohne Rollen indiziert zu werden
+     - Setzen Sie ``default_permissions``, um solche Dokumente weiterhin zu indizieren. Bisher waren sie für jeden Benutzer sichtbar, da eine leere Rollenliste den Berechtigungsfilter deaktiviert.
+   * - ``fields`` hat nicht mehr den Standardwert ``*``, sondern eine explizite Feldliste
+     - Ein Crawl-Skript, das ein ungewöhnliches Feld verwendet, liest jetzt null. Setzen Sie ``fields=*``, um die bisherige Projektion wiederherzustellen.
+   * - Google Docs werden als Markdown statt als reiner Text exportiert, Google Tabellen als TSV statt als CSV
+     - Der indizierte Text jedes Google-Dokuments enthält jetzt Markdown-Syntaxzeichen. Führen Sie einen vollständigen erneuten Crawl durch.
+   * - ``refresh_token_interval`` wird ignoriert
+     - Die Aktualisierung der Token übernimmt die Authentifizierungsbibliothek. Eine bestehende Konfiguration funktioniert weiter, und es wird eine Warnung protokolliert.
+   * - Google Formulare und Google Sites werden nur mit ihren Metadaten indiziert
+     - Für sie gibt es kein Exportformat in der Drive API. Bisher erzeugte jede dieser Dateien einen Crawl-Fehler.
+
+Neue Funktionen
+---------------
+
+- ``crawl_target`` bestimmt, was gecrawlt wird: die Sicht des Dienstkontos selbst
+  (``legacy``), jede freigegebene Ablage der Domain (``shared_drives``), die "Meine
+  Ablage" jedes Verzeichnisbenutzers (``users``) oder beides (``both``). Siehe
+  `Crawl-Ziel`_.
+- Elemente in freigegebenen Ablagen erhalten jetzt die korrekte ACL. Siehe
+  `Berechtigungen und Zugriffskontrolle`_.
+- Inkrementelles Crawling über den Änderungs-Feed von Drive. Siehe
+  `Inkrementelles Crawling`_.
+- Ratenbegrenzung mit exponentiellem Backoff, der ``Retry-After`` berücksichtigt, sowie
+  eine fehlschlagende freigegebene Ablage oder ein fehlschlagender Benutzer, die den
+  gesamten Crawl nicht mehr abbrechen. Siehe `Ratenbegrenzung und Wiederholungen`_.
+- ``proxy_username`` und ``proxy_password`` für einen Proxy mit Authentifizierung.
+
 Unterstützte Dienste
 ====================
 
 - Google Drive (Mein Drive, freigegebene Ablagen)
-- Google Docs, Tabellen, Präsentationen, Formulare usw.
+- Google Docs, Tabellen, Präsentationen, Zeichnungen, Apps Script
+- Google Formulare und Google Sites (nur Metadaten; für sie gibt es kein Exportformat)
 
 Voraussetzungen
 ===============
@@ -22,6 +90,8 @@ Voraussetzungen
 2. Ein Google Cloud Platform-Projekt muss erstellt werden
 3. Ein Dienstkonto muss erstellt und Anmeldedaten abgerufen werden
 4. Domain-weite Delegierung für Google Workspace muss konfiguriert werden
+5. Sofern nicht ``crawl_target=legacy`` verwendet wird, wird ein Google Workspace-Administratorkonto
+   benötigt, dessen Identität übernommen wird
 
 Plugin-Installation
 -------------------
@@ -73,6 +143,7 @@ Parameter-Einstellungen
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project.iam.gserviceaccount.com
+    impersonate_user=admin@example.com
 
 Parameterliste
 ~~~~~~~~~~~~~~
@@ -93,60 +164,204 @@ Parameterliste
    * - ``client_email``
      - Ja
      - E-Mail-Adresse des Dienstkontos
+   * - ``impersonate_user``
+     - Bedingt
+     - Das Google Workspace-Konto, dessen Identität über die Domain-weite Delegierung übernommen wird. Erforderlich, sofern nicht ``crawl_target=legacy`` gesetzt ist; ohne diesen Wert schlägt der Crawl beim Start fehl. ``shared_drives`` und ``both`` ermitteln die freigegebenen Ablagen mit Domain-Administratorzugriff, daher muss dieses Konto ein Domain-Administrator sein.
+   * - ``crawl_target``
+     - Nein
+     - Was gecrawlt wird: ``legacy``, ``shared_drives``, ``users`` oder ``both``. Standard: ``shared_drives``. Siehe `Crawl-Ziel`_.
+   * - ``scopes``
+     - Nein
+     - OAuth-Bereiche, kommagetrennt. Standard: ``https://www.googleapis.com/auth/drive.readonly``. ``crawl_target=users`` und ``crawl_target=both`` benötigen zusätzlich ``https://www.googleapis.com/auth/admin.directory.user.readonly``.
+   * - ``user_query``
+     - Nein
+     - Admin SDK-``query``, mit der die von ``crawl_target=users`` und ``crawl_target=both`` ermittelten Benutzer eingegrenzt werden. Standard: nicht gesetzt (alle Benutzer des Kundenkontos).
+   * - ``query``
+     - Nein
+     - Google Drive API-Suchabfragezeichenfolge. Wird nicht auf den Änderungs-Feed des inkrementellen Crawlings angewendet.
+   * - ``corpora``
+     - Nein
+     - Zu durchsuchende Korpora. Standard: ``allDrives``. Wird nur von ``crawl_target=legacy`` ausgewertet und hat daher beim Standardziel keine Wirkung: ``shared_drives`` listet jede Ablage mit ``drive`` und ``users`` jede "Meine Ablage" mit ``user`` auf, beides fest vorgegeben.
+   * - ``spaces``
+     - Nein
+     - Zu durchsuchende Bereiche (Google Drive API ``spaces``-Parameter, z.B. ``drive``, ``appDataFolder``). Standard: nicht gesetzt (API-Standard). Wird von ``crawl_target=legacy`` und ``users`` verwendet; bei ``shared_drives`` ignoriert.
+   * - ``fields``
+     - Nein
+     - Von der Google Drive API anzufordernde Dateifelder. Standard ist **nicht** ``*``, sondern eine explizite Feldliste. Sie deckt jedes Feld ab, das der Skript-Kontext, die ACL-Auflösung, die Index-URL und der inkrementelle Crawl benötigen; ein Feld außerhalb dieser Liste liest im Crawl-Skript null. Setzen Sie ``fields=*``, um wie in früheren Versionen alle Felder anzufordern.
+   * - ``default_permissions``
+     - Nein
+     - Berechtigungen, die verwendet werden, wenn die Drive-ACL eines Dokuments nichts ergibt (kommagetrennt, z.B. ``{role}drive-users``). Dies ist ein Rückfallwert, keine Ergänzung: Ein Dokument mit auflösbarer ACL erhält nur diese ACL.
    * - ``max_size``
      - Nein
      - Maximale Dateigröße (in Bytes) für die Indizierung. Standard: ``10000000`` (ca. 10MB)
-   * - ``ignore_folder``
-     - Nein
-     - Ob Ordner übersprungen werden sollen. Standard: ``true``
-   * - ``ignore_error``
-     - Nein
-     - Ob die Verarbeitung bei Fehlern fortgesetzt werden soll. Standard: ``true``
-   * - ``supported_mimetypes``
-     - Nein
-     - Zu indizierende MIME-Typen (regulärer Ausdruck, kommagetrennt). Standard: ``.*`` (alle Typen)
-   * - ``include_pattern``
-     - Nein
-     - Regulärer Ausdruck für zu indizierende URLs
-   * - ``exclude_pattern``
-     - Nein
-     - Regulärer Ausdruck für auszuschließende URLs
-   * - ``default_permissions``
-     - Nein
-     - Standardberechtigungen (kommagetrennt, z.B. ``{role}drive-users``)
    * - ``number_of_threads``
      - Nein
      - Anzahl der parallelen Verarbeitungs-Threads. Standard: ``1``
-   * - ``query``
+   * - ``incremental``
      - Nein
-     - Google Drive API-Suchabfragezeichenfolge
-   * - ``corpora``
-     - Nein
-     - Zu durchsuchende Korpora. Standard: ``allDrives``
-   * - ``spaces``
-     - Nein
-     - Zu durchsuchende Bereiche (Google Drive API ``spaces``-Parameter, z.B. ``drive``, ``appDataFolder``). Standard: nicht gesetzt (API-Standard).
-   * - ``fields``
-     - Nein
-     - Von der Google Drive API anzufordernde Dateifelder. Standard: ``*`` (alle Felder).
+     - Ob über den Änderungs-Feed von Drive gecrawlt wird, statt alles aufzulisten. Standard: ``false``. Der Wert wird vor dem Start des Crawls direkt aus dem Parameterfeld der Datenspeicher-Konfiguration gelesen. Siehe `Inkrementelles Crawling`_.
+
+Erweiterte Parameter
+~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Parameter
+     - Beschreibung
+   * - ``domain_permission_format``
+     - Rollenformat für eine Drive-Berechtigung des Typs ``domain``. ``{domain}`` wird durch den Domainnamen ersetzt. Standard: ``{group}{domain}``
+   * - ``thread_pool_timeout_seconds``
+     - Wie lange am Ende eines Crawls auf das Beenden der Worker-Threads gewartet wird (Sekunden). Standard: ``60``
+   * - ``page_size``
+     - Seitengröße für ``files.list`` und ``changes.list``. Standard: ``1000``; größere Werte werden auf ``1000`` begrenzt.
+   * - ``permission_page_size``
+     - Seitengröße für ``permissions.list`` und ``drives.list``. Standard: ``100``; größere Werte werden auf ``100`` begrenzt.
+   * - ``max_cached_content_size``
+     - Maximale Größe (in Bytes) des im Speicher gehaltenen Inhalts; größerer Inhalt wird in eine temporäre Datei ausgelagert. Standard: ``1048576`` (1MB).
+   * - ``max_retries``
+     - Maximale Anzahl von Wiederholungen bei einem durch Ratenbegrenzung oder vorübergehend fehlgeschlagenen Drive API-Aufruf. Standard: ``5``
+   * - ``retry_initial_interval_ms``
+     - Anfängliches Backoff-Intervall vor der ersten Wiederholung (Millisekunden). Standard: ``1000``
+   * - ``max_backoff_ms``
+     - Obergrenze für eine einzelne Wartezeit (Millisekunden). Standard: ``32000``
    * - ``read_timeout``
-     - Nein
      - HTTP-Lese-Timeout (in Millisekunden). Standard: ``20000``
    * - ``connect_timeout``
-     - Nein
      - HTTP-Verbindungs-Timeout (in Millisekunden). Standard: ``20000``
-   * - ``refresh_token_interval``
-     - Nein
-     - Intervall (in Sekunden) zum Erneuern des OAuth-Zugriffstokens. Standard: ``3540`` (59 Minuten).
-   * - ``max_cached_content_size``
-     - Nein
-     - Maximale Größe (in Bytes) des im Speicher gehaltenen Inhalts; größerer Inhalt wird in eine temporäre Datei ausgelagert. Standard: ``1048576`` (1MB).
    * - ``proxy_host``
-     - Nein
-     - Hostname des Proxyservers
+     - Hostname des Proxyservers. Der Proxy wird nur verwendet, wenn ``proxy_host`` und ``proxy_port`` beide gesetzt sind; einer allein bleibt wirkungslos.
    * - ``proxy_port``
-     - Nein
-     - Portnummer des Proxyservers
+     - Portnummer des Proxyservers. Siehe ``proxy_host``.
+   * - ``proxy_username``
+     - Benutzername für einen Proxy mit Authentifizierung. Ist er gesetzt, wird jeder Anfrage ein ``Proxy-Authorization``-Header hinzugefügt. Was damit authentifiziert wird und was nicht, steht unter `Einschränkungen`_.
+   * - ``proxy_password``
+     - Passwort für einen Proxy mit Authentifizierung
+   * - ``ignore_folder``
+     - Ob Ordner übersprungen werden sollen. Standard: ``true``
+   * - ``ignore_error``
+     - Ob die Verarbeitung bei Fehlern fortgesetzt werden soll. Standard: ``true``
+   * - ``supported_mimetypes``
+     - Zu indizierende MIME-Typen (regulärer Ausdruck, kommagetrennt). Standard: ``.*`` (alle Typen)
+   * - ``include_pattern``
+     - Regulärer Ausdruck für zu indizierende URLs
+   * - ``exclude_pattern``
+     - Regulärer Ausdruck für auszuschließende URLs
+   * - ``refresh_token_interval``
+     - Wird seit 15.9 ignoriert. Zugriffstoken werden von der Authentifizierungsbibliothek erneuert. Eine bestehende Einstellung funktioniert weiter, und es wird eine Warnung protokolliert.
+
+.. note::
+
+   ``private_key``, ``private_key_id``, ``client_email``, ``proxy_username`` und
+   ``proxy_password`` werden aus dem Auswertungskontext des Skripts entfernt, sodass ein
+   Crawl-Skript sie nicht indizieren kann und kein Suchergebnis sie preisgeben kann.
+
+.. note::
+
+   Bei aktiviertem inkrementellem Crawling schreibt der Konnektor ``start_page_tokens`` und
+   ``crawl_signature`` in das Parameterfeld der Datenspeicher-Konfiguration zurück. Diese
+   Werte werden vom Konnektor verwaltet und erscheinen neben den von Ihnen gesetzten
+   Parametern; lassen Sie sie unverändert. Werden sie bearbeitet oder gelöscht, crawlt der
+   nächste Lauf jeden Bereich vollständig.
+
+Crawl-Ziel
+----------
+
+Ein Dienstkonto besitzt kein eigenes Drive und gehört keiner Google-Gruppe an. Ein Crawl,
+der sich als das Dienstkonto selbst authentifiziert, erreicht daher nur die Dateien, die
+ausdrücklich für die Adresse des Dienstkontos freigegeben wurden. ``crawl_target``
+bestimmt deshalb, wessen Sicht auf Drive gecrawlt wird.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Wert
+     - Beschreibung
+   * - ``legacy``
+     - Die Sicht des Dienstkontos selbst, wie in früheren Versionen. ``impersonate_user`` ist nicht erforderlich. Es werden nur die Dateien gefunden, die ausdrücklich für das Dienstkonto freigegeben sind.
+   * - ``shared_drives``
+     - Standard. Jede freigegebene Ablage der Domain wird ermittelt und einzeln durchlaufen.
+   * - ``users``
+     - Jeder Benutzer des Verzeichnisses wird über das Admin SDK ermittelt, und die "Meine Ablage" jedes Benutzers wird durch Übernahme seiner Identität durchlaufen.
+   * - ``both``
+     - ``shared_drives``, gefolgt von ``users``. Eine Datei, die in mehreren Bereichen erscheint, wird nur einmal indiziert.
+
+Folgendes wird beim Start des Crawls geprüft; eine ungültige Kombination löst eine
+``DataStoreException`` aus, statt zu laufen:
+
+1. ``crawl_target`` muss ``legacy``, ``shared_drives``, ``users`` oder ``both`` sein.
+2. ``impersonate_user`` muss gesetzt sein, sofern nicht ``crawl_target=legacy`` gilt.
+3. ``scopes`` muss ``https://www.googleapis.com/auth/admin.directory.user.readonly``
+   enthalten, wenn ``crawl_target`` ``users`` oder ``both`` ist.
+
+.. note::
+
+   ``shared_drives`` und ``both`` ermitteln die freigegebenen Ablagen mit
+   Domain-Administratorzugriff, daher muss das unter ``impersonate_user`` genannte Konto
+   ein Google Workspace-Domain-Administrator sein. Diese Auflistung bestimmt den gesamten
+   Umfang des Crawls, sodass ein dauerhafter Fehler den Crawl abbricht, statt gemeldet und
+   übersprungen zu werden: Ein Crawl, der keine einzige Ablage ermitteln konnte, ist nicht
+   teilweise erfolgreich und darf nicht als erfolgreich gelten, während er nichts indiziert.
+
+Inkrementelles Crawling
+-----------------------
+
+Mit ``incremental=true`` liest jeder Bereich -- eine freigegebene Ablage oder die Sicht
+eines Benutzers, dessen Identität übernommen wird -- den Änderungs-Feed von Drive, statt
+alles aufzulisten. Ein Bereich ohne gespeicherten Token wird vollständig aufgelistet, und
+sein Änderungs-Feed wird für den nächsten Lauf verankert.
+
+::
+
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
+    incremental=true
+
+.. warning::
+
+   ``delete_old_docs`` wird bei jedem inkrementellen Lauf auf ``false`` erzwungen, und ein
+   ausdrückliches ``delete_old_docs=true`` wird überschrieben statt berücksichtigt (es wird
+   eine Warnung protokolliert). Das Entfernen veralteter Dokumente löscht jedes Dokument
+   der Konfiguration, das der aktuelle Crawl nicht berührt hat, und setzt damit einen
+   vollständigen Crawl voraus. Ein inkrementeller Lauf berührt nur die geänderten
+   Dokumente, sodass dieser Vorgang den Rest des Index löschen würde.
+
+   Um Dokumente zu entfernen, die aus Drive verschwunden sind, planen Sie eine separate
+   Datenspeicher-Konfiguration mit ``incremental=false``.
+
+Die Tokens werden nur gespeichert, wenn der Crawl abgeschlossen wurde und die
+Worker-Threads beendet sind. Ein abgebrochener Crawl lässt die Tokens unverändert, und der
+nächste Lauf liest dieselben Änderungen erneut.
+
+Die Tokens werden ebenfalls verworfen und jeder Bereich vollständig gecrawlt, wenn sich
+die Konfiguration geändert hat, die bestimmt, was ein Bereich liefert -- also eines von
+``crawl_target``, ``impersonate_user``, ``user_query``, ``query``, ``corpora`` oder
+``spaces``. Ein gespeicherter Token beschreibt nur den Bestand, über dem er genommen wurde;
+ihn nach einer solchen Änderung fortzusetzen, würde eine dauerhafte Lücke im Index
+hinterlassen.
+
+Ratenbegrenzung und Wiederholungen
+----------------------------------
+
+Ein durch Ratenbegrenzung oder vorübergehend fehlgeschlagener Drive API-Aufruf wird mit
+exponentiellem Backoff wiederholt, begrenzt durch ``max_retries``,
+``retry_initial_interval_ms`` und ``max_backoff_ms``. Ein ``Retry-After``-Header hat
+Vorrang vor der exponentiellen Wartezeit, wird aber durch ``max_backoff_ms`` begrenzt,
+damit ein fehlerhafter Header den Crawl nicht stundenlang blockieren kann. Nur die
+Sekundenform von ``Retry-After`` wird berücksichtigt; ein HTTP-Datum fällt auf die
+exponentielle Wartezeit zurück.
+
+``429``, ``500``, ``502``, ``503`` und ``504`` werden immer wiederholt. Ein ``403`` wird
+nur wiederholt, wenn es sich um einen Fehler wegen Ratenbegrenzung handelt; jedes andere
+``403`` ist ein Autorisierungsfehler, den eine Wiederholung nicht beheben kann, und wird
+sofort gemeldet.
+
+Eine Dateiauflistung, die nicht abgeschlossen werden konnte, bricht nicht mehr den gesamten
+Crawl ab: Die übrigen freigegebenen Ablagen und Benutzer werden weiterhin gecrawlt, und der
+Fehler wird im Crawler-Log und in der Liste der fehlgeschlagenen URLs in der
+Administrationsoberfläche festgehalten.
 
 Skript-Einstellungen
 --------------------
@@ -191,7 +406,7 @@ Verfügbare Felder
    * - ``file.web_view_link``
      - Link zum Öffnen im Browser
    * - ``file.url``
-     - URL der Datei
+     - URL der Datei. Dies ist ``webViewLink``; hat eine Datei keinen, wird stattdessen ``https://drive.google.com/open?id=<Datei-ID>`` verwendet.
    * - ``file.thumbnail_link``
      - Thumbnail-Link (kurze Gültigkeit)
    * - ``file.size``
@@ -199,7 +414,52 @@ Verfügbare Felder
    * - ``file.roles``
      - Zugriffsberechtigungen
 
+.. note::
+
+   Nur die im Parameter ``fields`` aufgeführten Felder werden gefüllt. Ein nicht
+   angefordertes Feld liest im Skript null. Setzen Sie ``fields=*``, um wie in früheren
+   Versionen alle Felder anzufordern.
+
 Weitere Details finden Sie unter `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_.
+
+Textextraktion nativer Google-Typen
+-----------------------------------
+
+Ein nativer Google-Typ kann nicht heruntergeladen, sondern muss exportiert werden. Das
+Exportziel wird aus den Exportformaten gewählt, die die Drive API tatsächlich meldet, nicht
+aus einer festen Tabelle, und ein Export ist auf 10MB begrenzt.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Typ
+     - Exportiert als
+   * - Google Docs
+     - Markdown (``text/markdown``), ersatzweise reiner Text und dann HTML
+   * - Google Tabellen
+     - TSV (``text/tab-separated-values``), ersatzweise CSV
+   * - Google Präsentationen
+     - Reiner Text
+   * - Google Zeichnungen
+     - PNG. Es gibt keinen Text zu indizieren, daher werden nur die Metadaten indiziert.
+   * - Apps Script
+     - Das exportierte JSON-Paket, aus dem die Skriptquellen indiziert werden
+   * - Google Formulare, Google Sites
+     - Nicht exportierbar. Die Metadaten werden indiziert, und es wird kein Fehler gemeldet.
+
+.. note::
+
+   Da Google Docs jetzt als Markdown exportiert werden, enthält der indizierte Text jedes
+   Google-Dokuments Markdown-Syntaxzeichen. Damit die Änderung bereits indizierte Dokumente
+   erreicht, ist ein vollständiger erneuter Crawl erforderlich.
+
+.. note::
+
+   Die Exportziele werden einmal pro Crawl von der Drive API gelesen. Schlägt dieser Aufruf
+   fehl, fällt der Konnektor auf die Konvertierungen zurück, die Drive schon immer
+   unterstützt hat -- reiner Text für Google Docs und CSV für Google Tabellen -- und
+   protokolliert eine Warnung.
 
 Google Cloud Platform-Konfiguration
 ===================================
@@ -220,6 +480,7 @@ Unter "APIs und Dienste" -> "Bibliothek":
 
 1. Suchen Sie nach "Google Drive API"
 2. Klicken Sie auf "Aktivieren"
+3. Aktivieren Sie außerdem "Admin SDK API", wenn ``crawl_target`` ``users`` oder ``both`` ist
 
 3. Dienstkonto erstellen
 ------------------------
@@ -265,9 +526,23 @@ Besuchen Sie https://admin.google.com/:
 
    ::
 
-       https://www.googleapis.com/auth/drive
+       https://www.googleapis.com/auth/drive.readonly
+
+   Ist ``crawl_target`` gleich ``users`` oder ``both``, geben Sie beide Bereiche ein:
+
+   ::
+
+       https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
 
 6. Klicken Sie auf "Autorisieren"
+
+.. warning::
+
+   Der Delegierungseintrag listet die Bereiche ausdrücklich auf, daher muss er beim
+   Aktualisieren von einer früheren Version angepasst werden. Der Standardbereich wurde in
+   15.9 von ``https://www.googleapis.com/auth/drive`` auf
+   ``https://www.googleapis.com/auth/drive.readonly`` eingeschränkt, und die hier erteilten
+   Bereiche müssen zum Parameter ``scopes`` der Datenspeicher-Konfiguration passen.
 
 Anmeldedaten konfigurieren
 ==========================
@@ -310,8 +585,8 @@ Format des privaten Schlüssels
 Anwendungsbeispiele
 ===================
 
-Gesamtes Google Drive crawlen
------------------------------
+Alle freigegebenen Ablagen crawlen
+----------------------------------
 
 Parameter:
 
@@ -320,6 +595,8 @@ Parameter:
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
 
 Skript:
 
@@ -334,7 +611,44 @@ Skript:
     thumbnail=file.thumbnail_link
     content_length=file.size
     filetype=file.filetype
+    role=file.roles
     filename=file.name
+
+Die "Meine Ablage" jedes Benutzers crawlen
+------------------------------------------
+
+Parameter:
+
+::
+
+    private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
+    private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
+    client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=users
+    impersonate_user=admin@example.com
+    scopes=https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
+
+Um die Benutzer einzugrenzen, fügen Sie eine Admin SDK-Abfrage hinzu:
+
+::
+
+    user_query=orgUnitPath=/Sales
+
+Das bisherige Verhalten beibehalten
+-----------------------------------
+
+``crawl_target=legacy`` behält den Durchlauf von vor 15.9 bei, bei dem nur die
+ausdrücklich für das Dienstkonto freigegebenen Dateien gefunden werden.
+``impersonate_user`` ist nicht erforderlich.
+
+Parameter:
+
+::
+
+    private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
+    private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
+    client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=legacy
 
 Crawlen mit Berechtigungen
 --------------------------
@@ -346,6 +660,8 @@ Parameter:
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     default_permissions={role}drive-users
 
 Skript:
@@ -360,6 +676,8 @@ Skript:
     url=file.web_view_link
     role=file.roles
     filename=file.name
+
+``default_permissions`` wird nur für ein Dokument verwendet, dessen Drive-ACL nichts ergibt.
 
 Nur bestimmte Dateitypen crawlen
 --------------------------------
@@ -380,6 +698,24 @@ Nur Google Docs:
 Fehlerbehebung
 ==============
 
+Der Crawl startet nicht
+-----------------------
+
+**Symptom**: Der Crawl endet sofort mit einer ``DataStoreException``
+
+**Lösung**:
+
+1. ``parameter 'crawl_target' must be one of ...``: Der Wert von ``crawl_target`` ist
+   weder ``legacy`` noch ``shared_drives``, ``users`` oder ``both``.
+2. ``parameter 'impersonate_user' is required when 'crawl_target' is not 'legacy'``:
+   Setzen Sie ``impersonate_user`` auf ein Domain-Administratorkonto oder setzen Sie
+   ``crawl_target=legacy``.
+3. ``parameter 'scopes' must include 'https://www.googleapis.com/auth/admin.directory.user.readonly'``:
+   Fügen Sie diesen Bereich zu ``scopes`` und zum Eintrag der Domain-weiten Delegierung hinzu.
+
+Beim unveränderten Aktualisieren einer bestehenden Konfiguration ist dies das erwartete
+Ergebnis. Siehe `Änderungen in 15.9`_.
+
 Authentifizierungsfehler
 ------------------------
 
@@ -396,7 +732,9 @@ Authentifizierungsfehler
 2. Überprüfen Sie, ob die Google Drive API aktiviert ist
 3. Überprüfen Sie, ob die Domain-weite Delegierung konfiguriert ist
 4. Überprüfen Sie, ob die Genehmigung in der Google Workspace Admin-Konsole erteilt wurde
-5. Überprüfen Sie den OAuth-Bereich (``https://www.googleapis.com/auth/drive``)
+5. Überprüfen Sie den OAuth-Bereich (``https://www.googleapis.com/auth/drive.readonly``,
+   zusätzlich ``https://www.googleapis.com/auth/admin.directory.user.readonly`` bei
+   ``crawl_target=users`` oder ``both``)
 
 Fehler bei Domain-weiter Delegierung
 ------------------------------------
@@ -408,9 +746,12 @@ Fehler bei Domain-weiter Delegierung
 1. Überprüfen Sie die Genehmigung in der Google Workspace Admin-Konsole:
 
    - Ist die Client-ID korrekt registriert?
-   - Ist der OAuth-Bereich korrekt (``https://www.googleapis.com/auth/drive``)?
+   - Sind die OAuth-Bereiche korrekt? Der Delegierungseintrag listet sie ausdrücklich auf,
+     daher erfordert die in 15.9 eingeführte Einschränkung eine Anpassung.
 
 2. Überprüfen Sie, ob die Domain-weite Delegierung beim Dienstkonto aktiviert ist
+3. Überprüfen Sie, ob das unter ``impersonate_user`` genannte Konto ein
+   Domain-Administrator ist, wenn ``crawl_target`` ``shared_drives`` oder ``both`` ist
 
 Keine Dateien abrufbar
 ----------------------
@@ -419,10 +760,34 @@ Keine Dateien abrufbar
 
 **Zu überprüfen**:
 
-1. Überprüfen Sie, ob Dateien in Google Drive existieren
-2. Überprüfen Sie, ob das Dienstkonto Leseberechtigung hat
-3. Überprüfen Sie, ob die Domain-weite Delegierung korrekt konfiguriert ist
-4. Überprüfen Sie, ob der Zugriff auf das Drive des Zielbenutzers möglich ist
+1. Überprüfen Sie, ob ``crawl_target`` dem entspricht, was Sie beabsichtigen. Mit
+   ``legacy`` werden nur die ausdrücklich für das Dienstkonto freigegebenen Dateien
+   gefunden, da ein Dienstkonto kein eigenes Drive besitzt und keiner Gruppe angehört.
+2. Überprüfen Sie, ob Dateien in Google Drive existieren
+3. Überprüfen Sie, ob das Dienstkonto Leseberechtigung hat
+4. Überprüfen Sie, ob die Domain-weite Delegierung korrekt konfiguriert ist
+5. Überprüfen Sie, ob der Zugriff auf das Drive des Zielbenutzers möglich ist
+
+Dokumente werden übersprungen
+-----------------------------
+
+**Symptom**: ``Skipped ... because no permission could be resolved`` im Crawler-Log
+
+**Lösung**:
+
+Die Drive-ACL des Dokuments ergab überhaupt keine Suchrolle, sodass es übersprungen statt
+indiziert wurde. Ein Dokument ohne Rolle zu indizieren, deaktiviert den
+|Fess|-Berechtigungsfilter für dieses Dokument und macht es für jeden Benutzer sichtbar --
+deshalb wird es stattdessen übersprungen. Ein übersprungenes Dokument ist kein Crawl-Fehler
+und erscheint daher nur im Crawler-Log, nicht in der Liste der fehlgeschlagenen URLs.
+
+1. Setzen Sie ``default_permissions``, um solche Dokumente mit einer Rückfallberechtigung
+   zu indizieren
+2. Überprüfen Sie, ob das unter ``impersonate_user`` genannte Konto ein
+   Domain-Administrator ist, damit die ACLs der freigegebenen Ablagen gelesen werden können
+3. Prüfen Sie, ob das Dokument nur per Link freigegeben ist. Eine ``domain``- oder
+   ``anyone``-Berechtigung mit ``allowFileDiscovery=false`` vergibt keine Suchrolle, da
+   Drive selbst ein solches Dokument ebenfalls nicht über die Suche auffindbar macht.
 
 API-Kontingentfehler
 --------------------
@@ -431,9 +796,12 @@ API-Kontingentfehler
 
 **Lösung**:
 
-1. Überprüfen Sie das Kontingent in der Google Cloud Platform
-2. Verlängern Sie das Crawl-Intervall
-3. Beantragen Sie bei Bedarf eine Kontingenterhöhung
+1. Ein solcher Fehler wird automatisch mit exponentiellem Backoff wiederholt. Erhöhen Sie
+   ``max_retries`` oder ``max_backoff_ms``, wenn der Crawl weiterhin fehlschlägt.
+2. Verringern Sie ``number_of_threads``, um die Anfragerate zu senken
+3. Überprüfen Sie das Kontingent in der Google Cloud Platform
+4. Verlängern Sie das Crawl-Intervall
+5. Beantragen Sie bei Bedarf eine Kontingenterhöhung
 
 Formatfehler beim privaten Schlüssel
 ------------------------------------
@@ -458,7 +826,12 @@ Freigegebene Ablagen crawlen
 ----------------------------
 
 .. note::
-   Beim Crawlen freigegebener Ablagen mit dem Dienstkonto muss das Dienstkonto als Mitglied zur freigegebenen Ablage hinzugefügt werden.
+   Mit ``crawl_target=shared_drives`` (dem Standard) werden die freigegebenen Ablagen mit
+   Domain-Administratorzugriff ermittelt, sodass das Dienstkonto nicht Mitglied jeder
+   einzelnen Ablage sein muss. Stattdessen muss ``impersonate_user`` einen
+   Domain-Administrator benennen.
+
+Mit ``crawl_target=legacy`` muss das Dienstkonto jeder freigegebenen Ablage hinzugefügt werden:
 
 1. Öffnen Sie die freigegebene Ablage in Google Drive
 2. Klicken Sie auf "Mitglieder verwalten"
@@ -472,13 +845,52 @@ Bei großen Dateimengen
 
 **Lösung**:
 
-1. Teilen Sie in mehrere Datenspeicher auf
-2. Verteilen Sie die Last über Zeitplaneinstellungen
-3. Passen Sie das Crawl-Intervall an
-4. Crawlen Sie nur bestimmte Ordner
+1. Aktivieren Sie ``incremental=true``, damit nur die Änderungen seit dem letzten Lauf
+   gecrawlt werden
+2. Teilen Sie freigegebene Ablagen und Benutzer auf getrennte Datenspeicher-Konfigurationen
+   auf, statt ``crawl_target=both`` zu verwenden
+3. Grenzen Sie den Umfang mit ``query``, ``user_query`` oder ``supported_mimetypes`` ein
+4. Verteilen Sie die Last über Zeitplaneinstellungen
+5. Passen Sie das Crawl-Intervall an
 
 Berechtigungen und Zugriffskontrolle
 ====================================
+
+Wie Drive-Berechtigungen zu Fess-Rollen werden
+----------------------------------------------
+
+Die ACL eines Dokuments wird in drei Stufen aufgelöst, damit die Anzahl zusätzlicher
+API-Aufrufe proportional zur Anzahl der freigegebenen Ablagen bleibt und nicht zur Anzahl
+der Dateien:
+
+1. die in der Dateiauflistung enthaltenen Berechtigungen, die nichts zusätzlich kosten;
+2. bei einem Element einer freigegebenen Ablage, für das die Drive API keine solchen
+   Berechtigungen liefert, die ACL der freigegebenen Ablage selbst. Sie wird einmal pro
+   Ablage mit Domain-Administratorzugriff abgerufen und zwischengespeichert;
+3. bei einem Element mit eigenen zusätzlichen Berechtigungen diese Berechtigungen.
+
+Jede Drive-Berechtigung wird zu einer |Fess|-Suchrolle:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Drive-Berechtigung
+     - Suchrolle
+   * - ``user``
+     - Die Suchrolle der E-Mail-Adresse dieses Benutzers. Die Eigentümer der Datei werden immer auf diese Weise hinzugefügt.
+   * - ``group``
+     - Die Suchrolle der E-Mail-Adresse dieser Gruppe. Die Mitgliedschaft in Google-Gruppen wird nie aufgelöst; es wird erwartet, dass |Fess| sie auf Benutzerseite über SSO oder LDAP auflöst.
+   * - ``domain``
+     - ``domain_permission_format``, wobei ``{domain}`` durch den Domainnamen ersetzt wird. Standard: ``{group}{domain}``
+   * - ``anyone``
+     - Die Rolle ``guest``
+   * - Eine der obigen mit ``allowFileDiscovery=false`` sowie eine gelöschte Berechtigung
+     - Keine Rolle. Eine reine Link-Freigabe ist auch in Drive selbst nicht über die Suche auffindbar.
+
+Ist das Ergebnis leer, wird stattdessen ``default_permissions`` verwendet -- als
+Rückfallwert, nicht als Ergänzung. Ist auch ``default_permissions`` nicht gesetzt, wird das
+Dokument übersprungen.
 
 Google Drive-Freigabeberechtigungen abbilden
 --------------------------------------------
@@ -492,6 +904,8 @@ Parameter:
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     default_permissions={role}drive-users
 
 Skript:
@@ -507,6 +921,37 @@ Skript:
     url=file.web_view_link
 
 ``file.roles`` enthält die Google Drive-Freigabeinformationen.
+
+Einschränkungen
+===============
+
+- Das Signal "entfernt" von Drive umfasst neben einer Löschung auch den Verlust des
+  Zugriffs. Mit ``crawl_target=users`` oder ``both`` führt der Entzug des Zugriffs eines
+  Benutzers dazu, dass das Dokument aus dem Index entfernt wird, obwohl ein anderer
+  Benutzer es weiterhin lesen kann. Es kehrt bei der nächsten Änderung dieser Datei oder
+  beim nächsten vollständigen Crawl zurück.
+- Fällt ein Bereich während eines inkrementellen Laufs auf einen vollständigen Crawl
+  zurück, bleibt das Entfernen veralteter Dokumente weiterhin unterdrückt. Dokumente, die
+  aus Drive gelöscht wurden, während ein Bereich nicht verankert war, bleiben daher im
+  Index. Abhilfe schafft eine separate Konfiguration mit ``incremental=false``, deren
+  vollständiger Crawl sie entfernt.
+- Das Weitergeben einer Löschung setzt voraus, dass die indizierte URL die Drive-Datei-ID
+  enthält, was für ``webViewLink`` und für die Ersatz-URL gilt. Bei einem Crawl-Skript, das
+  ``url`` auf einen Wert ohne die Datei-ID umschreibt, werden Löschungen nicht weitergegeben.
+- Der Änderungs-Feed wird nicht durch ``query`` gefiltert. Mit gesetztem ``query`` und
+  ``incremental=true`` wird eine geänderte Datei auch dann indiziert, wenn sie der Abfrage
+  nicht entspricht.
+- ``crawl_target=both`` löst in einer großen Domain etwa
+  ``2 + (Anzahl der freigegebenen Ablagen) + (Anzahl der Benutzer)`` Auflistungen aus. Die
+  praktische Abhilfe besteht darin, freigegebene Ablagen und Benutzer auf getrennte
+  Datenspeicher-Konfigurationen aufzuteilen.
+- ``proxy_username`` und ``proxy_password`` werden als ``Proxy-Authorization``-Anfrageheader
+  gesendet, der nur eine einfache HTTP-Anfrage authentifiziert. Der gesamte Google
+  API-Verkehr läuft über HTTPS, und eine HTTPS-Verbindung über einen Proxy mit
+  Authentifizierung wird durch einen ``CONNECT``-Austausch aufgebaut, den das JDK über
+  ``java.net.Authenticator`` und nicht über einen Anfrageheader abwickelt. Eine solche
+  Umgebung benötigt stattdessen die JVM-Option
+  ``-Djdk.http.auth.tunneling.disabledSchemes=`` und einen ``Authenticator``.
 
 Weiterführende Informationen
 ============================

--- a/en/15.9/config/datastore/ds-gsuite.rst
+++ b/en/15.9/config/datastore/ds-gsuite.rst
@@ -10,11 +10,75 @@ and register them in the |Fess| index.
 
 This feature requires the ``fess-ds-gsuite`` plugin.
 
+Changes in 15.9
+===============
+
+The connector was substantially reworked in |Fess| 15.9. Read this section before
+upgrading an existing data store configuration.
+
+.. warning::
+
+   ``crawl_target`` now defaults to ``shared_drives``, and every value other than
+   ``legacy`` requires ``impersonate_user``. An existing configuration that is
+   upgraded unchanged therefore **fails at startup** with a ``DataStoreException``
+   instead of running.
+
+   This is deliberate: the previous behaviour only ever reached the files that were
+   explicitly shared with the service account, so the alternative would be a crawl
+   that silently indexes nothing. Either set ``impersonate_user`` to a domain
+   administrator account, or set ``crawl_target=legacy`` to keep the previous
+   behaviour.
+
+Behaviour Changes
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Change
+     - What you have to do
+   * - ``crawl_target`` defaults to ``shared_drives`` and requires ``impersonate_user``
+     - Set ``impersonate_user``, or set ``crawl_target=legacy``. Otherwise the crawl fails at startup.
+   * - The default OAuth scope narrowed from ``https://www.googleapis.com/auth/drive`` to ``https://www.googleapis.com/auth/drive.readonly``
+     - Update the domain-wide delegation entry in the Google Workspace admin console, which lists the scopes explicitly.
+   * - ``crawl_target=users`` and ``crawl_target=both`` additionally require ``https://www.googleapis.com/auth/admin.directory.user.readonly``
+     - Add the scope both to the ``scopes`` parameter and to the delegation entry. This is validated at startup.
+   * - The indexed URL is now ``webViewLink`` (the browser-openable link) instead of the download link
+     - Run a full re-crawl to pick up the new URLs.
+   * - ``default_permissions`` is now a fallback, not an addition
+     - A document with a resolvable ACL indexes that ACL only, no longer the union of the ACL and ``default_permissions``. The result is strictly less permissive.
+   * - Link-only sharing no longer grants a search role
+     - A ``domain`` or ``anyone`` permission with ``allowFileDiscovery=false`` means "anyone with the link", which Drive itself does not make discoverable by search.
+   * - A document whose ACL resolves to nothing is skipped instead of being indexed with no roles
+     - Set ``default_permissions`` to keep indexing such documents. Previously they were visible to every user, because an empty role list disables the permission filter.
+   * - ``fields`` no longer defaults to ``*`` but to an explicit field list
+     - A crawl script that references an unusual field now reads null. Set ``fields=*`` to restore the previous projection.
+   * - Google Docs are exported as Markdown instead of plain text, and Google Sheets as TSV instead of CSV
+     - The indexed text of every Google Doc now contains Markdown syntax characters. Run a full re-crawl.
+   * - ``refresh_token_interval`` is ignored
+     - Token refresh is handled by the authentication library. An existing configuration keeps working, and a warning is logged.
+   * - Google Forms and Google Sites are indexed as metadata only
+     - They have no export format in the Drive API. Previously every one of them produced a crawl error.
+
+New Capabilities
+----------------
+
+- ``crawl_target`` selects what is crawled: the service account's own view (``legacy``),
+  every shared drive in the domain (``shared_drives``), every directory user's My Drive
+  (``users``), or both (``both``). See `Crawl Target`_.
+- Shared drive items now get the correct ACL. See `Permissions and Access Control`_.
+- Incremental crawling through the Drive change feed. See `Incremental Crawling`_.
+- Rate limiting with an exponential back-off that honours ``Retry-After``, and a failing
+  shared drive or user that no longer aborts the whole crawl. See `Rate Limiting and Retries`_.
+- ``proxy_username`` and ``proxy_password`` for an authenticating proxy.
+
 Supported Services
 ==================
 
 - Google Drive (My Drive, Shared Drives)
-- Google Docs, Spreadsheets, Slides, Forms, etc.
+- Google Docs, Spreadsheets, Slides, Drawings, Apps Script
+- Google Forms and Google Sites (metadata only; they have no export format)
 
 Prerequisites
 =============
@@ -23,6 +87,8 @@ Prerequisites
 2. A Google Cloud Platform project must be created
 3. A service account must be created and credentials obtained
 4. Domain-wide delegation must be configured for Google Workspace
+5. Unless ``crawl_target=legacy`` is used, a Google Workspace administrator account to
+   impersonate is required
 
 Plugin Installation
 -------------------
@@ -74,6 +140,7 @@ Parameter Configuration
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project.iam.gserviceaccount.com
+    impersonate_user=admin@example.com
 
 Parameter List
 ~~~~~~~~~~~~~~
@@ -94,60 +161,195 @@ Parameter List
    * - ``client_email``
      - Yes
      - Service account email address
+   * - ``impersonate_user``
+     - Conditional
+     - The Google Workspace account impersonated through domain-wide delegation. Required unless ``crawl_target=legacy``; the crawl fails at startup without it. ``shared_drives`` and ``both`` enumerate the shared drives with domain administrator access, so this account must be a domain administrator.
+   * - ``crawl_target``
+     - No
+     - What to crawl: ``legacy``, ``shared_drives``, ``users`` or ``both``. Default: ``shared_drives``. See `Crawl Target`_.
+   * - ``scopes``
+     - No
+     - OAuth scopes, comma-separated. Default: ``https://www.googleapis.com/auth/drive.readonly``. ``crawl_target=users`` and ``crawl_target=both`` additionally require ``https://www.googleapis.com/auth/admin.directory.user.readonly``.
+   * - ``user_query``
+     - No
+     - Admin SDK ``query`` used to narrow down the users enumerated by ``crawl_target=users`` and ``crawl_target=both``. Default: unset (every user of the customer).
+   * - ``query``
+     - No
+     - Google Drive API search query string. Not applied to the change feed used by incremental crawling.
+   * - ``corpora``
+     - No
+     - Corpora to search. Default: ``allDrives``. Only consumed by ``crawl_target=legacy``, so it has no effect under the default target: ``shared_drives`` lists each drive with ``drive`` and ``users`` lists each My Drive with ``user``, both fixed.
+   * - ``spaces``
+     - No
+     - Spaces to search (Google Drive API ``spaces`` parameter, e.g. ``drive``, ``appDataFolder``). Default: unset (API default). Used by ``crawl_target=legacy`` and ``users``; ignored for ``shared_drives``.
+   * - ``fields``
+     - No
+     - File fields to request from the Google Drive API. Default: an explicit field list, **not** ``*``. It covers every field the script context, the ACL resolution, the index URL and the incremental crawl need; a field outside the list reads as null in the crawl script. Set ``fields=*`` to request every field, as in previous versions.
+   * - ``default_permissions``
+     - No
+     - Permissions used when the Drive ACL of a document resolves to nothing (comma-separated, e.g. ``{role}drive-users``). This is a fallback, not an addition: a document with a resolvable ACL indexes that ACL only.
    * - ``max_size``
      - No
      - Maximum file size to index (bytes). Default: ``10000000`` (approx. 10MB)
-   * - ``ignore_folder``
-     - No
-     - Whether to skip folders. Default: ``true``
-   * - ``ignore_error``
-     - No
-     - Whether to continue processing on errors. Default: ``true``
-   * - ``supported_mimetypes``
-     - No
-     - MIME types to index (regex, comma-separated). Default: ``.*`` (all types)
-   * - ``include_pattern``
-     - No
-     - Regex pattern for URLs to include in the index
-   * - ``exclude_pattern``
-     - No
-     - Regex pattern for URLs to exclude
-   * - ``default_permissions``
-     - No
-     - Default permissions (comma-separated, e.g. ``{role}drive-users``)
    * - ``number_of_threads``
      - No
      - Number of parallel processing threads. Default: ``1``
-   * - ``query``
+   * - ``incremental``
      - No
-     - Google Drive API search query string
-   * - ``corpora``
-     - No
-     - Corpora to search. Default: ``allDrives``
-   * - ``spaces``
-     - No
-     - Spaces to search (Google Drive API ``spaces`` parameter, e.g. ``drive``, ``appDataFolder``). Default: unset (API default).
-   * - ``fields``
-     - No
-     - File fields to request from the Google Drive API. Default: ``*`` (all fields).
+     - Whether to crawl through the Drive change feed instead of listing everything. Default: ``false``. It is read straight from the parameter field of the data store configuration, before the crawl starts. See `Incremental Crawling`_.
+
+Advanced Parameters
+~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Parameter
+     - Description
+   * - ``domain_permission_format``
+     - Role format applied to a ``type=domain`` Drive permission. ``{domain}`` is replaced with the domain name. Default: ``{group}{domain}``
+   * - ``thread_pool_timeout_seconds``
+     - How long to wait for the worker threads to drain at the end of a crawl (seconds). Default: ``60``
+   * - ``page_size``
+     - Page size for ``files.list`` and ``changes.list``. Default: ``1000``; values above ``1000`` are clamped.
+   * - ``permission_page_size``
+     - Page size for ``permissions.list`` and ``drives.list``. Default: ``100``; values above ``100`` are clamped.
+   * - ``max_cached_content_size``
+     - Maximum size (in bytes) of content kept in memory; content larger than this is spooled to a temporary file. Default: ``1048576`` (1MB).
+   * - ``max_retries``
+     - Maximum number of retries for a throttled or transient Drive API failure. Default: ``5``
+   * - ``retry_initial_interval_ms``
+     - Initial back-off interval before the first retry (milliseconds). Default: ``1000``
+   * - ``max_backoff_ms``
+     - Upper bound of a single back-off wait (milliseconds). Default: ``32000``
    * - ``read_timeout``
-     - No
      - HTTP read timeout (milliseconds). Default: ``20000``
    * - ``connect_timeout``
-     - No
      - HTTP connection timeout (milliseconds). Default: ``20000``
-   * - ``refresh_token_interval``
-     - No
-     - Interval (in seconds) for refreshing the OAuth access token. Default: ``3540`` (59 minutes).
-   * - ``max_cached_content_size``
-     - No
-     - Maximum size (in bytes) of content kept in memory; content larger than this is spooled to a temporary file. Default: ``1048576`` (1MB).
    * - ``proxy_host``
-     - No
-     - Proxy server hostname
+     - Proxy server hostname. The proxy is used only when both ``proxy_host`` and ``proxy_port`` are set; either one alone has no effect.
    * - ``proxy_port``
-     - No
-     - Proxy server port number
+     - Proxy server port number. See ``proxy_host``.
+   * - ``proxy_username``
+     - User name for an authenticating proxy. When set, a ``Proxy-Authorization`` header is added to every request. See `Limitations`_ for what this does and does not authenticate.
+   * - ``proxy_password``
+     - Password for an authenticating proxy
+   * - ``ignore_folder``
+     - Whether to skip folders. Default: ``true``
+   * - ``ignore_error``
+     - Whether to continue processing on errors. Default: ``true``
+   * - ``supported_mimetypes``
+     - MIME types to index (regex, comma-separated). Default: ``.*`` (all types)
+   * - ``include_pattern``
+     - Regex pattern for URLs to include in the index
+   * - ``exclude_pattern``
+     - Regex pattern for URLs to exclude
+   * - ``refresh_token_interval``
+     - Ignored since 15.9. Access tokens are refreshed by the authentication library. An existing setting keeps working and a warning is logged.
+
+.. note::
+
+   ``private_key``, ``private_key_id``, ``client_email``, ``proxy_username`` and
+   ``proxy_password`` are removed from the script evaluation context, so a crawl script
+   cannot index them and no search result can disclose them.
+
+.. note::
+
+   When incremental crawling is enabled, the connector writes ``start_page_tokens`` and
+   ``crawl_signature`` back into the parameter field of the data store configuration. They
+   are managed by the connector and appear alongside the parameters you set; leave them
+   alone. Editing or deleting them makes the next run crawl every scope in full.
+
+Crawl Target
+------------
+
+A service account has no Drive of its own and belongs to no Google group, so a crawl
+that authenticates as the service account itself only ever reaches the files that were
+explicitly shared with the service account's address. ``crawl_target`` therefore selects
+whose view of Drive is crawled.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Value
+     - Description
+   * - ``legacy``
+     - The service account's own view, as in previous versions. ``impersonate_user`` is not required. Only the files explicitly shared with the service account are found.
+   * - ``shared_drives``
+     - Default. Every shared drive in the domain is enumerated, and each one is listed separately.
+   * - ``users``
+     - Every user in the directory is enumerated through the Admin SDK, and the My Drive of each one is listed by impersonating that user.
+   * - ``both``
+     - ``shared_drives`` followed by ``users``. A file that appears in several scopes is indexed once.
+
+The following is validated when the crawl starts, and an invalid combination raises a
+``DataStoreException`` instead of running:
+
+1. ``crawl_target`` must be one of ``legacy``, ``shared_drives``, ``users`` or ``both``.
+2. ``impersonate_user`` must be set unless ``crawl_target=legacy``.
+3. ``scopes`` must contain ``https://www.googleapis.com/auth/admin.directory.user.readonly``
+   when ``crawl_target`` is ``users`` or ``both``.
+
+.. note::
+
+   ``shared_drives`` and ``both`` enumerate the shared drives with domain administrator
+   access, so the account named by ``impersonate_user`` must be a Google Workspace domain
+   administrator. This listing decides the whole scope of the crawl, so a permanent
+   failure aborts the crawl rather than being reported and skipped -- a crawl that
+   enumerated no drive must not be able to report success while indexing nothing.
+
+Incremental Crawling
+--------------------
+
+Setting ``incremental=true`` makes each scope -- one shared drive, or the view of one
+impersonated user -- read the Drive change feed instead of listing everything. A scope
+with no stored token is listed in full and its change feed is anchored for the next run.
+
+::
+
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
+    incremental=true
+
+.. warning::
+
+   ``delete_old_docs`` is forced to ``false`` for every incremental run, and an explicit
+   ``delete_old_docs=true`` is overridden rather than honoured (a warning is logged).
+   The stale document sweep deletes every document of the configuration that the current
+   crawl did not touch, which assumes a full crawl; an incremental run only touches the
+   documents that changed, so the sweep would delete the rest of the index.
+
+   To drop documents that vanished from Drive, schedule a separate data store
+   configuration with ``incremental=false``.
+
+The start page tokens are persisted only when the crawl finished and the worker threads
+drained. A crawl that was stopped leaves the tokens untouched and the next run reads the
+same changes again.
+
+The tokens are also discarded, and every scope crawled in full, when the configuration
+that decides what a scope yields changed -- that is, any of ``crawl_target``,
+``impersonate_user``, ``user_query``, ``query``, ``corpora`` or ``spaces``. A stored token
+only describes the population it was taken over, and resuming it after such a change would
+leave a permanent hole in the index.
+
+Rate Limiting and Retries
+-------------------------
+
+A throttled or transient Drive API failure is retried with an exponential back-off,
+bounded by ``max_retries``, ``retry_initial_interval_ms`` and ``max_backoff_ms``. A
+``Retry-After`` header wins over the exponential wait, but is clamped by ``max_backoff_ms``
+so that a mistaken header cannot stall the crawl for hours. Only the delta-seconds form of
+``Retry-After`` is honoured; an HTTP-date falls back to the exponential wait.
+
+``429``, ``500``, ``502``, ``503`` and ``504`` are always retried. A ``403`` is retried
+only when it is a rate limit error; any other ``403`` is an authorization failure, which
+retrying cannot fix, and is reported immediately.
+
+A file listing that could not be finished no longer aborts the whole crawl: the remaining
+shared drives and users are still crawled, and the failure is written to the crawler log
+and to the failure URL list in the admin console.
 
 Script Configuration
 --------------------
@@ -192,7 +394,7 @@ Available Fields
    * - ``file.web_view_link``
      - Link to open in browser
    * - ``file.url``
-     - File URL
+     - File URL. This is ``webViewLink``; when a file has none, ``https://drive.google.com/open?id=<file id>`` is used instead.
    * - ``file.thumbnail_link``
      - Thumbnail link (valid for short period)
    * - ``file.size``
@@ -200,7 +402,51 @@ Available Fields
    * - ``file.roles``
      - Access permissions
 
+.. note::
+
+   Only the fields listed in the ``fields`` parameter are populated. A field that is not
+   requested reads null in the script. Set ``fields=*`` to request every field, as in
+   previous versions.
+
 For details, see the `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_.
+
+Text Extraction of Native Google Types
+--------------------------------------
+
+A native Google type cannot be downloaded and has to be exported. The export target is
+chosen from the export formats that the Drive API actually reports, not from a fixed
+table, and an export is bounded at 10MB.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Type
+     - Exported as
+   * - Google Docs
+     - Markdown (``text/markdown``), falling back to plain text and then HTML
+   * - Google Sheets
+     - TSV (``text/tab-separated-values``), falling back to CSV
+   * - Google Slides
+     - Plain text
+   * - Google Drawings
+     - PNG. There is no text to index, so the metadata is indexed on its own.
+   * - Apps Script
+     - The exported JSON bundle, from which the script sources are indexed
+   * - Google Forms, Google Sites
+     - Not exportable. The metadata is indexed and no error is reported.
+
+.. note::
+
+   Because Google Docs are now exported as Markdown, the indexed text of every Google Doc
+   contains Markdown syntax characters. A full re-crawl is required for the change to
+   reach documents that were already indexed.
+
+.. note::
+
+   The export targets are read from the Drive API once per crawl. If that call fails, the
+   connector falls back to the conversions Drive has always supported -- plain text for
+   Google Docs and CSV for Google Sheets -- and logs a warning.
 
 Google Cloud Platform Configuration
 ===================================
@@ -221,6 +467,7 @@ In "APIs & Services" -> "Library":
 
 1. Search for "Google Drive API"
 2. Click "Enable"
+3. When ``crawl_target`` is ``users`` or ``both``, also enable "Admin SDK API"
 
 3. Create a Service Account
 ---------------------------
@@ -266,9 +513,23 @@ Access https://admin.google.com/:
 
    ::
 
-       https://www.googleapis.com/auth/drive
+       https://www.googleapis.com/auth/drive.readonly
+
+   When ``crawl_target`` is ``users`` or ``both``, enter both scopes:
+
+   ::
+
+       https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
 
 6. Click "Authorize"
+
+.. warning::
+
+   The delegation entry lists the scopes explicitly, so upgrading from an earlier version
+   requires updating it. The default scope narrowed from
+   ``https://www.googleapis.com/auth/drive`` to
+   ``https://www.googleapis.com/auth/drive.readonly`` in 15.9, and the scopes granted here
+   must match the ``scopes`` parameter of the data store configuration.
 
 Credential Configuration
 ========================
@@ -311,8 +572,8 @@ Private Key Format
 Usage Examples
 ==============
 
-Crawl Entire Google Drive
--------------------------
+Crawl Every Shared Drive
+------------------------
 
 Parameters:
 
@@ -321,6 +582,8 @@ Parameters:
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
 
 Script:
 
@@ -335,7 +598,43 @@ Script:
     thumbnail=file.thumbnail_link
     content_length=file.size
     filetype=file.filetype
+    role=file.roles
     filename=file.name
+
+Crawl Every User's My Drive
+---------------------------
+
+Parameters:
+
+::
+
+    private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
+    private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
+    client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=users
+    impersonate_user=admin@example.com
+    scopes=https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
+
+To narrow the users down, add an Admin SDK query:
+
+::
+
+    user_query=orgUnitPath=/Sales
+
+Keep the Previous Behaviour
+---------------------------
+
+``crawl_target=legacy`` keeps the pre-15.9 traversal, in which only the files explicitly
+shared with the service account are found. ``impersonate_user`` is not required.
+
+Parameters:
+
+::
+
+    private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
+    private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
+    client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=legacy
 
 Crawl with Permissions
 ----------------------
@@ -347,6 +646,8 @@ Parameters:
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     default_permissions={role}drive-users
 
 Script:
@@ -361,6 +662,8 @@ Script:
     url=file.web_view_link
     role=file.roles
     filename=file.name
+
+``default_permissions`` is only used for a document whose Drive ACL resolves to nothing.
 
 Crawl Only Specific File Types
 ------------------------------
@@ -381,6 +684,23 @@ Google Docs only:
 Troubleshooting
 ===============
 
+The Crawl Fails to Start
+------------------------
+
+**Symptom**: The crawl ends immediately with a ``DataStoreException``
+
+**Resolution**:
+
+1. ``parameter 'crawl_target' must be one of ...``: the value of ``crawl_target`` is not
+   ``legacy``, ``shared_drives``, ``users`` or ``both``.
+2. ``parameter 'impersonate_user' is required when 'crawl_target' is not 'legacy'``: set
+   ``impersonate_user`` to a domain administrator account, or set ``crawl_target=legacy``.
+3. ``parameter 'scopes' must include 'https://www.googleapis.com/auth/admin.directory.user.readonly'``:
+   add that scope to ``scopes`` and to the domain-wide delegation entry.
+
+This is the expected outcome of upgrading an existing configuration unchanged. See
+`Changes in 15.9`_.
+
 Authentication Error
 --------------------
 
@@ -397,7 +717,9 @@ Authentication Error
 2. Verify Google Drive API is enabled
 3. Verify domain-wide delegation is configured
 4. Verify authorization in Google Workspace admin console
-5. Verify OAuth scope is correct (``https://www.googleapis.com/auth/drive``)
+5. Verify OAuth scope is correct (``https://www.googleapis.com/auth/drive.readonly``,
+   plus ``https://www.googleapis.com/auth/admin.directory.user.readonly`` for
+   ``crawl_target=users`` or ``both``)
 
 Domain-wide Delegation Error
 ----------------------------
@@ -409,9 +731,12 @@ Domain-wide Delegation Error
 1. Verify authorization in Google Workspace admin console:
 
    - Is the Client ID registered correctly?
-   - Is the OAuth scope correct? (``https://www.googleapis.com/auth/drive``)
+   - Are the OAuth scopes correct? The delegation entry lists them explicitly, so the
+     scope narrowing introduced in 15.9 requires updating it.
 
 2. Verify domain-wide delegation is enabled for the service account
+3. Verify that the account named by ``impersonate_user`` is a domain administrator when
+   ``crawl_target`` is ``shared_drives`` or ``both``
 
 Cannot Retrieve Files
 ---------------------
@@ -420,10 +745,33 @@ Cannot Retrieve Files
 
 **Check**:
 
-1. Verify files exist in Google Drive
-2. Verify service account has read permissions
-3. Verify domain-wide delegation is configured correctly
-4. Verify access to target user's Drive is possible
+1. Verify ``crawl_target`` is what you intend. With ``legacy``, only the files explicitly
+   shared with the service account are found, because a service account has no Drive of
+   its own and belongs to no group.
+2. Verify files exist in Google Drive
+3. Verify service account has read permissions
+4. Verify domain-wide delegation is configured correctly
+5. Verify access to target user's Drive is possible
+
+Documents Are Skipped
+---------------------
+
+**Symptom**: ``Skipped ... because no permission could be resolved`` in the crawler log
+
+**Resolution**:
+
+The Drive ACL of the document resolved to no search role at all, so it was skipped rather
+than indexed. Indexing a document with no role disables the |Fess| permission filter for
+it and makes it visible to every user, which is why it is skipped instead. A skipped
+document is not a crawl failure, so it appears only in the crawler log and not in the
+failure URL list.
+
+1. Set ``default_permissions`` to index such documents under a fallback permission
+2. Verify that the account named by ``impersonate_user`` is a domain administrator, so
+   that the shared drive ACLs can be read
+3. Check whether the document is shared by link only. A ``domain`` or ``anyone``
+   permission with ``allowFileDiscovery=false`` grants no search role, because Drive
+   itself does not make such a document discoverable by search.
 
 API Quota Error
 ---------------
@@ -432,9 +780,12 @@ API Quota Error
 
 **Resolution**:
 
-1. Check quota in Google Cloud Platform
-2. Increase crawl interval
-3. Request quota increase if needed
+1. Such a failure is retried automatically with an exponential back-off. Raise
+   ``max_retries`` or ``max_backoff_ms`` if the crawl still fails.
+2. Lower ``number_of_threads`` to reduce the request rate
+3. Check quota in Google Cloud Platform
+4. Increase crawl interval
+5. Request quota increase if needed
 
 Private Key Format Error
 ------------------------
@@ -459,8 +810,11 @@ Crawling Shared Drives
 ----------------------
 
 .. note::
-   To crawl shared drives with a service account,
-   the service account must be added as a member of the shared drive.
+   With ``crawl_target=shared_drives`` (the default) the shared drives are enumerated with
+   domain administrator access, so the service account does not have to be a member of
+   each shared drive. Instead, ``impersonate_user`` must name a domain administrator.
+
+With ``crawl_target=legacy`` the service account has to be added to each shared drive:
 
 1. Open the shared drive in Google Drive
 2. Click "Manage members"
@@ -474,13 +828,49 @@ Large Number of Files
 
 **Resolution**:
 
-1. Split into multiple data stores
-2. Distribute load with scheduled crawling
-3. Adjust crawl interval
-4. Crawl only specific folders
+1. Enable ``incremental=true`` so that only the changes since the previous run are crawled
+2. Split shared drives and users into separate data store configurations rather than using
+   ``crawl_target=both``
+3. Narrow the scope with ``query``, ``user_query`` or ``supported_mimetypes``
+4. Distribute load with scheduled crawling
+5. Adjust crawl interval
 
 Permissions and Access Control
 ==============================
+
+How Drive Permissions Become Fess Roles
+---------------------------------------
+
+The ACL of a document is resolved in three steps, so that the number of extra API calls
+stays proportional to the number of shared drives rather than to the number of files:
+
+1. the inline permissions returned by the file listing, which cost nothing extra;
+2. for an item of a shared drive, whose inline permissions the Drive API does not populate,
+   the ACL of the shared drive itself. It is fetched once per drive with domain
+   administrator access and cached;
+3. for an item that carries its own additional permissions, those permissions.
+
+Each Drive permission becomes a |Fess| search role:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Drive permission
+     - Search role
+   * - ``user``
+     - The search role of that user's email address. The file owners are always added this way.
+   * - ``group``
+     - The search role of that group's email address. Google group membership is never expanded; |Fess| is expected to resolve it on the user side through SSO or LDAP.
+   * - ``domain``
+     - ``domain_permission_format`` with ``{domain}`` replaced by the domain name. Default: ``{group}{domain}``
+   * - ``anyone``
+     - The ``guest`` role
+   * - Any of the above with ``allowFileDiscovery=false``, or a deleted permission
+     - No role. Link-only sharing is not discoverable by search in Drive itself either.
+
+When the result is empty, ``default_permissions`` is used instead -- as a fallback, not as
+an addition. When ``default_permissions`` is unset too, the document is skipped.
 
 Reflect Google Drive Sharing Permissions
 ----------------------------------------
@@ -494,6 +884,8 @@ Parameters:
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     default_permissions={role}drive-users
 
 Script:
@@ -509,6 +901,32 @@ Script:
     url=file.web_view_link
 
 ``file.roles`` contains Google Drive sharing information.
+
+Limitations
+===========
+
+- Drive's "removed" change signal covers a loss of access as well as a deletion. With
+  ``crawl_target=users`` or ``both``, revoking one user's access to a document drops it
+  from the index even though another user can still read it. It comes back on the next
+  change to that file, or on the next full crawl.
+- When a scope falls back to a full crawl during an incremental run, the stale document
+  sweep stays suppressed, so documents that were deleted from Drive while a scope was
+  unanchored remain in the index. The remedy is a separate ``incremental=false``
+  configuration whose full crawl sweeps them.
+- Propagating a deletion assumes the indexed URL contains the Drive file ID, which holds
+  for ``webViewLink`` and for the fallback URL. A crawl script that rewrites ``url`` to a
+  value the file ID does not appear in will not have deletions propagated to it.
+- The change feed is not filtered by ``query``. With ``query`` set and ``incremental=true``,
+  a changed file that does not match the query is still indexed.
+- ``crawl_target=both`` on a large domain issues roughly
+  ``2 + (number of shared drives) + (number of users)`` listing sequences. Splitting shared
+  drives and users into separate data store configurations is the practical mitigation.
+- ``proxy_username`` and ``proxy_password`` are sent as a ``Proxy-Authorization`` request
+  header, which only authenticates a plain HTTP request. All Google API traffic is HTTPS,
+  and an HTTPS connection through an authenticating proxy is established by a ``CONNECT``
+  exchange that the JDK drives through ``java.net.Authenticator`` rather than through a
+  request header. Such an environment needs the JVM option
+  ``-Djdk.http.auth.tunneling.disabledSchemes=`` and an ``Authenticator`` instead.
 
 Reference Information
 =====================

--- a/es/15.9/config/datastore/ds-gsuite.rst
+++ b/es/15.9/config/datastore/ds-gsuite.rst
@@ -10,11 +10,78 @@ El conector de Google Workspace proporciona funcionalidad para obtener archivos 
 
 Esta funcionalidad requiere el plugin ``fess-ds-gsuite``.
 
+Cambios en la Versión 15.9
+==========================
+
+El conector se ha rediseñado en profundidad en |Fess| 15.9. Lea esta sección antes de
+actualizar una configuración de almacén de datos existente.
+
+.. warning::
+
+   ``crawl_target`` ahora tiene el valor predeterminado ``shared_drives``, y cualquier valor
+   distinto de ``legacy`` requiere ``impersonate_user``. Por tanto, una configuración
+   existente que se actualice sin cambios **falla al iniciarse** con una
+   ``DataStoreException`` en lugar de ejecutarse.
+
+   Esto es deliberado: el comportamiento anterior solo alcanzaba los archivos compartidos
+   explícitamente con la cuenta de servicio, de modo que la alternativa sería un rastreo que
+   no indexa nada de forma silenciosa. Establezca ``impersonate_user`` en una cuenta de
+   administrador del dominio, o establezca ``crawl_target=legacy`` para mantener el
+   comportamiento anterior.
+
+Cambios de Comportamiento
+-------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Cambio
+     - Acción necesaria
+   * - ``crawl_target`` tiene el valor predeterminado ``shared_drives`` y requiere ``impersonate_user``
+     - Establezca ``impersonate_user`` o ``crawl_target=legacy``. De lo contrario, el rastreo falla al iniciarse.
+   * - El ámbito OAuth predeterminado se ha reducido de ``https://www.googleapis.com/auth/drive`` a ``https://www.googleapis.com/auth/drive.readonly``
+     - Actualice la entrada de delegación de dominio en la consola de administración de Google Workspace, que enumera los ámbitos de forma explícita.
+   * - ``crawl_target=users`` y ``crawl_target=both`` requieren además ``https://www.googleapis.com/auth/admin.directory.user.readonly``
+     - Añada el ámbito tanto al parámetro ``scopes`` como a la entrada de delegación. Esto se valida al iniciarse.
+   * - La URL indexada es ahora ``webViewLink`` (el enlace que se abre en el navegador) en lugar del enlace de descarga
+     - Realice un rastreo completo para adoptar las nuevas URL.
+   * - ``default_permissions`` es ahora un valor de reserva, no un añadido
+     - Un documento cuya ACL puede resolverse recibe únicamente esa ACL, ya no la unión con ``default_permissions``. El resultado es estrictamente más restrictivo.
+   * - Compartir solo mediante enlace ya no concede un rol de búsqueda
+     - Un permiso ``domain`` o ``anyone`` con ``allowFileDiscovery=false`` significa "cualquier persona con el enlace", algo que Drive tampoco hace localizable mediante la búsqueda.
+   * - Un documento cuya ACL no resuelve nada se omite en lugar de indexarse sin roles
+     - Establezca ``default_permissions`` para seguir indexando esos documentos. Antes eran visibles para todos los usuarios, porque una lista de roles vacía desactiva el filtro de permisos.
+   * - ``fields`` ya no tiene el valor predeterminado ``*``, sino una lista de campos explícita
+     - Un script de rastreo que haga referencia a un campo poco habitual leerá ahora null. Establezca ``fields=*`` para restaurar la proyección anterior.
+   * - Los Documentos de Google se exportan como Markdown en lugar de texto plano, y las Hojas de cálculo como TSV en lugar de CSV
+     - El texto indexado de cada Documento de Google contiene ahora caracteres de sintaxis Markdown. Realice un rastreo completo.
+   * - ``refresh_token_interval`` se ignora
+     - La renovación de los tokens la realiza la biblioteca de autenticación. Una configuración existente sigue funcionando y se registra una advertencia.
+   * - Los Formularios de Google y Google Sites se indexan solo con sus metadatos
+     - No tienen formato de exportación en la API de Drive. Antes, cada uno de ellos producía un error de rastreo.
+
+Nuevas Funcionalidades
+----------------------
+
+- ``crawl_target`` selecciona qué se rastrea: la vista propia de la cuenta de servicio
+  (``legacy``), todas las unidades compartidas del dominio (``shared_drives``), Mi unidad
+  de cada usuario del directorio (``users``) o ambas (``both``). Consulte
+  `Objetivo de Rastreo`_.
+- Los elementos de las unidades compartidas obtienen ahora la ACL correcta.
+- Rastreo incremental mediante el feed de cambios de Drive. Consulte
+  `Rastreo Incremental`_.
+- Límite de velocidad con retroceso exponencial que respeta ``Retry-After``, y una unidad
+  compartida o un usuario con errores que ya no interrumpen todo el rastreo. Consulte
+  `Límite de Velocidad y Reintentos`_.
+- ``proxy_username`` y ``proxy_password`` para un proxy con autenticación.
+
 Servicios Soportados
 ====================
 
 - Google Drive (Mi unidad, Unidades compartidas)
-- Documentos de Google, Hojas de cálculo, Presentaciones, Formularios, etc.
+- Documentos de Google, Hojas de cálculo, Presentaciones, Dibujos, Apps Script
+- Formularios de Google y Google Sites (solo metadatos; no tienen formato de exportación)
 
 Requisitos Previos
 ==================
@@ -23,6 +90,8 @@ Requisitos Previos
 2. Se requiere la creación de un proyecto en Google Cloud Platform
 3. Se requiere la creación de una cuenta de servicio y la obtención de credenciales
 4. Se requiere la configuración de delegación de dominio de Google Workspace
+5. Salvo que se use ``crawl_target=legacy``, se requiere una cuenta de administrador de
+   Google Workspace cuya identidad se suplantará
 
 Instalación del Plugin
 ----------------------
@@ -74,6 +143,7 @@ Configuración de Parámetros
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project.iam.gserviceaccount.com
+    impersonate_user=admin@example.com
 
 Lista de Parámetros
 ~~~~~~~~~~~~~~~~~~~
@@ -94,60 +164,201 @@ Lista de Parámetros
    * - ``client_email``
      - Sí
      - Dirección de correo de la cuenta de servicio
+   * - ``impersonate_user``
+     - Condicional
+     - La cuenta de Google Workspace cuya identidad se suplanta mediante la delegación de dominio. Requerido salvo que se use ``crawl_target=legacy``; sin él, el rastreo falla al iniciarse. ``shared_drives`` y ``both`` enumeran las unidades compartidas con acceso de administrador del dominio, por lo que esta cuenta debe ser administradora del dominio.
+   * - ``crawl_target``
+     - No
+     - Qué se rastrea: ``legacy``, ``shared_drives``, ``users`` o ``both``. Predeterminado: ``shared_drives``. Consulte `Objetivo de Rastreo`_.
+   * - ``scopes``
+     - No
+     - Ámbitos OAuth, separados por comas. Predeterminado: ``https://www.googleapis.com/auth/drive.readonly``. ``crawl_target=users`` y ``crawl_target=both`` requieren además ``https://www.googleapis.com/auth/admin.directory.user.readonly``.
+   * - ``user_query``
+     - No
+     - ``query`` del Admin SDK usada para acotar los usuarios que enumeran ``crawl_target=users`` y ``crawl_target=both``. Predeterminado: sin especificar (todos los usuarios del cliente).
+   * - ``query``
+     - No
+     - Cadena de consulta de búsqueda de la API de Google Drive. No se aplica al feed de cambios que utiliza el rastreo incremental.
+   * - ``corpora``
+     - No
+     - Corpora a buscar. Predeterminado: ``allDrives``. Solo lo consume ``crawl_target=legacy``, por lo que no tiene efecto con el objetivo predeterminado: ``shared_drives`` lista cada unidad con ``drive`` y ``users`` lista cada Mi unidad con ``user``, ambos fijos.
+   * - ``spaces``
+     - No
+     - Espacios a buscar (parámetro ``spaces`` de la API de Google Drive, p. ej. ``drive``, ``appDataFolder``). Predeterminado: sin especificar (valor predeterminado de la API). Lo usan ``crawl_target=legacy`` y ``users``; se ignora en ``shared_drives``.
+   * - ``fields``
+     - No
+     - Campos de archivo que se solicitan a la API de Google Drive. El valor predeterminado **no** es ``*``, sino una lista de campos explícita. Cubre todos los campos que necesitan el contexto del script, la resolución de la ACL, la URL del índice y el rastreo incremental; un campo que no figure en ella se lee como null en el script de rastreo. Establezca ``fields=*`` para solicitar todos los campos, como en versiones anteriores.
+   * - ``default_permissions``
+     - No
+     - Permisos utilizados cuando la ACL de Drive de un documento no resuelve nada (separados por comas, p. ej. ``{role}drive-users``). Es un valor de reserva, no un añadido: un documento cuya ACL puede resolverse recibe únicamente esa ACL.
    * - ``max_size``
      - No
      - Tamaño máximo de archivo a indexar (en bytes). Predeterminado: ``10000000`` (aprox. 10MB)
-   * - ``ignore_folder``
-     - No
-     - Si se deben omitir las carpetas. Predeterminado: ``true``
-   * - ``ignore_error``
-     - No
-     - Si se debe continuar el procesamiento cuando ocurre un error. Predeterminado: ``true``
-   * - ``supported_mimetypes``
-     - No
-     - Tipos MIME a indexar (expresión regular, separados por comas). Predeterminado: ``.*`` (todos los tipos)
-   * - ``include_pattern``
-     - No
-     - Patrón de expresión regular para las URL que se incluyen en el índice
-   * - ``exclude_pattern``
-     - No
-     - Patrón de expresión regular para las URL que se excluyen
-   * - ``default_permissions``
-     - No
-     - Permisos predeterminados (separados por comas, p. ej. ``{role}drive-users``)
    * - ``number_of_threads``
      - No
      - Número de hilos de procesamiento en paralelo. Predeterminado: ``1``
-   * - ``query``
+   * - ``incremental``
      - No
-     - Cadena de consulta de búsqueda de la API de Google Drive
-   * - ``corpora``
-     - No
-     - Corpora a buscar. Predeterminado: ``allDrives``
-   * - ``spaces``
-     - No
-     - Espacios a buscar (parámetro ``spaces`` de la API de Google Drive, p. ej. ``drive``, ``appDataFolder``). Predeterminado: sin especificar (valor predeterminado de la API).
-   * - ``fields``
-     - No
-     - Campos de archivo que se solicitan a la API de Google Drive. Predeterminado: ``*`` (todos los campos).
+     - Si se rastrea mediante el feed de cambios de Drive en lugar de listarlo todo. Predeterminado: ``false``. Se lee directamente del campo de parámetros de la configuración del almacén de datos, antes de que comience el rastreo. Consulte `Rastreo Incremental`_.
+
+Parámetros Avanzados
+~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Parámetro
+     - Descripción
+   * - ``domain_permission_format``
+     - Formato de rol aplicado a un permiso de Drive de tipo ``domain``. ``{domain}`` se sustituye por el nombre del dominio. Predeterminado: ``{group}{domain}``
+   * - ``thread_pool_timeout_seconds``
+     - Cuánto se espera a que terminen los hilos de trabajo al finalizar un rastreo (segundos). Predeterminado: ``60``
+   * - ``page_size``
+     - Tamaño de página para ``files.list`` y ``changes.list``. Predeterminado: ``1000``; los valores superiores a ``1000`` se recortan a ese límite.
+   * - ``permission_page_size``
+     - Tamaño de página para ``permissions.list`` y ``drives.list``. Predeterminado: ``100``; los valores superiores a ``100`` se recortan a ese límite.
+   * - ``max_cached_content_size``
+     - Tamaño máximo (en bytes) del contenido mantenido en memoria; el contenido mayor se vuelca a un archivo temporal. Predeterminado: ``1048576`` (1MB).
+   * - ``max_retries``
+     - Número máximo de reintentos para una llamada a la API de Drive limitada o fallida de forma transitoria. Predeterminado: ``5``
+   * - ``retry_initial_interval_ms``
+     - Intervalo de retroceso inicial antes del primer reintento (milisegundos). Predeterminado: ``1000``
+   * - ``max_backoff_ms``
+     - Límite superior de una espera individual (milisegundos). Predeterminado: ``32000``
    * - ``read_timeout``
-     - No
      - Tiempo de espera de lectura HTTP (en milisegundos). Predeterminado: ``20000``
    * - ``connect_timeout``
-     - No
      - Tiempo de espera de conexión HTTP (en milisegundos). Predeterminado: ``20000``
-   * - ``refresh_token_interval``
-     - No
-     - Intervalo (en segundos) para renovar el token de acceso OAuth. Predeterminado: ``3540`` (59 minutos).
-   * - ``max_cached_content_size``
-     - No
-     - Tamaño máximo (en bytes) del contenido mantenido en memoria; el contenido mayor se vuelca a un archivo temporal. Predeterminado: ``1048576`` (1MB).
    * - ``proxy_host``
-     - No
-     - Nombre de host del servidor proxy
+     - Nombre de host del servidor proxy. El proxy solo se usa cuando ``proxy_host`` y ``proxy_port`` están ambos definidos; uno solo no tiene efecto.
    * - ``proxy_port``
-     - No
-     - Número de puerto del servidor proxy
+     - Número de puerto del servidor proxy. Consulte ``proxy_host``.
+   * - ``proxy_username``
+     - Nombre de usuario para un proxy con autenticación. Si se define, se añade una cabecera ``Proxy-Authorization`` a cada petición. Consulte `Limitaciones`_ para saber qué autentica y qué no.
+   * - ``proxy_password``
+     - Contraseña para un proxy con autenticación
+   * - ``ignore_folder``
+     - Si se deben omitir las carpetas. Predeterminado: ``true``
+   * - ``ignore_error``
+     - Si se debe continuar el procesamiento cuando ocurre un error. Predeterminado: ``true``
+   * - ``supported_mimetypes``
+     - Tipos MIME a indexar (expresión regular, separados por comas). Predeterminado: ``.*`` (todos los tipos)
+   * - ``include_pattern``
+     - Patrón de expresión regular para las URL que se incluyen en el índice
+   * - ``exclude_pattern``
+     - Patrón de expresión regular para las URL que se excluyen
+   * - ``refresh_token_interval``
+     - Se ignora desde la versión 15.9. Los tokens de acceso los renueva la biblioteca de autenticación. Un valor existente sigue funcionando y se registra una advertencia.
+
+.. note::
+
+   ``private_key``, ``private_key_id``, ``client_email``, ``proxy_username`` y
+   ``proxy_password`` se eliminan del contexto de evaluación del script, de modo que un
+   script de rastreo no puede indexarlos y ningún resultado de búsqueda puede revelarlos.
+
+.. note::
+
+   Cuando el rastreo incremental está habilitado, el conector reescribe
+   ``start_page_tokens`` y ``crawl_signature`` en el campo de parámetros de la
+   configuración del almacén de datos. Son valores gestionados por el conector y aparecen
+   junto a los parámetros que usted define; no los modifique. Editarlos o eliminarlos hace
+   que la siguiente ejecución rastree por completo cada ámbito.
+
+Objetivo de Rastreo
+-------------------
+
+Una cuenta de servicio no tiene un Drive propio ni pertenece a ningún grupo de Google, por
+lo que un rastreo que se autentica como la propia cuenta de servicio solo alcanza los
+archivos compartidos explícitamente con su dirección. Por eso ``crawl_target`` selecciona
+qué vista de Drive se rastrea.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Valor
+     - Descripción
+   * - ``legacy``
+     - La vista propia de la cuenta de servicio, como en versiones anteriores. ``impersonate_user`` no es necesario. Solo se encuentran los archivos compartidos explícitamente con la cuenta de servicio.
+   * - ``shared_drives``
+     - Predeterminado. Se enumeran todas las unidades compartidas del dominio y cada una se recorre por separado.
+   * - ``users``
+     - Se enumeran todos los usuarios del directorio mediante el Admin SDK y se recorre Mi unidad de cada uno suplantando su identidad.
+   * - ``both``
+     - ``shared_drives`` seguido de ``users``. Un archivo presente en varios ámbitos se indexa una sola vez.
+
+Lo siguiente se valida al iniciarse el rastreo, y una combinación no válida lanza una
+``DataStoreException`` en lugar de ejecutarse:
+
+1. ``crawl_target`` debe ser ``legacy``, ``shared_drives``, ``users`` o ``both``.
+2. ``impersonate_user`` debe estar definido salvo que se use ``crawl_target=legacy``.
+3. ``scopes`` debe contener ``https://www.googleapis.com/auth/admin.directory.user.readonly``
+   cuando ``crawl_target`` es ``users`` o ``both``.
+
+.. note::
+
+   ``shared_drives`` y ``both`` enumeran las unidades compartidas con acceso de
+   administrador del dominio, por lo que la cuenta indicada en ``impersonate_user`` debe ser
+   administradora del dominio de Google Workspace. Esta enumeración determina todo el
+   alcance del rastreo, de modo que un fallo permanente interrumpe el rastreo en lugar de
+   registrarse y omitirse: un rastreo que no ha podido enumerar ninguna unidad no ha tenido
+   un éxito parcial y no debe poder informar de éxito mientras no indexa nada.
+
+Rastreo Incremental
+-------------------
+
+Establecer ``incremental=true`` hace que cada ámbito -- una unidad compartida, o la vista de
+un usuario cuya identidad se suplanta -- lea el feed de cambios de Drive en lugar de
+listarlo todo. Un ámbito sin token almacenado se lista por completo y su feed de cambios
+queda anclado para la siguiente ejecución.
+
+::
+
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
+    incremental=true
+
+.. warning::
+
+   ``delete_old_docs`` se fuerza a ``false`` en toda ejecución incremental, y un
+   ``delete_old_docs=true`` explícito se sobrescribe en lugar de respetarse (se registra una
+   advertencia). La eliminación de documentos obsoletos borra todos los documentos de la
+   configuración que el rastreo actual no ha tocado, lo que presupone un rastreo completo;
+   una ejecución incremental solo toca los documentos que han cambiado, por lo que esa
+   eliminación borraría el resto del índice.
+
+   Para eliminar los documentos que han desaparecido de Drive, programe una configuración de
+   almacén de datos aparte con ``incremental=false``.
+
+Los tokens solo se guardan cuando el rastreo ha finalizado y los hilos de trabajo han
+terminado. Un rastreo detenido deja los tokens intactos y la siguiente ejecución vuelve a
+leer los mismos cambios.
+
+Los tokens también se descartan, y cada ámbito se rastrea por completo, cuando cambia la
+configuración que determina lo que produce un ámbito, es decir, cualquiera de
+``crawl_target``, ``impersonate_user``, ``user_query``, ``query``, ``corpora`` o ``spaces``.
+Un token almacenado solo describe el conjunto sobre el que se tomó, y reanudarlo tras un
+cambio así dejaría un hueco permanente en el índice.
+
+Límite de Velocidad y Reintentos
+--------------------------------
+
+Una llamada a la API de Drive limitada o fallida de forma transitoria se reintenta con un
+retroceso exponencial, acotado por ``max_retries``, ``retry_initial_interval_ms`` y
+``max_backoff_ms``. Una cabecera ``Retry-After`` prevalece sobre la espera exponencial, pero
+queda limitada por ``max_backoff_ms`` para que una cabecera errónea no pueda detener el
+rastreo durante horas. Solo se respeta la forma en segundos de ``Retry-After``; una fecha
+HTTP recae en la espera exponencial.
+
+``429``, ``500``, ``502``, ``503`` y ``504`` se reintentan siempre. Un ``403`` solo se
+reintenta cuando se trata de un error de límite de velocidad; cualquier otro ``403`` es un
+fallo de autorización que un reintento no puede resolver, y se informa de inmediato.
+
+Un listado de archivos que no ha podido completarse ya no interrumpe todo el rastreo: las
+unidades compartidas y los usuarios restantes se siguen rastreando, y el fallo queda
+registrado en el log del rastreador y en la lista de URL fallidas de la pantalla de
+administración.
 
 Configuración de Script
 -----------------------
@@ -192,7 +403,7 @@ Campos Disponibles
    * - ``file.web_view_link``
      - Enlace para abrir en el navegador
    * - ``file.url``
-     - URL del archivo
+     - URL del archivo. Es ``webViewLink``; cuando un archivo no lo tiene, se usa ``https://drive.google.com/open?id=<ID del archivo>``.
    * - ``file.thumbnail_link``
      - Enlace de miniatura (válido por tiempo limitado)
    * - ``file.size``
@@ -200,7 +411,52 @@ Campos Disponibles
    * - ``file.roles``
      - Permisos de acceso
 
+.. note::
+
+   Solo se rellenan los campos indicados en el parámetro ``fields``. Un campo que no se haya
+   solicitado se lee como null en el script. Establezca ``fields=*`` para solicitar todos los
+   campos, como en versiones anteriores.
+
 Para más detalles, consulte `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_.
+
+Extracción de Texto de los Tipos Nativos de Google
+--------------------------------------------------
+
+Un tipo nativo de Google no puede descargarse y debe exportarse. El destino de exportación
+se elige entre los formatos de exportación que la API de Drive comunica realmente, no a
+partir de una tabla fija, y una exportación está limitada a 10MB.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Tipo
+     - Exportado como
+   * - Documentos de Google
+     - Markdown (``text/markdown``); en su defecto, texto plano y después HTML
+   * - Hojas de cálculo de Google
+     - TSV (``text/tab-separated-values``); en su defecto, CSV
+   * - Presentaciones de Google
+     - Texto plano
+   * - Dibujos de Google
+     - PNG. No hay texto que indexar, por lo que solo se indexan los metadatos.
+   * - Apps Script
+     - El paquete JSON exportado, del que se indexan las fuentes de los scripts
+   * - Formularios de Google, Google Sites
+     - No exportables. Se indexan los metadatos y no se informa de ningún error.
+
+.. note::
+
+   Dado que los Documentos de Google se exportan ahora como Markdown, el texto indexado de
+   cada Documento de Google contiene caracteres de sintaxis Markdown. Es necesario un
+   rastreo completo para que el cambio alcance a los documentos ya indexados.
+
+.. note::
+
+   Los destinos de exportación se leen de la API de Drive una vez por rastreo. Si esa
+   llamada falla, el conector recae en las conversiones que Drive siempre ha admitido --
+   texto plano para los Documentos de Google y CSV para las Hojas de cálculo -- y registra
+   una advertencia.
 
 Configuración de Google Cloud Platform
 ======================================
@@ -221,6 +477,7 @@ En "APIs y servicios" -> "Biblioteca":
 
 1. Busque "Google Drive API"
 2. Haga clic en "Habilitar"
+3. Habilite también "Admin SDK API" cuando ``crawl_target`` sea ``users`` o ``both``
 
 3. Crear Cuenta de Servicio
 ---------------------------
@@ -266,9 +523,23 @@ Acceda a https://admin.google.com/:
 
    ::
 
-       https://www.googleapis.com/auth/drive
+       https://www.googleapis.com/auth/drive.readonly
+
+   Cuando ``crawl_target`` sea ``users`` o ``both``, ingrese ambos ámbitos:
+
+   ::
+
+       https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
 
 6. Haga clic en "Autorizar"
+
+.. warning::
+
+   La entrada de delegación enumera los ámbitos de forma explícita, por lo que actualizar
+   desde una versión anterior obliga a modificarla. El ámbito predeterminado se redujo en
+   15.9 de ``https://www.googleapis.com/auth/drive`` a
+   ``https://www.googleapis.com/auth/drive.readonly``, y los ámbitos concedidos aquí deben
+   coincidir con el parámetro ``scopes`` de la configuración del almacén de datos.
 
 Configuración de Credenciales
 =============================
@@ -311,6 +582,24 @@ Formato de Clave Privada
 Solución de Problemas
 =====================
 
+El Rastreo No Se Inicia
+-----------------------
+
+**Síntoma**: El rastreo termina de inmediato con una ``DataStoreException``
+
+**Solución**:
+
+1. ``parameter 'crawl_target' must be one of ...``: el valor de ``crawl_target`` no es
+   ``legacy``, ``shared_drives``, ``users`` ni ``both``.
+2. ``parameter 'impersonate_user' is required when 'crawl_target' is not 'legacy'``:
+   establezca ``impersonate_user`` en una cuenta de administrador del dominio, o establezca
+   ``crawl_target=legacy``.
+3. ``parameter 'scopes' must include 'https://www.googleapis.com/auth/admin.directory.user.readonly'``:
+   añada ese ámbito a ``scopes`` y a la entrada de delegación de dominio.
+
+Este es el resultado esperado al actualizar una configuración existente sin cambios.
+Consulte `Cambios en la Versión 15.9`_.
+
 Error de Autenticación
 ----------------------
 
@@ -327,7 +616,10 @@ Error de Autenticación
 2. Verificar que Google Drive API esté habilitada
 3. Verificar que la delegación de dominio esté configurada
 4. Verificar que esté autorizado en la consola de administración de Google Workspace
-5. Verificar que el ámbito OAuth sea correcto (``https://www.googleapis.com/auth/drive``)
+5. Verificar que el ámbito OAuth sea correcto
+   (``https://www.googleapis.com/auth/drive.readonly``, más
+   ``https://www.googleapis.com/auth/admin.directory.user.readonly`` para
+   ``crawl_target=users`` o ``both``)
 
 Error de Delegación de Dominio
 ------------------------------
@@ -339,9 +631,12 @@ Error de Delegación de Dominio
 1. Verificar la autorización en la consola de administración de Google Workspace:
 
    - El ID de cliente está registrado correctamente
-   - El ámbito OAuth es correcto (``https://www.googleapis.com/auth/drive``)
+   - Los ámbitos OAuth son correctos. La entrada de delegación los enumera de forma
+     explícita, por lo que la reducción introducida en 15.9 obliga a actualizarla.
 
 2. Verificar que la delegación de dominio esté habilitada en la cuenta de servicio
+3. Verificar que la cuenta indicada en ``impersonate_user`` sea administradora del dominio
+   cuando ``crawl_target`` sea ``shared_drives`` o ``both``
 
 No se Pueden Obtener Archivos
 -----------------------------
@@ -350,10 +645,63 @@ No se Pueden Obtener Archivos
 
 **Verificar**:
 
-1. Verificar que existan archivos en Google Drive
-2. Verificar que la cuenta de servicio tenga permisos de lectura
-3. Verificar que la delegación de dominio esté configurada correctamente
-4. Verificar que se pueda acceder al Drive del usuario objetivo
+1. Verificar que ``crawl_target`` sea el que usted pretende. Con ``legacy`` solo se
+   encuentran los archivos compartidos explícitamente con la cuenta de servicio, porque una
+   cuenta de servicio no tiene un Drive propio ni pertenece a ningún grupo.
+2. Verificar que existan archivos en Google Drive
+3. Verificar que la cuenta de servicio tenga permisos de lectura
+4. Verificar que la delegación de dominio esté configurada correctamente
+5. Verificar que se pueda acceder al Drive del usuario objetivo
+
+Documentos Omitidos
+-------------------
+
+**Síntoma**: ``Skipped ... because no permission could be resolved`` en el log del rastreador
+
+**Solución**:
+
+La ACL de Drive del documento no resolvió ningún rol de búsqueda, por lo que se omitió en
+lugar de indexarse. Indexar un documento sin ningún rol desactiva el filtro de permisos de
+|Fess| para ese documento y lo hace visible para todos los usuarios; por eso se omite. Un
+documento omitido no es un fallo de rastreo, así que aparece solo en el log del rastreador y
+no en la lista de URL fallidas.
+
+1. Establezca ``default_permissions`` para indexar esos documentos con un permiso de reserva
+2. Verifique que la cuenta indicada en ``impersonate_user`` sea administradora del dominio,
+   para que puedan leerse las ACL de las unidades compartidas
+3. Compruebe si el documento se comparte solo mediante enlace. Un permiso ``domain`` o
+   ``anyone`` con ``allowFileDiscovery=false`` no concede ningún rol de búsqueda, porque
+   Drive tampoco hace localizable ese documento mediante la búsqueda.
+
+Limitaciones
+============
+
+- La señal de "eliminado" de Drive abarca tanto la pérdida de acceso como el borrado. Con
+  ``crawl_target=users`` o ``both``, revocar el acceso de un usuario a un documento lo
+  elimina del índice aunque otro usuario todavía pueda leerlo. Vuelve con el siguiente
+  cambio de ese archivo, o en el siguiente rastreo completo.
+- Cuando un ámbito recae en un rastreo completo durante una ejecución incremental, la
+  eliminación de documentos obsoletos sigue desactivada, por lo que los documentos borrados
+  de Drive mientras un ámbito no estaba anclado permanecen en el índice. El remedio es una
+  configuración aparte con ``incremental=false``, cuyo rastreo completo los elimina.
+- La propagación de un borrado presupone que la URL indexada contiene el ID del archivo de
+  Drive, lo cual se cumple para ``webViewLink`` y para la URL de reserva. Un script de
+  rastreo que reescriba ``url`` a un valor sin el ID del archivo impide que se propaguen los
+  borrados.
+- El feed de cambios no se filtra por ``query``. Con ``query`` definido e
+  ``incremental=true``, un archivo modificado que no coincide con la consulta se indexa de
+  todos modos.
+- ``crawl_target=both`` en un dominio grande genera aproximadamente
+  ``2 + (número de unidades compartidas) + (número de usuarios)`` secuencias de listado. La
+  mitigación práctica consiste en repartir las unidades compartidas y los usuarios en
+  configuraciones de almacén de datos distintas.
+- ``proxy_username`` y ``proxy_password`` se envían como cabecera de petición
+  ``Proxy-Authorization``, que solo autentica una petición HTTP en claro. Todo el tráfico de
+  las API de Google es HTTPS, y una conexión HTTPS a través de un proxy con autenticación se
+  establece mediante un intercambio ``CONNECT`` que el JDK gestiona con
+  ``java.net.Authenticator`` y no mediante una cabecera de petición. Un entorno así necesita
+  en su lugar la opción de JVM ``-Djdk.http.auth.tunneling.disabledSchemes=`` y un
+  ``Authenticator``.
 
 Información de Referencia
 =========================

--- a/fr/15.9/config/datastore/ds-gsuite.rst
+++ b/fr/15.9/config/datastore/ds-gsuite.rst
@@ -3,29 +3,98 @@ Connecteur Google Workspace
 ==================================
 
 Aperçu
-====
+======
 
 Le connecteur Google Workspace fournit la fonctionnalité permettant de récupérer les fichiers
 depuis Google Drive (anciennement G Suite) et de les enregistrer dans l'index |Fess|.
 
 Cette fonctionnalité nécessite le plugin ``fess-ds-gsuite``.
 
+Modifications dans la version 15.9
+==================================
+
+Le connecteur a été profondément remanié dans |Fess| 15.9. Lisez cette section avant de
+mettre à niveau une configuration de data store existante.
+
+.. warning::
+
+   ``crawl_target`` vaut désormais ``shared_drives`` par défaut, et toute valeur autre que
+   ``legacy`` exige ``impersonate_user``. Une configuration existante mise à niveau sans
+   modification **échoue donc au démarrage** avec une ``DataStoreException`` au lieu de
+   s'exécuter.
+
+   C'est délibéré : le comportement précédent n'atteignait que les fichiers explicitement
+   partagés avec le compte de service, si bien que l'alternative serait un crawl qui
+   n'indexe silencieusement rien. Définissez ``impersonate_user`` sur un compte
+   d'administrateur de domaine, ou définissez ``crawl_target=legacy`` pour conserver le
+   comportement précédent.
+
+Changements de comportement
+---------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Changement
+     - Action requise
+   * - ``crawl_target`` vaut ``shared_drives`` par défaut et exige ``impersonate_user``
+     - Définissez ``impersonate_user``, ou définissez ``crawl_target=legacy``. Sinon, le crawl échoue au démarrage.
+   * - Le scope OAuth par défaut est passé de ``https://www.googleapis.com/auth/drive`` à ``https://www.googleapis.com/auth/drive.readonly``
+     - Mettez à jour l'entrée de délégation à l'échelle du domaine dans la console d'administration Google Workspace, qui énumère explicitement les scopes.
+   * - ``crawl_target=users`` et ``crawl_target=both`` exigent en plus ``https://www.googleapis.com/auth/admin.directory.user.readonly``
+     - Ajoutez le scope à la fois au paramètre ``scopes`` et à l'entrée de délégation. Ceci est vérifié au démarrage.
+   * - L'URL indexée est désormais ``webViewLink`` (le lien ouvrable dans le navigateur) au lieu du lien de téléchargement
+     - Effectuez un crawl complet pour prendre en compte les nouvelles URL.
+   * - ``default_permissions`` est désormais une valeur de repli, et non un ajout
+     - Un document dont l'ACL peut être résolue reçoit uniquement cette ACL, et non plus l'union avec ``default_permissions``. Le résultat est strictement plus restrictif.
+   * - Le partage par lien seul n'accorde plus de rôle de recherche
+     - Une permission ``domain`` ou ``anyone`` avec ``allowFileDiscovery=false`` signifie « toute personne disposant du lien », ce que Drive lui-même ne rend pas non plus détectable par la recherche.
+   * - Un document dont l'ACL ne donne rien est ignoré au lieu d'être indexé sans rôle
+     - Définissez ``default_permissions`` pour continuer à indexer ces documents. Auparavant, ils étaient visibles par tous les utilisateurs, car une liste de rôles vide désactive le filtre de permissions.
+   * - ``fields`` ne vaut plus ``*`` par défaut, mais une liste de champs explicite
+     - Un script de crawl qui référence un champ inhabituel lit désormais null. Définissez ``fields=*`` pour rétablir la projection précédente.
+   * - Les Google Docs sont exportés en Markdown au lieu de texte brut, et les Google Sheets en TSV au lieu de CSV
+     - Le texte indexé de chaque Google Doc contient désormais des caractères de syntaxe Markdown. Effectuez un crawl complet.
+   * - ``refresh_token_interval`` est ignoré
+     - Le renouvellement des jetons est assuré par la bibliothèque d'authentification. Une configuration existante continue de fonctionner, et un avertissement est journalisé.
+   * - Google Forms et Google Sites ne sont indexés que par leurs métadonnées
+     - Ils n'ont pas de format d'export dans l'API Drive. Auparavant, chacun d'eux produisait une erreur de crawl.
+
+Nouvelles fonctionnalités
+-------------------------
+
+- ``crawl_target`` sélectionne ce qui est crawlé : la vue propre du compte de service
+  (``legacy``), tous les Drive partagés du domaine (``shared_drives``), le Mon Drive de
+  chaque utilisateur de l'annuaire (``users``), ou les deux (``both``). Voir
+  `Cible du crawl`_.
+- Les éléments des Drive partagés reçoivent désormais l'ACL correcte. Voir
+  `Permissions et contrôle d'accès`_.
+- Crawl incrémentiel via le flux de modifications de Drive. Voir `Crawl incrémentiel`_.
+- Limitation de débit avec un back-off exponentiel qui honore ``Retry-After``, et un Drive
+  partagé ou un utilisateur en échec qui n'interrompt plus l'ensemble du crawl. Voir
+  `Limitation de débit et nouvelles tentatives`_.
+- ``proxy_username`` et ``proxy_password`` pour un proxy avec authentification.
+
 Services pris en charge
-============
+=======================
 
 - Google Drive (Mon Drive, Drive partagés)
-- Google Docs, Sheets, Slides, Forms, etc.
+- Google Docs, Sheets, Slides, Drawings, Apps Script
+- Google Forms et Google Sites (métadonnées uniquement ; ils n'ont pas de format d'export)
 
 Prérequis
-========
+=========
 
 1. L'installation du plugin est requise
 2. La création d'un projet Google Cloud Platform est nécessaire
 3. La création d'un compte de service et l'obtention des identifiants sont nécessaires
 4. La configuration de la délégation à l'échelle du domaine Google Workspace est nécessaire
+5. Sauf si ``crawl_target=legacy`` est utilisé, un compte d'administrateur Google Workspace
+   à emprunter est nécessaire
 
 Installation du plugin
-------------------------
+----------------------
 
 Méthode 1 : Placement direct du fichier JAR
 
@@ -46,12 +115,12 @@ Méthode 2 : Installation depuis l'interface d'administration
 3. Redémarrer |Fess|
 
 Configuration
-========
+=============
 
 Configurez depuis l'interface d'administration via "Crawler" -> "Data Store" -> "Nouveau".
 
 Configuration de base
---------
+---------------------
 
 .. list-table::
    :header-rows: 1
@@ -67,16 +136,17 @@ Configuration de base
      - Oui
 
 Configuration des paramètres
-----------------
+----------------------------
 
 ::
 
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project.iam.gserviceaccount.com
+    impersonate_user=admin@example.com
 
 Liste des paramètres
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
@@ -94,63 +164,205 @@ Liste des paramètres
    * - ``client_email``
      - Oui
      - Adresse email du compte de service
+   * - ``impersonate_user``
+     - Conditionnel
+     - Le compte Google Workspace emprunté via la délégation à l'échelle du domaine. Requis sauf si ``crawl_target=legacy`` ; sans lui, le crawl échoue au démarrage. ``shared_drives`` et ``both`` énumèrent les Drive partagés avec un accès d'administrateur de domaine, ce compte doit donc être administrateur du domaine.
+   * - ``crawl_target``
+     - Non
+     - Ce qui est crawlé : ``legacy``, ``shared_drives``, ``users`` ou ``both``. Par défaut : ``shared_drives``. Voir `Cible du crawl`_.
+   * - ``scopes``
+     - Non
+     - Scopes OAuth, séparés par des virgules. Par défaut : ``https://www.googleapis.com/auth/drive.readonly``. ``crawl_target=users`` et ``crawl_target=both`` exigent en plus ``https://www.googleapis.com/auth/admin.directory.user.readonly``.
+   * - ``user_query``
+     - Non
+     - ``query`` de l'Admin SDK utilisée pour restreindre les utilisateurs énumérés par ``crawl_target=users`` et ``crawl_target=both``. Par défaut : non défini (tous les utilisateurs du client).
+   * - ``query``
+     - Non
+     - Chaîne de requête de recherche de l'API Google Drive. N'est pas appliquée au flux de modifications utilisé par le crawl incrémentiel.
+   * - ``corpora``
+     - Non
+     - Corpus à rechercher. Par défaut : ``allDrives``. Utilisé uniquement par ``crawl_target=legacy``, il n'a donc aucun effet avec la cible par défaut : ``shared_drives`` liste chaque Drive avec ``drive`` et ``users`` liste chaque Mon Drive avec ``user``, les deux étant fixés.
+   * - ``spaces``
+     - Non
+     - Espaces à rechercher (paramètre ``spaces`` de l'API Google Drive, par ex. ``drive``, ``appDataFolder``). Par défaut : non défini (valeur par défaut de l'API). Utilisé par ``crawl_target=legacy`` et ``users`` ; ignoré pour ``shared_drives``.
+   * - ``fields``
+     - Non
+     - Champs de fichier à demander à l'API Google Drive. La valeur par défaut n'est **pas** ``*``, mais une liste de champs explicite. Elle couvre tous les champs nécessaires au contexte de script, à la résolution des ACL, à l'URL d'index et au crawl incrémentiel ; un champ absent de cette liste vaut null dans le script de crawl. Définissez ``fields=*`` pour demander tous les champs, comme dans les versions précédentes.
+   * - ``default_permissions``
+     - Non
+     - Permissions utilisées lorsque l'ACL Drive d'un document ne donne rien (séparées par des virgules, ex : ``{role}drive-users``). C'est une valeur de repli, et non un ajout : un document dont l'ACL peut être résolue reçoit uniquement cette ACL.
    * - ``max_size``
      - Non
      - Taille maximale des fichiers à indexer (en octets). Par défaut : ``10000000`` (environ 10 Mo)
-   * - ``ignore_folder``
-     - Non
-     - Ignorer les dossiers ou non. Par défaut : ``true``
-   * - ``ignore_error``
-     - Non
-     - Continuer le traitement en cas d'erreur. Par défaut : ``true``
-   * - ``supported_mimetypes``
-     - Non
-     - Types MIME à indexer (expression régulière, séparés par des virgules). Par défaut : ``.*`` (tous les types)
-   * - ``include_pattern``
-     - Non
-     - Expression régulière des URL à inclure dans l'indexation
-   * - ``exclude_pattern``
-     - Non
-     - Expression régulière des URL à exclure de l'indexation
-   * - ``default_permissions``
-     - Non
-     - Permissions par défaut (séparées par des virgules, ex : ``{role}drive-users``)
    * - ``number_of_threads``
      - Non
      - Nombre de threads de traitement parallèle. Par défaut : ``1``
-   * - ``query``
+   * - ``incremental``
      - Non
-     - Chaîne de requête de recherche de l'API Google Drive
-   * - ``corpora``
-     - Non
-     - Corpus à rechercher. Par défaut : ``allDrives``
-   * - ``spaces``
-     - Non
-     - Espaces à rechercher (paramètre ``spaces`` de l'API Google Drive, par ex. ``drive``, ``appDataFolder``). Par défaut : non défini (valeur par défaut de l'API).
-   * - ``fields``
-     - Non
-     - Champs de fichier à demander à l'API Google Drive. Par défaut : ``*`` (tous les champs).
+     - Indique s'il faut crawler via le flux de modifications de Drive au lieu de tout lister. Par défaut : ``false``. La valeur est lue directement dans le champ de paramètres de la configuration du data store, avant le démarrage du crawl. Voir `Crawl incrémentiel`_.
+
+Paramètres avancés
+~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Paramètre
+     - Description
+   * - ``domain_permission_format``
+     - Format de rôle appliqué à une permission Drive de type ``domain``. ``{domain}`` est remplacé par le nom de domaine. Par défaut : ``{group}{domain}``
+   * - ``thread_pool_timeout_seconds``
+     - Durée d'attente de la fin des threads de traitement à l'issue d'un crawl (secondes). Par défaut : ``60``
+   * - ``page_size``
+     - Taille de page pour ``files.list`` et ``changes.list``. Par défaut : ``1000`` ; les valeurs supérieures à ``1000`` sont ramenées à cette limite.
+   * - ``permission_page_size``
+     - Taille de page pour ``permissions.list`` et ``drives.list``. Par défaut : ``100`` ; les valeurs supérieures à ``100`` sont ramenées à cette limite.
+   * - ``max_cached_content_size``
+     - Taille maximale (en octets) du contenu conservé en mémoire ; un contenu plus volumineux est déchargé dans un fichier temporaire. Par défaut : ``1048576`` (1 Mo).
+   * - ``max_retries``
+     - Nombre maximal de nouvelles tentatives pour un appel de l'API Drive limité ou temporairement en échec. Par défaut : ``5``
+   * - ``retry_initial_interval_ms``
+     - Intervalle de back-off initial avant la première nouvelle tentative (millisecondes). Par défaut : ``1000``
+   * - ``max_backoff_ms``
+     - Limite supérieure d'une attente unique (millisecondes). Par défaut : ``32000``
    * - ``read_timeout``
-     - Non
      - Délai de lecture HTTP (en millisecondes). Par défaut : ``20000``
    * - ``connect_timeout``
-     - Non
      - Délai de connexion HTTP (en millisecondes). Par défaut : ``20000``
-   * - ``refresh_token_interval``
-     - Non
-     - Intervalle (en secondes) pour renouveler le jeton d'accès OAuth. Par défaut : ``3540`` (59 minutes).
-   * - ``max_cached_content_size``
-     - Non
-     - Taille maximale (en octets) du contenu conservé en mémoire ; un contenu plus volumineux est déchargé dans un fichier temporaire. Par défaut : ``1048576`` (1 Mo).
    * - ``proxy_host``
-     - Non
-     - Nom d'hôte du serveur proxy
+     - Nom d'hôte du serveur proxy. Le proxy n'est utilisé que si ``proxy_host`` et ``proxy_port`` sont tous deux définis ; l'un sans l'autre n'a aucun effet.
    * - ``proxy_port``
-     - Non
-     - Numéro de port du serveur proxy
+     - Numéro de port du serveur proxy. Voir ``proxy_host``.
+   * - ``proxy_username``
+     - Nom d'utilisateur pour un proxy avec authentification. S'il est défini, un en-tête ``Proxy-Authorization`` est ajouté à chaque requête. Voir `Limitations`_ pour ce que cela authentifie ou non.
+   * - ``proxy_password``
+     - Mot de passe pour un proxy avec authentification
+   * - ``ignore_folder``
+     - Ignorer les dossiers ou non. Par défaut : ``true``
+   * - ``ignore_error``
+     - Continuer le traitement en cas d'erreur. Par défaut : ``true``
+   * - ``supported_mimetypes``
+     - Types MIME à indexer (expression régulière, séparés par des virgules). Par défaut : ``.*`` (tous les types)
+   * - ``include_pattern``
+     - Expression régulière des URL à inclure dans l'indexation
+   * - ``exclude_pattern``
+     - Expression régulière des URL à exclure de l'indexation
+   * - ``refresh_token_interval``
+     - Ignoré depuis la version 15.9. Les jetons d'accès sont renouvelés par la bibliothèque d'authentification. Un réglage existant continue de fonctionner et un avertissement est journalisé.
+
+.. note::
+
+   ``private_key``, ``private_key_id``, ``client_email``, ``proxy_username`` et
+   ``proxy_password`` sont retirés du contexte d'évaluation du script : un script de crawl
+   ne peut donc pas les indexer et aucun résultat de recherche ne peut les divulguer.
+
+.. note::
+
+   Lorsque le crawl incrémentiel est activé, le connecteur réécrit ``start_page_tokens`` et
+   ``crawl_signature`` dans le champ de paramètres de la configuration du data store. Ces
+   valeurs sont gérées par le connecteur et apparaissent à côté des paramètres que vous
+   définissez ; ne les modifiez pas. Les modifier ou les supprimer amène l'exécution
+   suivante à crawler intégralement chaque portée.
+
+Cible du crawl
+--------------
+
+Un compte de service ne possède pas de Drive propre et n'appartient à aucun groupe Google :
+un crawl qui s'authentifie en tant que compte de service n'atteint donc que les fichiers
+explicitement partagés avec l'adresse du compte de service. ``crawl_target`` sélectionne
+par conséquent la vue de Drive qui est crawlée.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Valeur
+     - Description
+   * - ``legacy``
+     - La vue propre du compte de service, comme dans les versions précédentes. ``impersonate_user`` n'est pas requis. Seuls les fichiers explicitement partagés avec le compte de service sont trouvés.
+   * - ``shared_drives``
+     - Valeur par défaut. Tous les Drive partagés du domaine sont énumérés, et chacun est parcouru séparément.
+   * - ``users``
+     - Tous les utilisateurs de l'annuaire sont énumérés via l'Admin SDK, et le Mon Drive de chacun est parcouru en empruntant son identité.
+   * - ``both``
+     - ``shared_drives`` puis ``users``. Un fichier présent dans plusieurs portées n'est indexé qu'une seule fois.
+
+Les points suivants sont vérifiés au démarrage du crawl ; une combinaison invalide lève une
+``DataStoreException`` au lieu de s'exécuter :
+
+1. ``crawl_target`` doit valoir ``legacy``, ``shared_drives``, ``users`` ou ``both``.
+2. ``impersonate_user`` doit être défini sauf si ``crawl_target=legacy``.
+3. ``scopes`` doit contenir ``https://www.googleapis.com/auth/admin.directory.user.readonly``
+   lorsque ``crawl_target`` vaut ``users`` ou ``both``.
+
+.. note::
+
+   ``shared_drives`` et ``both`` énumèrent les Drive partagés avec un accès d'administrateur
+   de domaine : le compte désigné par ``impersonate_user`` doit donc être administrateur du
+   domaine Google Workspace. Cette énumération détermine toute la portée du crawl, si bien
+   qu'un échec permanent interrompt le crawl au lieu d'être signalé et ignoré : un crawl qui
+   n'a énuméré aucun Drive n'a pas réussi partiellement et ne doit pas pouvoir se déclarer
+   réussi alors qu'il n'indexe rien.
+
+Crawl incrémentiel
+------------------
+
+Définir ``incremental=true`` amène chaque portée -- un Drive partagé, ou la vue d'un
+utilisateur dont l'identité est empruntée -- à lire le flux de modifications de Drive au
+lieu de tout lister. Une portée sans jeton enregistré est listée intégralement et son flux
+de modifications est ancré pour l'exécution suivante.
+
+::
+
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
+    incremental=true
+
+.. warning::
+
+   ``delete_old_docs`` est forcé à ``false`` pour toute exécution incrémentielle, et un
+   ``delete_old_docs=true`` explicite est écrasé plutôt qu'honoré (un avertissement est
+   journalisé). La suppression des documents obsolètes efface tous les documents de la
+   configuration que le crawl courant n'a pas touchés, ce qui suppose un crawl complet ; une
+   exécution incrémentielle ne touche que les documents modifiés, si bien que cette
+   suppression effacerait le reste de l'index.
+
+   Pour supprimer les documents disparus de Drive, planifiez une configuration de data store
+   distincte avec ``incremental=false``.
+
+Les jetons ne sont enregistrés que si le crawl s'est terminé et que les threads de
+traitement se sont achevés. Un crawl interrompu laisse les jetons intacts, et l'exécution
+suivante relit les mêmes modifications.
+
+Les jetons sont également abandonnés, et chaque portée crawlée intégralement, lorsque la
+configuration qui détermine ce que produit une portée a changé, c'est-à-dire l'un de
+``crawl_target``, ``impersonate_user``, ``user_query``, ``query``, ``corpora`` ou
+``spaces``. Un jeton enregistré ne décrit que la population sur laquelle il a été pris ;
+le reprendre après un tel changement laisserait un trou permanent dans l'index.
+
+Limitation de débit et nouvelles tentatives
+-------------------------------------------
+
+Un appel de l'API Drive limité ou temporairement en échec est retenté avec un back-off
+exponentiel, borné par ``max_retries``, ``retry_initial_interval_ms`` et ``max_backoff_ms``.
+Un en-tête ``Retry-After`` prime sur l'attente exponentielle, mais il est plafonné par
+``max_backoff_ms`` afin qu'un en-tête erroné ne puisse pas bloquer le crawl pendant des
+heures. Seule la forme en secondes de ``Retry-After`` est honorée ; une date HTTP retombe
+sur l'attente exponentielle.
+
+``429``, ``500``, ``502``, ``503`` et ``504`` sont toujours retentés. Un ``403`` n'est
+retenté que s'il s'agit d'une erreur de limitation de débit ; tout autre ``403`` est un
+échec d'autorisation qu'une nouvelle tentative ne peut pas résoudre, et il est signalé
+immédiatement.
+
+Un listage de fichiers qui n'a pas pu aboutir n'interrompt plus l'ensemble du crawl : les
+Drive partagés et les utilisateurs restants sont toujours crawlés, et l'échec est inscrit
+dans le journal du crawler ainsi que dans la liste des URL en échec de l'interface
+d'administration.
 
 Configuration du script
---------------
+-----------------------
 
 ::
 
@@ -167,7 +379,7 @@ Configuration du script
     filename=file.name
 
 Champs disponibles
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
@@ -192,7 +404,7 @@ Champs disponibles
    * - ``file.web_view_link``
      - Lien pour ouvrir dans le navigateur
    * - ``file.url``
-     - URL du fichier
+     - URL du fichier. Il s'agit de ``webViewLink`` ; lorsqu'un fichier n'en a pas, ``https://drive.google.com/open?id=<ID du fichier>`` est utilisé à la place.
    * - ``file.thumbnail_link``
      - Lien vers la miniature (valide temporairement)
    * - ``file.size``
@@ -200,10 +412,54 @@ Champs disponibles
    * - ``file.roles``
      - Permissions d'accès
 
+.. note::
+
+   Seuls les champs listés dans le paramètre ``fields`` sont renseignés. Un champ non
+   demandé vaut null dans le script. Définissez ``fields=*`` pour demander tous les champs,
+   comme dans les versions précédentes.
+
 Pour plus de détails, consultez `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_.
 
+Extraction de texte des types Google natifs
+-------------------------------------------
+
+Un type Google natif ne peut pas être téléchargé et doit être exporté. La cible d'export est
+choisie parmi les formats d'export que l'API Drive signale réellement, et non dans une table
+figée, et un export est limité à 10 Mo.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Type
+     - Exporté en
+   * - Google Docs
+     - Markdown (``text/markdown``), à défaut texte brut puis HTML
+   * - Google Sheets
+     - TSV (``text/tab-separated-values``), à défaut CSV
+   * - Google Slides
+     - Texte brut
+   * - Google Drawings
+     - PNG. Il n'y a pas de texte à indexer, seules les métadonnées sont donc indexées.
+   * - Apps Script
+     - Le paquet JSON exporté, dont les sources des scripts sont indexées
+   * - Google Forms, Google Sites
+     - Non exportables. Les métadonnées sont indexées et aucune erreur n'est signalée.
+
+.. note::
+
+   Comme les Google Docs sont désormais exportés en Markdown, le texte indexé de chaque
+   Google Doc contient des caractères de syntaxe Markdown. Un crawl complet est nécessaire
+   pour que le changement atteigne les documents déjà indexés.
+
+.. note::
+
+   Les cibles d'export sont lues une fois par crawl depuis l'API Drive. Si cet appel échoue,
+   le connecteur retombe sur les conversions que Drive a toujours prises en charge -- texte
+   brut pour les Google Docs et CSV pour les Google Sheets -- et journalise un avertissement.
+
 Configuration Google Cloud Platform
-=========================
+===================================
 
 1. Création du projet
 ---------------------
@@ -215,15 +471,16 @@ Accédez à https://console.cloud.google.com/ :
 3. Sélectionnez l'organisation et l'emplacement
 
 2. Activation de l'API Google Drive
----------------------------
+-----------------------------------
 
 Dans "APIs et services" -> "Bibliothèque" :
 
 1. Recherchez "Google Drive API"
 2. Cliquez sur "Activer"
+3. Activez également "Admin SDK API" si ``crawl_target`` vaut ``users`` ou ``both``
 
 3. Création du compte de service
----------------------------
+--------------------------------
 
 Dans "APIs et services" -> "Identifiants" :
 
@@ -234,7 +491,7 @@ Dans "APIs et services" -> "Identifiants" :
 5. Cliquez sur "Terminer"
 
 4. Création de la clé du compte de service
--------------------------------
+------------------------------------------
 
 Pour le compte de service créé :
 
@@ -245,7 +502,7 @@ Pour le compte de service créé :
 5. Enregistrez le fichier JSON téléchargé
 
 5. Activation de la délégation à l'échelle du domaine
------------------------------
+-----------------------------------------------------
 
 Dans les paramètres du compte de service :
 
@@ -254,7 +511,7 @@ Dans les paramètres du compte de service :
 3. Copiez "l'ID client OAuth 2"
 
 6. Autorisation dans la console d'administration Google Workspace
----------------------------------------
+-----------------------------------------------------------------
 
 Accédez à https://admin.google.com/ :
 
@@ -266,15 +523,29 @@ Accédez à https://admin.google.com/ :
 
    ::
 
-       https://www.googleapis.com/auth/drive
+       https://www.googleapis.com/auth/drive.readonly
+
+   Lorsque ``crawl_target`` vaut ``users`` ou ``both``, entrez les deux scopes :
+
+   ::
+
+       https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
 
 6. Cliquez sur "Autoriser"
 
+.. warning::
+
+   L'entrée de délégation énumère explicitement les scopes : une mise à niveau depuis une
+   version antérieure impose donc de la mettre à jour. Le scope par défaut est passé de
+   ``https://www.googleapis.com/auth/drive`` à
+   ``https://www.googleapis.com/auth/drive.readonly`` en 15.9, et les scopes accordés ici
+   doivent correspondre au paramètre ``scopes`` de la configuration du data store.
+
 Configuration des identifiants
-==============
+==============================
 
 Obtention des informations depuis le fichier JSON
---------------------------
+-------------------------------------------------
 
 Fichier JSON téléchargé :
 
@@ -300,7 +571,7 @@ Configurez les informations suivantes dans les paramètres :
 - ``client_email`` -> ``client_email``
 
 Format de la clé privée
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 ``private_key`` conserve les sauts de ligne en ``\n`` :
 
@@ -309,10 +580,10 @@ Format de la clé privée
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG...\n-----END PRIVATE KEY-----\n
 
 Exemples d'utilisation
-======
+======================
 
-Crawl de l'ensemble de Google Drive
---------------------------
+Crawl de tous les Drive partagés
+--------------------------------
 
 Paramètres :
 
@@ -321,6 +592,8 @@ Paramètres :
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
 
 Script :
 
@@ -335,10 +608,11 @@ Script :
     thumbnail=file.thumbnail_link
     content_length=file.size
     filetype=file.filetype
+    role=file.roles
     filename=file.name
 
-Crawl avec permissions
-----------------
+Crawl du Mon Drive de chaque utilisateur
+----------------------------------------
 
 Paramètres :
 
@@ -347,6 +621,44 @@ Paramètres :
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=users
+    impersonate_user=admin@example.com
+    scopes=https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
+
+Pour restreindre les utilisateurs, ajoutez une requête Admin SDK :
+
+::
+
+    user_query=orgUnitPath=/Sales
+
+Conserver le comportement précédent
+-----------------------------------
+
+``crawl_target=legacy`` conserve le parcours antérieur à la version 15.9, dans lequel seuls
+les fichiers explicitement partagés avec le compte de service sont trouvés.
+``impersonate_user`` n'est pas requis.
+
+Paramètres :
+
+::
+
+    private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
+    private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
+    client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=legacy
+
+Crawl avec permissions
+----------------------
+
+Paramètres :
+
+::
+
+    private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
+    private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
+    client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     default_permissions={role}drive-users
 
 Script :
@@ -362,8 +674,10 @@ Script :
     role=file.roles
     filename=file.name
 
+``default_permissions`` n'est utilisé que pour un document dont l'ACL Drive ne donne rien.
+
 Crawler uniquement certains types de fichiers
---------------------------------
+---------------------------------------------
 
 Google Docs uniquement :
 
@@ -379,10 +693,28 @@ Google Docs uniquement :
     }
 
 Dépannage
-======================
+=========
+
+Le crawl ne démarre pas
+-----------------------
+
+**Symptôme** : Le crawl se termine immédiatement avec une ``DataStoreException``
+
+**Solution** :
+
+1. ``parameter 'crawl_target' must be one of ...`` : la valeur de ``crawl_target`` n'est ni
+   ``legacy``, ni ``shared_drives``, ni ``users``, ni ``both``.
+2. ``parameter 'impersonate_user' is required when 'crawl_target' is not 'legacy'`` :
+   définissez ``impersonate_user`` sur un compte d'administrateur de domaine, ou définissez
+   ``crawl_target=legacy``.
+3. ``parameter 'scopes' must include 'https://www.googleapis.com/auth/admin.directory.user.readonly'`` :
+   ajoutez ce scope à ``scopes`` et à l'entrée de délégation à l'échelle du domaine.
+
+C'est le résultat attendu lorsqu'une configuration existante est mise à niveau sans
+modification. Voir `Modifications dans la version 15.9`_.
 
 Erreur d'authentification
-----------
+-------------------------
 
 **Symptôme** : ``401 Unauthorized`` ou ``403 Forbidden``
 
@@ -397,10 +729,12 @@ Erreur d'authentification
 2. Vérifier si l'API Google Drive est activée
 3. Vérifier si la délégation à l'échelle du domaine est configurée
 4. Vérifier si l'autorisation a été accordée dans la console d'administration Google Workspace
-5. Vérifier si le scope OAuth est correct (``https://www.googleapis.com/auth/drive``)
+5. Vérifier si le scope OAuth est correct (``https://www.googleapis.com/auth/drive.readonly``,
+   plus ``https://www.googleapis.com/auth/admin.directory.user.readonly`` pour
+   ``crawl_target=users`` ou ``both``)
 
 Erreur de délégation à l'échelle du domaine
-------------------------
+-------------------------------------------
 
 **Symptôme** : ``Not Authorized to access this resource/api``
 
@@ -409,35 +743,64 @@ Erreur de délégation à l'échelle du domaine
 1. Vérifier l'autorisation dans la console d'administration Google Workspace :
 
    - L'ID client est-il correctement enregistré ?
-   - Le scope OAuth est-il correct ? (``https://www.googleapis.com/auth/drive``)
+   - Les scopes OAuth sont-ils corrects ? L'entrée de délégation les énumère explicitement,
+     la restriction introduite en 15.9 impose donc de la mettre à jour.
 
 2. Vérifier si la délégation à l'échelle du domaine est activée sur le compte de service
+3. Vérifier que le compte désigné par ``impersonate_user`` est administrateur du domaine
+   lorsque ``crawl_target`` vaut ``shared_drives`` ou ``both``
 
 Impossible de récupérer les fichiers
-----------------------
+------------------------------------
 
 **Symptôme** : Le crawl réussit mais 0 fichiers
 
 **Points à vérifier** :
 
-1. Vérifier si des fichiers existent dans Google Drive
-2. Vérifier si le compte de service a les droits de lecture
-3. Vérifier si la délégation à l'échelle du domaine est correctement configurée
-4. Vérifier si le Drive de l'utilisateur cible est accessible
+1. Vérifier que ``crawl_target`` correspond à votre intention. Avec ``legacy``, seuls les
+   fichiers explicitement partagés avec le compte de service sont trouvés, car un compte de
+   service ne possède pas de Drive propre et n'appartient à aucun groupe.
+2. Vérifier si des fichiers existent dans Google Drive
+3. Vérifier si le compte de service a les droits de lecture
+4. Vérifier si la délégation à l'échelle du domaine est correctement configurée
+5. Vérifier si le Drive de l'utilisateur cible est accessible
+
+Des documents sont ignorés
+--------------------------
+
+**Symptôme** : ``Skipped ... because no permission could be resolved`` dans le journal du crawler
+
+**Solution** :
+
+L'ACL Drive du document n'a donné aucun rôle de recherche, le document a donc été ignoré au
+lieu d'être indexé. Indexer un document sans rôle désactive le filtre de permissions de
+|Fess| pour ce document et le rend visible par tous les utilisateurs : c'est pourquoi il est
+ignoré. Un document ignoré n'est pas un échec de crawl ; il n'apparaît donc que dans le
+journal du crawler, et non dans la liste des URL en échec.
+
+1. Définissez ``default_permissions`` pour indexer ces documents avec une permission de repli
+2. Vérifiez que le compte désigné par ``impersonate_user`` est administrateur du domaine,
+   afin que les ACL des Drive partagés puissent être lues
+3. Vérifiez si le document est partagé par lien seul. Une permission ``domain`` ou
+   ``anyone`` avec ``allowFileDiscovery=false`` n'accorde aucun rôle de recherche, car Drive
+   lui-même ne rend pas un tel document détectable par la recherche.
 
 Erreur de quota API
------------------
+-------------------
 
 **Symptôme** : ``403 Rate Limit Exceeded`` ou ``429 Too Many Requests``
 
 **Solution** :
 
-1. Vérifier le quota dans Google Cloud Platform
-2. Augmenter l'intervalle de crawl
-3. Demander une augmentation de quota si nécessaire
+1. Ce type d'échec est retenté automatiquement avec un back-off exponentiel. Augmentez
+   ``max_retries`` ou ``max_backoff_ms`` si le crawl échoue toujours.
+2. Diminuez ``number_of_threads`` pour réduire le débit de requêtes
+3. Vérifier le quota dans Google Cloud Platform
+4. Augmenter l'intervalle de crawl
+5. Demander une augmentation de quota si nécessaire
 
 Erreur de format de clé privée
---------------------------
+------------------------------
 
 **Symptôme** : ``Invalid private key format``
 
@@ -456,11 +819,15 @@ Vérifier si les sauts de ligne sont correctement en ``\n`` :
     -----END PRIVATE KEY-----
 
 Crawl des Drive partagés
-----------------------
+------------------------
 
 .. note::
-   Pour crawler les Drive partagés avec un compte de service,
-   vous devez ajouter le compte de service comme membre du Drive partagé.
+   Avec ``crawl_target=shared_drives`` (la valeur par défaut), les Drive partagés sont
+   énumérés avec un accès d'administrateur de domaine : le compte de service n'a donc pas
+   besoin d'être membre de chaque Drive partagé. En revanche, ``impersonate_user`` doit
+   désigner un administrateur du domaine.
+
+Avec ``crawl_target=legacy``, le compte de service doit être ajouté à chaque Drive partagé :
 
 1. Ouvrez le Drive partagé dans Google Drive
 2. Cliquez sur "Gérer les membres"
@@ -474,16 +841,55 @@ Cas de nombreux fichiers
 
 **Solution** :
 
-1. Diviser en plusieurs data stores
-2. Répartir la charge avec les paramètres de planification
-3. Ajuster l'intervalle de crawl
-4. Crawler uniquement des dossiers spécifiques
+1. Activez ``incremental=true`` afin que seules les modifications depuis l'exécution
+   précédente soient crawlées
+2. Répartissez les Drive partagés et les utilisateurs dans des configurations de data store
+   distinctes plutôt que d'utiliser ``crawl_target=both``
+3. Restreignez la portée avec ``query``, ``user_query`` ou ``supported_mimetypes``
+4. Répartir la charge avec les paramètres de planification
+5. Ajuster l'intervalle de crawl
 
 Permissions et contrôle d'accès
-==================
+===============================
+
+Conversion des permissions Drive en rôles Fess
+----------------------------------------------
+
+L'ACL d'un document est résolue en trois étapes, afin que le nombre d'appels d'API
+supplémentaires reste proportionnel au nombre de Drive partagés plutôt qu'au nombre de
+fichiers :
+
+1. les permissions incluses dans le listage des fichiers, qui ne coûtent rien de plus ;
+2. pour un élément d'un Drive partagé, dont l'API Drive ne renseigne pas ces permissions,
+   l'ACL du Drive partagé lui-même. Elle est récupérée une fois par Drive avec un accès
+   d'administrateur de domaine, puis mise en cache ;
+3. pour un élément portant ses propres permissions supplémentaires, ces permissions.
+
+Chaque permission Drive devient un rôle de recherche |Fess| :
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Permission Drive
+     - Rôle de recherche
+   * - ``user``
+     - Le rôle de recherche de l'adresse email de cet utilisateur. Les propriétaires du fichier sont toujours ajoutés de cette façon.
+   * - ``group``
+     - Le rôle de recherche de l'adresse email de ce groupe. L'appartenance aux groupes Google n'est jamais développée ; |Fess| est censé la résoudre côté utilisateur via SSO ou LDAP.
+   * - ``domain``
+     - ``domain_permission_format`` avec ``{domain}`` remplacé par le nom de domaine. Par défaut : ``{group}{domain}``
+   * - ``anyone``
+     - Le rôle ``guest``
+   * - L'une des précédentes avec ``allowFileDiscovery=false``, ainsi qu'une permission supprimée
+     - Aucun rôle. Le partage par lien seul n'est pas non plus détectable par la recherche dans Drive.
+
+Lorsque le résultat est vide, ``default_permissions`` est utilisé à la place -- comme valeur
+de repli, et non comme ajout. Lorsque ``default_permissions`` n'est pas défini non plus, le
+document est ignoré.
 
 Reflet des permissions de partage Google Drive
-----------------------------
+----------------------------------------------
 
 Reflet des paramètres de partage Google Drive dans les permissions Fess :
 
@@ -494,6 +900,8 @@ Paramètres :
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     default_permissions={role}drive-users
 
 Script :
@@ -510,8 +918,37 @@ Script :
 
 ``file.roles`` contient les informations de partage Google Drive.
 
+Limitations
+===========
+
+- Le signal « supprimé » de Drive couvre aussi bien la perte d'accès que la suppression.
+  Avec ``crawl_target=users`` ou ``both``, révoquer l'accès d'un utilisateur retire le
+  document de l'index alors même qu'un autre utilisateur peut encore le lire. Il revient à
+  la modification suivante de ce fichier, ou au prochain crawl complet.
+- Lorsqu'une portée retombe sur un crawl complet pendant une exécution incrémentielle, la
+  suppression des documents obsolètes reste désactivée : les documents supprimés de Drive
+  pendant qu'une portée n'était pas ancrée restent donc dans l'index. Le remède est une
+  configuration distincte avec ``incremental=false``, dont le crawl complet les élimine.
+- La propagation d'une suppression suppose que l'URL indexée contient l'ID du fichier Drive,
+  ce qui est le cas de ``webViewLink`` et de l'URL de repli. Un script de crawl qui réécrit
+  ``url`` en une valeur ne contenant pas l'ID du fichier empêche la propagation des
+  suppressions.
+- Le flux de modifications n'est pas filtré par ``query``. Avec ``query`` défini et
+  ``incremental=true``, un fichier modifié qui ne correspond pas à la requête est tout de
+  même indexé.
+- ``crawl_target=both`` sur un grand domaine déclenche environ
+  ``2 + (nombre de Drive partagés) + (nombre d'utilisateurs)`` séquences de listage. La
+  parade pratique consiste à répartir les Drive partagés et les utilisateurs dans des
+  configurations de data store distinctes.
+- ``proxy_username`` et ``proxy_password`` sont envoyés dans un en-tête de requête
+  ``Proxy-Authorization``, qui n'authentifie qu'une requête HTTP en clair. Tout le trafic
+  des API Google est en HTTPS, et une connexion HTTPS via un proxy avec authentification est
+  établie par un échange ``CONNECT`` que le JDK pilote au moyen de
+  ``java.net.Authenticator`` et non d'un en-tête de requête. Un tel environnement nécessite
+  plutôt l'option JVM ``-Djdk.http.auth.tunneling.disabledSchemes=`` et un ``Authenticator``.
+
 Informations de référence
-========
+=========================
 
 - :doc:`ds-overview` - Aperçu des connecteurs Data Store
 - :doc:`ds-microsoft365` - Connecteur Microsoft 365

--- a/ja/15.9/config/datastore/ds-gsuite.rst
+++ b/ja/15.9/config/datastore/ds-gsuite.rst
@@ -10,11 +10,73 @@ Google Workspaceコネクタは、Google Drive（旧G Suite）からファイル
 
 この機能には ``fess-ds-gsuite`` プラグインが必要です。
 
+15.9での変更点
+==============
+
+|Fess| 15.9でコネクタは大幅に再実装されました。既存のデータストア設定をアップグレードする前に、
+このセクションを確認してください。
+
+.. warning::
+
+   ``crawl_target`` のデフォルトが ``shared_drives`` になり、 ``legacy`` 以外の値では
+   ``impersonate_user`` が必須になりました。そのため、既存の設定をそのままアップグレードすると、
+   クロール開始時に ``DataStoreException`` が発生して **起動に失敗します** 。
+
+   これは意図的な動作です。従来の動作ではサービスアカウントに明示的に共有されたファイルにしか
+   到達できないため、そのまま動かすと何もインデックスされないクロールが黙って成功してしまいます。
+   ``impersonate_user`` にドメイン管理者のアカウントを設定するか、従来の動作を維持する場合は
+   ``crawl_target=legacy`` を設定してください。
+
+動作の変更
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 変更点
+     - 必要な対応
+   * - ``crawl_target`` のデフォルトが ``shared_drives`` になり、 ``impersonate_user`` が必須になった
+     - ``impersonate_user`` を設定するか、 ``crawl_target=legacy`` を設定します。設定しない場合、クロールは開始時に失敗します。
+   * - デフォルトのOAuthスコープが ``https://www.googleapis.com/auth/drive`` から ``https://www.googleapis.com/auth/drive.readonly`` に変更された
+     - Google Workspace管理コンソールのDomain全体への委任は、スコープを明示的に列挙するため、設定の更新が必要です。
+   * - ``crawl_target=users`` および ``crawl_target=both`` では ``https://www.googleapis.com/auth/admin.directory.user.readonly`` が追加で必要になった
+     - ``scopes`` パラメーターと管理コンソールの委任設定の両方にスコープを追加します。これはクロール開始時に検証されます。
+   * - インデックスされるURLがダウンロードリンクからブラウザで開けるリンク（ ``webViewLink`` ）に変更された
+     - 新しいURLを反映するには全体の再クロールが必要です。
+   * - ``default_permissions`` が追加ではなくフォールバックになった
+     - ACLが解決できたドキュメントには、そのACLのみが付与されます。 ``default_permissions`` との和集合ではなくなり、権限は従来より厳しくなります。
+   * - リンクを知っている人への共有では検索ロールが付与されなくなった
+     - ``allowFileDiscovery=false`` の ``domain`` および ``anyone`` 権限は「リンクを知っている全員」を意味し、Drive自体も検索では見つけられないようにしているためです。
+   * - ACLが何も解決できなかったドキュメントは、ロールなしでインデックスされるのではなくスキップされるようになった
+     - 引き続きインデックスする場合は ``default_permissions`` を設定します。従来はロールが空だと権限フィルターが無効になるため、そのようなドキュメントは全ユーザーから見えていました。
+   * - ``fields`` のデフォルトが ``*`` ではなく明示的なフィールドリストになった
+     - 通常使われないフィールドを参照しているクロールスクリプトではnullが返るようになります。従来の動作に戻すには ``fields=*`` を設定します。
+   * - GoogleドキュメントのエクスポートがプレーンテキストからMarkdownに、スプレッドシートがCSVからTSVに変更された
+     - すべてのGoogleドキュメントのインデックステキストにMarkdownの記法文字が含まれるようになります。全体の再クロールが必要です。
+   * - ``refresh_token_interval`` は無視されるようになった
+     - トークンの更新は認証ライブラリが行います。既存の設定はそのまま動作し、警告がログに出力されます。
+   * - GoogleフォームとGoogleサイトはメタデータのみがインデックスされるようになった
+     - Drive APIにエクスポート形式が存在しないためです。従来はこれらがすべてクロールエラーになっていました。
+
+新機能
+------
+
+- ``crawl_target`` でクロール対象を選択できます。サービスアカウント自身の視点（ ``legacy`` ）、
+  ドメイン内のすべての共有ドライブ（ ``shared_drives`` ）、ディレクトリ内の全ユーザーのマイドライブ
+  （ ``users`` ）、またはその両方（ ``both`` ）です。 `クロール対象`_ を参照してください。
+- 共有ドライブのアイテムに正しいACLが付与されるようになりました。 `権限とアクセス制御`_ を参照してください。
+- Driveの変更フィードを利用した差分クロールに対応しました。 `差分クロール`_ を参照してください。
+- ``Retry-After`` に対応した指数バックオフによるレート制限対応と、1つの共有ドライブやユーザーの失敗で
+  クロール全体が中断しない仕組みを追加しました。 `レート制限とリトライ`_ を参照してください。
+- 認証が必要なプロキシ用に ``proxy_username`` と ``proxy_password`` を追加しました。
+
 対応サービス
 ============
 
 - Google Drive（マイドライブ、共有ドライブ）
-- Googleドキュメント、スプレッドシート、スライド、フォームなど
+- Googleドキュメント、スプレッドシート、スライド、図形描画、Apps Script
+- Googleフォーム、Googleサイト（エクスポート形式がないためメタデータのみ）
 
 前提条件
 ========
@@ -23,6 +85,7 @@ Google Workspaceコネクタは、Google Drive（旧G Suite）からファイル
 2. Google Cloud Platformプロジェクトの作成が必要です
 3. サービスアカウントの作成と認証情報の取得が必要です
 4. Google Workspace Domain全体への委任設定が必要です
+5. ``crawl_target=legacy`` 以外を使用する場合、代理アクセスするGoogle Workspace管理者アカウントが必要です
 
 プラグインのインストール
 ------------------------
@@ -74,6 +137,7 @@ Google Workspaceコネクタは、Google Drive（旧G Suite）からファイル
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project.iam.gserviceaccount.com
+    impersonate_user=admin@example.com
 
 パラメーター一覧
 ~~~~~~~~~~~~~~~~
@@ -94,60 +158,192 @@ Google Workspaceコネクタは、Google Drive（旧G Suite）からファイル
    * - ``client_email``
      - はい
      - サービスアカウントのメールアドレス
+   * - ``impersonate_user``
+     - 条件付き
+     - Domain全体への委任で代理アクセスするGoogle Workspaceのアカウント。 ``crawl_target=legacy`` 以外では必須で、設定しない場合クロールは開始時に失敗します。 ``shared_drives`` と ``both`` はドメイン管理者権限で共有ドライブを列挙するため、このアカウントはドメイン管理者である必要があります。
+   * - ``crawl_target``
+     - いいえ
+     - クロール対象。 ``legacy`` 、 ``shared_drives`` 、 ``users`` 、 ``both`` のいずれか。デフォルト: ``shared_drives`` 。 `クロール対象`_ を参照してください。
+   * - ``scopes``
+     - いいえ
+     - OAuthスコープ（カンマ区切り）。デフォルト: ``https://www.googleapis.com/auth/drive.readonly`` 。 ``crawl_target=users`` および ``both`` では ``https://www.googleapis.com/auth/admin.directory.user.readonly`` が追加で必要です。
+   * - ``user_query``
+     - いいえ
+     - ``crawl_target=users`` および ``both`` で列挙するユーザーを絞り込むAdmin SDKの ``query`` 。デフォルトは未指定（顧客アカウントの全ユーザー）
+   * - ``query``
+     - いいえ
+     - Google Drive API検索クエリ文字列。差分クロールで使用する変更フィードには適用されません
+   * - ``corpora``
+     - いいえ
+     - 検索対象のコーパス。デフォルト: ``allDrives`` 。 ``crawl_target=legacy`` でのみ使用されるため、デフォルトのクロール対象では効果がありません。 ``shared_drives`` は各ドライブを ``drive`` で、 ``users`` は各マイドライブを ``user`` で列挙します
+   * - ``spaces``
+     - いいえ
+     - 検索対象とするスペース（Google Drive APIの ``spaces`` パラメーター。例: ``drive``、``appDataFolder``）。デフォルトは未指定（API既定値）。 ``crawl_target=legacy`` と ``users`` で使用され、 ``shared_drives`` では無視されます
+   * - ``fields``
+     - いいえ
+     - Google Drive APIから取得するファイルフィールドの指定。デフォルトは ``*`` ではなく明示的なフィールドリストです。スクリプトコンテキスト、ACLの解決、インデックスURL、差分クロールに必要なフィールドを網羅していますが、リストにないフィールドはクロールスクリプトでnullになります。従来どおり全フィールドを取得するには ``fields=*`` を設定します
+   * - ``default_permissions``
+     - いいえ
+     - ドキュメントのDrive ACLが何も解決できなかった場合に使用する権限（カンマ区切り、例: ``{role}drive-users``）。追加ではなくフォールバックであり、ACLが解決できたドキュメントにはそのACLのみが付与されます
    * - ``max_size``
      - いいえ
      - インデックス対象の最大ファイルサイズ（バイト）。デフォルト: ``10000000`` （約10MB）
-   * - ``ignore_folder``
-     - いいえ
-     - フォルダをスキップするかどうか。デフォルト: ``true``
-   * - ``ignore_error``
-     - いいえ
-     - エラー発生時に処理を継続するかどうか。デフォルト: ``true``
-   * - ``supported_mimetypes``
-     - いいえ
-     - インデックス対象のMIMEタイプ（正規表現、カンマ区切り）。デフォルト: ``.*`` （全タイプ）
-   * - ``include_pattern``
-     - いいえ
-     - インデックス対象URLの正規表現パターン
-   * - ``exclude_pattern``
-     - いいえ
-     - 除外するURLの正規表現パターン
-   * - ``default_permissions``
-     - いいえ
-     - デフォルトの権限（カンマ区切り、例: ``{role}drive-users``）
    * - ``number_of_threads``
      - いいえ
      - 並列処理スレッド数。デフォルト: ``1``
-   * - ``query``
+   * - ``incremental``
      - いいえ
-     - Google Drive API検索クエリ文字列
-   * - ``corpora``
-     - いいえ
-     - 検索対象のコーパス。デフォルト: ``allDrives``
-   * - ``spaces``
-     - いいえ
-     - 検索対象とするスペース（Google Drive APIの ``spaces`` パラメーター。例: ``drive``、``appDataFolder``）。デフォルトは未指定（API既定値）
-   * - ``fields``
-     - いいえ
-     - Google Drive APIから取得するファイルフィールドの指定。デフォルト: ``*`` （全フィールド）
+     - すべてを列挙する代わりにDriveの変更フィードでクロールするかどうか。デフォルト: ``false`` 。クロール開始前にデータストア設定のパラメーター欄から直接読み込まれます。 `差分クロール`_ を参照してください
+
+詳細パラメーター
+~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - パラメーター
+     - 説明
+   * - ``domain_permission_format``
+     - ``type=domain`` のDrive権限に適用するロールの書式。 ``{domain}`` がドメイン名に置換されます。デフォルト: ``{group}{domain}``
+   * - ``thread_pool_timeout_seconds``
+     - クロール終了時にワーカースレッドの完了を待つ時間（秒）。デフォルト: ``60``
+   * - ``page_size``
+     - ``files.list`` と ``changes.list`` のページサイズ。デフォルト: ``1000`` 。 ``1000`` を超える値は自動的に切り詰められます
+   * - ``permission_page_size``
+     - ``permissions.list`` と ``drives.list`` のページサイズ。デフォルト: ``100`` 。 ``100`` を超える値は自動的に切り詰められます
+   * - ``max_cached_content_size``
+     - メモリ上に保持するコンテンツの最大サイズ（バイト）。これを超えるコンテンツは一時ファイルに退避されます。デフォルト: ``1048576`` （1MB）
+   * - ``max_retries``
+     - Drive APIのレート制限や一時的な失敗に対するリトライの最大回数。デフォルト: ``5``
+   * - ``retry_initial_interval_ms``
+     - 最初のリトライまでのバックオフ間隔（ミリ秒）。デフォルト: ``1000``
+   * - ``max_backoff_ms``
+     - 1回の待機時間の上限（ミリ秒）。デフォルト: ``32000``
    * - ``read_timeout``
-     - いいえ
      - HTTP読み取りタイムアウト（ミリ秒）。デフォルト: ``20000``
    * - ``connect_timeout``
-     - いいえ
      - HTTP接続タイムアウト（ミリ秒）。デフォルト: ``20000``
-   * - ``refresh_token_interval``
-     - いいえ
-     - OAuthアクセストークンを再取得する間隔（秒）。デフォルト: ``3540`` （59分）
-   * - ``max_cached_content_size``
-     - いいえ
-     - メモリ上に保持するコンテンツの最大サイズ（バイト）。これを超えるコンテンツは一時ファイルに退避されます。デフォルト: ``1048576`` （1MB）
    * - ``proxy_host``
-     - いいえ
-     - プロキシサーバーのホスト名
+     - プロキシサーバーのホスト名。プロキシは ``proxy_host`` と ``proxy_port`` の両方が設定されている場合にのみ使用され、片方だけでは効果がありません
    * - ``proxy_port``
-     - いいえ
-     - プロキシサーバーのポート番号
+     - プロキシサーバーのポート番号。 ``proxy_host`` を参照してください
+   * - ``proxy_username``
+     - 認証が必要なプロキシのユーザー名。設定すると、すべてのリクエストに ``Proxy-Authorization`` ヘッダーが付与されます。何が認証され、何が認証されないかは `制限事項`_ を参照してください
+   * - ``proxy_password``
+     - 認証が必要なプロキシのパスワード
+   * - ``ignore_folder``
+     - フォルダをスキップするかどうか。デフォルト: ``true``
+   * - ``ignore_error``
+     - エラー発生時に処理を継続するかどうか。デフォルト: ``true``
+   * - ``supported_mimetypes``
+     - インデックス対象のMIMEタイプ（正規表現、カンマ区切り）。デフォルト: ``.*`` （全タイプ）
+   * - ``include_pattern``
+     - インデックス対象URLの正規表現パターン
+   * - ``exclude_pattern``
+     - 除外するURLの正規表現パターン
+   * - ``refresh_token_interval``
+     - 15.9以降は無視されます。アクセストークンの更新は認証ライブラリが行います。既存の設定はそのまま動作し、警告がログに出力されます
+
+.. note::
+
+   ``private_key`` 、 ``private_key_id`` 、 ``client_email`` 、 ``proxy_username`` 、
+   ``proxy_password`` はスクリプトの評価コンテキストから除去されるため、クロールスクリプトから
+   インデックスに登録することはできず、検索結果に現れることもありません。
+
+.. note::
+
+   差分クロールを有効にすると、コネクタは ``start_page_tokens`` と ``crawl_signature`` を
+   データストア設定のパラメーター欄に書き戻します。これらはコネクタが管理する値で、設定した
+   パラメーターと並んで表示されますが、編集しないでください。編集や削除を行うと、次回の実行で
+   すべてのスコープが全体クロールになります。
+
+クロール対象
+------------
+
+サービスアカウントは自身のDriveを持たず、どのGoogleグループにも所属しないため、サービスアカウント
+自身として認証するクロールでは、サービスアカウントのアドレスに明示的に共有されたファイルにしか
+到達できません。 ``crawl_target`` は、誰の視点でDriveをクロールするかを選択します。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - 値
+     - 説明
+   * - ``legacy``
+     - 従来どおりサービスアカウント自身の視点でクロールします。 ``impersonate_user`` は不要です。サービスアカウントに明示的に共有されたファイルのみが見つかります
+   * - ``shared_drives``
+     - デフォルト。ドメイン内のすべての共有ドライブを列挙し、それぞれを個別に走査します
+   * - ``users``
+     - Admin SDKでディレクトリ内の全ユーザーを列挙し、各ユーザーに代理アクセスしてマイドライブを走査します
+   * - ``both``
+     - ``shared_drives`` の後に ``users`` を実行します。複数のスコープに現れるファイルは1回だけインデックスされます
+
+以下はクロール開始時に検証され、不正な組み合わせの場合は実行されずに ``DataStoreException`` が
+発生します。
+
+1. ``crawl_target`` は ``legacy`` 、 ``shared_drives`` 、 ``users`` 、 ``both`` のいずれかであること
+2. ``crawl_target=legacy`` 以外の場合、 ``impersonate_user`` が設定されていること
+3. ``crawl_target`` が ``users`` または ``both`` の場合、 ``scopes`` に
+   ``https://www.googleapis.com/auth/admin.directory.user.readonly`` が含まれていること
+
+.. note::
+
+   ``shared_drives`` と ``both`` はドメイン管理者権限で共有ドライブを列挙するため、
+   ``impersonate_user`` に指定するアカウントはGoogle Workspaceのドメイン管理者である必要が
+   あります。この列挙はクロール範囲全体を決めるものであるため、恒久的な失敗は記録してスキップ
+   するのではなくクロールを中断します。1つも共有ドライブを列挙できなかったクロールは部分的な
+   成功ではなく、何もインデックスしないまま成功と報告してはならないためです。
+
+差分クロール
+------------
+
+``incremental=true`` を設定すると、各スコープ（1つの共有ドライブ、または代理アクセスする1人の
+ユーザーの視点）は、すべてを列挙する代わりにDriveの変更フィードを読み込みます。トークンが保存
+されていないスコープは全体をクロールし、次回実行のために変更フィードの開始位置を記録します。
+
+::
+
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
+    incremental=true
+
+.. warning::
+
+   差分クロールの実行では ``delete_old_docs`` が強制的に ``false`` になり、明示的に
+   ``delete_old_docs=true`` を指定しても尊重されずに上書きされます（警告がログに出力されます）。
+   古いドキュメントの削除処理は、今回のクロールで登録されなかったこのデータ設定のドキュメントを
+   すべて削除するもので、全体クロールを前提としています。差分クロールでは変更のあったドキュメント
+   しか処理しないため、この削除処理はインデックスの残り全部を削除してしまいます。
+
+   Driveから消えたドキュメントを削除するには、 ``incremental=false`` の別のデータストア設定を
+   スケジュールしてください。
+
+変更フィードの開始位置は、クロールが完了しワーカースレッドがすべて終了した場合にのみ保存されます。
+途中で停止したクロールでは保存されず、次回の実行は同じ変更をもう一度読み込みます。
+
+スコープが返す対象を決める設定、すなわち ``crawl_target`` 、 ``impersonate_user`` 、
+``user_query`` 、 ``query`` 、 ``corpora`` 、 ``spaces`` のいずれかが変更された場合も、
+保存されている開始位置は破棄され、すべてのスコープが全体クロールになります。保存された開始位置は
+それを取得した時点の対象範囲しか表しておらず、設定変更後にそこから再開すると、インデックスに
+恒久的な欠落が生じるためです。
+
+レート制限とリトライ
+--------------------
+
+Drive APIのレート制限や一時的な失敗は、 ``max_retries`` 、 ``retry_initial_interval_ms`` 、
+``max_backoff_ms`` の範囲で指数バックオフによりリトライされます。 ``Retry-After`` ヘッダーは
+指数バックオフより優先されますが、誤った値によってクロールが何時間も停止しないよう
+``max_backoff_ms`` で上限が設けられます。 ``Retry-After`` は秒数形式のみ有効で、HTTP日付形式の
+場合は指数バックオフにフォールバックします。
+
+``429`` 、 ``500`` 、 ``502`` 、 ``503`` 、 ``504`` は常にリトライされます。 ``403`` は
+レート制限エラーの場合のみリトライされ、それ以外の ``403`` はリトライしても解決しない認可の失敗
+であるため、ただちに記録されます。
+
+ファイル一覧の取得に失敗しても、クロール全体は中断されなくなりました。残りの共有ドライブや
+ユーザーのクロールは継続され、失敗はクローラーのログと管理画面の障害URL一覧に記録されます。
 
 スクリプト設定
 --------------
@@ -192,7 +388,7 @@ Google Workspaceコネクタは、Google Drive（旧G Suite）からファイル
    * - ``file.web_view_link``
      - ブラウザで開くリンク
    * - ``file.url``
-     - ファイルのURL
+     - ファイルのURL。 ``webViewLink`` が使用されます。存在しない場合は ``https://drive.google.com/open?id=<ファイルID>`` が使用されます
    * - ``file.thumbnail_link``
      - サムネイルリンク（短期間有効）
    * - ``file.size``
@@ -222,8 +418,51 @@ Google Workspaceコネクタは、Google Drive（旧G Suite）からファイル
    * - ``file.kind``
      - リソースの種類（``drive#file``）
 
+.. note::
+
+   値が設定されるのは ``fields`` パラメーターで指定したフィールドのみです。取得していない
+   フィールドはスクリプト内でnullになります。従来どおり全フィールドを取得するには
+   ``fields=*`` を設定してください。
+
 上記以外にも多数のフィールドが利用可能です。
 詳細は `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_ を参照してください。
+
+Google形式ファイルのテキスト抽出
+--------------------------------
+
+Google形式のファイルはダウンロードできないため、エクスポートが必要です。エクスポート形式は
+固定の対応表ではなくDrive APIが実際に返す形式から選択され、エクスポートは10MBが上限です。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 種類
+     - エクスポート形式
+   * - Googleドキュメント
+     - Markdown（ ``text/markdown`` ）。利用できない場合はプレーンテキスト、次にHTML
+   * - Googleスプレッドシート
+     - TSV（ ``text/tab-separated-values`` ）。利用できない場合はCSV
+   * - Googleスライド
+     - プレーンテキスト
+   * - Google図形描画
+     - PNG。インデックスするテキストがないため、メタデータのみが登録されます
+   * - Apps Script
+     - エクスポートされたJSONから、スクリプトのソースが抽出されてインデックスされます
+   * - Googleフォーム、Googleサイト
+     - エクスポート不可。メタデータのみが登録され、エラーにはなりません
+
+.. note::
+
+   GoogleドキュメントがMarkdownでエクスポートされるようになったため、すべてのGoogleドキュメントの
+   インデックステキストにMarkdownの記法文字が含まれます。すでにインデックスされているドキュメントに
+   反映するには、全体の再クロールが必要です。
+
+.. note::
+
+   エクスポート形式はクロールごとに1回Drive APIから取得されます。この取得に失敗した場合は、
+   Driveが従来から対応している変換（Googleドキュメントはプレーンテキスト、Googleスプレッドシートは
+   CSV）にフォールバックし、警告がログに出力されます。
 
 Google Cloud Platform設定
 =========================
@@ -244,6 +483,7 @@ https://console.cloud.google.com/ にアクセス:
 
 1. 「Google Drive API」を検索
 2. 「有効にする」をクリック
+3. ``crawl_target`` が ``users`` または ``both`` の場合は「Admin SDK API」も有効にする
 
 3. サービスアカウントの作成
 ---------------------------
@@ -289,9 +529,22 @@ https://admin.google.com/ にアクセス:
 
    ::
 
-       https://www.googleapis.com/auth/drive
+       https://www.googleapis.com/auth/drive.readonly
+
+   ``crawl_target`` が ``users`` または ``both`` の場合は、両方のスコープを入力します:
+
+   ::
+
+       https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
 
 6. 「承認」をクリック
+
+.. warning::
+
+   委任の設定はスコープを明示的に列挙するため、以前のバージョンからアップグレードする場合は
+   更新が必要です。15.9でデフォルトのスコープが ``https://www.googleapis.com/auth/drive`` から
+   ``https://www.googleapis.com/auth/drive.readonly`` に変更されており、ここで許可するスコープは
+   データストア設定の ``scopes`` パラメーターと一致している必要があります。
 
 認証情報の設定
 ==============
@@ -334,8 +587,8 @@ JSONファイルから情報を取得
 使用例
 ======
 
-Google Drive全体のクロール
---------------------------
+すべての共有ドライブのクロール
+------------------------------
 
 パラメーター:
 
@@ -344,6 +597,8 @@ Google Drive全体のクロール
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
 
 スクリプト:
 
@@ -358,7 +613,43 @@ Google Drive全体のクロール
     thumbnail=file.thumbnail_link
     content_length=file.size
     filetype=file.filetype
+    role=file.roles
     filename=file.name
+
+全ユーザーのマイドライブのクロール
+----------------------------------
+
+パラメーター:
+
+::
+
+    private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
+    private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
+    client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=users
+    impersonate_user=admin@example.com
+    scopes=https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
+
+ユーザーを絞り込む場合は、Admin SDKのクエリを追加します:
+
+::
+
+    user_query=orgUnitPath=/Sales
+
+従来の動作を維持する場合
+------------------------
+
+``crawl_target=legacy`` は15.9より前の動作を維持し、サービスアカウントに明示的に共有された
+ファイルのみが見つかります。 ``impersonate_user`` は不要です。
+
+パラメーター:
+
+::
+
+    private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
+    private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
+    client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=legacy
 
 権限付きクロール
 ----------------
@@ -370,6 +661,8 @@ Google Drive全体のクロール
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     default_permissions={role}drive-users
 
 スクリプト:
@@ -385,6 +678,8 @@ Google Drive全体のクロール
     role=file.roles
     filename=file.name
 
+``default_permissions`` は、Drive ACLが何も解決できなかったドキュメントにのみ使用されます。
+
 特定のファイルタイプのみクロール
 --------------------------------
 
@@ -397,6 +692,8 @@ Googleドキュメントのみをクロールする場合は、 ``supported_mime
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     supported_mimetypes=application/vnd\.google-apps\.document
 
 スクリプト:
@@ -414,6 +711,24 @@ Googleドキュメントのみをクロールする場合は、 ``supported_mime
 トラブルシューティング
 ======================
 
+クロールが開始できない
+----------------------
+
+**症状**: クロールが ``DataStoreException`` ですぐに終了する
+
+**解決方法**:
+
+1. ``parameter 'crawl_target' must be one of ...`` : ``crawl_target`` の値が ``legacy`` 、
+   ``shared_drives`` 、 ``users`` 、 ``both`` のいずれでもありません
+2. ``parameter 'impersonate_user' is required when 'crawl_target' is not 'legacy'`` :
+   ``impersonate_user`` にドメイン管理者のアカウントを設定するか、 ``crawl_target=legacy``
+   を設定します
+3. ``parameter 'scopes' must include 'https://www.googleapis.com/auth/admin.directory.user.readonly'`` :
+   ``scopes`` とDomain全体への委任の設定にこのスコープを追加します
+
+既存の設定をそのままアップグレードした場合、これは想定どおりの結果です。
+`15.9での変更点`_ を参照してください。
+
 認証エラー
 ----------
 
@@ -430,7 +745,9 @@ Googleドキュメントのみをクロールする場合は、 ``supported_mime
 2. Google Drive APIが有効になっているか確認
 3. Domain全体への委任が設定されているか確認
 4. Google Workspace管理コンソールで承認されているか確認
-5. OAuth スコープが正しいか確認（``https://www.googleapis.com/auth/drive``）
+5. OAuth スコープが正しいか確認（ ``https://www.googleapis.com/auth/drive.readonly`` 。
+   ``crawl_target`` が ``users`` または ``both`` の場合は
+   ``https://www.googleapis.com/auth/admin.directory.user.readonly`` も必要）
 
 Domain全体への委任エラー
 ------------------------
@@ -442,9 +759,12 @@ Domain全体への委任エラー
 1. Google Workspace管理コンソールで承認を確認:
 
    - クライアントIDが正しく登録されているか
-   - OAuth スコープが正しいか（``https://www.googleapis.com/auth/drive``）
+   - OAuth スコープが正しいか。委任の設定はスコープを明示的に列挙するため、15.9のスコープ変更に
+     合わせて更新が必要です
 
 2. サービスアカウントでDomain全体への委任が有効になっているか確認
+3. ``crawl_target`` が ``shared_drives`` または ``both`` の場合、 ``impersonate_user`` に
+   指定したアカウントがドメイン管理者であるか確認
 
 ファイルが取得できない
 ----------------------
@@ -453,10 +773,31 @@ Domain全体への委任エラー
 
 **確認事項**:
 
-1. Google Driveにファイルが存在するか確認
-2. サービスアカウントに読み取り権限があるか確認
-3. Domain全体への委任が正しく設定されているか確認
-4. 対象ユーザーのDriveにアクセス可能か確認
+1. ``crawl_target`` が意図した値になっているか確認。 ``legacy`` の場合、サービスアカウントは
+   自身のDriveを持たずどのグループにも所属しないため、明示的に共有されたファイルしか見つかりません
+2. Google Driveにファイルが存在するか確認
+3. サービスアカウントに読み取り権限があるか確認
+4. Domain全体への委任が正しく設定されているか確認
+5. 対象ユーザーのDriveにアクセス可能か確認
+
+ドキュメントがスキップされる
+----------------------------
+
+**症状**: クローラーのログに ``Skipped ... because no permission could be resolved`` が出力される
+
+**解決方法**:
+
+ドキュメントのDrive ACLから検索ロールが1つも解決できなかったため、インデックスされずに
+スキップされました。ロールなしでインデックスすると、そのドキュメントでは |Fess| の権限フィルターが
+無効になり全ユーザーから見えてしまうため、スキップされます。スキップはクロールの失敗ではないため、
+クローラーのログにのみ出力され、障害URL一覧には表示されません。
+
+1. フォールバックの権限を付けてインデックスする場合は ``default_permissions`` を設定します
+2. 共有ドライブのACLを読み取れるよう、 ``impersonate_user`` に指定したアカウントがドメイン管理者で
+   あるか確認します
+3. ドキュメントがリンク共有のみになっていないか確認します。 ``allowFileDiscovery=false`` の
+   ``domain`` および ``anyone`` 権限には検索ロールが付与されません。Drive自体もそのような
+   ドキュメントを検索で見つけられないようにしているためです
 
 APIクォータエラー
 -----------------
@@ -465,9 +806,12 @@ APIクォータエラー
 
 **解決方法**:
 
-1. Google Cloud Platformでクォータを確認
-2. クロール間隔を長くする
-3. 必要に応じてクォータの増加をリクエスト
+1. このような失敗は指数バックオフで自動的にリトライされます。それでも失敗する場合は
+   ``max_retries`` または ``max_backoff_ms`` を大きくします
+2. ``number_of_threads`` を小さくしてリクエスト頻度を下げます
+3. Google Cloud Platformでクォータを確認
+4. クロール間隔を長くする
+5. 必要に応じてクォータの増加をリクエスト
 
 秘密鍵のフォーマットエラー
 --------------------------
@@ -492,8 +836,11 @@ APIクォータエラー
 ----------------------
 
 .. note::
-   サービスアカウントで共有ドライブをクロールする場合、
-   共有ドライブにサービスアカウントをメンバーとして追加する必要があります。
+   ``crawl_target=shared_drives`` （デフォルト）では、ドメイン管理者権限で共有ドライブを列挙する
+   ため、サービスアカウントを個々の共有ドライブのメンバーに追加する必要はありません。代わりに
+   ``impersonate_user`` にドメイン管理者を指定してください。
+
+``crawl_target=legacy`` の場合は、各共有ドライブにサービスアカウントを追加する必要があります。
 
 1. Google Driveで共有ドライブを開く
 2. 「メンバーを管理」をクリック
@@ -507,13 +854,47 @@ APIクォータエラー
 
 **解決方法**:
 
-1. データストアを複数に分割
-2. スケジュール設定で負荷を分散
-3. クロール間隔を調整
-4. 特定のフォルダのみをクロール
+1. ``incremental=true`` を有効にして、前回からの変更のみをクロールする
+2. ``crawl_target=both`` を使わず、共有ドライブとユーザーを別々のデータストア設定に分割する
+3. ``query`` 、 ``user_query`` 、 ``supported_mimetypes`` で対象を絞り込む
+4. スケジュール設定で負荷を分散
+5. クロール間隔を調整
 
 権限とアクセス制御
 ==================
+
+Drive権限からFessロールへの変換
+-------------------------------
+
+ドキュメントのACLは、追加のAPI呼び出し回数がファイル数ではなく共有ドライブ数に比例するよう、
+次の3段階で解決されます。
+
+1. ファイル一覧に含まれるインラインの権限。追加のコストはかかりません
+2. インラインの権限が返らない共有ドライブのアイテムについては、共有ドライブ自体のACL。ドメイン
+   管理者権限でドライブごとに1回だけ取得され、キャッシュされます
+3. 個別に追加の権限を持つアイテムについては、そのアイテム自身の権限
+
+各Drive権限は次のように |Fess| の検索ロールに変換されます。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Drive権限
+     - 検索ロール
+   * - ``user``
+     - そのユーザーのメールアドレスに対応する検索ロール。ファイルのオーナーも常にこの形式で追加されます
+   * - ``group``
+     - そのグループのメールアドレスに対応する検索ロール。Googleグループのメンバーは展開されません。 |Fess| 側でSSOやLDAPによって解決することを想定しています
+   * - ``domain``
+     - ``domain_permission_format`` の ``{domain}`` をドメイン名に置換したもの。デフォルト: ``{group}{domain}``
+   * - ``anyone``
+     - ``guest`` ロール
+   * - 上記のうち ``allowFileDiscovery=false`` のもの、および削除済みの権限
+     - ロールなし。リンク共有はDrive自体でも検索で見つけられないためです
+
+解決結果が空の場合は、追加ではなくフォールバックとして ``default_permissions`` が使用されます。
+``default_permissions`` も未設定の場合、ドキュメントはスキップされます。
 
 Google Driveの共有権限を反映
 ----------------------------
@@ -527,6 +908,8 @@ Google Driveの共有設定をFessの権限に反映:
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     default_permissions={role}drive-users
 
 スクリプト:
@@ -542,6 +925,31 @@ Google Driveの共有設定をFessの権限に反映:
     url=file.web_view_link
 
 ``file.roles`` にGoogle Driveの共有情報が含まれます。
+
+制限事項
+========
+
+- Driveの「削除」を示す変更通知には、削除だけでなくアクセス権の喪失も含まれます。
+  ``crawl_target=users`` または ``both`` の場合、あるユーザーのアクセス権を剥奪すると、
+  別のユーザーがまだ読めるドキュメントであってもインデックスから削除されます。そのファイルに
+  次の変更があったとき、または次回の全体クロールで復帰します。
+- 差分クロール中にスコープが全体クロールにフォールバックした場合も古いドキュメントの削除処理は
+  抑止されたままのため、スコープの開始位置が記録されていない間にDriveから削除されたドキュメントは
+  インデックスに残ります。これを削除するには ``incremental=false`` の別のデータストア設定が必要です。
+- 削除の反映は、インデックスされたURLにDriveのファイルIDが含まれていることを前提としています。
+  ``webViewLink`` とフォールバックURLはこの条件を満たしますが、クロールスクリプトで ``url`` を
+  ファイルIDを含まない値に書き換えている場合、削除は反映されません。
+- 変更フィードは ``query`` で絞り込まれません。 ``query`` を設定して ``incremental=true`` に
+  している場合、クエリに一致しない変更されたファイルもインデックスされます。
+- 大規模なドメインで ``crawl_target=both`` を使用すると、およそ
+  ``2 + 共有ドライブ数 + ユーザー数`` 回の一覧取得が行われます。共有ドライブとユーザーを別々の
+  データストア設定に分割することが現実的な回避策です。
+- ``proxy_username`` と ``proxy_password`` は ``Proxy-Authorization`` リクエストヘッダーとして
+  送信されるため、認証できるのは平文HTTPのリクエストのみです。Google APIの通信はすべてHTTPSであり、
+  認証が必要なプロキシ経由のHTTPS接続は ``CONNECT`` によって確立されますが、これはリクエスト
+  ヘッダーではなくJDKの ``java.net.Authenticator`` によって処理されます。このような環境では、
+  JVMオプション ``-Djdk.http.auth.tunneling.disabledSchemes=`` と ``Authenticator`` の設定が
+  必要です。
 
 参考情報
 ========

--- a/ko/15.9/config/datastore/ds-gsuite.rst
+++ b/ko/15.9/config/datastore/ds-gsuite.rst
@@ -10,11 +10,74 @@ Google Workspace 커넥터는 Google Drive(구 G Suite)에서 파일을 가져�
 
 이 기능을 사용하려면 ``fess-ds-gsuite`` 플러그인이 필요합니다.
 
+15.9 변경 사항
+==============
+
+|Fess| 15.9에서 커넥터가 대폭 재작성되었습니다. 기존 데이터 스토어 설정을 업그레이드하기 전에
+이 절을 읽어 주세요.
+
+.. warning::
+
+   ``crawl_target``\ 의 기본값이 ``shared_drives``\ 가 되었고, ``legacy`` 이외의 값에서는
+   ``impersonate_user``\ 가 필수가 되었습니다. 따라서 기존 설정을 그대로 업그레이드하면
+   실행되지 않고 ``DataStoreException``\ 과 함께 **시작 시점에 실패합니다** .
+
+   이는 의도된 동작입니다. 기존 동작으로는 서비스 계정에 명시적으로 공유된 파일에만 도달할 수
+   있으므로, 그대로 두면 아무것도 인덱싱하지 않는 크롤링이 조용히 성공해 버립니다.
+   ``impersonate_user``\ 에 도메인 관리자 계정을 설정하거나, 기존 동작을 유지하려면
+   ``crawl_target=legacy``\ 를 설정하세요.
+
+동작 변경
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 변경 사항
+     - 필요한 조치
+   * - ``crawl_target``\ 의 기본값이 ``shared_drives``\ 가 되고 ``impersonate_user``\ 가 필수가 됨
+     - ``impersonate_user``\ 를 설정하거나 ``crawl_target=legacy``\ 를 설정합니다. 그렇지 않으면 크롤링이 시작 시점에 실패합니다.
+   * - 기본 OAuth 범위가 ``https://www.googleapis.com/auth/drive``\ 에서 ``https://www.googleapis.com/auth/drive.readonly``\ 로 축소됨
+     - Google Workspace 관리 콘솔의 도메인 전체 위임 설정은 범위를 명시적으로 나열하므로 업데이트가 필요합니다.
+   * - ``crawl_target=users`` 및 ``crawl_target=both``\ 에서 ``https://www.googleapis.com/auth/admin.directory.user.readonly``\ 가 추가로 필요해짐
+     - ``scopes`` 파라미터와 관리 콘솔의 위임 설정 양쪽에 범위를 추가합니다. 이는 시작 시점에 검증됩니다.
+   * - 인덱싱되는 URL이 다운로드 링크에서 브라우저에서 열 수 있는 링크(``webViewLink``)로 변경됨
+     - 새 URL을 반영하려면 전체 재크롤링이 필요합니다.
+   * - ``default_permissions``\ 가 추가가 아니라 대체값이 됨
+     - ACL이 해결된 문서에는 해당 ACL만 부여되며, ``default_permissions``\ 와의 합집합이 아닙니다. 결과적으로 권한이 더 엄격해집니다.
+   * - 링크 공유만으로는 검색 역할이 부여되지 않음
+     - ``allowFileDiscovery=false``\ 인 ``domain`` 및 ``anyone`` 권한은 "링크가 있는 모든 사용자"를 의미하며, Drive 자체도 이를 검색으로 찾을 수 있게 하지 않습니다.
+   * - ACL이 아무것도 해결되지 않은 문서는 역할 없이 인덱싱되지 않고 건너뜀
+     - 계속 인덱싱하려면 ``default_permissions``\ 를 설정합니다. 기존에는 역할 목록이 비어 있으면 권한 필터가 비활성화되어 모든 사용자에게 보였습니다.
+   * - ``fields``\ 의 기본값이 ``*``\ 가 아니라 명시적인 필드 목록이 됨
+     - 잘 쓰이지 않는 필드를 참조하는 크롤링 스크립트에서는 null이 반환됩니다. 기존 동작으로 되돌리려면 ``fields=*``\ 를 설정합니다.
+   * - Google 문서가 일반 텍스트 대신 Markdown으로, 스프레드시트가 CSV 대신 TSV로 내보내짐
+     - 모든 Google 문서의 인덱싱 텍스트에 Markdown 구문 문자가 포함됩니다. 전체 재크롤링이 필요합니다.
+   * - ``refresh_token_interval``\ 이 무시됨
+     - 토큰 갱신은 인증 라이브러리가 처리합니다. 기존 설정은 그대로 동작하며 경고가 로그에 출력됩니다.
+   * - Google 설문지와 Google 사이트 도구는 메타데이터만 인덱싱됨
+     - Drive API에 내보내기 형식이 없기 때문입니다. 기존에는 이러한 파일이 모두 크롤링 오류가 되었습니다.
+
+새로운 기능
+-----------
+
+- ``crawl_target``\ 으로 크롤링 대상을 선택할 수 있습니다. 서비스 계정 자신의 시점(``legacy``),
+  도메인 내의 모든 공유 드라이브(``shared_drives``), 디렉터리 전체 사용자의 마이 드라이브
+  (``users``), 또는 둘 다(``both``)입니다. `크롤링 대상`_\ 을 참조하세요.
+- 공유 드라이브 항목에 올바른 ACL이 부여됩니다. `권한과 액세스 제어`_\ 를 참조하세요.
+- Drive 변경 피드를 이용한 증분 크롤링을 지원합니다. `증분 크롤링`_\ 을 참조하세요.
+- ``Retry-After``\ 를 존중하는 지수 백오프 기반의 속도 제한 대응과, 하나의 공유 드라이브나
+  사용자의 실패가 전체 크롤링을 중단시키지 않는 구조를 추가했습니다.
+  `속도 제한과 재시도`_\ 를 참조하세요.
+- 인증이 필요한 프록시를 위해 ``proxy_username``\ 과 ``proxy_password``\ 를 추가했습니다.
+
 지원 서비스
-============
+===========
 
 - Google Drive(마이 드라이브, 공유 드라이브)
-- Google 문서, 스프레드시트, 프레젠테이션, 설문지 등
+- Google 문서, 스프레드시트, 프레젠테이션, 그림, Apps Script
+- Google 설문지, Google 사이트 도구(내보내기 형식이 없어 메타데이터만 인덱싱)
 
 전제조건
 ========
@@ -23,9 +86,11 @@ Google Workspace 커넥터는 Google Drive(구 G Suite)에서 파일을 가져�
 2. Google Cloud Platform 프로젝트 생성이 필요합니다
 3. 서비스 계정 생성과 인증 정보 취득이 필요합니다
 4. Google Workspace 도메인 전체 위임 설정이 필요합니다
+5. ``crawl_target=legacy`` 이외를 사용하는 경우, 대신 액세스할 Google Workspace 관리자 계정이
+   필요합니다
 
 플러그인 설치
-------------------------
+-------------
 
 방법 1: JAR 파일 직접 배치
 
@@ -46,12 +111,12 @@ Google Workspace 커넥터는 Google Drive(구 G Suite)에서 파일을 가져�
 3. |Fess| 재시작
 
 설정 방법
-========
+=========
 
 관리 화면에서 "크롤러" → "데이터 스토어" → "새로 만들기"에서 설정합니다.
 
 기본 설정
---------
+---------
 
 .. list-table::
    :header-rows: 1
@@ -67,16 +132,17 @@ Google Workspace 커넥터는 Google Drive(구 G Suite)에서 파일을 가져�
      - 켬
 
 파라미터 설정
-----------------
+-------------
 
 ::
 
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project.iam.gserviceaccount.com
+    impersonate_user=admin@example.com
 
 파라미터 목록
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
@@ -94,63 +160,195 @@ Google Workspace 커넥터는 Google Drive(구 G Suite)에서 파일을 가져�
    * - ``client_email``
      - 예
      - 서비스 계정의 이메일 주소
+   * - ``impersonate_user``
+     - 조건부
+     - 도메인 전체 위임으로 대신 액세스할 Google Workspace 계정. ``crawl_target=legacy`` 이외에서는 필수이며, 설정하지 않으면 크롤링이 시작 시점에 실패합니다. ``shared_drives``\ 와 ``both``\ 는 도메인 관리자 권한으로 공유 드라이브를 열거하므로, 이 계정은 도메인 관리자여야 합니다.
+   * - ``crawl_target``
+     - 아니오
+     - 크롤링 대상. ``legacy``, ``shared_drives``, ``users``, ``both`` 중 하나. 기본값: ``shared_drives``. `크롤링 대상`_\ 을 참조하세요.
+   * - ``scopes``
+     - 아니오
+     - OAuth 범위(쉼표 구분). 기본값: ``https://www.googleapis.com/auth/drive.readonly``. ``crawl_target=users`` 및 ``both``\ 에서는 ``https://www.googleapis.com/auth/admin.directory.user.readonly``\ 가 추가로 필요합니다.
+   * - ``user_query``
+     - 아니오
+     - ``crawl_target=users`` 및 ``both``\ 에서 열거할 사용자를 좁히는 Admin SDK의 ``query``. 기본값: 지정 안 함(고객 계정의 전체 사용자)
+   * - ``query``
+     - 아니오
+     - Google Drive API 검색 쿼리 문자열. 증분 크롤링에서 사용하는 변경 피드에는 적용되지 않습니다
+   * - ``corpora``
+     - 아니오
+     - 검색 대상 코퍼스. 기본값: ``allDrives``. ``crawl_target=legacy``\ 에서만 사용되므로 기본 크롤링 대상에서는 효과가 없습니다. ``shared_drives``\ 는 각 드라이브를 ``drive``\ 로, ``users``\ 는 각 마이 드라이브를 ``user``\ 로 열거하며 둘 다 고정입니다
+   * - ``spaces``
+     - 아니오
+     - 검색 대상 공간(Google Drive API의 ``spaces`` 매개변수, 예: ``drive``, ``appDataFolder``). 기본값: 지정 안 함(API 기본값). ``crawl_target=legacy``\ 와 ``users``\ 에서 사용되며 ``shared_drives``\ 에서는 무시됩니다
+   * - ``fields``
+     - 아니오
+     - Google Drive API에서 가져올 파일 필드 지정. 기본값은 ``*``\ 가 **아니라** 명시적인 필드 목록입니다. 스크립트 컨텍스트, ACL 해결, 인덱스 URL, 증분 크롤링에 필요한 필드를 모두 포함하지만, 목록에 없는 필드는 크롤링 스크립트에서 null이 됩니다. 기존처럼 모든 필드를 가져오려면 ``fields=*``\ 를 설정합니다
+   * - ``default_permissions``
+     - 아니오
+     - 문서의 Drive ACL이 아무것도 해결되지 않았을 때 사용할 권한(쉼표 구분, 예: ``{role}drive-users``). 추가가 아니라 대체값이며, ACL이 해결된 문서에는 해당 ACL만 부여됩니다
    * - ``max_size``
      - 아니오
      - 인덱스 대상 최대 파일 크기(바이트). 기본값: ``10000000`` (약 10MB)
-   * - ``ignore_folder``
-     - 아니오
-     - 폴더를 건너뛸지 여부. 기본값: ``true``
-   * - ``ignore_error``
-     - 아니오
-     - 오류 발생 시 처리를 계속할지 여부. 기본값: ``true``
-   * - ``supported_mimetypes``
-     - 아니오
-     - 인덱스 대상 MIME 타입(정규식, 쉼표 구분). 기본값: ``.*`` (전체 타입)
-   * - ``include_pattern``
-     - 아니오
-     - 인덱스 대상 URL의 정규식 패턴
-   * - ``exclude_pattern``
-     - 아니오
-     - 제외할 URL의 정규식 패턴
-   * - ``default_permissions``
-     - 아니오
-     - 기본 권한(쉼표 구분, 예: ``{role}drive-users``)
    * - ``number_of_threads``
      - 아니오
      - 병렬 처리 스레드 수. 기본값: ``1``
-   * - ``query``
+   * - ``incremental``
      - 아니오
-     - Google Drive API 검색 쿼리 문자열
-   * - ``corpora``
-     - 아니오
-     - 검색 대상 코퍼스. 기본값: ``allDrives``
-   * - ``spaces``
-     - 아니오
-     - 검색 대상 공간(Google Drive API의 ``spaces`` 매개변수, 예: ``drive``, ``appDataFolder``). 기본값: 지정 안 함(API 기본값).
-   * - ``fields``
-     - 아니오
-     - Google Drive API에서 가져올 파일 필드 지정. 기본값: ``*`` (모든 필드).
+     - 전부 열거하는 대신 Drive 변경 피드로 크롤링할지 여부. 기본값: ``false``. 크롤링 시작 전에 데이터 스토어 설정의 파라미터 항목에서 직접 읽습니다. `증분 크롤링`_\ 을 참조하세요
+
+고급 파라미터
+~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 파라미터
+     - 설명
+   * - ``domain_permission_format``
+     - ``type=domain``\ 인 Drive 권한에 적용할 역할 형식. ``{domain}``\ 이 도메인 이름으로 치환됩니다. 기본값: ``{group}{domain}``
+   * - ``thread_pool_timeout_seconds``
+     - 크롤링 종료 시 작업 스레드의 종료를 기다리는 시간(초). 기본값: ``60``
+   * - ``page_size``
+     - ``files.list``\ 와 ``changes.list``\ 의 페이지 크기. 기본값: ``1000``. ``1000``\ 을 넘는 값은 자동으로 축소됩니다
+   * - ``permission_page_size``
+     - ``permissions.list``\ 와 ``drives.list``\ 의 페이지 크기. 기본값: ``100``. ``100``\ 을 넘는 값은 자동으로 축소됩니다
+   * - ``max_cached_content_size``
+     - 메모리에 유지하는 콘텐츠의 최대 크기(바이트). 이를 초과하는 콘텐츠는 임시 파일로 저장됩니다. 기본값: ``1048576`` (1MB)
+   * - ``max_retries``
+     - Drive API의 속도 제한이나 일시적인 실패에 대한 최대 재시도 횟수. 기본값: ``5``
+   * - ``retry_initial_interval_ms``
+     - 첫 재시도까지의 백오프 간격(밀리초). 기본값: ``1000``
+   * - ``max_backoff_ms``
+     - 한 번의 대기 시간 상한(밀리초). 기본값: ``32000``
    * - ``read_timeout``
-     - 아니오
      - HTTP 읽기 타임아웃(밀리초). 기본값: ``20000``
    * - ``connect_timeout``
-     - 아니오
      - HTTP 연결 타임아웃(밀리초). 기본값: ``20000``
-   * - ``refresh_token_interval``
-     - 아니오
-     - OAuth 액세스 토큰을 갱신하는 간격(초). 기본값: ``3540`` (59분).
-   * - ``max_cached_content_size``
-     - 아니오
-     - 메모리에 유지하는 콘텐츠의 최대 크기(바이트). 이를 초과하는 콘텐츠는 임시 파일로 저장됩니다. 기본값: ``1048576`` (1MB).
    * - ``proxy_host``
-     - 아니오
-     - 프록시 서버 호스트명
+     - 프록시 서버 호스트명. 프록시는 ``proxy_host``\ 와 ``proxy_port``\ 가 모두 설정된 경우에만 사용되며, 한쪽만으로는 효과가 없습니다
    * - ``proxy_port``
-     - 아니오
-     - 프록시 서버 포트 번호
+     - 프록시 서버 포트 번호. ``proxy_host``\ 를 참조하세요
+   * - ``proxy_username``
+     - 인증이 필요한 프록시의 사용자 이름. 설정하면 모든 요청에 ``Proxy-Authorization`` 헤더가 추가됩니다. 무엇이 인증되고 무엇이 인증되지 않는지는 `제한 사항`_\ 을 참조하세요
+   * - ``proxy_password``
+     - 인증이 필요한 프록시의 비밀번호
+   * - ``ignore_folder``
+     - 폴더를 건너뛸지 여부. 기본값: ``true``
+   * - ``ignore_error``
+     - 오류 발생 시 처리를 계속할지 여부. 기본값: ``true``
+   * - ``supported_mimetypes``
+     - 인덱스 대상 MIME 타입(정규식, 쉼표 구분). 기본값: ``.*`` (전체 타입)
+   * - ``include_pattern``
+     - 인덱스 대상 URL의 정규식 패턴
+   * - ``exclude_pattern``
+     - 제외할 URL의 정규식 패턴
+   * - ``refresh_token_interval``
+     - 15.9부터 무시됩니다. 액세스 토큰 갱신은 인증 라이브러리가 처리합니다. 기존 설정은 그대로 동작하며 경고가 로그에 출력됩니다
+
+.. note::
+
+   ``private_key``, ``private_key_id``, ``client_email``, ``proxy_username``,
+   ``proxy_password``\ 는 스크립트 평가 컨텍스트에서 제거되므로, 크롤링 스크립트로 인덱스에
+   등록할 수 없고 검색 결과로 노출되지도 않습니다.
+
+.. note::
+
+   증분 크롤링을 활성화하면 커넥터가 ``start_page_tokens``\ 와 ``crawl_signature``\ 를
+   데이터 스토어 설정의 파라미터 항목에 다시 기록합니다. 이 값들은 커넥터가 관리하며 사용자가
+   설정한 파라미터와 함께 표시되지만, 수정하지 마세요. 수정하거나 삭제하면 다음 실행에서
+   모든 스코프가 전체 크롤링이 됩니다.
+
+크롤링 대상
+-----------
+
+서비스 계정은 자신의 Drive를 갖지 않고 어떤 Google 그룹에도 속하지 않으므로, 서비스 계정
+자신으로 인증하는 크롤링은 서비스 계정 주소에 명시적으로 공유된 파일에만 도달할 수 있습니다.
+따라서 ``crawl_target``\ 은 누구의 시점으로 Drive를 크롤링할지를 선택합니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - 값
+     - 설명
+   * - ``legacy``
+     - 기존 버전과 마찬가지로 서비스 계정 자신의 시점으로 크롤링합니다. ``impersonate_user``\ 는 필요하지 않습니다. 서비스 계정에 명시적으로 공유된 파일만 찾을 수 있습니다
+   * - ``shared_drives``
+     - 기본값. 도메인 내의 모든 공유 드라이브를 열거하고 각각을 개별적으로 순회합니다
+   * - ``users``
+     - Admin SDK로 디렉터리의 전체 사용자를 열거하고, 각 사용자를 대신하여 마이 드라이브를 순회합니다
+   * - ``both``
+     - ``shared_drives`` 다음에 ``users``\ 를 실행합니다. 여러 스코프에 나타나는 파일은 한 번만 인덱싱됩니다
+
+다음 항목은 크롤링 시작 시점에 검증되며, 잘못된 조합이면 실행되지 않고
+``DataStoreException``\ 이 발생합니다.
+
+1. ``crawl_target``\ 은 ``legacy``, ``shared_drives``, ``users``, ``both`` 중 하나여야 합니다
+2. ``crawl_target=legacy`` 이외인 경우 ``impersonate_user``\ 가 설정되어 있어야 합니다
+3. ``crawl_target``\ 이 ``users`` 또는 ``both``\ 인 경우 ``scopes``\ 에
+   ``https://www.googleapis.com/auth/admin.directory.user.readonly``\ 가 포함되어 있어야 합니다
+
+.. note::
+
+   ``shared_drives``\ 와 ``both``\ 는 도메인 관리자 권한으로 공유 드라이브를 열거하므로,
+   ``impersonate_user``\ 에 지정하는 계정은 Google Workspace의 도메인 관리자여야 합니다.
+   이 열거는 크롤링 범위 전체를 결정하므로, 영구적인 실패는 기록하고 건너뛰는 대신 크롤링을
+   중단합니다. 공유 드라이브를 하나도 열거하지 못한 크롤링은 부분적인 성공이 아니며, 아무것도
+   인덱싱하지 않은 채 성공으로 보고해서는 안 되기 때문입니다.
+
+증분 크롤링
+-----------
+
+``incremental=true``\ 를 설정하면 각 스코프(공유 드라이브 하나, 또는 대신 액세스하는 사용자
+한 명의 시점)가 전부 열거하는 대신 Drive의 변경 피드를 읽습니다. 토큰이 저장되어 있지 않은
+스코프는 전체를 크롤링하고, 다음 실행을 위해 변경 피드의 시작 위치를 기록합니다.
+
+::
+
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
+    incremental=true
+
+.. warning::
+
+   증분 크롤링 실행에서는 ``delete_old_docs``\ 가 강제로 ``false``\ 가 되며, 명시적으로
+   ``delete_old_docs=true``\ 를 지정해도 존중되지 않고 덮어써집니다(경고가 로그에 출력됩니다).
+   오래된 문서 삭제 처리는 이번 크롤링에서 등록되지 않은 이 데이터 설정의 모든 문서를 삭제하는
+   것으로, 전체 크롤링을 전제로 합니다. 증분 크롤링은 변경된 문서만 처리하므로, 이 삭제 처리는
+   인덱스의 나머지 전부를 삭제하게 됩니다.
+
+   Drive에서 사라진 문서를 삭제하려면 ``incremental=false``\ 인 별도의 데이터 스토어 설정을
+   스케줄링하세요.
+
+변경 피드의 시작 위치는 크롤링이 완료되고 작업 스레드가 모두 종료된 경우에만 저장됩니다.
+도중에 중지된 크롤링에서는 저장되지 않으며, 다음 실행은 같은 변경을 다시 읽습니다.
+
+스코프가 반환하는 대상을 결정하는 설정, 즉 ``crawl_target``, ``impersonate_user``,
+``user_query``, ``query``, ``corpora``, ``spaces`` 중 하나가 변경된 경우에도 저장된 시작
+위치는 폐기되고 모든 스코프가 전체 크롤링이 됩니다. 저장된 시작 위치는 그것을 취득한 시점의
+대상 범위만 나타내므로, 설정 변경 후에 거기서 재개하면 인덱스에 영구적인 누락이 생기기
+때문입니다.
+
+속도 제한과 재시도
+------------------
+
+Drive API의 속도 제한이나 일시적인 실패는 ``max_retries``, ``retry_initial_interval_ms``,
+``max_backoff_ms`` 범위에서 지수 백오프로 재시도됩니다. ``Retry-After`` 헤더는 지수 백오프보다
+우선하지만, 잘못된 값으로 크롤링이 몇 시간씩 멈추지 않도록 ``max_backoff_ms``\ 로 상한이
+적용됩니다. ``Retry-After``\ 는 초 단위 형식만 유효하며, HTTP 날짜 형식인 경우에는 지수
+백오프로 대체됩니다.
+
+``429``, ``500``, ``502``, ``503``, ``504``\ 는 항상 재시도됩니다. ``403``\ 은 속도 제한
+오류인 경우에만 재시도되며, 그 밖의 ``403``\ 은 재시도해도 해결되지 않는 인가 실패이므로 즉시
+기록됩니다.
+
+파일 목록 조회에 실패해도 더 이상 전체 크롤링이 중단되지 않습니다. 남은 공유 드라이브와
+사용자의 크롤링은 계속되며, 실패는 크롤러 로그와 관리 화면의 실패 URL 목록에 기록됩니다.
 
 스크립트 설정
---------------
+-------------
 
 ::
 
@@ -167,7 +365,7 @@ Google Workspace 커넥터는 Google Drive(구 G Suite)에서 파일을 가져�
     filename=file.name
 
 사용 가능한 필드
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
@@ -192,7 +390,7 @@ Google Workspace 커넥터는 Google Drive(구 G Suite)에서 파일을 가져�
    * - ``file.web_view_link``
      - 브라우저에서 열기 링크
    * - ``file.url``
-     - 파일 URL
+     - 파일 URL. ``webViewLink``\ 가 사용되며, 없는 경우에는 ``https://drive.google.com/open?id=<파일 ID>``\ 가 사용됩니다
    * - ``file.thumbnail_link``
      - 썸네일 링크(단기간 유효)
    * - ``file.size``
@@ -200,13 +398,54 @@ Google Workspace 커넥터는 Google Drive(구 G Suite)에서 파일을 가져�
    * - ``file.roles``
      - 액세스 권한
 
+.. note::
+
+   값이 채워지는 것은 ``fields`` 파라미터에 지정한 필드뿐입니다. 요청하지 않은 필드는
+   스크립트에서 null이 됩니다. 기존처럼 모든 필드를 가져오려면 ``fields=*``\ 를 설정하세요.
+
 자세한 내용은 `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_\ 를 참조하세요.
 
+Google 형식 파일의 텍스트 추출
+------------------------------
+
+Google 형식 파일은 다운로드할 수 없으므로 내보내기가 필요합니다. 내보내기 형식은 고정된
+대응표가 아니라 Drive API가 실제로 반환하는 형식에서 선택되며, 내보내기는 10MB가 상한입니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 종류
+     - 내보내기 형식
+   * - Google 문서
+     - Markdown(``text/markdown``). 사용할 수 없으면 일반 텍스트, 그다음 HTML
+   * - Google 스프레드시트
+     - TSV(``text/tab-separated-values``). 사용할 수 없으면 CSV
+   * - Google 프레젠테이션
+     - 일반 텍스트
+   * - Google 그림
+     - PNG. 인덱싱할 텍스트가 없으므로 메타데이터만 등록됩니다
+   * - Apps Script
+     - 내보낸 JSON에서 스크립트 소스를 추출하여 인덱싱합니다
+   * - Google 설문지, Google 사이트 도구
+     - 내보내기 불가. 메타데이터만 등록되며 오류가 되지 않습니다
+
+.. note::
+
+   Google 문서가 Markdown으로 내보내지므로, 모든 Google 문서의 인덱싱 텍스트에 Markdown 구문
+   문자가 포함됩니다. 이미 인덱싱된 문서에 반영하려면 전체 재크롤링이 필요합니다.
+
+.. note::
+
+   내보내기 형식은 크롤링마다 한 번 Drive API에서 가져옵니다. 이 호출에 실패하면 Drive가
+   기존부터 지원해 온 변환(Google 문서는 일반 텍스트, Google 스프레드시트는 CSV)으로
+   대체되며 경고가 로그에 출력됩니다.
+
 Google Cloud Platform 설정
-=========================
+==========================
 
 1. 프로젝트 생성
----------------------
+----------------
 
 https://console.cloud.google.com/ 에 접속:
 
@@ -215,15 +454,16 @@ https://console.cloud.google.com/ 에 접속:
 3. 조직과 위치 선택
 
 2. Google Drive API 활성화
----------------------------
+--------------------------
 
 "API 및 서비스" → "라이브러리"에서:
 
 1. "Google Drive API" 검색
 2. "사용 설정" 클릭
+3. ``crawl_target``\ 이 ``users`` 또는 ``both``\ 인 경우 "Admin SDK API"도 사용 설정
 
 3. 서비스 계정 생성
----------------------------
+-------------------
 
 "API 및 서비스" → "사용자 인증 정보"에서:
 
@@ -234,7 +474,7 @@ https://console.cloud.google.com/ 에 접속:
 5. "완료" 클릭
 
 4. 서비스 계정 키 생성
--------------------------------
+----------------------
 
 생성한 서비스 계정에서:
 
@@ -245,7 +485,7 @@ https://console.cloud.google.com/ 에 접속:
 5. 다운로드된 JSON 파일 저장
 
 5. 도메인 전체 위임 활성화
------------------------------
+--------------------------
 
 서비스 계정 설정에서:
 
@@ -254,7 +494,7 @@ https://console.cloud.google.com/ 에 접속:
 3. "OAuth 2 클라이언트 ID" 복사
 
 6. Google Workspace 관리 콘솔에서 승인
----------------------------------------
+--------------------------------------
 
 https://admin.google.com/ 에 접속:
 
@@ -266,15 +506,28 @@ https://admin.google.com/ 에 접속:
 
    ::
 
-       https://www.googleapis.com/auth/drive
+       https://www.googleapis.com/auth/drive.readonly
+
+   ``crawl_target``\ 이 ``users`` 또는 ``both``\ 인 경우에는 두 범위를 모두 입력합니다:
+
+   ::
+
+       https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
 
 6. "승인" 클릭
+
+.. warning::
+
+   위임 설정은 범위를 명시적으로 나열하므로, 이전 버전에서 업그레이드하는 경우 업데이트가
+   필요합니다. 15.9에서 기본 범위가 ``https://www.googleapis.com/auth/drive``\ 에서
+   ``https://www.googleapis.com/auth/drive.readonly``\ 로 변경되었으며, 여기서 허용하는 범위는
+   데이터 스토어 설정의 ``scopes`` 파라미터와 일치해야 합니다.
 
 인증 정보 설정
 ==============
 
 JSON 파일에서 정보 취득
---------------------------
+-----------------------
 
 다운로드한 JSON 파일:
 
@@ -309,10 +562,10 @@ JSON 파일에서 정보 취득
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG...\n-----END PRIVATE KEY-----\n
 
 사용 예
-======
+=======
 
-Google Drive 전체 크롤링
---------------------------
+모든 공유 드라이브 크롤링
+-------------------------
 
 파라미터:
 
@@ -321,6 +574,8 @@ Google Drive 전체 크롤링
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
 
 스크립트:
 
@@ -335,7 +590,43 @@ Google Drive 전체 크롤링
     thumbnail=file.thumbnail_link
     content_length=file.size
     filetype=file.filetype
+    role=file.roles
     filename=file.name
+
+전체 사용자의 마이 드라이브 크롤링
+----------------------------------
+
+파라미터:
+
+::
+
+    private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
+    private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
+    client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=users
+    impersonate_user=admin@example.com
+    scopes=https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
+
+사용자를 좁히려면 Admin SDK 쿼리를 추가합니다:
+
+::
+
+    user_query=orgUnitPath=/Sales
+
+기존 동작을 유지하는 경우
+-------------------------
+
+``crawl_target=legacy``\ 는 15.9 이전의 동작을 유지하며, 서비스 계정에 명시적으로 공유된
+파일만 찾을 수 있습니다. ``impersonate_user``\ 는 필요하지 않습니다.
+
+파라미터:
+
+::
+
+    private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
+    private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
+    client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=legacy
 
 권한 포함 크롤링
 ----------------
@@ -347,6 +638,8 @@ Google Drive 전체 크롤링
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     default_permissions={role}drive-users
 
 스크립트:
@@ -362,8 +655,10 @@ Google Drive 전체 크롤링
     role=file.roles
     filename=file.name
 
+``default_permissions``\ 는 Drive ACL이 아무것도 해결되지 않은 문서에만 사용됩니다.
+
 특정 파일 타입만 크롤링
---------------------------------
+-----------------------
 
 Google 문서만:
 
@@ -379,10 +674,28 @@ Google 문서만:
     }
 
 문제 해결
-======================
+=========
+
+크롤링을 시작할 수 없음
+-----------------------
+
+**증상**: 크롤링이 ``DataStoreException``\ 과 함께 즉시 종료됨
+
+**해결 방법**:
+
+1. ``parameter 'crawl_target' must be one of ...`` : ``crawl_target``\ 의 값이 ``legacy``,
+   ``shared_drives``, ``users``, ``both`` 중 어느 것도 아닙니다
+2. ``parameter 'impersonate_user' is required when 'crawl_target' is not 'legacy'`` :
+   ``impersonate_user``\ 에 도메인 관리자 계정을 설정하거나 ``crawl_target=legacy``\ 를
+   설정합니다
+3. ``parameter 'scopes' must include 'https://www.googleapis.com/auth/admin.directory.user.readonly'`` :
+   ``scopes``\ 와 도메인 전체 위임 설정에 이 범위를 추가합니다
+
+기존 설정을 그대로 업그레이드한 경우 이는 예상된 결과입니다. `15.9 변경 사항`_\ 을
+참조하세요.
 
 인증 오류
-----------
+---------
 
 **증상**: ``401 Unauthorized`` 또는 ``403 Forbidden``
 
@@ -397,10 +710,12 @@ Google 문서만:
 2. Google Drive API가 활성화되어 있는지 확인
 3. 도메인 전체 위임이 설정되어 있는지 확인
 4. Google Workspace 관리 콘솔에서 승인되었는지 확인
-5. OAuth 범위가 올바른지 확인(``https://www.googleapis.com/auth/drive``)
+5. OAuth 범위가 올바른지 확인(``https://www.googleapis.com/auth/drive.readonly``.
+   ``crawl_target``\ 이 ``users`` 또는 ``both``\ 인 경우
+   ``https://www.googleapis.com/auth/admin.directory.user.readonly``\ 도 필요)
 
 도메인 전체 위임 오류
-------------------------
+---------------------
 
 **증상**: ``Not Authorized to access this resource/api``
 
@@ -409,35 +724,62 @@ Google 문서만:
 1. Google Workspace 관리 콘솔에서 승인 확인:
 
    - 클라이언트 ID가 올바르게 등록되어 있는지
-   - OAuth 범위가 올바른지(``https://www.googleapis.com/auth/drive``)
+   - OAuth 범위가 올바른지. 위임 설정은 범위를 명시적으로 나열하므로 15.9의 범위 변경에 맞춰
+     업데이트가 필요합니다
 
 2. 서비스 계정에서 도메인 전체 위임이 활성화되어 있는지 확인
+3. ``crawl_target``\ 이 ``shared_drives`` 또는 ``both``\ 인 경우, ``impersonate_user``\ 에
+   지정한 계정이 도메인 관리자인지 확인
 
 파일을 가져올 수 없음
-----------------------
+---------------------
 
 **증상**: 크롤링은 성공하지만 파일이 0개
 
 **확인 사항**:
 
-1. Google Drive에 파일이 존재하는지 확인
-2. 서비스 계정에 읽기 권한이 있는지 확인
-3. 도메인 전체 위임이 올바르게 설정되어 있는지 확인
-4. 대상 사용자의 Drive에 액세스 가능한지 확인
+1. ``crawl_target``\ 이 의도한 값인지 확인합니다. ``legacy``\ 인 경우 서비스 계정은 자신의
+   Drive를 갖지 않고 어떤 그룹에도 속하지 않으므로, 명시적으로 공유된 파일만 찾을 수 있습니다
+2. Google Drive에 파일이 존재하는지 확인
+3. 서비스 계정에 읽기 권한이 있는지 확인
+4. 도메인 전체 위임이 올바르게 설정되어 있는지 확인
+5. 대상 사용자의 Drive에 액세스 가능한지 확인
+
+문서가 건너뛰어짐
+-----------------
+
+**증상**: 크롤러 로그에 ``Skipped ... because no permission could be resolved``\ 가 출력됨
+
+**해결 방법**:
+
+문서의 Drive ACL에서 검색 역할이 하나도 해결되지 않아 인덱싱되지 않고 건너뛰었습니다. 역할
+없이 인덱싱하면 해당 문서에서 |Fess| 의 권한 필터가 비활성화되어 모든 사용자에게 보이므로
+건너뜁니다. 건너뛰기는 크롤링 실패가 아니므로 크롤러 로그에만 출력되고 실패 URL 목록에는
+표시되지 않습니다.
+
+1. 대체 권한을 부여해 인덱싱하려면 ``default_permissions``\ 를 설정합니다
+2. 공유 드라이브의 ACL을 읽을 수 있도록, ``impersonate_user``\ 에 지정한 계정이 도메인
+   관리자인지 확인합니다
+3. 문서가 링크 공유만으로 되어 있지 않은지 확인합니다. ``allowFileDiscovery=false``\ 인
+   ``domain`` 및 ``anyone`` 권한에는 검색 역할이 부여되지 않습니다. Drive 자체도 그러한
+   문서를 검색으로 찾을 수 있게 하지 않기 때문입니다
 
 API 할당량 오류
------------------
+---------------
 
 **증상**: ``403 Rate Limit Exceeded`` 또는 ``429 Too Many Requests``
 
 **해결 방법**:
 
-1. Google Cloud Platform에서 할당량 확인
-2. 크롤링 간격을 늘림
-3. 필요 시 할당량 증가 요청
+1. 이러한 실패는 지수 백오프로 자동 재시도됩니다. 그래도 실패하는 경우 ``max_retries``
+   또는 ``max_backoff_ms``\ 를 크게 설정합니다
+2. ``number_of_threads``\ 를 줄여 요청 빈도를 낮춥니다
+3. Google Cloud Platform에서 할당량 확인
+4. 크롤링 간격을 늘림
+5. 필요 시 할당량 증가 요청
 
 비밀 키 형식 오류
---------------------------
+-----------------
 
 **증상**: ``Invalid private key format``
 
@@ -456,11 +798,14 @@ API 할당량 오류
     -----END PRIVATE KEY-----
 
 공유 드라이브 크롤링
-----------------------
+--------------------
 
 .. note::
-   서비스 계정으로 공유 드라이브를 크롤링하는 경우,
-   공유 드라이브에 서비스 계정을 멤버로 추가해야 합니다.
+   ``crawl_target=shared_drives``\ (기본값)에서는 도메인 관리자 권한으로 공유 드라이브를
+   열거하므로, 개별 공유 드라이브에 서비스 계정을 멤버로 추가할 필요가 없습니다. 대신
+   ``impersonate_user``\ 에 도메인 관리자를 지정하세요.
+
+``crawl_target=legacy``\ 인 경우에는 각 공유 드라이브에 서비스 계정을 추가해야 합니다.
 
 1. Google Drive에서 공유 드라이브 열기
 2. "멤버 관리" 클릭
@@ -468,22 +813,57 @@ API 할당량 오류
 4. 권한 수준을 "뷰어"로 설정
 
 대량의 파일이 있는 경우
-------------------------
+-----------------------
 
 **증상**: 크롤링에 시간이 오래 걸리거나 타임아웃됨
 
 **해결 방법**:
 
-1. 데이터 스토어를 여러 개로 분할
-2. 스케줄 설정으로 부하 분산
-3. 크롤링 간격 조정
-4. 특정 폴더만 크롤링
+1. ``incremental=true``\ 를 활성화하여 이전 실행 이후의 변경만 크롤링합니다
+2. ``crawl_target=both``\ 를 사용하지 않고 공유 드라이브와 사용자를 별도의 데이터 스토어
+   설정으로 분할합니다
+3. ``query``, ``user_query``, ``supported_mimetypes``\ 로 대상을 좁힙니다
+4. 스케줄 설정으로 부하 분산
+5. 크롤링 간격 조정
 
 권한과 액세스 제어
 ==================
 
+Drive 권한에서 Fess 역할로의 변환
+---------------------------------
+
+문서의 ACL은 추가 API 호출 횟수가 파일 수가 아니라 공유 드라이브 수에 비례하도록 다음 세
+단계로 해결됩니다.
+
+1. 파일 목록에 포함된 인라인 권한. 추가 비용이 들지 않습니다
+2. 인라인 권한이 반환되지 않는 공유 드라이브 항목에 대해서는 공유 드라이브 자체의 ACL.
+   도메인 관리자 권한으로 드라이브마다 한 번만 가져와 캐시합니다
+3. 개별적으로 추가 권한을 가진 항목에 대해서는 그 항목 자신의 권한
+
+각 Drive 권한은 다음과 같이 |Fess| 의 검색 역할로 변환됩니다.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Drive 권한
+     - 검색 역할
+   * - ``user``
+     - 해당 사용자의 이메일 주소에 대응하는 검색 역할. 파일의 소유자도 항상 이 형식으로 추가됩니다
+   * - ``group``
+     - 해당 그룹의 이메일 주소에 대응하는 검색 역할. Google 그룹의 멤버는 전개되지 않으며, |Fess| 측에서 SSO나 LDAP로 해결하는 것을 전제로 합니다
+   * - ``domain``
+     - ``domain_permission_format``\ 의 ``{domain}``\ 을 도메인 이름으로 치환한 것. 기본값: ``{group}{domain}``
+   * - ``anyone``
+     - ``guest`` 역할
+   * - 위 항목 중 ``allowFileDiscovery=false``\ 인 것과 삭제된 권한
+     - 역할 없음. 링크 공유는 Drive 자체에서도 검색으로 찾을 수 없기 때문입니다
+
+해결 결과가 비어 있으면 추가가 아니라 대체값으로 ``default_permissions``\ 가 사용됩니다.
+``default_permissions``\ 도 설정되어 있지 않으면 문서는 건너뜁니다.
+
 Google Drive 공유 권한 반영
-----------------------------
+---------------------------
 
 Google Drive 공유 설정을 Fess 권한에 반영:
 
@@ -494,6 +874,8 @@ Google Drive 공유 설정을 Fess 권한에 반영:
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     default_permissions={role}drive-users
 
 스크립트:
@@ -510,8 +892,32 @@ Google Drive 공유 설정을 Fess 권한에 반영:
 
 ``file.roles``\ 에 Google Drive 공유 정보가 포함됩니다.
 
+제한 사항
+=========
+
+- Drive의 "삭제됨"을 나타내는 변경 알림에는 삭제뿐 아니라 액세스 권한의 상실도 포함됩니다.
+  ``crawl_target=users`` 또는 ``both``\ 인 경우, 한 사용자의 액세스 권한을 회수하면 다른
+  사용자가 아직 읽을 수 있는 문서라도 인덱스에서 삭제됩니다. 해당 파일에 다음 변경이 있을 때,
+  또는 다음 전체 크롤링에서 복구됩니다.
+- 증분 크롤링 중에 스코프가 전체 크롤링으로 대체된 경우에도 오래된 문서 삭제 처리는 계속
+  억제되므로, 스코프의 시작 위치가 기록되지 않은 동안 Drive에서 삭제된 문서는 인덱스에
+  남습니다. 이를 삭제하려면 ``incremental=false``\ 인 별도의 데이터 스토어 설정이 필요합니다.
+- 삭제의 반영은 인덱싱된 URL에 Drive 파일 ID가 포함되어 있음을 전제로 합니다. ``webViewLink``\ 와
+  대체 URL은 이 조건을 만족하지만, 크롤링 스크립트에서 ``url``\ 을 파일 ID가 포함되지 않은
+  값으로 바꾸는 경우 삭제는 반영되지 않습니다.
+- 변경 피드는 ``query``\ 로 좁혀지지 않습니다. ``query``\ 를 설정하고 ``incremental=true``\ 로
+  한 경우, 쿼리에 일치하지 않는 변경된 파일도 인덱싱됩니다.
+- 대규모 도메인에서 ``crawl_target=both``\ 를 사용하면 대략
+  ``2 + 공유 드라이브 수 + 사용자 수`` 회의 목록 조회가 발생합니다. 공유 드라이브와 사용자를
+  별도의 데이터 스토어 설정으로 분할하는 것이 현실적인 완화책입니다.
+- ``proxy_username``\ 과 ``proxy_password``\ 는 ``Proxy-Authorization`` 요청 헤더로 전송되므로
+  평문 HTTP 요청만 인증할 수 있습니다. Google API 통신은 모두 HTTPS이며, 인증이 필요한 프록시를
+  경유하는 HTTPS 연결은 ``CONNECT``\ 로 성립되는데 이는 요청 헤더가 아니라 JDK의
+  ``java.net.Authenticator``\ 가 처리합니다. 이러한 환경에서는 JVM 옵션
+  ``-Djdk.http.auth.tunneling.disabledSchemes=``\ 와 ``Authenticator`` 설정이 필요합니다.
+
 참고 정보
-========
+=========
 
 - :doc:`ds-overview` - 데이터 스토어 커넥터 개요
 - :doc:`ds-microsoft365` - Microsoft 365 커넥터

--- a/zh-cn/15.9/config/datastore/ds-gsuite.rst
+++ b/zh-cn/15.9/config/datastore/ds-gsuite.rst
@@ -10,11 +10,71 @@ Google Workspace连接器提供从Google Drive（原G Suite）获取文件并注
 
 此功能需要 ``fess-ds-gsuite`` 插件。
 
+15.9的变更
+==========
+
+|Fess| 15.9对该连接器进行了大幅重构。升级现有的数据存储配置之前，请先阅读本节。
+
+.. warning::
+
+   ``crawl_target`` 的默认值变为 ``shared_drives``\ ，且除 ``legacy`` 以外的值都要求设置
+   ``impersonate_user``\ 。因此，将现有配置原样升级后，爬取会在启动时抛出
+   ``DataStoreException`` 而 **无法启动** 。
+
+   这是有意为之的行为。原有行为只能访问到显式共享给服务账号的文件，若继续沿用，将出现一次
+   什么都没有索引却悄然成功的爬取。请将 ``impersonate_user`` 设置为域管理员账号；如需保留
+   原有行为，请设置 ``crawl_target=legacy``\ 。
+
+行为变更
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 变更内容
+     - 需要采取的措施
+   * - ``crawl_target`` 的默认值变为 ``shared_drives``\ ，并要求设置 ``impersonate_user``
+     - 设置 ``impersonate_user``\ ，或设置 ``crawl_target=legacy``\ 。否则爬取会在启动时失败。
+   * - 默认OAuth范围从 ``https://www.googleapis.com/auth/drive`` 收窄为 ``https://www.googleapis.com/auth/drive.readonly``
+     - Google Workspace管理控制台的域全域委派会明确列出各个范围，因此需要更新该配置。
+   * - ``crawl_target=users`` 和 ``crawl_target=both`` 额外需要 ``https://www.googleapis.com/auth/admin.directory.user.readonly``
+     - 需要同时在 ``scopes`` 参数和管理控制台的委派配置中添加该范围。这会在启动时进行校验。
+   * - 索引的URL改为可在浏览器中打开的链接（``webViewLink``\ ），而不再是下载链接
+     - 需要执行一次全量重新爬取才能采用新的URL。
+   * - ``default_permissions`` 现在是回退值，而不是追加值
+     - 能够解析出ACL的文档只会获得该ACL，不再与 ``default_permissions`` 取并集。结果严格更为严格。
+   * - 仅通过链接共享不再授予搜索角色
+     - ``allowFileDiscovery=false`` 的 ``domain`` 和 ``anyone`` 权限表示「知道链接的任何人」，Drive自身同样不会让这类文件可被搜索发现。
+   * - ACL解析结果为空的文档会被跳过，而不再以无角色的方式索引
+     - 如需继续索引，请设置 ``default_permissions``\ 。此前角色列表为空会导致权限过滤失效，这类文档对所有用户可见。
+   * - ``fields`` 的默认值不再是 ``*``\ ，而是一份明确的字段列表
+     - 引用了不常用字段的爬取脚本现在会读到null。设置 ``fields=*`` 可恢复原有行为。
+   * - Google文档的导出格式由纯文本改为Markdown，电子表格由CSV改为TSV
+     - 所有Google文档的索引文本中都会包含Markdown语法字符。需要执行全量重新爬取。
+   * - ``refresh_token_interval`` 会被忽略
+     - 令牌刷新由认证库负责。现有配置仍可正常工作，并会输出一条警告日志。
+   * - Google表单和Google协作平台仅索引元数据
+     - 因为Drive API中没有它们的导出格式。此前每一个这类文件都会产生爬取错误。
+
+新功能
+------
+
+- ``crawl_target`` 用于选择爬取对象：服务账号自身的视角（``legacy``\ ）、域内的所有共享云端
+  硬盘（``shared_drives``\ ）、目录中所有用户的「我的云端硬盘」（``users``\ ），或两者
+  （``both``\ ）。请参阅 `爬取目标`_\ 。
+- 共享云端硬盘中的项目现在会获得正确的ACL。请参阅 `权限和访问控制`_\ 。
+- 支持基于Drive变更源的增量爬取。请参阅 `增量爬取`_\ 。
+- 支持 ``Retry-After`` 的指数退避速率限制处理，且单个共享云端硬盘或用户的失败不再中断整个
+  爬取。请参阅 `速率限制与重试`_\ 。
+- 新增 ``proxy_username`` 和 ``proxy_password``\ ，用于需要认证的代理。
+
 支持的服务
-============
+==========
 
 - Google Drive（我的云端硬盘、共享云端硬盘）
-- Google文档、电子表格、幻灯片、表单等
+- Google文档、电子表格、幻灯片、绘图、Apps Script
+- Google表单、Google协作平台（没有导出格式，仅索引元数据）
 
 前提条件
 ========
@@ -23,9 +83,10 @@ Google Workspace连接器提供从Google Drive（原G Suite）获取文件并注
 2. 需要创建Google Cloud Platform项目
 3. 需要创建服务账号并获取认证信息
 4. 需要设置Google Workspace域全域委派
+5. 除非使用 ``crawl_target=legacy``\ ，否则需要一个用于模拟身份的Google Workspace管理员账号
 
 插件安装
-------------------------
+--------
 
 方法1: 直接放置JAR文件
 
@@ -67,16 +128,17 @@ Google Workspace连接器提供从Google Drive（原G Suite）获取文件并注
      - 开
 
 参数设置
-----------------
+--------
 
 ::
 
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project.iam.gserviceaccount.com
+    impersonate_user=admin@example.com
 
 参数列表
-~~~~~~~~~~~~~~~~
+~~~~~~~~
 
 .. list-table::
    :header-rows: 1
@@ -94,63 +156,186 @@ Google Workspace连接器提供从Google Drive（原G Suite）获取文件并注
    * - ``client_email``
      - 是
      - 服务账号的邮箱地址
+   * - ``impersonate_user``
+     - 视情况
+     - 通过域全域委派模拟的Google Workspace账号。除 ``crawl_target=legacy`` 外均为必需，未设置时爬取会在启动时失败。``shared_drives`` 和 ``both`` 以域管理员权限枚举共享云端硬盘，因此该账号必须是域管理员。
+   * - ``crawl_target``
+     - 否
+     - 爬取对象：``legacy``\ 、``shared_drives``\ 、``users`` 或 ``both``\ 。默认值：``shared_drives``\ 。请参阅 `爬取目标`_\ 。
+   * - ``scopes``
+     - 否
+     - OAuth范围（逗号分隔）。默认值：``https://www.googleapis.com/auth/drive.readonly``\ 。``crawl_target=users`` 和 ``both`` 额外需要 ``https://www.googleapis.com/auth/admin.directory.user.readonly``\ 。
+   * - ``user_query``
+     - 否
+     - 用于缩小 ``crawl_target=users`` 和 ``both`` 所枚举用户范围的Admin SDK ``query``\ 。默认值：未指定（客户账号下的所有用户）
+   * - ``query``
+     - 否
+     - Google Drive API搜索查询字符串。不会应用于增量爬取所使用的变更源
+   * - ``corpora``
+     - 否
+     - 搜索对象的语料库。默认值：``allDrives``\ 。仅在 ``crawl_target=legacy`` 时生效，因此在默认爬取对象下没有作用：``shared_drives`` 以 ``drive`` 枚举每个云端硬盘，``users`` 以 ``user`` 枚举每个「我的云端硬盘」，两者均为固定值
+   * - ``spaces``
+     - 否
+     - 要搜索的空间（Google Drive API 的 ``spaces`` 参数，例如 ``drive``\ 、``appDataFolder``\ ）。默认值：未指定（API 默认值）。在 ``crawl_target=legacy`` 和 ``users`` 时使用，``shared_drives`` 时被忽略
+   * - ``fields``
+     - 否
+     - 从 Google Drive API 请求的文件字段。默认值 **不是** ``*``\ ，而是一份明确的字段列表。它涵盖了脚本上下文、ACL解析、索引URL和增量爬取所需的全部字段；不在该列表中的字段在爬取脚本中为null。如需像旧版本那样请求全部字段，请设置 ``fields=*``
+   * - ``default_permissions``
+     - 否
+     - 文档的Drive ACL解析结果为空时使用的权限（逗号分隔，例：``{role}drive-users``\ ）。这是回退值而非追加值：能够解析出ACL的文档只会获得该ACL
    * - ``max_size``
      - 否
      - 索引对象的最大文件大小（字节）。默认值：``10000000``\ （约 10MB）
-   * - ``ignore_folder``
-     - 否
-     - 是否跳过文件夹。默认值：``true``
-   * - ``ignore_error``
-     - 否
-     - 发生错误时是否继续处理。默认值：``true``
-   * - ``supported_mimetypes``
-     - 否
-     - 索引对象的MIME类型（正则表达式，逗号分隔）。默认值：``.*``\ （所有类型）
-   * - ``include_pattern``
-     - 否
-     - 索引对象URL的正则表达式模式
-   * - ``exclude_pattern``
-     - 否
-     - 排除URL的正则表达式模式
-   * - ``default_permissions``
-     - 否
-     - 默认权限（逗号分隔，例：``{role}drive-users``）
    * - ``number_of_threads``
      - 否
      - 并行处理线程数。默认值：``1``
-   * - ``query``
+   * - ``incremental``
      - 否
-     - Google Drive API搜索查询字符串
-   * - ``corpora``
-     - 否
-     - 搜索对象的语料库。默认值：``allDrives``
-   * - ``spaces``
-     - 否
-     - 要搜索的空间（Google Drive API 的 ``spaces`` 参数，例如 ``drive``、``appDataFolder``）。默认值：未指定（API 默认值）。
-   * - ``fields``
-     - 否
-     - 从 Google Drive API 请求的文件字段。默认值：``*``\ （所有字段）。
+     - 是否通过Drive变更源进行爬取，而不是列出全部内容。默认值：``false``\ 。该值在爬取开始前直接从数据存储配置的参数栏读取。请参阅 `增量爬取`_\ 。
+
+高级参数
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 参数
+     - 说明
+   * - ``domain_permission_format``
+     - 应用于 ``type=domain`` 的Drive权限的角色格式。``{domain}`` 会被替换为域名。默认值：``{group}{domain}``
+   * - ``thread_pool_timeout_seconds``
+     - 爬取结束时等待工作线程结束的时间（秒）。默认值：``60``
+   * - ``page_size``
+     - ``files.list`` 和 ``changes.list`` 的分页大小。默认值：``1000``\ ；超过 ``1000`` 的值会被自动收窄
+   * - ``permission_page_size``
+     - ``permissions.list`` 和 ``drives.list`` 的分页大小。默认值：``100``\ ；超过 ``100`` 的值会被自动收窄
+   * - ``max_cached_content_size``
+     - 在内存中保留的内容的最大大小（字节）；超过此大小的内容将转存到临时文件。默认值：``1048576``\ （1MB）
+   * - ``max_retries``
+     - Drive API出现速率限制或临时性失败时的最大重试次数。默认值：``5``
+   * - ``retry_initial_interval_ms``
+     - 首次重试前的退避间隔（毫秒）。默认值：``1000``
+   * - ``max_backoff_ms``
+     - 单次等待时间的上限（毫秒）。默认值：``32000``
    * - ``read_timeout``
-     - 否
      - HTTP读取超时时间（毫秒）。默认值：``20000``
    * - ``connect_timeout``
-     - 否
      - HTTP连接超时时间（毫秒）。默认值：``20000``
-   * - ``refresh_token_interval``
-     - 否
-     - 刷新 OAuth 访问令牌的间隔（秒）。默认值：``3540``\ （59 分钟）。
-   * - ``max_cached_content_size``
-     - 否
-     - 在内存中保留的内容的最大大小（字节）；超过此大小的内容将转存到临时文件。默认值：``1048576``\ （1MB）。
    * - ``proxy_host``
-     - 否
-     - 代理服务器的主机名
+     - 代理服务器的主机名。仅当 ``proxy_host`` 和 ``proxy_port`` 同时设置时才会使用代理，只设置其中一个不起作用
    * - ``proxy_port``
-     - 否
-     - 代理服务器的端口号
+     - 代理服务器的端口号。请参阅 ``proxy_host``
+   * - ``proxy_username``
+     - 需要认证的代理的用户名。设置后，每个请求都会附加 ``Proxy-Authorization`` 头。关于它能认证什么、不能认证什么，请参阅 `限制事项`_
+   * - ``proxy_password``
+     - 需要认证的代理的密码
+   * - ``ignore_folder``
+     - 是否跳过文件夹。默认值：``true``
+   * - ``ignore_error``
+     - 发生错误时是否继续处理。默认值：``true``
+   * - ``supported_mimetypes``
+     - 索引对象的MIME类型（正则表达式，逗号分隔）。默认值：``.*``\ （所有类型）
+   * - ``include_pattern``
+     - 索引对象URL的正则表达式模式
+   * - ``exclude_pattern``
+     - 排除URL的正则表达式模式
+   * - ``refresh_token_interval``
+     - 自15.9起被忽略。访问令牌由认证库负责刷新。现有设置仍可正常工作，并会输出一条警告日志
+
+.. note::
+
+   ``private_key``\ 、``private_key_id``\ 、``client_email``\ 、``proxy_username`` 和
+   ``proxy_password`` 会从脚本的求值上下文中移除，因此爬取脚本无法将其写入索引，搜索结果中
+   也不会泄露这些值。
+
+.. note::
+
+   启用增量爬取后，连接器会将 ``start_page_tokens`` 和 ``crawl_signature`` 写回数据存储配置
+   的参数栏。这些值由连接器管理，会与您设置的参数一同显示，但请不要修改。一旦修改或删除，
+   下次执行时所有范围都会变成全量爬取。
+
+爬取目标
+--------
+
+服务账号没有自己的Drive，也不属于任何Google群组，因此以服务账号自身身份认证的爬取，只能访问到
+显式共享给服务账号地址的文件。``crawl_target`` 因此用于选择以谁的视角来爬取Drive。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - 值
+     - 说明
+   * - ``legacy``
+     - 与旧版本相同，以服务账号自身的视角进行爬取。不需要 ``impersonate_user``\ 。只能找到显式共享给服务账号的文件
+   * - ``shared_drives``
+     - 默认值。枚举域内的所有共享云端硬盘，并逐个遍历
+   * - ``users``
+     - 通过Admin SDK枚举目录中的所有用户，并逐个模拟其身份遍历「我的云端硬盘」
+   * - ``both``
+     - 先执行 ``shared_drives``\ ，再执行 ``users``\ 。出现在多个范围中的文件只会被索引一次
+
+以下内容会在爬取启动时校验，组合不合法时不会执行，而是抛出 ``DataStoreException``\ ：
+
+1. ``crawl_target`` 必须是 ``legacy``\ 、``shared_drives``\ 、``users`` 或 ``both`` 之一
+2. 除 ``crawl_target=legacy`` 外，必须设置 ``impersonate_user``
+3. 当 ``crawl_target`` 为 ``users`` 或 ``both`` 时，``scopes`` 必须包含
+   ``https://www.googleapis.com/auth/admin.directory.user.readonly``
+
+.. note::
+
+   ``shared_drives`` 和 ``both`` 以域管理员权限枚举共享云端硬盘，因此 ``impersonate_user``
+   指定的账号必须是Google Workspace的域管理员。该枚举决定了整个爬取的范围，因此永久性失败会
+   中断爬取，而不是记录后跳过：一次未能枚举出任何云端硬盘的爬取并非部分成功，不应在什么都没有
+   索引的情况下报告为成功。
+
+增量爬取
+--------
+
+设置 ``incremental=true`` 后，每个范围（一个共享云端硬盘，或一位被模拟用户的视角）都会读取
+Drive的变更源，而不是列出全部内容。没有保存令牌的范围会被完整爬取，并为下次执行记录变更源的
+起始位置。
+
+::
+
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
+    incremental=true
+
+.. warning::
+
+   增量爬取执行时 ``delete_old_docs`` 会被强制设为 ``false``\ ，即使显式指定
+   ``delete_old_docs=true`` 也会被覆盖而不是被采纳（并会输出警告日志）。删除旧文档的处理会
+   删除本次爬取中未重新注册的、属于该数据配置的所有文档，其前提是全量爬取；而增量爬取只处理
+   发生变更的文档，因此该删除处理会把索引中其余全部内容删掉。
+
+   如需删除已从Drive中消失的文档，请另行调度一个 ``incremental=false`` 的数据存储配置。
+
+只有在爬取完成且工作线程全部结束时，变更源的起始位置才会被保存。中途停止的爬取不会保存，
+下次执行会重新读取相同的变更。
+
+当决定某个范围返回内容的配置发生变化时——即 ``crawl_target``\ 、``impersonate_user``\ 、
+``user_query``\ 、``query``\ 、``corpora``\ 、``spaces`` 中的任意一项——已保存的起始位置也会
+被丢弃，所有范围都改为全量爬取。已保存的起始位置只描述取得它时的对象集合，配置变更后从该处
+续读会在索引中留下永久性的缺失。
+
+速率限制与重试
+--------------
+
+Drive API的速率限制或临时性失败会在 ``max_retries``\ 、``retry_initial_interval_ms``\ 、
+``max_backoff_ms`` 的范围内以指数退避方式重试。``Retry-After`` 头优先于指数退避，但会受
+``max_backoff_ms`` 的上限约束，以免错误的取值让爬取停滞数小时。``Retry-After`` 仅支持秒数
+形式；HTTP日期形式会回退为指数退避。
+
+``429``\ 、``500``\ 、``502``\ 、``503``\ 、``504`` 总是会重试。``403`` 仅在属于速率限制错误
+时才会重试；其他 ``403`` 属于重试也无法解决的授权失败，会立即记录。
+
+文件列表获取失败不再中断整个爬取：其余共享云端硬盘和用户仍会继续爬取，失败会记录到爬虫日志
+以及管理界面的失败URL列表中。
 
 脚本设置
---------------
+--------
 
 ::
 
@@ -167,7 +352,7 @@ Google Workspace连接器提供从Google Drive（原G Suite）获取文件并注
     filename=file.name
 
 可用字段
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~
 
 .. list-table::
    :header-rows: 1
@@ -192,7 +377,7 @@ Google Workspace连接器提供从Google Drive（原G Suite）获取文件并注
    * - ``file.web_view_link``
      - 在浏览器中打开的链接
    * - ``file.url``
-     - 文件的URL
+     - 文件的URL。使用 ``webViewLink``\ ；若文件没有该值，则使用 ``https://drive.google.com/open?id=<文件ID>``
    * - ``file.thumbnail_link``
      - 缩略图链接（短期有效）
    * - ``file.size``
@@ -200,13 +385,53 @@ Google Workspace连接器提供从Google Drive（原G Suite）获取文件并注
    * - ``file.roles``
      - 访问权限
 
+.. note::
+
+   只有 ``fields`` 参数中列出的字段才会被填充。未请求的字段在脚本中为null。如需像旧版本那样
+   请求全部字段，请设置 ``fields=*``\ 。
+
 详情请参阅 `Google Drive Files API <https://developers.google.com/drive/api/v3/reference/files>`_\ 。
+
+Google原生格式的文本提取
+------------------------
+
+Google原生格式的文件无法下载，必须导出。导出目标格式并非取自固定的对照表，而是从Drive API
+实际返回的导出格式中选择，且单次导出上限为10MB。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 类型
+     - 导出格式
+   * - Google文档
+     - Markdown（``text/markdown``\ ）。不可用时依次回退为纯文本、HTML
+   * - Google电子表格
+     - TSV（``text/tab-separated-values``\ ）。不可用时回退为CSV
+   * - Google幻灯片
+     - 纯文本
+   * - Google绘图
+     - PNG。没有可索引的文本，因此仅注册元数据
+   * - Apps Script
+     - 从导出的JSON中提取脚本源代码并索引
+   * - Google表单、Google协作平台
+     - 无法导出。仅注册元数据，且不会产生错误
+
+.. note::
+
+   由于Google文档现在以Markdown导出，所有Google文档的索引文本中都会包含Markdown语法字符。
+   要让该变更作用于已索引的文档，需要执行一次全量重新爬取。
+
+.. note::
+
+   导出格式每次爬取会从Drive API获取一次。若该调用失败，连接器会回退到Drive一直以来支持的
+   转换方式（Google文档为纯文本，Google电子表格为CSV），并输出一条警告日志。
 
 Google Cloud Platform设置
 =========================
 
 1. 创建项目
----------------------
+-----------
 
 访问 https://console.cloud.google.com/:
 
@@ -215,15 +440,16 @@ Google Cloud Platform设置
 3. 选择组织和位置
 
 2. 启用Google Drive API
----------------------------
+-----------------------
 
 在「API和服务」→「库」中:
 
 1. 搜索「Google Drive API」
 2. 点击「启用」
+3. 当 ``crawl_target`` 为 ``users`` 或 ``both`` 时，同时启用「Admin SDK API」
 
 3. 创建服务账号
----------------------------
+---------------
 
 在「API和服务」→「凭据」中:
 
@@ -234,7 +460,7 @@ Google Cloud Platform设置
 5. 点击「完成」
 
 4. 创建服务账号密钥
--------------------------------
+-------------------
 
 在创建的服务账号中:
 
@@ -245,7 +471,7 @@ Google Cloud Platform设置
 5. 保存下载的JSON文件
 
 5. 启用域全域委派
------------------------------
+-----------------
 
 在服务账号设置中:
 
@@ -254,7 +480,7 @@ Google Cloud Platform设置
 3. 复制「OAuth 2客户端ID」
 
 6. 在Google Workspace管理控制台授权
----------------------------------------
+-----------------------------------
 
 访问 https://admin.google.com/:
 
@@ -266,15 +492,28 @@ Google Cloud Platform设置
 
    ::
 
-       https://www.googleapis.com/auth/drive
+       https://www.googleapis.com/auth/drive.readonly
+
+   当 ``crawl_target`` 为 ``users`` 或 ``both`` 时，请输入两个范围:
+
+   ::
+
+       https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
 
 6. 点击「授权」
 
+.. warning::
+
+   委派配置会明确列出各个范围，因此从旧版本升级时必须更新。15.9中默认范围已从
+   ``https://www.googleapis.com/auth/drive`` 收窄为
+   ``https://www.googleapis.com/auth/drive.readonly``\ ，此处授予的范围必须与数据存储配置的
+   ``scopes`` 参数保持一致。
+
 认证信息设置
-==============
+============
 
 从JSON文件获取信息
---------------------------
+------------------
 
 下载的JSON文件:
 
@@ -300,7 +539,7 @@ Google Cloud Platform设置
 - ``client_email`` → ``client_email``
 
 私钥格式
-~~~~~~~~~~~~
+~~~~~~~~
 
 ``private_key`` 的换行保持为 ``\n``:
 
@@ -309,10 +548,10 @@ Google Cloud Platform设置
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG...\n-----END PRIVATE KEY-----\n
 
 使用示例
-======
+========
 
-Google Drive全体爬取
---------------------------
+爬取所有共享云端硬盘
+--------------------
 
 参数:
 
@@ -321,6 +560,8 @@ Google Drive全体爬取
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
 
 脚本:
 
@@ -335,10 +576,11 @@ Google Drive全体爬取
     thumbnail=file.thumbnail_link
     content_length=file.size
     filetype=file.filetype
+    role=file.roles
     filename=file.name
 
-带权限爬取
-----------------
+爬取所有用户的「我的云端硬盘」
+------------------------------
 
 参数:
 
@@ -347,6 +589,43 @@ Google Drive全体爬取
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=users
+    impersonate_user=admin@example.com
+    scopes=https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
+
+如需缩小用户范围，可添加Admin SDK查询:
+
+::
+
+    user_query=orgUnitPath=/Sales
+
+保留原有行为
+------------
+
+``crawl_target=legacy`` 保留15.9之前的遍历方式，只能找到显式共享给服务账号的文件。
+不需要 ``impersonate_user``\ 。
+
+参数:
+
+::
+
+    private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
+    private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
+    client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=legacy
+
+带权限爬取
+----------
+
+参数:
+
+::
+
+    private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
+    private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
+    client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     default_permissions={role}drive-users
 
 脚本:
@@ -362,8 +641,10 @@ Google Drive全体爬取
     role=file.roles
     filename=file.name
 
+``default_permissions`` 仅用于Drive ACL解析结果为空的文档。
+
 只爬取特定文件类型
---------------------------------
+------------------
 
 只爬取Google文档:
 
@@ -379,10 +660,26 @@ Google Drive全体爬取
     }
 
 故障排除
-======================
+========
+
+爬取无法启动
+------------
+
+**症状**: 爬取立即以 ``DataStoreException`` 结束
+
+**解决方法**:
+
+1. ``parameter 'crawl_target' must be one of ...`` : ``crawl_target`` 的值不是 ``legacy``\ 、
+   ``shared_drives``\ 、``users``\ 、``both`` 中的任何一个
+2. ``parameter 'impersonate_user' is required when 'crawl_target' is not 'legacy'`` :
+   请将 ``impersonate_user`` 设置为域管理员账号，或设置 ``crawl_target=legacy``
+3. ``parameter 'scopes' must include 'https://www.googleapis.com/auth/admin.directory.user.readonly'`` :
+   请将该范围添加到 ``scopes`` 以及域全域委派的配置中
+
+将现有配置原样升级时，这是预期结果。请参阅 `15.9的变更`_\ 。
 
 认证错误
-----------
+--------
 
 **症状**: ``401 Unauthorized`` 或 ``403 Forbidden``
 
@@ -397,10 +694,12 @@ Google Drive全体爬取
 2. 确认Google Drive API是否已启用
 3. 确认是否已设置域全域委派
 4. 确认是否已在Google Workspace管理控制台授权
-5. 确认OAuth范围是否正确（``https://www.googleapis.com/auth/drive``）
+5. 确认OAuth范围是否正确（``https://www.googleapis.com/auth/drive.readonly``\ ；当
+   ``crawl_target`` 为 ``users`` 或 ``both`` 时还需要
+   ``https://www.googleapis.com/auth/admin.directory.user.readonly``\ ）
 
 域全域委派错误
-------------------------
+--------------
 
 **症状**: ``Not Authorized to access this resource/api``
 
@@ -409,35 +708,57 @@ Google Drive全体爬取
 1. 在Google Workspace管理控制台确认授权:
 
    - 客户端ID是否正确注册
-   - OAuth范围是否正确（``https://www.googleapis.com/auth/drive``）
+   - OAuth范围是否正确。委派配置会明确列出各个范围，因此需要配合15.9的范围变更进行更新
 
 2. 确认服务账号是否启用了域全域委派
+3. 当 ``crawl_target`` 为 ``shared_drives`` 或 ``both`` 时，确认 ``impersonate_user``
+   指定的账号是否为域管理员
 
 无法获取文件
-----------------------
+------------
 
 **症状**: 爬取成功但文件数为0
 
 **确认事项**:
 
-1. 确认Google Drive中是否存在文件
-2. 确认服务账号是否有读取权限
-3. 确认域全域委派是否正确设置
-4. 确认是否可以访问目标用户的Drive
+1. 确认 ``crawl_target`` 是否为预期的值。使用 ``legacy`` 时，由于服务账号没有自己的Drive
+   且不属于任何群组，只能找到显式共享的文件
+2. 确认Google Drive中是否存在文件
+3. 确认服务账号是否有读取权限
+4. 确认域全域委派是否正确设置
+5. 确认是否可以访问目标用户的Drive
+
+文档被跳过
+----------
+
+**症状**: 爬虫日志中输出 ``Skipped ... because no permission could be resolved``
+
+**解决方法**:
+
+该文档的Drive ACL未能解析出任何搜索角色，因此被跳过而未被索引。以无角色的方式索引会使该文档
+的 |Fess| 权限过滤失效，从而对所有用户可见，因此选择跳过。跳过不属于爬取失败，只会输出到爬虫
+日志，不会出现在失败URL列表中。
+
+1. 如需以回退权限索引这类文档，请设置 ``default_permissions``
+2. 为了能够读取共享云端硬盘的ACL，请确认 ``impersonate_user`` 指定的账号是域管理员
+3. 确认该文档是否仅通过链接共享。``allowFileDiscovery=false`` 的 ``domain`` 和 ``anyone``
+   权限不会授予搜索角色，因为Drive自身同样不会让这类文档可被搜索发现
 
 API配额错误
------------------
+-----------
 
 **症状**: ``403 Rate Limit Exceeded`` 或 ``429 Too Many Requests``
 
 **解决方法**:
 
-1. 在Google Cloud Platform确认配额
-2. 增加爬取间隔
-3. 如需要，请求增加配额
+1. 这类失败会以指数退避自动重试。若仍然失败，请调大 ``max_retries`` 或 ``max_backoff_ms``
+2. 调小 ``number_of_threads`` 以降低请求频率
+3. 在Google Cloud Platform确认配额
+4. 增加爬取间隔
+5. 如需要，请求增加配额
 
 私钥格式错误
---------------------------
+------------
 
 **症状**: ``Invalid private key format``
 
@@ -456,11 +777,14 @@ API配额错误
     -----END PRIVATE KEY-----
 
 共享云端硬盘爬取
-----------------------
+----------------
 
 .. note::
-   使用服务账号爬取共享云端硬盘时，
-   需要将服务账号作为成员添加到共享云端硬盘。
+   使用 ``crawl_target=shared_drives``\ （默认值）时，会以域管理员权限枚举共享云端硬盘，
+   因此不需要把服务账号逐一加入各个共享云端硬盘。取而代之的是，``impersonate_user`` 必须
+   指定一个域管理员。
+
+使用 ``crawl_target=legacy`` 时，需要将服务账号添加到每个共享云端硬盘:
 
 1. 在Google Drive中打开共享云端硬盘
 2. 点击「管理成员」
@@ -468,22 +792,56 @@ API配额错误
 4. 将权限级别设置为「查看者」
 
 有大量文件的情况
-------------------------
+----------------
 
 **症状**: 爬取耗时长或超时
 
 **解决方法**:
 
-1. 分割成多个数据存储
-2. 通过计划设置分散负载
-3. 调整爬取间隔
-4. 只爬取特定文件夹
+1. 启用 ``incremental=true``\ ，只爬取自上次执行以来的变更
+2. 不使用 ``crawl_target=both``\ ，而是将共享云端硬盘和用户拆分到不同的数据存储配置中
+3. 使用 ``query``\ 、``user_query``\ 、``supported_mimetypes`` 缩小范围
+4. 通过计划设置分散负载
+5. 调整爬取间隔
 
 权限和访问控制
-==================
+==============
+
+Drive权限到Fess角色的转换
+-------------------------
+
+文档的ACL按以下三个阶段解析，使额外的API调用次数与共享云端硬盘的数量成正比，而不是与文件数量
+成正比：
+
+1. 文件列表中已包含的内联权限，不产生额外开销；
+2. 对于Drive API不返回内联权限的共享云端硬盘项目，使用共享云端硬盘自身的ACL。它以域管理员
+   权限按云端硬盘获取一次并被缓存；
+3. 对于自身带有额外权限的项目，使用该项目自身的权限。
+
+每条Drive权限按下表转换为 |Fess| 的搜索角色：
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Drive权限
+     - 搜索角色
+   * - ``user``
+     - 该用户邮箱地址对应的搜索角色。文件的所有者也始终以这种方式添加
+   * - ``group``
+     - 该群组邮箱地址对应的搜索角色。Google群组的成员不会被展开，需要由 |Fess| 一侧通过SSO或LDAP解析
+   * - ``domain``
+     - 将 ``domain_permission_format`` 中的 ``{domain}`` 替换为域名后的结果。默认值：``{group}{domain}``
+   * - ``anyone``
+     - ``guest`` 角色
+   * - 上述权限中 ``allowFileDiscovery=false`` 的，以及已删除的权限
+     - 无角色。因为仅通过链接共享在Drive自身也无法被搜索发现
+
+当解析结果为空时，会改用 ``default_permissions``\ ——作为回退值，而非追加值。若
+``default_permissions`` 也未设置，则该文档会被跳过。
 
 反映Google Drive的共享权限
-----------------------------
+--------------------------
 
 将Google Drive的共享设置反映到Fess的权限:
 
@@ -494,6 +852,8 @@ API配额错误
     private_key=-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQE...\n-----END PRIVATE KEY-----\n
     private_key_id=46812a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r
     client_email=fess-crawler@your-project-123456.iam.gserviceaccount.com
+    crawl_target=shared_drives
+    impersonate_user=admin@example.com
     default_permissions={role}drive-users
 
 脚本:
@@ -509,6 +869,27 @@ API配额错误
     url=file.web_view_link
 
 ``file.roles`` 包含Google Drive的共享信息。
+
+限制事项
+========
+
+- Drive表示「已移除」的变更通知不仅包含删除，也包含访问权限的丧失。当 ``crawl_target=users``
+  或 ``both`` 时，撤销某个用户的访问权限会使该文档从索引中删除，即使另一个用户仍然可以读取它。
+  该文档会在下一次变更时，或下一次全量爬取时恢复。
+- 增量爬取过程中某个范围回退为全量爬取时，删除旧文档的处理仍然处于关闭状态，因此在该范围
+  未记录起始位置期间从Drive删除的文档会残留在索引中。要删除它们，需要另行准备一个
+  ``incremental=false`` 的数据存储配置。
+- 删除的传播以索引URL中包含Drive文件ID为前提。``webViewLink`` 和回退URL满足该条件，但如果
+  爬取脚本将 ``url`` 改写为不包含文件ID的值，删除将无法传播。
+- 变更源不会按 ``query`` 过滤。设置了 ``query`` 且 ``incremental=true`` 时，即使发生变更的
+  文件不匹配该查询，也仍会被索引。
+- 在大型域中使用 ``crawl_target=both`` 时，大约会产生
+  ``2 + 共享云端硬盘数量 + 用户数量`` 次列表获取。将共享云端硬盘和用户拆分到不同的数据存储
+  配置中是切实可行的缓解方式。
+- ``proxy_username`` 和 ``proxy_password`` 以 ``Proxy-Authorization`` 请求头发送，因此只能
+  认证明文HTTP请求。Google API的通信全部为HTTPS，而经由需要认证的代理建立HTTPS连接是通过
+  ``CONNECT`` 完成的，该过程由JDK的 ``java.net.Authenticator`` 处理，而不是请求头。这类环境
+  需要改用JVM选项 ``-Djdk.http.auth.tunneling.disabledSchemes=`` 并配置 ``Authenticator``\ 。
 
 参考信息
 ========


### PR DESCRIPTION
## Summary

Revises the Google Workspace connector page for 15.9 in all seven languages. The connector was
substantially reworked and several of the changes break existing configurations at startup, so the
documentation needed to change with it.

Only the `15.9` (development) tree is touched. No released version tree is modified.

## Why this is a large diff

15.9 changes the connector's default behaviour in ways an operator must know about before upgrading:

- `crawl_target` defaults to `shared_drives` and requires `impersonate_user`, so an unchanged
  configuration **fails at startup**. The `crawl_target=legacy` escape hatch is documented alongside it.
- The default OAuth scope narrowed to `drive.readonly`, and `crawl_target=users`/`both` additionally
  require `admin.directory.user.readonly` — both of which must also be authorised in the Google
  Workspace admin console's domain-wide delegation entry.
- `default_permissions` became a fallback rather than an addition; link-only sharing no longer grants
  a search role; a document whose ACL resolves to nothing is now skipped rather than indexed with no
  roles at all.
- The indexed URL, the `fields` default, and the Google Docs/Sheets export formats all changed, each
  requiring a re-crawl.

New sections cover `crawl_target`, incremental crawling, rate limiting and retries, text extraction,
and a Limitations section.

## Accuracy

Everything was checked against the connector source rather than against the plan, which corrected
several points:

- **`url_filter` is not a parameter.** It exists as an internal constant but is never read from the
  configuration, so setting it does nothing. `include_pattern` / `exclude_pattern` are the real
  filtering knobs, and are documented instead.
- `corpora` is inert under the default crawl target — only `legacy` reads it.
- `spaces` applies to `legacy` and `users`, not `legacy` alone.
- `page_size` and `permission_page_size` are clamped, not merely defaulted; a larger value is
  silently reduced because the API rejects anything above the cap.
- "A failing drive or user no longer aborts the crawl" is only half true: per-drive and per-user file
  listings are skipped and reported, but drive enumeration, user enumeration and permission listing
  still fail the crawl deliberately, so a crawl that enumerated nothing cannot report success.
- Export targets are chosen from the live `exportFormats` map, so Markdown and TSV apply only where
  Drive offers them; the documented fallback is plain text and CSV.
- Drawings are metadata-only as well as Forms and Sites.
- `start_page_tokens` and `crawl_signature` are written back by the plugin into the handler parameter
  field, where they look user-editable. The pages now say to leave them alone.

The proxy authentication limitation is documented rather than glossed: the credentials travel as a
`Proxy-Authorization` request header, which does not authenticate an HTTPS `CONNECT` tunnel — and all
Google API traffic is HTTPS. The JVM-level workaround is given.

## Validation

All seven files parse cleanly under `docutils` at INFO level and above, with the Sphinx-only `:doc:`
role and the `|Fess|` substitution stubbed. That covers heading underline widths, directive syntax,
`list-table` structure, inline markup and internal target resolution. Two pre-existing warning sets
were fixed in passing (30 in `fr`, 5 in `ko`, all short underlines); both are now zero.

Parity was checked by script: the parameter-name set is identical across all seven files, and every
internal section reference resolves in each.

**A full Sphinx build was not run.** `conf/ext.py` is Python 2 source and fails to import under the
available Python 3.12 / Sphinx 9.1. That is unrelated to this change, but it means the HTML output is
unverified here.

## Pre-existing gap in the Spanish page — not introduced here

`es/15.9/config/datastore/ds-gsuite.rst` is missing **ten** sections that the other six languages
have, and has been for some time:

- the entire Usage Examples chapter and its three subsections,
- the entire Permissions and Access Control chapter and its subsection,
- four troubleshooting entries: API Quota Error, Private Key Format Error, Crawling Shared Drives,
  and Large Number of Files.

Every genuinely new 15.9 section was added to Spanish along with the rest. The pre-existing gap was
deliberately left alone rather than folded into this change. One consequence worth noting: because
Spanish has no permissions chapter, the Drive-permission-to-Fess-role mapping table appears in six
languages but not Spanish, which carries the same semantics in its changes table, the
`default_permissions` row and Limitations instead.

Worth a separate issue.
