### PR TITLE
docs: rewrite the JSON connector page for the 15.9 implementation

### DIFF
--- a/de/15.9/config/datastore/ds-json.rst
+++ b/de/15.9/config/datastore/ds-json.rst
@@ -1,50 +1,74 @@
-==============
+================
 JSON-Konnektor
-==============
+================
 
 Übersicht
-=========
+===========
 
-Der JSON-Konnektor bietet die Funktionalität, Daten aus lokalen JSONL-Dateien
-(JSON-Lines-Format) abzurufen und im |Fess|-Index zu registrieren.
+Der JSON-Konnektor bietet die Funktionalität, Daten aus JSON-Dateien im lokalen
+Dateisystem abzurufen und im |Fess|-Index zu registrieren.
 
 Für diese Funktion ist das Plugin ``fess-ds-json`` erforderlich.
 
+Es werden die folgenden drei Formate unterstützt; standardmäßig wird das Format
+automatisch anhand des Dateiinhalts erkannt.
+
+- JSON-Lines-Format (ein JSON-Objekt pro Zeile)
+- Array von JSON-Objekten (sowohl formatiert/eingerückt als auch in einer einzigen
+  Zeile möglich)
+- ein einzelnes JSON-Objekt
+
+Da die Datensätze einzeln eingelesen werden, wird selbst bei einem großen Array
+niemals die gesamte Datei im Speicher gehalten.
+
+.. note::
+
+   Dieser Konnektor verarbeitet ausschließlich JSON-Dateien im lokalen Dateisystem.
+   Ein entfernter Abruf, etwa über HTTP, wird nicht unterstützt; wird der Parameter
+   ``urls`` angegeben, wird dieser nicht ignoriert, sondern führt zu einem Fehler.
+
 Voraussetzungen
-================
+==================
 
 1. Die Installation des Plugins ist erforderlich
-2. Lesezugriff auf die JSON-Dateien ist erforderlich
+2. Zugriffsrechte auf die JSON-Dateien sind erforderlich
 3. Die Struktur der JSON-Daten muss bekannt sein
 
 Plugin-Installation
---------------------
+----------------------
 
-Methode 1: JAR-Datei direkt platzieren
-
-::
-
-    # Von Maven Central herunterladen
-    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
-
-    # Platzieren
-    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
-    # oder
-    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
-
-Methode 2: Über die Administrationsoberfläche installieren
+Methode 1: Installation über die Administrationsoberfläche
 
 1. Öffnen Sie "System" -> "Plugins"
 2. Laden Sie die JAR-Datei hoch
 3. Starten Sie |Fess| neu
 
+Methode 2: JAR-Datei direkt platzieren
+
+::
+
+    # Vom CodeLibs-Repository herunterladen
+    wget https://maven.codelibs.org/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
+
+    # Platzieren
+    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/plugin/
+    # oder
+    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/plugin/
+
+.. note::
+
+   Ab Version 15.8.0 werden die JAR-Dateien über das
+   `CodeLibs-Repository <https://maven.codelibs.org/release/org/codelibs/fess/fess-ds-json/>`_
+   bereitgestellt. Für Version 15.7.0 und früher finden Sie sie auf
+   `Maven Central <https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/>`_.
+
 Konfiguration
-=============
+===============
 
 Konfigurieren Sie über die Administrationsoberfläche unter "Crawler" -> "Datenspeicher" -> "Neu erstellen".
 
 Grundeinstellungen
--------------------
+----------------------
 
 .. list-table::
    :header-rows: 1
@@ -60,87 +84,192 @@ Grundeinstellungen
      - Ein
 
 Parameter-Einstellungen
-------------------------
+---------------------------
 
 Lokale Datei:
 
 ::
 
-    files=/path/to/data.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
 Mehrere Dateien:
 
 ::
 
-    files=/path/to/data1.json,/path/to/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/data1.json,/var/data/data2.json
+    file_encoding=UTF-8
 
 Verzeichnisangabe:
 
 ::
 
-    directories=/path/to/json_dir/
-    fileEncoding=UTF-8
+    directories=/var/data/json_dir/
+    file_encoding=UTF-8
 
 Parameterliste
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 10 70
+   :widths: 22 12 66
 
    * - Parameter
-     - Erforderlich
+     - Standardwert
      - Beschreibung
    * - ``files``
-     - Nein
-     - Pfad zur zu verarbeitenden JSON-Datei (mehrere Angaben möglich: kommagetrennt). Nur Dateien mit der Erweiterung ``.json`` oder ``.jsonl`` werden verarbeitet.
+     -
+     - Pfad zu den zu verarbeitenden JSON-Dateien (mehrere Angaben möglich: kommagetrennt). Die Dateien werden in der angegebenen Reihenfolge verarbeitet.
    * - ``directories``
-     - Nein
-     - Pfad zum Verzeichnis mit JSON-Dateien (mehrere Angaben möglich: kommagetrennt)
-   * - ``fileEncoding``
-     - Nein
-     - Zeichenkodierung (Standard: UTF-8)
+     -
+     - Pfad zu Verzeichnissen, die JSON-Dateien enthalten (mehrere Angaben möglich: kommagetrennt).
+   * - ``recursive``
+     - ``false``
+     - Gibt an, ob ``directories`` auch in Unterverzeichnissen durchsucht wird.
+   * - ``max_depth``
+     - ``10``
+     - Bei ``recursive=true`` die Anzahl der Verzeichnisebenen, bis zu der jeweils hinabgestiegen wird. Bei ``0`` entspricht das Verhalten ``recursive=false``.
+   * - ``include_pattern``
+     -
+     - Regulärer Ausdruck, dem der absolute Pfad einer Datei vollständig entsprechen muss.
+   * - ``exclude_pattern``
+     -
+     - Regulärer Ausdruck, dem der absolute Pfad einer Datei nicht entsprechen darf.
+   * - ``file_suffixes``
+     - ``.json,.jsonl``
+     - Zu verarbeitende Dateiendungen (mehrere Angaben möglich: kommagetrennt). Groß-/Kleinschreibung wird nicht unterschieden.
+   * - ``file_encoding``
+     - ``UTF-8``
+     - Zeichenkodierung der Datei.
+   * - ``format``
+     - ``auto``
+     - Format des Dokuments. Einer von ``auto``, ``jsonl`` oder ``json``.
+   * - ``root_path``
+     -
+     - JSON Pointer, der die Position angibt, ab der Datensätze gelesen werden (Beispiel: ``/data/items``).
+
+.. note::
+
+   Die Parameternamen sind hier in snake_case angegeben; die entsprechende Schreibweise
+   in camelCase (z. B. ``fileEncoding`` für ``file_encoding``) kann jedoch ebenso
+   verwendet werden.
+
+.. note::
+
+   Geben Sie mindestens einen der Parameter ``files`` oder ``directories`` an.
+   Sind beide leer, führt dies zu einem Fehler.
+   Die beiden Parameter schließen sich nicht gegenseitig aus; werden beide angegeben,
+   werden beide verarbeitet. Ist dieselbe Datei über beide Parameter erreichbar, wird
+   sie dennoch nur einmal eingelesen.
+
+Verarbeitungsreihenfolge der Dateien
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Die mit ``files`` angegebenen Dateien werden in der angegebenen Reihenfolge
+  verarbeitet.
+- Die unter ``directories`` gefundenen Dateien werden in aufsteigender Reihenfolge
+  nach Änderungsdatum (älteste zuerst) verarbeitet.
+- Die mit ``files`` angegebenen Dateien werden vor den Dateien unter ``directories``
+  verarbeitet.
+
+Die Einschränkung durch ``file_suffixes`` gilt auch für die direkt über ``files``
+angegebenen Dateien. Dateien, deren Endung nicht übereinstimmt, werden übersprungen,
+wobei der Grund im Log ausgegeben wird.
+
+Ein nicht vorhandener Pfad, ein bei ``files`` angegebenes Verzeichnis oder eine bei
+``directories`` angegebene Datei werden jeweils als Warnung im Log protokolliert;
+das Crawling selbst wird fortgesetzt.
+
+``format``
+-------------
+
+``auto`` liest den Anfang des Dokuments und bestimmt das Format anhand seiner Syntax.
+Bei einer korrekt geschriebenen Datei lässt sich das Format so unabhängig davon
+erkennen, um welches der drei Formate es sich handelt.
+
+``format=jsonl`` sollten Sie explizit angeben, wenn es sich um eine Datei im
+JSON-Lines-Format handelt, bei der die Zeilen nahe dem Dateianfang möglicherweise
+beschädigt sind (z. B. Banner-Zeilen, Fortschrittsprotokolle oder durch einen
+abgebrochenen Transfer unvollständige Datensätze). Die automatische Erkennung müsste
+solche Zeilen überspringen, um das Format zu bestimmen.
+
+Diese Einstellung bestimmt zugleich, wie weit sich ein fehlerhafter Datensatz
+auswirkt.
+
+- **JSON-Lines-Format**: Da jede Zeile unabhängig geparst wird, betrifft eine
+  fehlerhafte Zeile ausschließlich diese Zeile selbst. Der Fehler wird unter dem
+  Schlüssel ``<absoluter Dateipfad>@<Zeilennummer>`` als Fehler-URL erfasst, und die
+  Verarbeitung wird ab der nächsten Zeile unverändert fortgesetzt.
+- **Alle anderen Formate**: Da die Datei als Token-Stream eingelesen wird, kann ein
+  einzelner Fehler nachfolgende Datensätze in Mitleidenschaft ziehen. Ein Dokument,
+  das mitten in einem Objekt abbricht, kann sich davon nicht mehr erholen; schlägt die
+  Verarbeitung eine bestimmte Anzahl Mal in Folge fehl, wird die betreffende Datei mit
+  einer Warnung abgebrochen.
+
+``root_path``
+----------------
+
+Geben Sie einen JSON Pointer an, der auf ein verschachteltes Array zeigt, werden
+dessen Elemente als Datensätze registriert.
+
+::
+
+    root_path=/data/items
+
+.. code-block:: json
+
+    { "meta": { "count": 2 }, "data": { "items": [ { "id": "1" }, { "id": "2" } ] } }
+
+- Zeigt der Pointer auf ein Array, wird jedes seiner Elemente zu einem Datensatz.
+- Zeigt der Pointer auf ein Objekt, wird dieses Objekt zu einem einzigen Datensatz.
+- Trifft der Pointer auf nichts zu, führt dies nicht zu einem Fehler, sondern zu
+  0 Datensätzen.
+- Die JSON-Pointer-Escape-Sequenzen (``~1`` für ``/`` und ``~0`` für ``~``) können
+  verwendet werden.
+
+``root_path`` hat Vorrang vor ``format``. Ein über einen JSON Pointer erreichtes
+Dokument wird nicht zeilenweise eingelesen; wird ``root_path`` zusammen mit
+``format=jsonl`` angegeben, wird dazu eine entsprechende Warnung im Log ausgegeben.
 
 .. warning::
-   Es muss entweder ``files`` oder ``directories`` angegeben werden.
-   Wenn keiner der beiden Parameter angegeben ist (leer), wird eine ``DataStoreException`` ausgelöst.
-   Wenn beide angegeben sind, hat ``files`` Vorrang und ``directories`` wird ignoriert.
+
+   ``root_path`` muss mit ``/`` beginnen. Fehlt das führende ``/`` wie bei
+   ``data/items``, kann der Wert nicht als JSON Pointer interpretiert werden, und die
+   gesamte Datenspeicher-Konfiguration schlägt mit einem Fehler fehl. Die Fehler-URL
+   wird in diesem Fall nicht unter dem Parameternamen, sondern unter der
+   Datenspeicher-Konfiguration selbst erfasst; welcher Parameter die Ursache ist,
+   lässt sich daher nur anhand von
+   ``JSON Pointer expression must start with '/'`` im Log erkennen.
 
 .. note::
-   Der Parametername lautet im camelCase ``fileEncoding`` (nicht ``file_encoding`` in snake_case).
 
-Verhalten bei Verzeichnisangabe
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Wenn ``directories`` angegeben ist, werden die Dateien direkt im jeweiligen Verzeichnis nach folgenden Regeln verarbeitet.
-
-- **Unterverzeichnisse werden nicht durchsucht** (keine rekursive Suche).
-- Nur Dateien mit der Erweiterung ``.json`` oder ``.jsonl`` werden berücksichtigt (Groß-/Kleinschreibung wird nicht unterschieden).
-- Die Dateien werden in aufsteigender Reihenfolge nach Änderungsdatum (letzter Änderungszeitpunkt) verarbeitet.
-
-.. note::
-   Dieser Konnektor unterstützt ausschließlich JSON-Dateien im lokalen Dateisystem. HTTP-Zugriff und API-Authentifizierung werden nicht unterstützt.
+   Wird ein über mehrere Zeilen formatiertes Dokument (ein sogenanntes
+   Wrapper-Format, das Metainformationen und ein Array enthält) ohne Angabe von
+   ``root_path`` eingelesen, wird versucht, es zeilenweise zu parsen; die
+   beabsichtigten Datensätze werden dabei nicht erfasst, und es wird ein Fehler
+   aufgezeichnet. Geben Sie für solche Dokumente ``root_path`` an.
 
 Skript-Einstellungen
----------------------
+------------------------
 
-Die Werte der einzelnen Felder werden aus den Feldern des jeweiligen JSON-Objekts zusammengesetzt.
-Felder auf der obersten Ebene des JSON-Objekts können im Skript als **Variablen ohne Präfix**
-direkt referenziert werden (kein Präfix wie ``data.``).
+Die Werte der einzelnen Felder werden unter Bezugnahme auf die Werte der Felder des
+JSON-Objekts zusammengesetzt. Auf die Felder der obersten Ebene des JSON-Objekts kann
+im Skript direkt als **Variablen ohne Präfix** zugegriffen werden (es wird kein
+Präfix wie ``data.`` verwendet).
 
 Einfaches JSON-Objekt:
 
 ::
 
-    url="https://example.com/product/" + id
+    url="https://shop.example.com/product/" + id
     title=name
     content=description
-    price=price
-    category=category
+    digest=description
+    host="shop.example.com"
+    site="shop.example.com"
 
-Verschachteltes JSON-Objekt (verschachtelte Objekte werden als Map referenziert):
+Verschachtelte Objekte können als Map, verschachtelte Arrays als Liste referenziert
+werden:
 
 ::
 
@@ -148,67 +277,79 @@ Verschachteltes JSON-Objekt (verschachtelte Objekte werden als Map referenziert)
     title=product.name
     content=product.description
     price=product.pricing.amount
-    author=product.author.name
-
-Verarbeitung von Array-Elementen:
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=body
-    tags=tags.join(", ")
-    categories=categories[0].name
+    first_tag=tags[0]
 
 Verfügbare Felder
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
-- ``<Feldname>`` - Felder auf der obersten Ebene des JSON-Objekts werden direkt beim Namen referenziert
-- ``<Elternteil>.<Kind>`` - Felder eines verschachtelten Objekts
+- ``<Feldname>`` - direkter Zugriff auf ein Feld der obersten Ebene des
+  JSON-Objekts über seinen Namen
+- ``<Elternteil>.<Kind>`` - Feld eines verschachtelten Objekts
 - ``<Array>[<Index>]`` - Array-Element
-- ``<Array>.<Methode>`` - Array-Methoden (``join``, ``collect``, ``size`` usw.)
 
 .. note::
 
-   Enthält ein Feldname Leerzeichen, Bindestriche oder andere Zeichen, die als Groovy-Bezeichner
-   ungültig sind, kann dieses Feld nicht direkt als Variablenname referenziert werden.
-
-JSON-Format-Details
-====================
-
-JSON-Dateiformat
------------------
-
-Der JSON-Konnektor liest Dateien im JSONL-Format (JSON Lines).
-Dabei wird pro Zeile ein JSON-Objekt geschrieben. Die Datei wird zeilenweise eingelesen,
-und jede Zeile wird als eigenständiges JSON-Objekt verarbeitet.
+   Ist der Wert eines Feldes ``null``, wird dieses Feld nicht im Dokument
+   registriert.
 
 .. note::
-   Dateien mit der Erweiterung ``.json`` werden ebenfalls verarbeitet, der Inhalt muss jedoch
-   im JSONL-Format vorliegen (ein Objekt pro Zeile).
-   JSON-Dateien im Array-Format (``[{...}, {...}]``) oder mehrzeilig formatierte
-   (pretty-printed) JSON-Dateien können nicht direkt eingelesen werden. Bitte konvertieren Sie
-   diese in das JSONL-Format.
 
-JSONL-Datei:
+   In |Fess| 15.9 ist JavaScript die eingebaute Skript-Engine. Groovy wird als
+   Plugin ``fess-script-groovy`` bereitgestellt. Welche Engine verwendet wird, geben
+   Sie über den Datenspeicher-Parameter ``script_type`` an (z. B.
+   ``script_type=javascript``). Wird der Parameter weggelassen, wird ``groovy``
+   verwendet. Einfache Verweise und Zeichenkettenverkettungen wie in den obigen
+   Beispielen funktionieren mit beiden Engines auf dieselbe Weise; darüber
+   hinausgehende Notationen unterscheiden sich jedoch je nach Engine.
 
-::
+Hinweise
+==========
 
-    {"id": 1, "name": "Product A", "description": "Description A"}
-    {"id": 2, "name": "Product B", "description": "Description B"}
+Parameter, deren Name auf ``app.encrypt.property.pattern`` passt (standardmäßig
+Namen, die auf ``password``, ``key``, ``token`` oder ``secret`` enden), werden im
+Skript als ``null`` referenziert. Dies verhindert, dass in den
+Datenspeicher-Parametern hinterlegte Zugangsdaten in ein Indexfeld kopiert werden.
+
+Existiert auf Seiten des Datensatzes ein Feld mit demselben Namen, hat wie bei den
+übrigen Parametern der Wert aus dem Datensatz Vorrang.
+
+.. note::
+
+   Der Abgleich erfolgt als vollständige, groß-/kleinschreibungssensitive
+   Übereinstimmung mit dem Parameternamen. ``access_token`` wird erfasst, das in
+   camelCase geschriebene ``accessToken`` hingegen nicht. Notieren Sie Zugangsdaten
+   in Parametern daher in snake_case.
+
+Fehlerhafte Parameter und Fehler
+===================================
+
+Wird für ``format``, ``include_pattern``, ``exclude_pattern`` oder ``urls`` ein
+ungültiger Wert angegeben, endet das Crawling bereits vor dem Einlesen der Dateien,
+und es wird eine Fehler-URL erfasst, die den Parameternamen enthält (Beispiel:
+``JsonDataStore:format``).
+
+Wird für ``max_depth`` ein nicht-numerischer Wert angegeben, wird dies im Log
+vermerkt, und es wird der Standardwert verwendet.
+
+.. note::
+
+   Ein Datenspeicher-Crawling wird als Job selbst dann erfolgreich beendet, wenn
+   kein einziger Datensatz abgerufen werden konnte. Weicht die Anzahl der
+   abgerufenen Datensätze von der Erwartung ab, überprüfen Sie die Anzahl der
+   Dokumente im Index, die Fehler-URLs sowie ``fess-crawler.log``.
 
 Anwendungsbeispiele
-====================
+======================
 
 Produktkatalog
----------------
+------------------
 
 Parameter:
 
 ::
 
-    files=/var/data/products.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
 Skript:
 
@@ -216,19 +357,20 @@ Skript:
 
     url="https://shop.example.com/product/" + product_id
     title=name
-    content=description + " Preis: " + price + " Yen"
+    content=description
     digest=category
-    price=price
+    host="shop.example.com"
+    site="shop.example.com"
 
-Integration mehrerer JSON-Dateien
------------------------------------
+Als Datei gespeicherte API-Antwort
+--------------------------------------
 
 Parameter:
 
 ::
 
-    files=/var/data/data1.json,/var/data/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/response.json
+    root_path=/data/items
 
 Skript:
 
@@ -236,136 +378,115 @@ Skript:
 
     url="https://example.com/item/" + id
     title=title
-    content=content
+    content=body
+    host="example.com"
+    site="example.com"
+
+Rekursive Verarbeitung eines Verzeichnisses
+-----------------------------------------------
+
+Parameter:
+
+::
+
+    directories=/var/data/exports
+    recursive=true
+    max_depth=3
+    include_pattern=.*\.jsonl
+    file_encoding=UTF-8
 
 Fehlerbehebung
-===============
+================
 
 Datei nicht gefunden
-----------------------
+------------------------
 
-**Symptom**: Im Protokoll wird ``... is not found.`` oder ``Source file ... does not exist.`` ausgegeben
+**Symptom**: Im Log wird ``... does not exist.``, ``... is not a file.`` oder
+``... is skipped because its suffix is not one of ...`` ausgegeben
 
-**Prüfpunkte**:
+**Zu überprüfen**:
 
 1. Überprüfen Sie, ob der Dateipfad korrekt ist
-2. Überprüfen Sie, ob die Datei vorhanden ist
-3. Überprüfen Sie, ob die Dateiendung ``.json`` oder ``.jsonl`` ist
-4. Überprüfen Sie, ob Leserechte für die Datei vorhanden sind
+2. Überprüfen Sie, ob die Datei existiert
+3. Überprüfen Sie, ob die Dateiendung mit ``file_suffixes`` (standardmäßig
+   ``.json`` oder ``.jsonl``) übereinstimmt
+4. Überprüfen Sie, ob der |Fess|-Ausführungsbenutzer über Leserechte verfügt
 
 JSON-Analysefehler
---------------------
+----------------------
 
-**Symptom**: Im Protokoll wird ``Crawling Access Exception`` zusammen mit ``JsonParseException`` o. a. ausgegeben
+**Symptom**: Im Log wird ``Failed to parse ...`` oder ``Failed to read ...``
+ausgegeben, oder es wird eine Fehler-URL erfasst
 
-Enthält eine Zeile ungültige Daten, wird nur diese Zeile übersprungen und als fehlgeschlagene URL
-erfasst; das Crawling selbst wird ab der nächsten Zeile fortgesetzt.
+**Zu überprüfen**:
 
-**Prüfpunkte**:
-
-1. Überprüfen Sie, ob die JSON-Datei im korrekten Format vorliegt (JSONL: ein Objekt pro Zeile):
+1. Prüfen Sie, ob die Datei gültiges JSON enthält
 
    ::
 
-       # Jede Zeile auf gültige JSON-Objekte prüfen
-       cat data.json | jq -c .
+       # Bei JSON-Lines-Format: prüfen, ob jede Zeile ein gültiges JSON-Objekt ist
+       cat data.jsonl | jq -c .
 
-2. Überprüfen Sie die Zeichenkodierung
-3. Überprüfen Sie, ob ein einzelnes Objekt über mehrere Zeilen verteilt ist
-4. Überprüfen Sie, ob Kommentare enthalten sind (Kommentare sind im JSON-Standard nicht erlaubt)
+       # Bei Array oder einzelnem Objekt
+       jq . data.json
 
-Keine Daten abgerufen
------------------------
+2. Überprüfen Sie, ob die Zeichenkodierung korrekt ist
+3. Überprüfen Sie, ob die Datei nicht abgeschnitten ist
+4. Überprüfen Sie, ob Kommentare enthalten sind (Kommentare sind im JSON-Standard
+   nicht zulässig)
 
-**Symptom**: Das Crawling ist erfolgreich, aber die Trefferanzahl beträgt 0
+Keine Daten abrufbar
+------------------------
 
-**Prüfpunkte**:
+**Symptom**: Das Crawling ist erfolgreich, die Anzahl beträgt jedoch 0
 
-1. Überprüfen Sie die JSON-Struktur
-2. Überprüfen Sie die Skript-Einstellungen (Felder werden ohne ``data.``-Präfix referenziert)
-3. Überprüfen Sie die Feldnamen (einschließlich Groß-/Kleinschreibung)
-4. Überprüfen Sie die Protokolldateien auf Fehlermeldungen
+**Zu überprüfen**:
+
+1. Wenn ``root_path`` angegeben ist, überprüfen Sie, ob der JSON Pointer mit der
+   Struktur des Dokuments übereinstimmt (bei fehlender Übereinstimmung entsteht kein
+   Fehler, sondern es werden 0 Datensätze erzeugt)
+2. Überprüfen Sie, ob durch ``include_pattern``, ``exclude_pattern`` oder
+   ``file_suffixes`` sämtliche Dateien ausgeschlossen wurden. In diesem Fall wird im
+   Log ``No sources to process`` ausgegeben
+3. Überprüfen Sie die Skript-Einstellungen (ob Feldverweise ohne ``data.``-Präfix
+   angegeben sind)
+4. Überprüfen Sie die Feldnamen (einschließlich Groß-/Kleinschreibung)
+5. Überprüfen Sie, ob ``url`` korrekt zusammengesetzt wird. Ist ``url`` leer,
+   schlägt der jeweilige Datensatz fehl
+
+Zeichenkodierungsprobleme
+-----------------------------
+
+**Symptom**: Die Zeichen im registrierten Dokument sind verstümmelt
+
+Geben Sie bei ``file_encoding`` eine existierende, aber falsche Kodierung an, tritt
+kein Fehler auf, und das Dokument wird mit verstümmelten Zeichen registriert.
+Überprüfen Sie die tatsächliche Zeichenkodierung der Datei. Geben Sie einen nicht
+existierenden Kodierungsnamen an, wird für jede Datei eine Fehler-URL erfasst.
 
 Große JSON-Dateien
---------------------
+----------------------
 
 **Symptom**: Speichermangel oder Zeitüberschreitung
 
-Da die Datei zeilenweise eingelesen wird, wirkt sich die Gesamtgröße der Datei nicht direkt auf
-den Speicherverbrauch aus. Probleme können jedoch auftreten, wenn eine einzelne Zeile
-(ein einzelnes Objekt) extrem groß ist oder die Last beim Indexieren sehr hoch ist.
+Da die Datensätze einzeln eingelesen werden, wirkt sich die Gesamtgröße der Datei
+nicht direkt auf den Speicherverbrauch aus. Probleme können jedoch auftreten, wenn
+ein einzelner Datensatz extrem groß ist oder die Last bei der Indexierung sehr hoch
+ist.
 
 **Lösung**:
 
 1. Teilen Sie die JSON-Datei in mehrere Dateien auf
 2. Erhöhen Sie die Heap-Größe von |Fess|
 
-Erweiterte Skript-Beispiele
-============================
-
-Bedingte Verarbeitung
------------------------
-
-Jedes Feld wird als eigenständiger Ausdruck ausgewertet. Für bedingte Werte verwenden Sie den
-ternären Operator:
-
-::
-
-    url=status == "published" ? "https://example.com/product/" + id : null
-    title=status == "published" ? name : null
-    content=status == "published" ? description : null
-    price=status == "published" ? price : null
-
-Array-Verknüpfung
--------------------
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=content
-    tags=tags ? tags.join(", ") : ""
-    categories=categories.collect { it.name }.join(", ")
-
-Standardwerte festlegen
--------------------------
-
-::
-
-    url="https://example.com/item/" + id
-    title=title ?: "Ohne Titel"
-    content=description ?: (summary ?: "Keine Beschreibung")
-    price=price ?: 0
-
-Datumsformatierung
---------------------
-
-::
-
-    url="https://example.com/post/" + id
-    title=title
-    content=body
-    created=created_at
-    last_modified=updated_at
-
-Numerische Verarbeitung
--------------------------
-
-::
-
-    url="https://example.com/product/" + id
-    title=name
-    content=description
-    price=price as Float
-    stock=stock_quantity as Integer
-
-Referenzen
-==========
+Weiterführende Informationen
+===============================
 
 - :doc:`ds-overview` - Übersicht der Datenspeicher-Konnektoren
 - :doc:`ds-csv` - CSV-Konnektor
 - :doc:`ds-database` - Datenbank-Konnektor
-- :doc:`../../admin/dataconfig-guide` - Datenspeicher-Konfigurationsleitfaden
+- :doc:`../../admin/dataconfig-guide` - Leitfaden zur Datenspeicher-Konfiguration
 - `JSON (JavaScript Object Notation) <https://www.json.org/>`_
 - `JSON Lines <https://jsonlines.org/>`_
+- `JSON Pointer (RFC 6901) <https://datatracker.ietf.org/doc/html/rfc6901>`_
 - `jq - JSON processor <https://stedolan.github.io/jq/>`_

--- a/en/15.9/config/datastore/ds-json.rst
+++ b/en/15.9/config/datastore/ds-json.rst
@@ -1,47 +1,70 @@
-==============
+==================================
 JSON Connector
-==============
+==================================
 
 Overview
 ========
 
-The JSON Connector provides functionality to retrieve data from local JSONL files
-(JSON Lines format) and register them in the |Fess| index.
+The JSON Connector provides functionality to retrieve data from JSON files
+on the local file system and register it in the |Fess| index.
 
 This feature requires the ``fess-ds-json`` plugin.
+
+It supports the following three formats, which are automatically detected
+from the file content by default.
+
+- JSON Lines format (one JSON object per line)
+- An array of JSON objects (either pretty-printed or on a single line)
+- A single JSON object
+
+Records are read one at a time, so even for a large array, the entire file
+is never held in memory.
+
+.. note::
+
+   This connector only targets JSON files on the local file system. It does
+   not support remote retrieval such as HTTP, and specifying the ``urls``
+   parameter results in an error rather than being ignored.
 
 Prerequisites
 =============
 
 1. Plugin installation is required
-2. Access to JSON files is required
-3. Understanding of JSON structure is necessary
+2. Access to the JSON file is required
+3. You must understand the structure of the JSON
 
 Plugin Installation
--------------------
+--------------------
 
-Method 1: Place JAR file directly
-
-::
-
-    # Download from Maven Central
-    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
-
-    # Place the file
-    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
-    # or
-    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
-
-Method 2: Install from admin console
+Method 1: Install from the admin console
 
 1. Open "System" -> "Plugins"
 2. Upload the JAR file
 3. Restart |Fess|
 
+Method 2: Place the JAR file directly
+
+::
+
+    # Download from the CodeLibs repository
+    wget https://maven.codelibs.org/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
+
+    # Place the file
+    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/plugin/
+    # or
+    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/plugin/
+
+.. note::
+
+   From 15.8.0 onward, JARs are distributed via the
+   `CodeLibs repository <https://maven.codelibs.org/release/org/codelibs/fess/fess-ds-json/>`_.
+   For 15.7.0 and earlier, they are available on
+   `Maven Central <https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/>`_.
+
 Configuration
 =============
 
-Configure in the admin console under "Crawler" -> "Data Store" -> "Create New".
+Configure from the admin console via "Crawler" -> "Data Store" -> "Create New".
 
 Basic Settings
 --------------
@@ -59,88 +82,191 @@ Basic Settings
    * - Enabled
      - On
 
-Parameter Configuration
------------------------
+Parameter Settings
+-------------------
 
 Local file:
 
 ::
 
-    files=/path/to/data.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
 Multiple files:
 
 ::
 
-    files=/path/to/data1.json,/path/to/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/data1.json,/var/data/data2.json
+    file_encoding=UTF-8
 
-Directory:
+Directory specification:
 
 ::
 
-    directories=/path/to/json_dir/
-    fileEncoding=UTF-8
+    directories=/var/data/json_dir/
+    file_encoding=UTF-8
 
 Parameter List
 ~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 10 70
+   :widths: 22 12 66
 
    * - Parameter
-     - Required
+     - Default
      - Description
    * - ``files``
-     - No
-     - Path to the JSON file(s) to process (multiple paths allowed: comma-separated). Only files with a ``.json`` or ``.jsonl`` extension are processed.
+     -
+     - Path(s) of the JSON files to process (multiple paths can be specified,
+       separated by commas). Files are processed in the order specified.
    * - ``directories``
-     - No
-     - Path to the directory containing JSON files (multiple paths allowed: comma-separated)
-   * - ``fileEncoding``
-     - No
-     - Character encoding (default: UTF-8)
+     -
+     - Path(s) of directories containing JSON files (multiple paths can be
+       specified, separated by commas).
+   * - ``recursive``
+     - ``false``
+     - Whether to traverse ``directories`` into subdirectories.
+   * - ``max_depth``
+     - ``10``
+     - When ``recursive=true``, how many levels down into each directory to
+       descend. Specifying ``0`` behaves the same as ``recursive=false``.
+   * - ``include_pattern``
+     -
+     - Regular expression that the file's absolute path must fully match.
+   * - ``exclude_pattern``
+     -
+     - Regular expression that the file's absolute path must not match.
+   * - ``file_suffixes``
+     - ``.json,.jsonl``
+     - Suffixes of the files to target (multiple suffixes can be specified,
+       separated by commas). Case-insensitive.
+   * - ``file_encoding``
+     - ``UTF-8``
+     - Character encoding of the file.
+   * - ``format``
+     - ``auto``
+     - The document format. One of ``auto``, ``jsonl``, or ``json``.
+   * - ``root_path``
+     -
+     - JSON Pointer specifying where to read records from (e.g.,
+       ``/data/items``).
+
+.. note::
+
+   Parameter names are written in snake_case above, but camelCase spellings
+   (such as ``fileEncoding`` for ``file_encoding``) can be used in the same
+   way.
+
+.. note::
+
+   Specify at least one of ``files`` or ``directories``. If both are empty,
+   an error occurs. The two are not mutually exclusive; if both are
+   specified, both are processed. If the same file is reachable from both,
+   it is read only once.
+
+File Discovery Order
+~~~~~~~~~~~~~~~~~~~~~
+
+- Files specified in ``files`` are processed in the order specified.
+- Files found under ``directories`` are processed in ascending order of
+  last-modified time.
+- Files specified in ``files`` are processed before files under
+  ``directories``.
+
+Filtering by ``file_suffixes`` also applies to files specified directly in
+``files``. Files whose suffix does not match are skipped, with the reason
+logged.
+
+Non-existent paths, directories specified in ``files``, and files specified
+in ``directories`` are all recorded as warnings in the log, and the crawl
+itself continues.
+
+``format``
+----------
+
+``auto`` reads the start of the document and determines the format from its
+grammar. This can correctly identify any of the three formats, as long as
+the file is well-formed.
+
+Specify ``format=jsonl`` explicitly when the file is in JSON Lines format
+and the lines near the start might be malformed (banner lines, progress
+logs, records cut off mid-transfer, etc.), since automatic detection needs
+to skip over such lines to make its determination.
+
+This setting also determines the scope of impact of a malformed record.
+
+- **JSON Lines format**: Since each line is parsed independently, the cost
+  of a malformed line is limited to that line. The failure is recorded in
+  the failure URL under the key ``<file's absolute path>@<line number>``,
+  and processing continues with the next line.
+- **Other formats**: Since the file is read as a token stream, a single
+  failure can involve subsequent records. A document cut off in the middle
+  of an object cannot recover, and if failures occur a certain number of
+  times in a row, that file is aborted with a warning.
+
+``root_path``
+-------------
+
+Specifying a JSON Pointer that points to a nested array registers each of
+its elements as a record.
+
+::
+
+    root_path=/data/items
+
+.. code-block:: json
+
+    { "meta": { "count": 2 }, "data": { "items": [ { "id": "1" }, { "id": "2" } ] } }
+
+- If it points to an array, each element becomes one record.
+- If it points to an object, that object becomes one record.
+- If it does not match anything, this is not an error; the number of
+  records is 0.
+- JSON Pointer escaping (``~1`` for ``/``, ``~0`` for ``~``) can be used.
+
+``root_path`` takes precedence over ``format``. This is because the
+document reached via the JSON Pointer is not read line by line; if
+specified together with ``format=jsonl``, a warning to that effect is
+output to the log.
 
 .. warning::
-   Either ``files`` or ``directories`` must be specified.
-   If neither is specified (both are empty), a ``DataStoreException`` will be thrown.
-   If both are specified, ``files`` takes precedence and ``directories`` is ignored.
+
+   ``root_path`` must start with ``/``. If you forget the leading ``/``, as
+   in ``data/items``, it cannot be interpreted as a JSON Pointer, and the
+   entire data store config fails with an error. In this case, the failure
+   URL is recorded as the data store config rather than the parameter name,
+   so determine which parameter is responsible from
+   ``JSON Pointer expression must start with '/'`` in the log.
 
 .. note::
-   The parameter name uses camelCase: ``fileEncoding`` (not the snake_case form ``file_encoding``).
 
-Directory Behavior
-~~~~~~~~~~~~~~~~~~
+   If you load, without specifying ``root_path``, a document formatted
+   across multiple lines (a so-called wrapper format containing metadata
+   and an array), line-by-line parsing is attempted, so the intended
+   records cannot be obtained and failures are recorded. For such
+   documents, specify ``root_path``.
 
-When ``directories`` is specified, files directly inside each directory are processed according to the following rules.
+Script Settings
+----------------
 
-- **Subdirectories are not traversed** (no recursive search is performed).
-- Only files with a ``.json`` or ``.jsonl`` extension are targeted (case-insensitive).
-- Files are processed in ascending order of their last-modified timestamp.
-
-.. note::
-   This connector targets only JSON files on the local filesystem. HTTP access and API authentication are not supported.
-
-Script Configuration
---------------------
-
-The value of each field is assembled by referencing the fields of the JSON object.
-Top-level fields of a JSON object can be referenced directly inside scripts as
-**variables without a prefix** (no ``data.`` prefix is used).
+The value of each field is assembled by referencing the values of each
+field in the JSON object. Top-level fields of the JSON object can be
+referenced directly in scripts as **variables without any prefix** (there
+is no ``data.`` prefix).
 
 Simple JSON object:
 
 ::
 
-    url="https://example.com/product/" + id
+    url="https://shop.example.com/product/" + id
     title=name
     content=description
-    price=price
-    category=category
+    digest=description
+    host="shop.example.com"
+    site="shop.example.com"
 
-Nested JSON object (nested objects are referenced as maps):
+Nested objects can be referenced as maps, and nested arrays as lists:
 
 ::
 
@@ -148,66 +274,78 @@ Nested JSON object (nested objects are referenced as maps):
     title=product.name
     content=product.description
     price=product.pricing.amount
-    author=product.author.name
-
-Array element processing:
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=body
-    tags=tags.join(", ")
-    categories=categories[0].name
+    first_tag=tags[0]
 
 Available Fields
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
-- ``<field_name>`` - Reference a top-level field of the JSON object directly by name
-- ``<parent>.<child>`` - Field of a nested object
-- ``<array>[<index>]`` - Array element
-- ``<array>.<method>`` - Array methods (``join``, ``collect``, ``size``, etc.)
+- ``<field name>`` - References a top-level field of the JSON object
+  directly by name
+- ``<parent>.<child>`` - A field of a nested object
+- ``<array>[<index>]`` - An array element
+
+.. note::
+
+   If a field's value is ``null``, that field is not registered in the
+   document.
 
 .. note::
 
-   If a field name contains characters that are invalid as a Groovy identifier,
-   such as spaces or hyphens, that field cannot be referenced directly as a variable name.
+   In |Fess| 15.9, the built-in scripting engine has become JavaScript.
+   Groovy is provided as the ``fess-script-groovy`` plugin. The engine to
+   use is specified via the data store parameter ``script_type`` (e.g.,
+   ``script_type=javascript``). If omitted, ``groovy`` is used. Simple
+   references and string concatenation, as in the examples above, work the
+   same way regardless of engine, but other notations differ between
+   engines.
 
-JSON Format Details
-===================
+Notes
+=====
 
-JSON File Format
-----------------
+Parameters whose names match ``app.encrypt.property.pattern`` (by default,
+those ending in ``password``, ``key``, ``token``, or ``secret``) are
+referenced from the script as ``null``. This is to prevent credentials
+written in data store parameters from being copied into index fields.
 
-The JSON Connector reads files in JSONL (JSON Lines) format.
-This format places one JSON object per line. Files are read line by line,
-and each line is parsed as an independent JSON object.
+If a field with the same name exists on the record side, the record's
+value takes precedence, just as with other parameters.
 
 .. note::
-   Files with a ``.json`` extension are also processed, but their content must be in
-   JSONL format (one object per line).
-   Array-format JSON files (``[{...}, {...}]``) and pretty-printed JSON spanning
-   multiple lines cannot be read directly. Please convert them to JSONL format.
 
-JSONL format file:
+   The match is a case-sensitive exact match against the parameter name.
+   ``access_token`` is subject to this, but the camelCase ``accessToken``
+   is not. When writing credentials in parameters, use snake_case.
 
-::
+Incorrect Parameters and Errors
+================================
 
-    {"id": 1, "name": "Product A", "description": "Description A"}
-    {"id": 2, "name": "Product B", "description": "Description B"}
+If an unusable value is specified for ``format``, ``include_pattern``,
+``exclude_pattern``, or ``urls``, the crawl ends before any files are read,
+and a failure URL containing that parameter name (e.g.,
+``JsonDataStore:format``) is recorded.
+
+If a non-numeric value is specified for ``max_depth``, it is logged and
+the default value is used.
+
+.. note::
+
+   A data store crawl completes as a normal job even if no targets were
+   retrieved at all. If the number of items retrieved differs from what
+   you expect, check the index count, the failure URLs, and
+   ``fess-crawler.log``.
 
 Usage Examples
 ==============
 
 Product Catalog
----------------
+----------------
 
 Parameters:
 
 ::
 
-    files=/var/data/products.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
 Script:
 
@@ -215,19 +353,20 @@ Script:
 
     url="https://shop.example.com/product/" + product_id
     title=name
-    content=description + " Price: " + price + " yen"
+    content=description
     digest=category
-    price=price
+    host="shop.example.com"
+    site="shop.example.com"
 
-Merging Multiple JSON Files
----------------------------
+A File Containing a Saved API Response
+----------------------------------------
 
 Parameters:
 
 ::
 
-    files=/var/data/data1.json,/var/data/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/response.json
+    root_path=/data/items
 
 Script:
 
@@ -235,135 +374,114 @@ Script:
 
     url="https://example.com/item/" + id
     title=title
-    content=content
+    content=body
+    host="example.com"
+    site="example.com"
+
+Processing a Directory Recursively
+------------------------------------
+
+Parameters:
+
+::
+
+    directories=/var/data/exports
+    recursive=true
+    max_depth=3
+    include_pattern=.*\.jsonl
+    file_encoding=UTF-8
 
 Troubleshooting
-===============
+================
 
 File Not Found
---------------
+----------------
 
-**Symptom**: The log outputs ``... is not found.`` or ``Source file ... does not exist.``
+**Symptom**: The log outputs ``... does not exist.``, ``... is not a
+file.``, or ``... is skipped because its suffix is not one of ...``
 
-**Checklist**:
+**Check**:
 
 1. Verify the file path is correct
 2. Verify the file exists
-3. Verify the file extension is ``.json`` or ``.jsonl``
-4. Verify read permissions on the file
+3. Verify the file suffix matches ``file_suffixes`` (default: ``.json`` or
+   ``.jsonl``)
+4. Verify the |Fess| process user has read permission
 
-JSON Parse Error
-----------------
+JSON Parse Errors
+-------------------
 
-**Symptom**: The log outputs ``Crawling Access Exception`` and ``JsonParseException`` or similar messages
+**Symptom**: The log outputs ``Failed to parse ...`` or ``Failed to read
+...``, or a failure URL is recorded
 
-When a line contains invalid content, only that line is skipped and recorded as a
-failed URL; the crawl itself continues from the next line.
+**Check**:
 
-**Checklist**:
-
-1. Verify the JSON file is in the correct format (JSONL: one object per line):
+1. Verify the file is valid JSON
 
    ::
 
-       # Validate that each line is a valid JSON object
-       cat data.json | jq -c .
+       # For JSON Lines format, verify each line is a valid JSON object
+       cat data.jsonl | jq -c .
+
+       # For an array or a single object
+       jq . data.json
 
 2. Verify the character encoding is correct
-3. Check that a single object is not split across multiple lines
-4. Check for comments (comments are not allowed in standard JSON)
+3. Verify the file is not cut off partway through
+4. Verify the file does not contain comments (comments are not allowed by
+   the JSON standard)
 
 No Data Retrieved
------------------
+--------------------
 
-**Symptom**: Crawl succeeds but item count is 0
+**Symptom**: The crawl succeeds but the count is 0
 
-**Checklist**:
+**Check**:
 
-1. Verify the JSON structure
-2. Verify the script configuration is correct (check that field references do not use the ``data.`` prefix)
-3. Verify field names are correct (including case sensitivity)
-4. Check log messages for errors
+1. If you specified ``root_path``, verify that the JSON Pointer matches
+   the document's structure (if it does not match, this is not an error;
+   the count is simply 0)
+2. Verify that ``include_pattern``, ``exclude_pattern``, and
+   ``file_suffixes`` are not excluding all targets. In this case,
+   ``No sources to process`` is output to the log
+3. Verify the script settings are correct (field references must not have
+   a ``data.`` prefix)
+4. Verify the field names are correct (including case)
+5. Verify that ``url`` is being assembled. If ``url`` is empty, it results
+   in a failure for that record
+
+Garbled Characters
+--------------------
+
+**Symptom**: Characters in the registered document are corrupted
+
+If you specify a ``file_encoding`` value that exists but is incorrect,
+this does not result in an error; the document is registered with garbled
+characters. Verify the file's actual encoding. If you specify a
+nonexistent encoding name, a failure URL is recorded for that file.
 
 Large JSON Files
-----------------
+-------------------
 
 **Symptom**: Out of memory or timeout
 
-Files are read line by line, so the total file size does not directly affect memory usage.
-However, problems may occur when a single line (object) is extremely large or when the
-indexing load is high.
+Records are read one at a time, so the overall file size does not
+directly affect memory usage. However, problems can occur if a single
+record is extremely large or if the load from indexing is high.
 
 **Solution**:
 
 1. Split the JSON file into multiple files
 2. Increase the |Fess| heap size
 
-Advanced Script Examples
-========================
-
-Conditional Processing
-----------------------
-
-Each field is evaluated as an independent expression. Use ternary operators for conditional values:
-
-::
-
-    url=status == "published" ? "https://example.com/product/" + id : null
-    title=status == "published" ? name : null
-    content=status == "published" ? description : null
-    price=status == "published" ? price : null
-
-Joining Arrays
---------------
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=content
-    tags=tags ? tags.join(", ") : ""
-    categories=categories.collect { it.name }.join(", ")
-
-Setting Default Values
-----------------------
-
-::
-
-    url="https://example.com/item/" + id
-    title=title ?: "Untitled"
-    content=description ?: (summary ?: "No description")
-    price=price ?: 0
-
-Date Formatting
----------------
-
-::
-
-    url="https://example.com/post/" + id
-    title=title
-    content=body
-    created=created_at
-    last_modified=updated_at
-
-Numeric Processing
-------------------
-
-::
-
-    url="https://example.com/product/" + id
-    title=name
-    content=description
-    price=price as Float
-    stock=stock_quantity as Integer
-
 Reference
 =========
 
-- :doc:`ds-overview` - Data Store Connector Overview
+- :doc:`ds-overview` - DataStore Connector Overview
 - :doc:`ds-csv` - CSV Connector
 - :doc:`ds-database` - Database Connector
 - :doc:`../../admin/dataconfig-guide` - Data Store Configuration Guide
 - `JSON (JavaScript Object Notation) <https://www.json.org/>`_
 - `JSON Lines <https://jsonlines.org/>`_
+- `JSON Pointer (RFC 6901) <https://datatracker.ietf.org/doc/html/rfc6901>`_
 - `jq - JSON processor <https://stedolan.github.io/jq/>`_

--- a/es/15.9/config/datastore/ds-json.rst
+++ b/es/15.9/config/datastore/ds-json.rst
@@ -1,45 +1,68 @@
-==============================
+=============
 Conector JSON
-==============================
+=============
 
 Descripción general
 ===================
 
-El conector JSON proporciona la funcionalidad para obtener datos de archivos JSONL
-locales (formato JSON Lines) y registrarlos en el índice de |Fess|.
+El conector JSON proporciona la funcionalidad para obtener datos de archivos JSON
+del sistema de archivos local y registrarlos en el índice de |Fess|.
 
 Esta funcionalidad requiere el plugin ``fess-ds-json``.
+
+Es compatible con los siguientes tres formatos, y de forma predeterminada el formato
+se determina automáticamente a partir del contenido del archivo.
+
+- Formato JSON Lines (un objeto JSON por línea)
+- Un array de objetos JSON (ya sea con formato legible o compactado en una sola línea)
+- Un único objeto JSON
+
+Los registros se leen uno por uno, por lo que incluso con un array grande, el archivo
+completo no se mantiene en memoria.
+
+.. note::
+
+   Este conector solo admite archivos JSON en el sistema de archivos local. No admite
+   la obtención remota mediante HTTP u otros medios, y si se especifica el parámetro
+   ``urls``, esto no se ignora, sino que provoca un error.
 
 Requisitos previos
 ==================
 
 1. Es necesario instalar el plugin
-2. Se requiere permiso de acceso a los archivos JSON
+2. Se requiere acceso a los archivos JSON
 3. Es necesario comprender la estructura del JSON
 
 Instalación del plugin
 ----------------------
 
-Método 1: Colocar el archivo JAR directamente
-
-::
-
-    # Descargar desde Maven Central
-    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
-
-    # Colocar
-    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
-    # o
-    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
-
-Método 2: Instalar desde la pantalla de administración
+Método 1: Instalar desde la pantalla de administración
 
 1. Abrir "Sistema" -> "Plugins"
 2. Subir el archivo JAR
 3. Reiniciar |Fess|
 
-Método de configuración
-=======================
+Método 2: Colocar el archivo JAR directamente
+
+::
+
+    # Descargar desde el repositorio de CodeLibs
+    wget https://maven.codelibs.org/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
+
+    # Colocar
+    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/plugin/
+    # o
+    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/plugin/
+
+.. note::
+
+   A partir de la versión 15.8.0, los JAR se distribuyen en el
+   `repositorio de CodeLibs <https://maven.codelibs.org/release/org/codelibs/fess/fess-ds-json/>`_.
+   Para la versión 15.7.0 y anteriores, se encuentran en
+   `Maven Central <https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/>`_.
+
+Configuración
+=============
 
 Configure desde la pantalla de administración en "Crawler" -> "Data Store" -> "Crear nuevo".
 
@@ -51,7 +74,7 @@ Configuración básica
    :widths: 25 75
 
    * - Campo
-     - Ejemplo de configuración
+     - Ejemplo
    * - Nombre
      - Products JSON
    * - Nombre del handler
@@ -60,87 +83,184 @@ Configuración básica
      - Activado
 
 Configuración de parámetros
-----------------------------
+---------------------------
 
 Archivo local:
 
 ::
 
-    files=/path/to/data.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
 Múltiples archivos:
 
 ::
 
-    files=/path/to/data1.json,/path/to/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/data1.json,/var/data/data2.json
+    file_encoding=UTF-8
 
-Especificación de directorio:
+Especificar un directorio:
 
 ::
 
-    directories=/path/to/json_dir/
-    fileEncoding=UTF-8
+    directories=/var/data/json_dir/
+    file_encoding=UTF-8
 
 Lista de parámetros
 ~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 10 70
+   :widths: 22 12 66
 
    * - Parámetro
-     - Requerido
+     - Valor predeterminado
      - Descripción
    * - ``files``
-     - No
-     - Ruta de los archivos JSON a procesar (se pueden especificar varios separados por comas). Solo se procesan archivos con extensión ``.json`` o ``.jsonl``.
+     -
+     - Ruta de los archivos JSON a procesar (se pueden especificar varias, separadas por comas). Se procesan en el orden especificado.
    * - ``directories``
-     - No
-     - Ruta de los directorios que contienen archivos JSON (se pueden especificar varios separados por comas)
-   * - ``fileEncoding``
-     - No
-     - Codificación de caracteres (predeterminado: UTF-8)
+     -
+     - Ruta de los directorios que contienen archivos JSON (se pueden especificar varias, separadas por comas).
+   * - ``recursive``
+     - ``false``
+     - Indica si se debe recorrer ``directories`` incluyendo sus subdirectorios.
+   * - ``max_depth``
+     - ``10``
+     - Cuando ``recursive=true``, indica hasta cuántos niveles de profundidad se desciende en cada directorio. Si se especifica ``0``, el comportamiento es el mismo que ``recursive=false``.
+   * - ``include_pattern``
+     -
+     - Expresión regular con la que debe coincidir completamente la ruta absoluta del archivo.
+   * - ``exclude_pattern``
+     -
+     - Expresión regular con la que no debe coincidir la ruta absoluta del archivo.
+   * - ``file_suffixes``
+     - ``.json,.jsonl``
+     - Extensiones de los archivos a procesar (se pueden especificar varias, separadas por comas). No distingue entre mayúsculas y minúsculas.
+   * - ``file_encoding``
+     - ``UTF-8``
+     - Codificación de caracteres del archivo.
+   * - ``format``
+     - ``auto``
+     - Formato del documento. Uno de ``auto``, ``jsonl`` o ``json``.
+   * - ``root_path``
+     -
+     - JSON Pointer que indica la posición desde la que se leen los registros (ejemplo: ``/data/items``).
+
+.. note::
+
+   Los nombres de los parámetros se muestran en snake_case, pero también se pueden usar
+   en camelCase de la misma manera (por ejemplo, ``fileEncoding`` en lugar de
+   ``file_encoding``).
+
+.. note::
+
+   Especifique al menos uno de ``files`` o ``directories``. Si ambos están vacíos, se
+   produce un error. No son excluyentes entre sí: si se especifican ambos, se procesan
+   los dos. Aunque el mismo archivo sea alcanzable desde ambos, solo se lee una vez.
+
+Orden de exploración de archivos
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Los archivos especificados en ``files`` se procesan en el orden especificado.
+- Los archivos encontrados bajo ``directories`` se procesan en orden de fecha de
+  modificación, del más antiguo al más reciente.
+- Los archivos especificados en ``files`` se procesan antes que los archivos bajo
+  ``directories``.
+
+El filtrado mediante ``file_suffixes`` también se aplica a los archivos especificados
+directamente en ``files``. Los archivos cuya extensión no coincide se omiten, y el motivo
+se registra en el log.
+
+Las rutas inexistentes, los directorios especificados en ``files`` y los archivos
+especificados en ``directories`` se registran como advertencias en el log, y el crawl
+continúa.
+
+``format``
+----------
+
+``auto`` lee el inicio del documento y determina el formato a partir de su sintaxis.
+Esto permite la detección correcta con cualquiera de los tres formatos, siempre que el
+archivo esté escrito correctamente.
+
+Especifique explícitamente ``format=jsonl`` cuando el archivo esté en formato JSON Lines
+y exista la posibilidad de que las líneas cercanas al inicio estén dañadas (líneas de
+banner, logs de progreso, registros cortados a mitad de una transferencia, etc.), ya que
+la detección automática necesitaría omitir esas líneas para poder determinar el formato.
+
+Esta configuración también determina el alcance del impacto de los registros no válidos.
+
+- **Formato JSON Lines**: como cada línea se analiza de forma independiente, el costo de
+  una línea no válida se limita a esa línea. El fallo se registra en las URL fallidas con
+  la clave ``<ruta absoluta del archivo>@<número de línea>``, y el procesamiento continúa
+  normalmente desde la línea siguiente.
+- **El resto de formatos**: como se leen como un flujo de tokens, un único fallo puede
+  afectar a los registros posteriores. Un documento cortado a mitad de un objeto no puede
+  recuperarse, y si se producen fallos consecutivos un número determinado de veces, el
+  procesamiento de ese archivo se interrumpe con una advertencia.
+
+``root_path``
+-------------
+
+Si se especifica un JSON Pointer que apunta a un array anidado, sus elementos se
+registran como registros.
+
+::
+
+    root_path=/data/items
+
+.. code-block:: json
+
+    { "meta": { "count": 2 }, "data": { "items": [ { "id": "1" }, { "id": "2" } ] } }
+
+- Si apunta a un array, cada uno de sus elementos se convierte en un registro.
+- Si apunta a un objeto, ese objeto se convierte en un único registro.
+- Si no coincide con ninguna posición, no se produce un error, sino que el número de
+  registros resultante es 0.
+- Se pueden usar los caracteres de escape de JSON Pointer (``~1`` para ``/`` y ``~0``
+  para ``~``).
+
+``root_path`` tiene prioridad sobre ``format``. Esto se debe a que el documento al que se
+llega mediante el JSON Pointer no se lee línea por línea; si se especifica junto con
+``format=jsonl``, se registra en el log una advertencia al respecto.
 
 .. warning::
-   Es necesario especificar ``files`` o ``directories``.
-   Si no se especifica ninguno (ambos vacíos), se producirá una ``DataStoreException``.
-   Si se especifican ambos, ``files`` tiene prioridad y ``directories`` se ignora.
+
+   ``root_path`` debe comenzar con ``/``. Si se olvida el ``/`` inicial, como en
+   ``data/items``, no puede interpretarse como un JSON Pointer y toda la configuración de
+   Data Store termina en error. En este caso, la URL fallida se registra con el nombre de
+   la configuración de Data Store, no con el nombre del parámetro, por lo que debe
+   identificar el parámetro causante a partir del mensaje
+   ``JSON Pointer expression must start with '/'`` en el log.
 
 .. note::
-   El nombre del parámetro usa camelCase: ``fileEncoding`` (no snake_case ``file_encoding``).
 
-Comportamiento al especificar directorios
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Cuando se especifica ``directories``, los archivos ubicados directamente en cada directorio se procesan según las siguientes reglas.
-
-- **Los subdirectorios no se recorren** (no se realiza búsqueda recursiva).
-- Solo se procesan archivos con extensión ``.json`` o ``.jsonl`` (sin distinguir mayúsculas de minúsculas).
-- Los archivos se procesan en orden ascendente por fecha de modificación (hora de última modificación).
-
-.. note::
-   Este conector solo admite archivos JSON en el sistema de archivos local. No es compatible con acceso HTTP ni funciones de autenticación de API.
+   Si se lee, sin especificar ``root_path``, un documento con formato legible cuyos
+   registros abarcan varias líneas (el llamado formato envoltorio, que incluye
+   metainformación y un array), se intentará un análisis línea por línea, por lo que no
+   se obtendrán los registros previstos y se registrarán fallos. Para este tipo de
+   documentos, especifique ``root_path``.
 
 Configuración de scripts
--------------------------
+------------------------
 
-Los valores de cada campo se construyen referenciando los valores de los campos del objeto JSON.
-Los campos del nivel superior del objeto JSON se pueden referenciar directamente dentro del script
-como **variables sin prefijo** (no se usa ningún prefijo como ``data.``).
+Los valores de cada campo se construyen referenciando los valores de cada campo del
+objeto JSON. Los campos de nivel superior del objeto JSON pueden referenciarse
+directamente en el script como **variables sin prefijo** (no se usa ningún prefijo como
+``data.``).
 
 Objeto JSON simple:
 
 ::
 
-    url="https://example.com/product/" + id
+    url="https://shop.example.com/product/" + id
     title=name
     content=description
-    price=price
-    category=category
+    digest=description
+    host="shop.example.com"
+    site="shop.example.com"
 
-Objeto JSON anidado (los objetos anidados se referencian como mapas):
+Los objetos anidados pueden referenciarse como mapas, y los arrays anidados como listas:
 
 ::
 
@@ -148,217 +268,207 @@ Objeto JSON anidado (los objetos anidados se referencian como mapas):
     title=product.name
     content=product.description
     price=product.pricing.amount
-    author=product.author.name
-
-Procesamiento de elementos de array:
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=body
-    tags=tags.join(", ")
-    categories=categories[0].name
+    first_tag=tags[0]
 
 Campos disponibles
 ~~~~~~~~~~~~~~~~~~
 
-- ``<nombre_campo>`` - Referencia directa a un campo del nivel superior del objeto JSON por nombre
+- ``<nombre_de_campo>`` - Referencia directa por nombre a un campo de nivel superior del
+  objeto JSON
 - ``<padre>.<hijo>`` - Campo de un objeto anidado
-- ``<array>[<índice>]`` - Elemento de array
-- ``<array>.<método>`` - Métodos de array (``join``, ``collect``, ``size``, etc.)
+- ``<array>[<índice>]`` - Elemento de un array
 
 .. note::
 
-   Si el nombre de un campo contiene caracteres inválidos como identificador de Groovy (espacios,
-   guiones, etc.), ese campo no puede referenciarse directamente como nombre de variable.
+   Si el valor de un campo es ``null``, ese campo no se registra en el documento.
 
-Detalles del formato JSON
+.. note::
+
+   En |Fess| 15.9, el motor de scripts integrado pasó a ser JavaScript. Groovy se ofrece
+   como el plugin ``fess-script-groovy``. El motor a utilizar se especifica mediante el
+   parámetro de Data Store ``script_type`` (por ejemplo, ``script_type=javascript``). Si
+   se omite, se utiliza ``groovy``. Las referencias simples y la concatenación de cadenas
+   como en los ejemplos anteriores funcionan igual en ambos motores, pero el resto de la
+   sintaxis difiere según el motor.
+
+Consideraciones
+===============
+
+Los parámetros cuyo nombre coincide con ``app.encrypt.property.pattern`` (por defecto,
+los que terminan en ``password``, ``key``, ``token`` o ``secret``) se referencian desde
+el script como ``null``. Esto evita que las credenciales escritas en los parámetros de
+Data Store se copien a los campos del índice.
+
+Si existe un campo con el mismo nombre en el registro, al igual que con los demás
+parámetros, tiene prioridad el valor del registro.
+
+.. note::
+
+   La coincidencia se determina mediante una comparación exacta y sensible a mayúsculas
+   y minúsculas sobre el nombre del parámetro. ``access_token`` está incluido, pero su
+   variante en camelCase, ``accessToken``, no lo está. Si escribe credenciales en los
+   parámetros, hágalo en snake_case.
+
+Errores en los parámetros
 =========================
 
-Formato de archivo JSON
-------------------------
+Si se especifica un valor no válido para ``format``, ``include_pattern``,
+``exclude_pattern`` o ``urls``, el crawl finaliza antes de leer ningún archivo, y se
+registra una URL fallida que incluye el nombre del parámetro (por ejemplo,
+``JsonDataStore:format``).
 
-El conector JSON lee archivos en formato JSONL (JSON Lines).
-Es un formato en el que se escribe un objeto JSON por línea. El archivo se lee línea a línea
-y cada línea se analiza como un objeto JSON independiente.
+Si se especifica un valor no numérico para ``max_depth``, esto se registra en el log y se
+utiliza el valor predeterminado.
 
 .. note::
-   Los archivos con extensión ``.json`` también son procesados, pero su contenido debe estar
-   en formato JSONL (un objeto por línea).
-   Los archivos JSON en formato de array ( ``[{...}, {...}]`` ) o con formato de varias líneas
-   (pretty-printed) no se pueden leer directamente. Conviértelos al formato JSONL.
 
-Archivo en formato JSONL:
-
-::
-
-    {"id": 1, "name": "Product A", "description": "Description A"}
-    {"id": 2, "name": "Product B", "description": "Description B"}
+   El crawl de Data Store finaliza como un trabajo exitoso incluso si no se obtiene
+   ningún objetivo. Si el número de elementos obtenidos difiere de lo esperado, verifique
+   el número de documentos en el índice, las URL fallidas y el archivo
+   ``fess-crawler.log``.
 
 Ejemplos de uso
 ===============
 
 Catálogo de productos
-----------------------
+---------------------
 
 Parámetros:
 
 ::
 
-    files=/var/data/products.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
-Scripts:
+Script:
 
 ::
 
     url="https://shop.example.com/product/" + product_id
     title=name
-    content=description + " Precio: " + price + " yenes"
+    content=description
     digest=category
-    price=price
+    host="shop.example.com"
+    site="shop.example.com"
 
-Integración de múltiples archivos JSON
----------------------------------------
+Archivo con una respuesta de API guardada
+-----------------------------------------
 
 Parámetros:
 
 ::
 
-    files=/var/data/data1.json,/var/data/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/response.json
+    root_path=/data/items
 
-Scripts:
+Script:
 
 ::
 
     url="https://example.com/item/" + id
     title=title
-    content=content
+    content=body
+    host="example.com"
+    site="example.com"
+
+Procesar un directorio de forma recursiva
+-----------------------------------------
+
+Parámetros:
+
+::
+
+    directories=/var/data/exports
+    recursive=true
+    max_depth=3
+    include_pattern=.*\.jsonl
+    file_encoding=UTF-8
 
 Solución de problemas
-======================
+=====================
 
 Archivo no encontrado
-----------------------
+---------------------
 
-**Síntoma**: El registro muestra ``... is not found.`` o ``Source file ... does not exist.``
+**Síntoma**: en el log aparece ``... does not exist.``, ``... is not a file.`` o
+``... is skipped because its suffix is not one of ...``
 
-**Puntos a verificar**:
+**Verificaciones**:
 
 1. Verificar que la ruta del archivo sea correcta
-2. Verificar que el archivo exista
-3. Verificar que la extensión del archivo sea ``.json`` o ``.jsonl``
-4. Verificar que el archivo tenga permisos de lectura
+2. Confirmar que el archivo existe
+3. Verificar que la extensión del archivo coincide con ``file_suffixes`` (por defecto,
+   ``.json`` o ``.jsonl``)
+4. Verificar que el usuario que ejecuta |Fess| tiene permisos de lectura
 
-Error de análisis JSON
------------------------
+Error de análisis de JSON
+-------------------------
 
-**Síntoma**: El registro muestra ``Crawling Access Exception`` y ``JsonParseException``, entre otros
+**Síntoma**: en el log aparece ``Failed to parse ...`` o ``Failed to read ...``, o se
+registra una URL fallida
 
-Si una línea contiene datos inválidos, solo esa línea se omite y se registra como URL fallida,
-y el crawling continúa desde la siguiente línea.
+**Verificaciones**:
 
-**Puntos a verificar**:
-
-1. Verificar que el archivo JSON tenga el formato correcto (JSONL: un objeto por línea):
+1. Verificar que el archivo sea JSON válido
 
    ::
 
-       # Validar que cada linea sea un objeto JSON valido
-       cat data.json | jq -c .
+       # Para el formato JSON Lines, verificar que cada línea sea un objeto JSON válido
+       cat data.jsonl | jq -c .
 
-2. Verificar la codificación de caracteres
-3. Verificar que un mismo objeto no esté dividido en varias líneas
-4. Verificar que no contenga comentarios (no permitidos en el estándar JSON)
+       # Para arrays u objetos únicos
+       jq . data.json
+
+2. Verificar que la codificación de caracteres sea correcta
+3. Verificar que el archivo no esté cortado a mitad
+4. Verificar que no contenga comentarios (el estándar JSON no admite comentarios)
 
 No se obtienen datos
----------------------
+--------------------
 
-**Síntoma**: El crawling se completa con éxito pero el recuento es 0
+**Síntoma**: el crawl tiene éxito pero el conteo es 0
 
-**Puntos a verificar**:
+**Verificaciones**:
 
-1. Verificar la estructura JSON
-2. Verificar que la configuración de scripts sea correcta (que las referencias a campos no tengan el prefijo ``data.``)
-3. Verificar los nombres de campo (incluyendo mayúsculas y minúsculas)
-4. Verificar los mensajes de error en los registros
+1. Si especifica ``root_path``, verificar que ese JSON Pointer coincide con la
+   estructura del documento (si no coincide, no se produce un error, sino que el
+   resultado es 0 registros)
+2. Verificar que ``include_pattern``, ``exclude_pattern`` o ``file_suffixes`` no estén
+   excluyendo todos los objetivos. En ese caso, en el log aparece
+   ``No sources to process``
+3. Verificar que la configuración del script sea correcta (comprobar que las referencias
+   a campos no llevan el prefijo ``data.``)
+4. Verificar que los nombres de los campos sean correctos (incluyendo mayúsculas y
+   minúsculas)
+5. Verificar que ``url`` se construye correctamente. Si ``url`` está vacío, cada registro
+   se cuenta como un fallo
 
-Archivos JSON grandes
-----------------------
+Caracteres ilegibles
+--------------------
 
-**Síntoma**: Falta de memoria o tiempo de espera agotado
+**Síntoma**: los caracteres del documento registrado están corruptos
 
-El archivo se lee línea a línea, por lo que el tamaño total del archivo no afecta directamente
-al uso de memoria. Sin embargo, pueden surgir problemas si una sola línea (un objeto) es
-extremadamente grande o si la carga de indexación es elevada.
+Si se especifica en ``file_encoding`` una codificación que existe pero es incorrecta, no
+se produce un error y el documento se registra con los caracteres corruptos. Verifique la
+codificación real del archivo. Si se especifica el nombre de una codificación que no
+existe, se registra una URL fallida por cada archivo.
+
+Archivo JSON grande
+-------------------
+
+**Síntoma**: memoria insuficiente o timeout
+
+Los registros se leen uno por uno, por lo que el tamaño total del archivo no afecta
+directamente al uso de memoria. Sin embargo, pueden surgir problemas cuando un registro
+individual es extremadamente grande o cuando la carga del registro en el índice es alta.
 
 **Solución**:
 
-1. Dividir el archivo JSON en varios archivos
+1. Dividir el archivo JSON en varios
 2. Aumentar el tamaño del heap de |Fess|
 
-Uso avanzado de scripts
-========================
-
-Procesamiento condicional
---------------------------
-
-Cada campo se evalúa como una expresión independiente. Para valores condicionales, utilice el operador ternario:
-
-::
-
-    url=status == "published" ? "https://example.com/product/" + id : null
-    title=status == "published" ? name : null
-    content=status == "published" ? description : null
-    price=status == "published" ? price : null
-
-Unión de arrays
-----------------
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=content
-    tags=tags ? tags.join(", ") : ""
-    categories=categories.collect { it.name }.join(", ")
-
-Configuración de valores predeterminados
------------------------------------------
-
-::
-
-    url="https://example.com/item/" + id
-    title=title ?: "Sin titulo"
-    content=description ?: (summary ?: "Sin descripcion")
-    price=price ?: 0
-
-Formato de fechas
-------------------
-
-::
-
-    url="https://example.com/post/" + id
-    title=title
-    content=body
-    created=created_at
-    last_modified=updated_at
-
-Procesamiento de números
--------------------------
-
-::
-
-    url="https://example.com/product/" + id
-    title=name
-    content=description
-    price=price as Float
-    stock=stock_quantity as Integer
-
 Información de referencia
-==========================
+=========================
 
 - :doc:`ds-overview` - Descripción general de conectores de Data Store
 - :doc:`ds-csv` - Conector CSV
@@ -366,4 +476,5 @@ Información de referencia
 - :doc:`../../admin/dataconfig-guide` - Guía de configuración de Data Store
 - `JSON (JavaScript Object Notation) <https://www.json.org/>`_
 - `JSON Lines <https://jsonlines.org/>`_
+- `JSON Pointer (RFC 6901) <https://datatracker.ietf.org/doc/html/rfc6901>`_
 - `jq - JSON processor <https://stedolan.github.io/jq/>`_

--- a/fr/15.9/config/datastore/ds-json.rst
+++ b/fr/15.9/config/datastore/ds-json.rst
@@ -1,48 +1,71 @@
-==============================
+===============
 Connecteur JSON
-==============================
+===============
 
-Apercu
+Aperçu
 ======
 
-Le connecteur JSON fournit la fonctionnalite permettant de recuperer des donnees
-a partir de fichiers JSONL locaux (format JSON Lines) et de les enregistrer dans
-l'index |Fess|.
+Le connecteur JSON fournit la fonctionnalité permettant de récupérer des données à partir de
+fichiers JSON présents sur le système de fichiers local et de les enregistrer dans l'index
+|Fess|.
 
-Cette fonctionnalite necessite le plugin ``fess-ds-json``.
+Cette fonctionnalité nécessite le plugin ``fess-ds-json``.
 
-Prerequis
+Il prend en charge les trois formats suivants ; par défaut, le format est déterminé
+automatiquement à partir du contenu du fichier.
+
+- Format JSON Lines (un objet JSON par ligne)
+- Tableau d'objets JSON (mis en forme ou tenu sur une seule ligne, les deux étant possibles)
+- Objet JSON unique
+
+Comme les enregistrements sont lus un par un, même un tableau volumineux n'entraîne pas le
+maintien de l'intégralité du fichier en mémoire.
+
+.. note::
+
+   Ce connecteur ne traite que les fichiers JSON présents sur le système de fichiers local.
+   Il ne prend pas en charge la récupération distante via HTTP ou un autre protocole ; si le
+   paramètre ``urls`` est spécifié, cela ne sera pas ignoré mais provoquera une erreur.
+
+Prérequis
 =========
 
 1. L'installation du plugin est requise
-2. L'acces aux fichiers JSON est necessaire
-3. La structure du JSON doit etre comprise
+2. L'accès au fichier JSON est nécessaire
+3. La structure du JSON doit être connue
 
 Installation du plugin
 ----------------------
 
-Methode 1 : Placement direct du fichier JAR
+Méthode 1 : Installation depuis l'interface d'administration
+
+1. Ouvrir « Système » → « Plugins »
+2. Téléverser le fichier JAR
+3. Redémarrer |Fess|
+
+Méthode 2 : Placement direct du fichier JAR
 
 ::
 
-    # Telecharger depuis Maven Central
-    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
+    # Télécharger depuis le dépôt CodeLibs
+    wget https://maven.codelibs.org/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
 
     # Placement
-    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
+    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/plugin/
     # ou
-    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
+    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/plugin/
 
-Methode 2 : Installation depuis l'interface d'administration
+.. note::
 
-1. Ouvrir "Systeme" -> "Plugins"
-2. Telecharger le fichier JAR
-3. Redemarrer |Fess|
+   À partir de la version 15.8.0, les fichiers JAR sont distribués via le
+   `dépôt CodeLibs <https://maven.codelibs.org/release/org/codelibs/fess/fess-ds-json/>`_.
+   Pour les versions 15.7.0 et antérieures, ils se trouvent sur
+   `Maven Central <https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/>`_.
 
 Configuration
 =============
 
-Configurez depuis l'interface d'administration via "Crawler" -> "Data Store" -> "Nouveau".
+Configurez depuis l'interface d'administration via « Crawler » → « Data Store » → « Nouveau ».
 
 Configuration de base
 ---------------------
@@ -51,97 +74,195 @@ Configuration de base
    :header-rows: 1
    :widths: 25 75
 
-   * - Element
-     - Exemple de configuration
+   * - Élément
+     - Exemple
    * - Nom
      - Products JSON
    * - Nom du gestionnaire
      - JsonDataStore
-   * - Actif
+   * - Activé
      - Oui
 
-Configuration des parametres
------------------------------
+Configuration des paramètres
+----------------------------
 
 Fichier local :
 
 ::
 
-    files=/path/to/data.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
 Fichiers multiples :
 
 ::
 
-    files=/path/to/data1.json,/path/to/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/data1.json,/var/data/data2.json
+    file_encoding=UTF-8
 
-Specification de repertoire :
+Spécification d'un répertoire :
 
 ::
 
-    directories=/path/to/json_dir/
-    fileEncoding=UTF-8
+    directories=/var/data/json_dir/
+    file_encoding=UTF-8
 
-Liste des parametres
+Liste des paramètres
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 10 70
+   :widths: 22 12 66
 
-   * - Parametre
-     - Requis
+   * - Paramètre
+     - Valeur par défaut
      - Description
    * - ``files``
-     - Non
-     - Chemin des fichiers JSON a traiter (plusieurs valeurs possibles, separees par des virgules). Seuls les fichiers avec l'extension ``.json`` ou ``.jsonl`` sont traites.
+     -
+     - Chemins des fichiers JSON à traiter (plusieurs fichiers séparés par des virgules). Ils sont traités dans l'ordre indiqué.
    * - ``directories``
-     - Non
-     - Chemin des repertoires contenant les fichiers JSON (plusieurs valeurs possibles, separees par des virgules)
-   * - ``fileEncoding``
-     - Non
-     - Encodage des caracteres (par defaut : UTF-8)
+     -
+     - Chemins des répertoires contenant des fichiers JSON (plusieurs répertoires séparés par des virgules).
+   * - ``recursive``
+     - ``false``
+     - Indique si ``directories`` doit être parcouru y compris ses sous-répertoires.
+   * - ``max_depth``
+     - ``10``
+     - Lorsque ``recursive=true``, nombre de niveaux de sous-répertoires à descendre pour chaque répertoire. La valeur ``0`` produit le même comportement que ``recursive=false``.
+   * - ``include_pattern``
+     -
+     - Expression régulière à laquelle le chemin absolu du fichier doit correspondre entièrement.
+   * - ``exclude_pattern``
+     -
+     - Expression régulière à laquelle le chemin absolu du fichier ne doit pas correspondre.
+   * - ``file_suffixes``
+     - ``.json,.jsonl``
+     - Suffixes des fichiers ciblés (plusieurs suffixes séparés par des virgules). La casse n'est pas prise en compte.
+   * - ``file_encoding``
+     - ``UTF-8``
+     - Encodage des caractères du fichier.
+   * - ``format``
+     - ``auto``
+     - Format du document. L'une des valeurs suivantes : ``auto``, ``jsonl``, ``json``.
+   * - ``root_path``
+     -
+     - JSON Pointer indiquant l'emplacement à partir duquel lire les enregistrements (exemple : ``/data/items``).
+
+.. note::
+
+   Les noms de paramètres sont indiqués ici en snake_case, mais leur équivalent en camelCase
+   (par exemple ``fileEncoding`` pour ``file_encoding``) peut être utilisé de la même manière.
+
+.. note::
+
+   Spécifiez au moins l'un des paramètres ``files`` ou ``directories``.
+   Si les deux sont vides, une erreur se produit.
+   Les deux ne sont pas exclusifs l'un de l'autre : si les deux sont spécifiés, ils sont tous
+   deux traités.
+   Si un même fichier est atteint par les deux, il n'est lu qu'une seule fois.
+
+Ordre d'exploration des fichiers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Les fichiers spécifiés via ``files`` sont traités dans l'ordre indiqué.
+- Les fichiers trouvés sous ``directories`` sont traités par ordre croissant de date de
+  dernière modification.
+- Les fichiers spécifiés via ``files`` sont traités avant ceux trouvés sous ``directories``.
+
+Le filtrage par ``file_suffixes`` s'applique également aux fichiers spécifiés directement via
+``files``. Les fichiers dont le suffixe ne correspond pas sont ignorés, et la raison en est
+indiquée dans le log.
+
+Un chemin inexistant, un répertoire spécifié dans ``files``, ou un fichier spécifié dans
+``directories`` sont, dans tous les cas, consignés dans le log comme avertissement, et le crawl
+lui-même se poursuit.
+
+``format``
+----------
+
+``auto`` lit le début du document et détermine le format à partir de sa syntaxe. Quel que soit
+le format parmi les trois, cette méthode permet de le déterminer correctement dès lors que le
+fichier est correctement écrit.
+
+Il convient de spécifier explicitement ``format=jsonl`` lorsqu'il s'agit d'un fichier au format
+JSON Lines dont les lignes situées près du début risquent d'être corrompues (ligne de bannière,
+log de progression, enregistrement interrompu en cours de transfert, etc.). En effet, la
+détection automatique doit pouvoir ignorer de telles lignes pour effectuer son jugement.
+
+Ce paramètre détermine également l'étendue de l'impact d'un enregistrement invalide.
+
+- **Format JSON Lines** : chaque ligne est analysée indépendamment, de sorte que le coût d'une
+  ligne invalide se limite à cette seule ligne. L'échec est enregistré dans les URL en échec
+  sous la clé ``<chemin absolu du fichier>@<numéro de ligne>``, et le traitement se poursuit
+  normalement à partir de la ligne suivante.
+- **Autres formats** : comme la lecture se fait sous forme de flux de jetons, un seul échec
+  peut entraîner celui des enregistrements suivants. Un document interrompu au milieu d'un
+  objet ne peut pas être récupéré, et si un nombre défini d'échecs consécutifs se produit, le
+  traitement du fichier est interrompu avec un avertissement.
+
+``root_path``
+-------------
+
+Spécifier un JSON Pointer désignant un tableau imbriqué permet d'enregistrer chacun de ses
+éléments comme un enregistrement.
+
+::
+
+    root_path=/data/items
+
+.. code-block:: json
+
+    { "meta": { "count": 2 }, "data": { "items": [ { "id": "1" }, { "id": "2" } ] } }
+
+- Si le pointeur désigne un tableau, chacun de ses éléments constitue un enregistrement.
+- Si le pointeur désigne un objet, cet objet constitue un unique enregistrement.
+- Si aucune correspondance n'est trouvée, il n'y a pas d'erreur ; le nombre d'enregistrements
+  est simplement de 0.
+- Les séquences d'échappement du JSON Pointer sont prises en charge (``~1`` pour ``/``, ``~0``
+  pour ``~``).
+
+``root_path`` est prioritaire sur ``format``. En effet, un document atteint via un JSON Pointer
+n'est pas lu ligne par ligne ; si ``root_path`` est spécifié en même temps que
+``format=jsonl``, un avertissement à ce sujet est consigné dans le log.
 
 .. warning::
-   Il est necessaire de specifier ``files`` ou ``directories``.
-   Si aucun des deux n'est specifie (vide), une ``DataStoreException`` sera levee.
-   Si les deux sont specifies, ``files`` a la priorite et ``directories`` est ignore.
+
+   ``root_path`` doit commencer par ``/``. Si le ``/`` initial est omis, comme dans
+   ``data/items``, la valeur ne peut pas être interprétée comme un JSON Pointer et l'ensemble
+   de la configuration Data Store échoue.
+   Dans ce cas, l'URL en échec est enregistrée non pas sous le nom du paramètre mais sous celui
+   de la configuration Data Store ; déterminez quel paramètre en est la cause à partir du
+   message ``JSON Pointer expression must start with '/'`` figurant dans le log.
 
 .. note::
-   Le nom du parametre est en camelCase : ``fileEncoding`` (et non en snake_case : ``file_encoding``).
 
-Comportement lors de la specification d'un repertoire
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   Si vous lisez, sans spécifier ``root_path``, un document mis en forme sur plusieurs lignes
+   dont les enregistrements font partie d'une structure englobante (dite « wrapper »,
+   contenant par exemple des métadonnées ainsi qu'un tableau), l'analyse ligne par ligne est
+   tentée, ce qui empêche d'obtenir les enregistrements attendus et provoque l'enregistrement
+   d'échecs.
+   Pour ce type de document, spécifiez ``root_path``.
 
-Lorsque ``directories`` est specifie, les fichiers directement dans chaque repertoire sont traites selon les regles suivantes.
+Configuration du script
+-----------------------
 
-- **Les sous-repertoires ne sont pas parcourus** (pas d'exploration recursive).
-- Seuls les fichiers avec l'extension ``.json`` ou ``.jsonl`` sont concernes (sans distinction de casse).
-- Les fichiers sont traites dans l'ordre croissant de leur date de modification (date de derniere modification).
-
-.. note::
-   Ce connecteur traite uniquement les fichiers JSON sur le systeme de fichiers local. L'acces HTTP et les fonctions d'authentification API ne sont pas pris en charge.
-
-Configuration des scripts
---------------------------
-
-La valeur de chaque champ est construite en referençant les valeurs des champs de l'objet JSON.
-Les champs de niveau superieur de l'objet JSON sont directement accessibles dans les scripts
-sous forme de **variables sans prefixe** (sans prefixe tel que ``data.``).
+Les valeurs de chaque champ sont construites en référençant les valeurs des champs de l'objet
+JSON. Les champs de premier niveau de l'objet JSON sont accessibles directement dans le script
+en tant que **variables sans préfixe** (sans préfixe ``data.`` ni autre).
 
 Objet JSON simple :
 
 ::
 
-    url="https://example.com/product/" + id
+    url="https://shop.example.com/product/" + id
     title=name
     content=description
-    price=price
-    category=category
+    digest=description
+    host="shop.example.com"
+    site="shop.example.com"
 
-Objet JSON imbrique (les objets imbriques sont references comme des maps) :
+Les objets imbriqués sont accessibles comme des maps, et les tableaux imbriqués comme des
+listes :
 
 ::
 
@@ -149,224 +270,213 @@ Objet JSON imbrique (les objets imbriques sont references comme des maps) :
     title=product.name
     content=product.description
     price=product.pricing.amount
-    author=product.author.name
-
-Traitement des elements de tableau :
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=body
-    tags=tags.join(", ")
-    categories=categories[0].name
+    first_tag=tags[0]
 
 Champs disponibles
 ~~~~~~~~~~~~~~~~~~
 
-- ``<nom_champ>`` - Reference directe par nom d'un champ de niveau superieur de l'objet JSON
-- ``<parent>.<enfant>`` - Champ d'un objet imbrique
-- ``<tableau>[<indice>]`` - Element de tableau
-- ``<tableau>.<methode>`` - Methodes de tableau (``join``, ``collect``, ``size``, etc.)
+- ``<nom_du_champ>`` — Référence directe par le nom d'un champ de premier niveau de l'objet
+  JSON
+- ``<parent>.<enfant>`` — Champ d'un objet imbriqué
+- ``<tableau>[<index>]`` — Élément d'un tableau
 
 .. note::
 
-   Si un nom de champ contient des caracteres invalides comme identificateur Groovy
-   (espaces, tirets, etc.), ce champ ne peut pas etre reference directement comme variable.
-
-Details du format JSON
-=======================
-
-Format de fichier JSON
------------------------
-
-Le connecteur JSON lit les fichiers au format JSONL (JSON Lines).
-C'est un format ou un objet JSON est ecrit par ligne. Le fichier est lu ligne par ligne,
-et chaque ligne est analysee comme un objet JSON independant.
+   Si la valeur d'un champ vaut ``null``, ce champ n'est pas enregistré dans le document.
 
 .. note::
-   Les fichiers avec l'extension ``.json`` sont egalement traites, mais leur contenu
-   doit etre au format JSONL (un objet par ligne).
-   Les fichiers JSON au format tableau ( ``[{...}, {...}]`` ) ou mis en forme sur plusieurs
-   lignes (pretty-print) ne peuvent pas etre lus directement. Veuillez les convertir
-   au format JSONL.
 
-Fichier au format JSONL :
+   Dans |Fess| 15.9, le moteur de script intégré est devenu JavaScript.
+   Groovy est fourni sous forme de plugin ``fess-script-groovy``.
+   Le moteur à utiliser est indiqué via le paramètre de la configuration Data Store
+   ``script_type`` (par exemple ``script_type=javascript``). Si ce paramètre est omis,
+   ``groovy`` est utilisé.
+   Les références simples et les concaténations de chaînes telles que dans les exemples
+   ci-dessus fonctionnent de la même manière avec les deux moteurs, mais les autres notations
+   diffèrent selon le moteur.
 
-::
+Remarques
+=========
 
-    {"id": 1, "name": "Product A", "description": "Description A"}
-    {"id": 2, "name": "Product B", "description": "Description B"}
+Un paramètre dont le nom correspond à ``app.encrypt.property.pattern`` (par défaut, les
+paramètres se terminant par ``password``, ``key``, ``token`` ou ``secret``) est référencé
+depuis le script comme valant ``null``. Cela permet d'éviter que des identifiants inscrits dans
+les paramètres de la configuration Data Store ne soient copiés dans un champ de l'index.
+
+Si un champ de même nom existe côté enregistrement, la valeur de l'enregistrement est
+prioritaire, comme pour les autres paramètres.
+
+.. note::
+
+   La correspondance porte sur une égalité exacte, sensible à la casse, avec le nom du
+   paramètre. ``access_token`` est concerné, mais pas son équivalent en camelCase
+   ``accessToken``. Si vous inscrivez des identifiants dans un paramètre, utilisez le
+   snake_case.
+
+Paramètres incorrects et erreurs
+================================
+
+Si une valeur non valide est spécifiée pour ``format``, ``include_pattern``,
+``exclude_pattern`` ou ``urls``, le crawl se termine avant même la lecture des fichiers, et une
+URL en échec incluant le nom du paramètre concerné (exemple : ``JsonDataStore:format``) est
+enregistrée.
+
+Si une valeur non numérique est spécifiée pour ``max_depth``, cela est consigné dans le log et
+la valeur par défaut est utilisée.
+
+.. note::
+
+   Le crawl d'une configuration Data Store se termine comme un job normal même si aucun élément
+   n'a pu être récupéré. Si le nombre d'éléments récupérés diffère de ce qui était attendu,
+   vérifiez le nombre de documents dans l'index, les URL en échec, ainsi que le fichier
+   ``fess-crawler.log``.
 
 Exemples d'utilisation
-=======================
+======================
 
 Catalogue de produits
-----------------------
+---------------------
 
-Parametres :
+Paramètres :
 
 ::
 
-    files=/var/data/products.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
-Scripts :
+Script :
 
 ::
 
     url="https://shop.example.com/product/" + product_id
     title=name
-    content=description + " Prix : " + price + " yens"
+    content=description
     digest=category
-    price=price
+    host="shop.example.com"
+    site="shop.example.com"
 
-Integration de plusieurs fichiers JSON
----------------------------------------
+Fichier de réponse d'API enregistrée
+------------------------------------
 
-Parametres :
+Paramètres :
 
 ::
 
-    files=/var/data/data1.json,/var/data/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/response.json
+    root_path=/data/items
 
-Scripts :
+Script :
 
 ::
 
     url="https://example.com/item/" + id
     title=title
-    content=content
+    content=body
+    host="example.com"
+    site="example.com"
 
-Depannage
-==========
+Traitement récursif d'un répertoire
+-----------------------------------
+
+Paramètres :
+
+::
+
+    directories=/var/data/exports
+    recursive=true
+    max_depth=3
+    include_pattern=.*\.jsonl
+    file_encoding=UTF-8
+
+Dépannage
+=========
 
 Fichier introuvable
---------------------
+-------------------
 
-**Symptome** : ``... is not found.`` ou ``Source file ... does not exist.`` apparait dans les journaux
+**Symptôme** : le log affiche ``... does not exist.``, ``... is not a file.`` ou
+``... is skipped because its suffix is not one of ...``
 
-**Verifications** :
+**Points à vérifier** :
 
-1. Verifier que le chemin du fichier est correct
-2. Verifier que le fichier existe
-3. Verifier que l'extension du fichier est ``.json`` ou ``.jsonl``
-4. Verifier les permissions de lecture du fichier
+1. Vérifier que le chemin du fichier est correct
+2. Vérifier que le fichier existe
+3. Vérifier que le suffixe du fichier correspond à ``file_suffixes`` (par défaut ``.json`` ou
+   ``.jsonl``)
+4. Vérifier que l'utilisateur exécutant |Fess| dispose des droits de lecture
 
 Erreur d'analyse JSON
-----------------------
+---------------------
 
-**Symptome** : ``Crawling Access Exception`` et ``JsonParseException`` apparaissent dans les journaux
+**Symptôme** : le log affiche ``Failed to parse ...`` ou ``Failed to read ...``, ou une URL en
+échec est enregistrée
 
-Si une ligne invalide est rencontree, seule cette ligne est ignoree et enregistree comme URL
-en echec ; le crawl continue a partir de la ligne suivante.
+**Points à vérifier** :
 
-**Verifications** :
-
-1. Verifier que le fichier JSON est au bon format (JSONL : un objet par ligne) :
+1. Vérifier que le fichier est un JSON valide
 
    ::
 
-       # Valider que chaque ligne est un objet JSON valide
-       cat data.json | jq -c .
+       # Pour un fichier au format JSON Lines, vérifier que chaque ligne est un objet JSON valide
+       cat data.jsonl | jq -c .
 
-2. Verifier l'encodage des caracteres
-3. Verifier qu'un seul objet ne s'etend pas sur plusieurs lignes
-4. Verifier l'absence de commentaires (non autorises dans la norme JSON)
+       # Pour un tableau ou un objet unique
+       jq . data.json
 
-Aucune donnee recuperee
-------------------------
+2. Vérifier que l'encodage des caractères est correct
+3. Vérifier que le fichier n'est pas interrompu en cours de route
+4. Vérifier qu'il ne contient pas de commentaires (les commentaires ne sont pas autorisés par
+   le standard JSON)
 
-**Symptome** : Le crawl reussit mais le nombre de resultats est 0
+Impossible de récupérer les données
+-----------------------------------
 
-**Verifications** :
+**Symptôme** : le crawl réussit mais le nombre d'éléments est 0
 
-1. Verifier la structure JSON
-2. Verifier la configuration des scripts (les references de champs ne doivent pas avoir de prefixe ``data.``)
-3. Verifier les noms de champs (y compris la casse)
-4. Verifier les messages d'erreur dans les journaux
+**Points à vérifier** :
 
-Fichiers JSON volumineux
--------------------------
+1. Si ``root_path`` est spécifié, vérifier que ce JSON Pointer correspond à la structure du
+   document (si ce n'est pas le cas, il n'y a pas d'erreur, mais le nombre d'éléments est de 0)
+2. Vérifier que ``include_pattern``, ``exclude_pattern`` et ``file_suffixes`` n'excluent pas la
+   totalité des fichiers ciblés. Dans ce cas, le log affiche ``No sources to process``
+3. Vérifier que la configuration du script est correcte (les références de champs doivent être
+   sans préfixe ``data.``)
+4. Vérifier que les noms de champs sont corrects (y compris la casse)
+5. Vérifier que ``url`` est bien construit. Si ``url`` est vide, chaque enregistrement concerné
+   est comptabilisé comme un échec
 
-**Symptome** : Memoire insuffisante ou delai d'attente depasse
-
-Les fichiers etant lus ligne par ligne, la taille totale du fichier n'affecte pas directement
-la consommation memoire. Des problemes peuvent toutefois survenir si une seule ligne
-(un objet) est extremement grande ou si la charge d'indexation est elevee.
-
-**Solutions** :
-
-1. Diviser le fichier JSON en plusieurs fichiers
-2. Augmenter la taille du tas (heap) de |Fess|
-
-Utilisation avancee des scripts
-================================
-
-Traitement conditionnel
-------------------------
-
-Chaque champ est evalue comme une expression independante. Pour les valeurs conditionnelles,
-utilisez l'operateur ternaire :
-
-::
-
-    url=status == "published" ? "https://example.com/product/" + id : null
-    title=status == "published" ? name : null
-    content=status == "published" ? description : null
-    price=status == "published" ? price : null
-
-Jointure de tableaux
+Caractères illisibles
 ---------------------
 
-::
+**Symptôme** : les caractères du document enregistré sont corrompus
 
-    url="https://example.com/article/" + id
-    title=title
-    content=content
-    tags=tags ? tags.join(", ") : ""
-    categories=categories.collect { it.name }.join(", ")
+Si vous spécifiez pour ``file_encoding`` un encodage qui existe réellement mais qui est
+incorrect, il n'y a pas d'erreur : le document est enregistré tel quel, avec des caractères
+corrompus. Vérifiez l'encodage réel du fichier. Si vous spécifiez un nom d'encodage qui
+n'existe pas, une URL en échec est enregistrée pour chaque fichier concerné.
 
-Configuration des valeurs par defaut
---------------------------------------
+Fichiers JSON volumineux
+------------------------
 
-::
+**Symptôme** : mémoire insuffisante ou timeout
 
-    url="https://example.com/item/" + id
-    title=title ?: "Sans titre"
-    content=description ?: (summary ?: "Sans description")
-    price=price ?: 0
+Comme les enregistrements sont lus un par un, la taille totale du fichier n'a pas d'impact
+direct sur la consommation de mémoire. Cependant, un problème peut survenir si un enregistrement
+est extrêmement volumineux, ou si la charge liée à l'indexation est élevée.
 
-Formatage des dates
---------------------
+**Solution** :
 
-::
+1. Diviser le fichier JSON en plusieurs fichiers
+2. Augmenter la taille du tas de |Fess|
 
-    url="https://example.com/post/" + id
-    title=title
-    content=body
-    created=created_at
-    last_modified=updated_at
+Informations de référence
+=========================
 
-Traitement des nombres
------------------------
-
-::
-
-    url="https://example.com/product/" + id
-    title=name
-    content=description
-    price=price as Float
-    stock=stock_quantity as Integer
-
-Informations de reference
-==========================
-
-- :doc:`ds-overview` - Apercu des connecteurs Data Store
+- :doc:`ds-overview` - Aperçu des connecteurs Data Store
 - :doc:`ds-csv` - Connecteur CSV
-- :doc:`ds-database` - Connecteur de base de donnees
+- :doc:`ds-database` - Connecteur de base de données
 - :doc:`../../admin/dataconfig-guide` - Guide de configuration Data Store
 - `JSON (JavaScript Object Notation) <https://www.json.org/>`_
 - `JSON Lines <https://jsonlines.org/>`_
+- `JSON Pointer (RFC 6901) <https://datatracker.ietf.org/doc/html/rfc6901>`_
 - `jq - JSON processor <https://stedolan.github.io/jq/>`_

--- a/ja/15.9/config/datastore/ds-json.rst
+++ b/ja/15.9/config/datastore/ds-json.rst
@@ -5,10 +5,25 @@ JSONコネクタ
 概要
 ====
 
-JSONコネクタは、ローカルのJSONLファイル（JSON Lines形式）からデータを取得して
+JSONコネクタは、ローカルファイルシステム上のJSONファイルからデータを取得して
 |Fess| のインデックスに登録する機能を提供します。
 
 この機能には ``fess-ds-json`` プラグインが必要です。
+
+次の3つの形式に対応しており、既定ではファイルの内容から自動的に判別されます。
+
+- JSON Lines形式（1行に1つのJSONオブジェクト）
+- JSONオブジェクトの配列（整形されたもの、1行にまとめられたもののどちらも可）
+- 単一のJSONオブジェクト
+
+レコードは1件ずつ読み込まれるため、大きな配列であってもファイル全体がメモリに
+保持されることはありません。
+
+.. note::
+
+   このコネクタはローカルファイルシステム上のJSONファイルのみを対象とします。
+   HTTPなどのリモート取得には対応しておらず、 ``urls`` パラメーターを指定した場合は
+   無視されるのではなくエラーになります。
 
 前提条件
 ========
@@ -20,23 +35,29 @@ JSONコネクタは、ローカルのJSONLファイル（JSON Lines形式）か�
 プラグインのインストール
 ------------------------
 
-方法1: JARファイルを直接配置
-
-::
-
-    # Maven Centralからダウンロード
-    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
-
-    # 配置
-    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
-    # または
-    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
-
-方法2: 管理画面からインストール
+方法1: 管理画面からインストール
 
 1. 「システム」→「プラグイン」を開く
 2. JARファイルをアップロード
 3. |Fess| を再起動
+
+方法2: JARファイルを直接配置
+
+::
+
+    # CodeLibsリポジトリからダウンロード
+    wget https://maven.codelibs.org/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
+
+    # 配置
+    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/plugin/
+    # または
+    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/plugin/
+
+.. note::
+
+   15.8.0以降のJARは `CodeLibsリポジトリ <https://maven.codelibs.org/release/org/codelibs/fess/fess-ds-json/>`_
+   で配布しています。15.7.0以前は
+   `Maven Central <https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/>`_ にあります。
 
 設定方法
 ========
@@ -66,62 +87,144 @@ JSONコネクタは、ローカルのJSONLファイル（JSON Lines形式）か�
 
 ::
 
-    files=/path/to/data.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
 複数ファイル:
 
 ::
 
-    files=/path/to/data1.json,/path/to/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/data1.json,/var/data/data2.json
+    file_encoding=UTF-8
 
 ディレクトリ指定:
 
 ::
 
-    directories=/path/to/json_dir/
-    fileEncoding=UTF-8
+    directories=/var/data/json_dir/
+    file_encoding=UTF-8
 
 パラメーター一覧
 ~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 10 70
+   :widths: 22 12 66
 
    * - パラメーター
-     - 必須
+     - 既定値
      - 説明
    * - ``files``
-     - いいえ
-     - 処理するJSONファイルのパス（複数指定可：カンマ区切り）。 ``.json`` または ``.jsonl`` 拡張子のファイルのみ処理されます。
+     -
+     - 処理するJSONファイルのパス（複数指定可：カンマ区切り）。指定した順に処理されます。
    * - ``directories``
-     - いいえ
-     - JSONファイルを含むディレクトリのパス（複数指定可：カンマ区切り）
-   * - ``fileEncoding``
-     - いいえ
-     - 文字エンコーディング（デフォルト: UTF-8）
+     -
+     - JSONファイルを含むディレクトリのパス（複数指定可：カンマ区切り）。
+   * - ``recursive``
+     - ``false``
+     - ``directories`` をサブディレクトリまで走査するか。
+   * - ``max_depth``
+     - ``10``
+     - ``recursive=true`` のときに、各ディレクトリの何階層下まで降りるか。 ``0`` を指定すると ``recursive=false`` と同じ動作になります。
+   * - ``include_pattern``
+     -
+     - ファイルの絶対パスが完全一致しなければならない正規表現。
+   * - ``exclude_pattern``
+     -
+     - ファイルの絶対パスが一致してはならない正規表現。
+   * - ``file_suffixes``
+     - ``.json,.jsonl``
+     - 対象とするファイルの接尾辞（複数指定可：カンマ区切り）。大文字小文字は区別しません。
+   * - ``file_encoding``
+     - ``UTF-8``
+     - ファイルの文字エンコーディング。
+   * - ``format``
+     - ``auto``
+     - ドキュメントの形式。 ``auto`` 、 ``jsonl`` 、 ``json`` のいずれか。
+   * - ``root_path``
+     -
+     - レコードを読み取る位置を指定するJSON Pointer（例: ``/data/items`` ）。
+
+.. note::
+
+   パラメーター名はスネークケースで記載していますが、キャメルケースの綴り
+   （ ``file_encoding`` に対する ``fileEncoding`` など）も同じように使用できます。
+
+.. note::
+
+   ``files`` と ``directories`` の少なくとも一方を指定してください。
+   両方が空の場合はエラーになります。
+   両者は排他ではなく、両方を指定した場合は双方が処理されます。
+   同じファイルが両方から到達する場合でも、読み込まれるのは1回だけです。
+
+ファイルの探索順序
+~~~~~~~~~~~~~~~~~~
+
+- ``files`` で指定したファイルは、指定した順に処理されます。
+- ``directories`` の下で見つかったファイルは、更新日時の古い順に処理されます。
+- ``files`` で指定したファイルは ``directories`` の下のファイルより先に処理されます。
+
+``file_suffixes`` による絞り込みは ``files`` で直接指定したファイルにも適用されます。
+接尾辞が一致しないファイルはログに理由が出力されたうえでスキップされます。
+
+存在しないパス、 ``files`` に指定されたディレクトリ、 ``directories`` に指定されたファイルは、
+いずれも警告としてログに記録され、クロール自体は続行されます。
+
+``format``
+----------
+
+``auto`` はドキュメントの先頭を読み、その文法から形式を判別します。3つの形式の
+いずれであっても、正しく記述されたファイルであればこれで判別できます。
+
+``format=jsonl`` を明示するのは、JSON Lines形式のファイルであって、かつ先頭付近の行が
+壊れている可能性がある場合です（バナー行、進捗ログ、転送が途中で切れたレコードなど）。
+自動判別はそうした行を読み飛ばして判断する必要があるためです。
+
+この設定は、不正なレコードの影響範囲も決めます。
+
+- **JSON Lines形式**: 各行が独立して解析されるため、不正な行のコストはその行だけです。
+  失敗は ``<ファイルの絶対パス>@<行番号>`` というキーで失敗URLに記録され、
+  次の行からそのまま処理が続きます。
+- **それ以外の形式**: トークンストリームとして読み込むため、1つの失敗が後続のレコードを
+  巻き込むことがあります。オブジェクトの途中で切れたドキュメントは復帰できず、
+  一定回数連続して失敗するとそのファイルは警告を出して打ち切られます。
+
+``root_path``
+-------------
+
+ネストした配列を指すJSON Pointerを指定すると、その要素がレコードとして登録されます。
+
+::
+
+    root_path=/data/items
+
+.. code-block:: json
+
+    { "meta": { "count": 2 }, "data": { "items": [ { "id": "1" }, { "id": "2" } ] } }
+
+- 配列を指した場合は、その要素ごとに1レコードになります。
+- オブジェクトを指した場合は、そのオブジェクトが1レコードになります。
+- どこにも一致しない場合は、エラーにはならずレコードが0件になります。
+- JSON Pointerのエスケープ（ ``~1`` が ``/`` 、 ``~0`` が ``~`` ）が使用できます。
+
+``root_path`` は ``format`` より優先されます。JSON Pointerで到達したドキュメントは
+行単位では読み込まれないためで、 ``format=jsonl`` と同時に指定した場合は
+その旨の警告がログに出力されます。
 
 .. warning::
-   ``files`` または ``directories`` のいずれかを指定する必要があります。
-   両方が未指定（空）の場合、 ``DataStoreException`` が発生します。
-   両方を指定した場合、 ``files`` が優先され ``directories`` は無視されます。
+
+   ``root_path`` は ``/`` で始まる必要があります。 ``data/items`` のように先頭の ``/`` を
+   忘れると、JSON Pointerとして解釈できずデータ設定全体がエラーになります。
+   このとき失敗URLはパラメーター名ではなくデータ設定として記録されるため、
+   どのパラメーターが原因かはログの
+   ``JSON Pointer expression must start with '/'`` から判断してください。
 
 .. note::
-   パラメーター名はキャメルケースの ``fileEncoding`` です（スネークケースの ``file_encoding`` ではありません）。
 
-ディレクトリ指定時の動作
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``directories`` を指定した場合、各ディレクトリ直下のファイルが以下の規則で処理されます。
-
-- **サブディレクトリは走査されません**\ （再帰的な探索は行いません）。
-- 拡張子が ``.json`` または ``.jsonl`` のファイルのみが対象です（大文字小文字は区別しません）。
-- ファイルは更新日時（最終更新時刻）の昇順で処理されます。
-
-.. note::
-   このコネクタはローカルファイルシステム上のJSONファイルのみを対象とし、HTTPアクセスやAPI認証機能はサポートしていません。
+   ``root_path`` を指定せずに、レコードが複数行にまたがって整形されたドキュメント
+   （メタ情報と配列を含むいわゆるラッパー形式）を読み込むと、行単位での解析が
+   試みられるため、意図したレコードが取得できず失敗が記録されます。
+   そのようなドキュメントでは ``root_path`` を指定してください。
 
 スクリプト設定
 --------------
@@ -134,13 +237,14 @@ JSONオブジェクトのトップレベルのフィールドは、スクリプ�
 
 ::
 
-    url="https://example.com/product/" + id
+    url="https://shop.example.com/product/" + id
     title=name
     content=description
-    price=price
-    category=category
+    digest=description
+    host="shop.example.com"
+    site="shop.example.com"
 
-ネストしたJSONオブジェクト（ネストしたオブジェクトはマップとして参照します）:
+ネストしたオブジェクトはマップ、ネストした配列はリストとして参照できます:
 
 ::
 
@@ -148,17 +252,7 @@ JSONオブジェクトのトップレベルのフィールドは、スクリプ�
     title=product.name
     content=product.description
     price=product.pricing.amount
-    author=product.author.name
-
-配列要素の処理:
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=body
-    tags=tags.join(", ")
-    categories=categories[0].name
+    first_tag=tags[0]
 
 利用可能なフィールド
 ~~~~~~~~~~~~~~~~~~~~
@@ -166,48 +260,65 @@ JSONオブジェクトのトップレベルのフィールドは、スクリプ�
 - ``<フィールド名>`` - JSONオブジェクトのトップレベルのフィールドを名前で直接参照します
 - ``<親>.<子>`` - ネストしたオブジェクトのフィールド
 - ``<配列>[<インデックス>]`` - 配列要素
-- ``<配列>.<メソッド>`` - 配列のメソッド（ ``join``、``collect``、``size`` など）
 
 .. note::
 
-   フィールド名にスペースやハイフンなど、Groovyの識別子として無効な文字が含まれる場合は、
-   そのフィールドを変数名として直接参照できません。
-
-JSON形式の詳細
-==============
-
-JSONファイル形式
-----------------
-
-JSONコネクタは、JSONL（JSON Lines）形式のファイルを読み込みます。
-1行に1つのJSONオブジェクトを記述する形式です。ファイルは1行ずつ読み込まれ、
-各行が独立したJSONオブジェクトとして解析されます。
+   フィールドの値が ``null`` の場合、そのフィールドはドキュメントに登録されません。
 
 .. note::
-   拡張子が ``.json`` のファイルも処理対象になりますが、内容はJSONL形式
-   （1行1オブジェクト）である必要があります。
-   配列形式のJSONファイル（ ``[{...}, {...}]`` ）や、複数行に整形された
-   （pretty-printされた）JSONは直接読み込めません。JSONL形式に変換してください。
 
-JSONL形式のファイル:
+   |Fess| 15.9 では、組み込みのスクリプトエンジンがJavaScriptになりました。
+   Groovyは ``fess-script-groovy`` プラグインとして提供されます。
+   使用するエンジンはデータストアのパラメーター ``script_type`` で指定します
+   （ ``script_type=javascript`` など）。省略した場合は ``groovy`` が使用されます。
+   上記の例のような単純な参照や文字列連結は、どちらのエンジンでも同じように動作しますが、
+   それ以外の記法はエンジンによって異なります。
 
-::
+注意事項
+========
 
-    {"id": 1, "name": "Product A", "description": "Description A"}
-    {"id": 2, "name": "Product B", "description": "Description B"}
+``app.encrypt.property.pattern`` に一致する名前のパラメーター（既定では ``password`` 、
+``key`` 、 ``token`` 、 ``secret`` で終わるもの）は、スクリプトからは ``null`` として
+参照されます。データストアのパラメーターに記述した資格情報が、インデックスの
+フィールドへコピーされることを防ぐためです。
+
+同名のフィールドがレコード側にある場合は、他のパラメーターと同様にレコード側の値が
+優先されます。
+
+.. note::
+
+   一致判定はパラメーター名に対する大文字小文字を区別した完全一致です。
+   ``access_token`` は対象になりますが、キャメルケースの ``accessToken`` は
+   対象になりません。資格情報をパラメーターに記述する場合はスネークケースで
+   記述してください。
+
+パラメーターの誤りとエラー
+==========================
+
+``format`` 、 ``include_pattern`` 、 ``exclude_pattern`` 、 ``urls`` に使用できない値を
+指定した場合は、ファイルを読み込む前にクロールが終了し、そのパラメーター名を含む
+失敗URL（例: ``JsonDataStore:format`` ）が記録されます。
+
+``max_depth`` に数値以外を指定した場合は、ログに記録されたうえで既定値が使用されます。
+
+.. note::
+
+   データストアのクロールは、対象が1件も取得できなかった場合でもジョブとしては
+   正常終了します。取得件数が想定と異なる場合は、インデックスの件数、失敗URL、
+   および ``fess-crawler.log`` を確認してください。
 
 使用例
 ======
 
 製品カタログ
---------------
+------------
 
 パラメーター:
 
 ::
 
-    files=/var/data/products.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
 スクリプト:
 
@@ -215,19 +326,20 @@ JSONL形式のファイル:
 
     url="https://shop.example.com/product/" + product_id
     title=name
-    content=description + " 価格: " + price + "円"
+    content=description
     digest=category
-    price=price
+    host="shop.example.com"
+    site="shop.example.com"
 
-複数JSONファイルの統合
-----------------------
+APIレスポンスを保存したファイル
+--------------------------------
 
 パラメーター:
 
 ::
 
-    files=/var/data/data1.json,/var/data/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/response.json
+    root_path=/data/items
 
 スクリプト:
 
@@ -235,7 +347,22 @@ JSONL形式のファイル:
 
     url="https://example.com/item/" + id
     title=title
-    content=content
+    content=body
+    host="example.com"
+    site="example.com"
+
+ディレクトリを再帰的に処理する
+------------------------------
+
+パラメーター:
+
+::
+
+    directories=/var/data/exports
+    recursive=true
+    max_depth=3
+    include_pattern=.*\.jsonl
+    file_encoding=UTF-8
 
 トラブルシューティング
 ======================
@@ -243,34 +370,37 @@ JSONL形式のファイル:
 ファイルが見つからない
 ----------------------
 
-**症状**: ログに ``... is not found.`` または ``Source file ... does not exist.`` と出力される
+**症状**: ログに ``... does not exist.`` 、 ``... is not a file.`` 、
+``... is skipped because its suffix is not one of ...`` と出力される
 
 **確認事項**:
 
 1. ファイルパスが正しいか確認
 2. ファイルが存在するか確認
-3. ファイルの拡張子が ``.json`` または ``.jsonl`` か確認
-4. ファイルの読み取り権限があるか確認
+3. ファイルの接尾辞が ``file_suffixes`` （既定では ``.json`` または ``.jsonl`` ）に
+   一致するか確認
+4. |Fess| の実行ユーザーに読み取り権限があるか確認
 
 JSON解析エラー
 --------------
 
-**症状**: ログに ``Crawling Access Exception`` と ``JsonParseException`` などが出力される
-
-不正な行が含まれる場合、その行のみがスキップされて失敗URLとして記録され、
-クロール自体は次の行から継続します。
+**症状**: ログに ``Failed to parse ...`` や ``Failed to read ...`` が出力される、
+または失敗URLが記録される
 
 **確認事項**:
 
-1. JSONファイルが正しい形式（1行1オブジェクトのJSONL）か確認:
+1. ファイルが正しいJSONか検証する
 
    ::
 
-       # 各行が有効なJSONオブジェクトかを検証
-       cat data.json | jq -c .
+       # JSON Lines形式の場合、各行が有効なJSONオブジェクトかを検証
+       cat data.jsonl | jq -c .
+
+       # 配列や単一オブジェクトの場合
+       jq . data.json
 
 2. 文字エンコーディングが正しいか確認
-3. 1つのオブジェクトが複数行に分かれていないか確認
+3. ファイルが途中で切れていないか確認
 4. コメントが含まれていないか確認（JSON標準ではコメント不可）
 
 データが取得できない
@@ -280,82 +410,37 @@ JSON解析エラー
 
 **確認事項**:
 
-1. JSON構造を確認
-2. スクリプト設定が正しいか確認（フィールド参照が ``data.`` 接頭辞なしになっているか）
-3. フィールド名が正しいか確認（大文字小文字を含む）
-4. ログでエラーメッセージを確認
+1. ``root_path`` を指定している場合、そのJSON Pointerがドキュメントの構造と
+   一致しているか確認（一致しない場合はエラーにならず0件になります）
+2. ``include_pattern`` 、 ``exclude_pattern`` 、 ``file_suffixes`` で対象が
+   すべて除外されていないか確認。この場合はログに ``No sources to process`` が
+   出力されます
+3. スクリプト設定が正しいか確認（フィールド参照が ``data.`` 接頭辞なしになっているか）
+4. フィールド名が正しいか確認（大文字小文字を含む）
+5. ``url`` が組み立てられているか確認。 ``url`` が空の場合はレコードごとに失敗になります
+
+文字化けする
+------------
+
+**症状**: 登録されたドキュメントの文字が壊れている
+
+``file_encoding`` に実在するが誤ったエンコーディングを指定した場合、エラーにはならず
+文字化けしたまま登録されます。ファイルの実際のエンコーディングを確認してください。
+存在しないエンコーディング名を指定した場合は、ファイルごとに失敗URLが記録されます。
 
 大きなJSONファイル
 ------------------
 
 **症状**: メモリ不足またはタイムアウト
 
-ファイルは1行ずつ読み込まれるため、ファイル全体のサイズが直接メモリ使用量に
-影響することはありません。ただし、1行（1オブジェクト）が極端に大きい場合や、
+レコードは1件ずつ読み込まれるため、ファイル全体のサイズが直接メモリ使用量に
+影響することはありません。ただし、1つのレコードが極端に大きい場合や、
 インデックス登録の負荷が高い場合に問題が発生することがあります。
 
 **解決方法**:
 
 1. JSONファイルを複数に分割
 2. |Fess| のヒープサイズを増やす
-
-スクリプトの高度な使用例
-========================
-
-条件付き処理
-------------
-
-各フィールドは独立した式として評価されます。条件付きの値は三項演算子を使用します:
-
-::
-
-    url=status == "published" ? "https://example.com/product/" + id : null
-    title=status == "published" ? name : null
-    content=status == "published" ? description : null
-    price=status == "published" ? price : null
-
-配列の結合
-----------
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=content
-    tags=tags ? tags.join(", ") : ""
-    categories=categories.collect { it.name }.join(", ")
-
-デフォルト値の設定
-------------------
-
-::
-
-    url="https://example.com/item/" + id
-    title=title ?: "無題"
-    content=description ?: (summary ?: "説明なし")
-    price=price ?: 0
-
-日付のフォーマット
-------------------
-
-::
-
-    url="https://example.com/post/" + id
-    title=title
-    content=body
-    created=created_at
-    last_modified=updated_at
-
-数値の処理
-----------
-
-::
-
-    url="https://example.com/product/" + id
-    title=name
-    content=description
-    price=price as Float
-    stock=stock_quantity as Integer
 
 参考情報
 ========
@@ -366,4 +451,5 @@ JSON解析エラー
 - :doc:`../../admin/dataconfig-guide` - データストア設定ガイド
 - `JSON (JavaScript Object Notation) <https://www.json.org/>`_
 - `JSON Lines <https://jsonlines.org/>`_
+- `JSON Pointer (RFC 6901) <https://datatracker.ietf.org/doc/html/rfc6901>`_
 - `jq - JSON processor <https://stedolan.github.io/jq/>`_

--- a/ko/15.9/config/datastore/ds-json.rst
+++ b/ko/15.9/config/datastore/ds-json.rst
@@ -5,10 +5,25 @@ JSON 커넥터
 개요
 ====
 
-JSON 커넥터는 로컬 JSONL 파일(JSON Lines 형식)에서 데이터를 가져와
+JSON 커넥터는 로컬 파일 시스템 상의 JSON 파일에서 데이터를 가져와
 |Fess| 인덱스에 등록하는 기능을 제공합니다.
 
 이 기능을 사용하려면 ``fess-ds-json`` 플러그인이 필요합니다.
+
+다음 3가지 형식을 지원하며, 기본적으로 파일 내용으로부터 자동으로 판별됩니다.
+
+- JSON Lines 형식(1행에 1개의 JSON 오브젝트)
+- JSON 오브젝트의 배열(정형화된 것, 1행으로 정리된 것 모두 가능)
+- 단일 JSON 오브젝트
+
+레코드는 1건씩 읽어들이므로, 큰 배열이라도 파일 전체가 메모리에
+유지되는 일은 없습니다.
+
+.. note::
+
+   이 커넥터는 로컬 파일 시스템 상의 JSON 파일만을 대상으로 합니다.
+   HTTP 등을 통한 원격 취득에는 대응하지 않으며, ``urls`` 파라미터를 지정한 경우에는
+   무시되는 것이 아니라 오류가 됩니다.
 
 전제 조건
 =========
@@ -20,23 +35,29 @@ JSON 커넥터는 로컬 JSONL 파일(JSON Lines 형식)에서 데이터를 가�
 플러그인 설치
 -------------
 
-방법 1: JAR 파일 직접 배치
-
-::
-
-    # Maven Central에서 다운로드
-    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
-
-    # 배치
-    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
-    # 또는
-    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
-
-방법 2: 관리 화면에서 설치
+방법 1: 관리 화면에서 설치
 
 1. "시스템" → "플러그인" 열기
 2. JAR 파일 업로드
 3. |Fess| 재시작
+
+방법 2: JAR 파일 직접 배치
+
+::
+
+    # CodeLibs 저장소에서 다운로드
+    wget https://maven.codelibs.org/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
+
+    # 배치
+    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/plugin/
+    # 또는
+    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/plugin/
+
+.. note::
+
+   15.8.0 이후 버전의 JAR는 `CodeLibs 저장소 <https://maven.codelibs.org/release/org/codelibs/fess/fess-ds-json/>`_
+   에서 배포하고 있습니다. 15.7.0 이전 버전은
+   `Maven Central <https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/>`_ 에 있습니다.
 
 설정 방법
 =========
@@ -66,67 +87,149 @@ JSON 커넥터는 로컬 JSONL 파일(JSON Lines 형식)에서 데이터를 가�
 
 ::
 
-    files=/path/to/data.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
 복수 파일:
 
 ::
 
-    files=/path/to/data1.json,/path/to/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/data1.json,/var/data/data2.json
+    file_encoding=UTF-8
 
 디렉터리 지정:
 
 ::
 
-    directories=/path/to/json_dir/
-    fileEncoding=UTF-8
+    directories=/var/data/json_dir/
+    file_encoding=UTF-8
 
 파라미터 목록
 ~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 10 70
+   :widths: 22 12 66
 
    * - 파라미터
-     - 필수
+     - 기본값
      - 설명
    * - ``files``
-     - 아니오
-     - 처리할 JSON 파일 경로(복수 지정 가능: 쉼표 구분). ``.json`` 또는 ``.jsonl`` 확장자 파일만 처리됩니다.
+     -
+     - 처리할 JSON 파일의 경로(복수 지정 가능: 쉼표 구분). 지정한 순서대로 처리됩니다.
    * - ``directories``
-     - 아니오
-     - JSON 파일을 포함하는 디렉터리 경로(복수 지정 가능: 쉼표 구분)
-   * - ``fileEncoding``
-     - 아니오
-     - 문자 인코딩(기본값: UTF-8)
+     -
+     - JSON 파일이 포함된 디렉터리의 경로(복수 지정 가능: 쉼표 구분).
+   * - ``recursive``
+     - ``false``
+     - ``directories`` 를 하위 디렉터리까지 탐색할지 여부.
+   * - ``max_depth``
+     - ``10``
+     - ``recursive=true`` 일 때, 각 디렉터리의 몇 계층 아래까지 내려갈지. ``0`` 을 지정하면 ``recursive=false`` 와 동일하게 동작합니다.
+   * - ``include_pattern``
+     -
+     - 파일의 절대 경로가 완전히 일치해야 하는 정규 표현식.
+   * - ``exclude_pattern``
+     -
+     - 파일의 절대 경로가 일치해서는 안 되는 정규 표현식.
+   * - ``file_suffixes``
+     - ``.json,.jsonl``
+     - 대상으로 할 파일의 접미사(복수 지정 가능: 쉼표 구분). 대소문자를 구분하지 않습니다.
+   * - ``file_encoding``
+     - ``UTF-8``
+     - 파일의 문자 인코딩.
+   * - ``format``
+     - ``auto``
+     - 문서의 형식. ``auto`` , ``jsonl`` , ``json`` 중 하나.
+   * - ``root_path``
+     -
+     - 레코드를 읽어들일 위치를 지정하는 JSON Pointer(예: ``/data/items`` ).
+
+.. note::
+
+   파라미터 이름은 스네이크 케이스로 기재했지만, 캐멀 케이스 표기
+   ( ``file_encoding`` 에 대한 ``fileEncoding`` 등)도 동일하게 사용할 수 있습니다.
+
+.. note::
+
+   ``files`` 와 ``directories`` 중 적어도 하나를 지정하십시오.
+   양쪽 모두 비어 있으면 오류가 발생합니다.
+   양자는 배타적이지 않으며, 양쪽을 모두 지정한 경우 양쪽 모두 처리됩니다.
+   같은 파일이 양쪽에서 도달하는 경우에도 읽어들이는 것은 1회뿐입니다.
+
+파일 탐색 순서
+~~~~~~~~~~~~~~
+
+- ``files`` 로 지정한 파일은 지정한 순서대로 처리됩니다.
+- ``directories`` 아래에서 발견된 파일은 수정 일시가 오래된 순서로 처리됩니다.
+- ``files`` 로 지정한 파일은 ``directories`` 아래의 파일보다 먼저 처리됩니다.
+
+``file_suffixes`` 에 의한 필터링은 ``files`` 로 직접 지정한 파일에도 적용됩니다.
+접미사가 일치하지 않는 파일은 로그에 이유가 출력된 후 건너뜁니다.
+
+존재하지 않는 경로, ``files`` 에 지정된 디렉터리, ``directories`` 에 지정된 파일은,
+모두 경고로 로그에 기록되며, 크롤링 자체는 계속 진행됩니다.
+
+``format``
+----------
+
+``auto`` 는 문서의 앞부분을 읽어 그 문법으로부터 형식을 판별합니다. 3가지 형식 중 어느
+것이든, 올바르게 작성된 파일이라면 이 방법으로 판별할 수 있습니다.
+
+``format=jsonl`` 을 명시하는 것은, JSON Lines 형식의 파일이면서 앞부분 근처의 행이
+손상되어 있을 가능성이 있는 경우입니다(배너 행, 진행 로그, 전송이 도중에 끊긴 레코드 등).
+자동 판별은 그런 행을 건너뛰어 판단해야 하기 때문입니다.
+
+이 설정은 잘못된 레코드의 영향 범위도 결정합니다.
+
+- **JSON Lines 형식**: 각 행이 독립적으로 파싱되므로, 잘못된 행의 비용은 그 행뿐입니다.
+  실패는 ``<파일의 절대 경로>@<행 번호>`` 라는 키로 실패 URL에 기록되며,
+  다음 행부터 그대로 처리가 계속됩니다.
+- **그 외 형식**: 토큰 스트림으로 읽어들이기 때문에, 하나의 실패가 후속 레코드까지
+  끌어들이는 경우가 있습니다. 오브젝트 도중에 끊긴 문서는 복구할 수 없으며,
+  일정 횟수 연속으로 실패하면 해당 파일은 경고를 출력하고 중단됩니다.
+
+``root_path``
+-------------
+
+중첩된 배열을 가리키는 JSON Pointer를 지정하면, 그 요소가 레코드로 등록됩니다.
+
+::
+
+    root_path=/data/items
+
+.. code-block:: json
+
+    { "meta": { "count": 2 }, "data": { "items": [ { "id": "1" }, { "id": "2" } ] } }
+
+- 배열을 가리킨 경우, 그 요소마다 1개의 레코드가 됩니다.
+- 오브젝트를 가리킨 경우, 그 오브젝트가 1개의 레코드가 됩니다.
+- 어디에도 일치하지 않는 경우, 오류가 되지 않고 레코드가 0건이 됩니다.
+- JSON Pointer의 이스케이프( ``~1`` 이 ``/`` , ``~0`` 이 ``~`` )를 사용할 수 있습니다.
+
+``root_path`` 는 ``format`` 보다 우선됩니다. JSON Pointer로 도달한 문서는 행 단위로
+읽어들이지 않기 때문이며, ``format=jsonl`` 과 동시에 지정한 경우에는 그 취지의 경고가
+로그에 출력됩니다.
 
 .. warning::
-   ``files`` 또는 ``directories`` 중 하나를 반드시 지정해야 합니다.
-   둘 다 미지정(공백)인 경우 ``DataStoreException`` 이 발생합니다.
-   둘 다 지정한 경우 ``files`` 가 우선되며 ``directories`` 는 무시됩니다.
+
+   ``root_path`` 는 ``/`` 로 시작해야 합니다. ``data/items`` 처럼 앞의 ``/`` 를
+   빠뜨리면, JSON Pointer로 해석할 수 없어 데이터 설정 전체가 오류가 됩니다.
+   이때 실패 URL은 파라미터 이름이 아니라 데이터 설정으로 기록되므로,
+   어느 파라미터가 원인인지는 로그의
+   ``JSON Pointer expression must start with '/'`` 를 통해 판단하십시오.
 
 .. note::
-   파라미터 이름은 카멜 케이스의 ``fileEncoding`` 입니다(스네이크 케이스의 ``file_encoding`` 이 아닙니다).
 
-디렉터리 지정 시의 동작
-~~~~~~~~~~~~~~~~~~~~~~~
-
-``directories`` 를 지정한 경우, 각 디렉터리 바로 아래의 파일이 다음 규칙으로 처리됩니다.
-
-- **하위 디렉터리는 탐색되지 않습니다** (재귀적 탐색은 수행하지 않습니다).
-- 확장자가 ``.json`` 또는 ``.jsonl`` 인 파일만 대상입니다(대소문자 구분 없음).
-- 파일은 수정 일시(최종 수정 시각) 오름차순으로 처리됩니다.
-
-.. note::
-   이 커넥터는 로컬 파일 시스템의 JSON 파일만 대상으로 하며, HTTP 액세스나 API 인증 기능은 지원하지 않습니다.
+   ``root_path`` 를 지정하지 않고, 레코드가 여러 행에 걸쳐 정형화된 문서
+   (메타 정보와 배열을 포함하는 이른바 래퍼 형식)를 읽어들이면, 행 단위 파싱이
+   시도되기 때문에 의도한 레코드를 가져오지 못하고 실패가 기록됩니다.
+   그러한 문서에서는 ``root_path`` 를 지정하십시오.
 
 스크립트 설정
 -------------
 
-각 필드의 값은 JSON 오브젝트의 각 필드 값을 참조하여 조합합니다.
+각 필드의 값은 JSON 오브젝트의 각 필드 값을 참조하여 구성합니다.
 JSON 오브젝트 최상위 레벨의 필드는 스크립트 내에서 **접두사 없는 변수**
 로 직접 참조할 수 있습니다( ``data.`` 와 같은 접두사는 붙지 않습니다).
 
@@ -134,13 +237,14 @@ JSON 오브젝트 최상위 레벨의 필드는 스크립트 내에서 **접두�
 
 ::
 
-    url="https://example.com/product/" + id
+    url="https://shop.example.com/product/" + id
     title=name
     content=description
-    price=price
-    category=category
+    digest=description
+    host="shop.example.com"
+    site="shop.example.com"
 
-중첩된 JSON 오브젝트(중첩된 오브젝트는 맵으로 참조합니다):
+중첩된 오브젝트는 맵, 중첩된 배열은 리스트로 참조할 수 있습니다:
 
 ::
 
@@ -148,17 +252,7 @@ JSON 오브젝트 최상위 레벨의 필드는 스크립트 내에서 **접두�
     title=product.name
     content=product.description
     price=product.pricing.amount
-    author=product.author.name
-
-배열 요소 처리:
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=body
-    tags=tags.join(", ")
-    categories=categories[0].name
+    first_tag=tags[0]
 
 사용 가능한 필드
 ~~~~~~~~~~~~~~~~
@@ -166,35 +260,52 @@ JSON 오브젝트 최상위 레벨의 필드는 스크립트 내에서 **접두�
 - ``<필드명>`` - JSON 오브젝트 최상위 레벨의 필드를 이름으로 직접 참조합니다
 - ``<부모>.<자식>`` - 중첩된 오브젝트의 필드
 - ``<배열>[<인덱스>]`` - 배열 요소
-- ``<배열>.<메서드>`` - 배열 메서드( ``join``, ``collect``, ``size`` 등)
 
 .. note::
 
-   필드 이름에 공백이나 하이픈 등 Groovy 식별자로 유효하지 않은 문자가 포함된 경우,
-   해당 필드를 변수명으로 직접 참조할 수 없습니다.
-
-JSON 형식 상세
-==============
-
-JSON 파일 형식
---------------
-
-JSON 커넥터는 JSONL(JSON Lines) 형식의 파일을 읽어들입니다.
-한 줄에 하나의 JSON 오브젝트를 기술하는 형식입니다. 파일은 한 줄씩 읽어들이며,
-각 줄이 독립된 JSON 오브젝트로 파싱됩니다.
+   필드의 값이 ``null`` 인 경우, 그 필드는 문서에 등록되지 않습니다.
 
 .. note::
-   확장자가 ``.json`` 인 파일도 처리 대상이 되지만, 내용은 JSONL 형식
-   (한 줄에 하나의 오브젝트)이어야 합니다.
-   배열 형식의 JSON 파일( ``[{...}, {...}]`` )이나, 여러 줄로 포맷된
-   (pretty-print된) JSON은 직접 읽어들일 수 없습니다. JSONL 형식으로 변환해 주세요.
 
-JSONL 형식 파일:
+   |Fess| 15.9 부터 내장 스크립트 엔진이 JavaScript로 변경되었습니다.
+   Groovy는 ``fess-script-groovy`` 플러그인으로 제공됩니다.
+   사용할 엔진은 데이터 스토어의 파라미터 ``script_type`` 으로 지정합니다
+   ( ``script_type=javascript`` 등). 생략한 경우에는 ``groovy`` 가 사용됩니다.
+   위 예시와 같은 단순한 참조나 문자열 연결은 두 엔진 모두 동일하게 동작하지만,
+   그 외의 표기법은 엔진에 따라 다릅니다.
 
-::
+주의 사항
+=========
 
-    {"id": 1, "name": "Product A", "description": "Description A"}
-    {"id": 2, "name": "Product B", "description": "Description B"}
+``app.encrypt.property.pattern`` 에 일치하는 이름의 파라미터(기본값에서는 ``password`` ,
+``key`` , ``token`` , ``secret`` 으로 끝나는 것)는 스크립트에서는 ``null`` 로
+참조됩니다. 데이터 스토어의 파라미터에 기재한 자격 증명이 인덱스
+필드로 복사되는 것을 방지하기 위해서입니다.
+
+같은 이름의 필드가 레코드 쪽에 있는 경우, 다른 파라미터와 마찬가지로 레코드 쪽의 값이
+우선됩니다.
+
+.. note::
+
+   일치 판정은 파라미터 이름에 대한 대소문자를 구분하는 완전 일치입니다.
+   ``access_token`` 은 대상이 되지만, 캐멀 케이스인 ``accessToken`` 은
+   대상이 되지 않습니다. 자격 증명을 파라미터에 기재하는 경우에는 스네이크 케이스로
+   기재하십시오.
+
+잘못된 파라미터와 오류
+======================
+
+``format`` , ``include_pattern`` , ``exclude_pattern`` , ``urls`` 에 사용할 수 없는 값을
+지정한 경우에는 파일을 읽어들이기 전에 크롤링이 종료되며, 해당 파라미터 이름을 포함한
+실패 URL(예: ``JsonDataStore:format`` )이 기록됩니다.
+
+``max_depth`` 에 숫자가 아닌 값을 지정한 경우에는 로그에 기록된 후 기본값이 사용됩니다.
+
+.. note::
+
+   데이터 스토어의 크롤링은 대상을 1건도 가져오지 못한 경우에도 작업으로서는
+   정상 종료합니다. 가져온 건수가 예상과 다른 경우에는 인덱스 건수, 실패 URL,
+   그리고 ``fess-crawler.log`` 를 확인하십시오.
 
 사용 예
 =======
@@ -206,8 +317,8 @@ JSONL 형식 파일:
 
 ::
 
-    files=/var/data/products.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
 스크립트:
 
@@ -215,19 +326,20 @@ JSONL 형식 파일:
 
     url="https://shop.example.com/product/" + product_id
     title=name
-    content=description + " 가격: " + price + "원"
+    content=description
     digest=category
-    price=price
+    host="shop.example.com"
+    site="shop.example.com"
 
-복수 JSON 파일 통합
--------------------
+API 응답을 저장한 파일
+-----------------------
 
 파라미터:
 
 ::
 
-    files=/var/data/data1.json,/var/data/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/response.json
+    root_path=/data/items
 
 스크립트:
 
@@ -235,127 +347,101 @@ JSONL 형식 파일:
 
     url="https://example.com/item/" + id
     title=title
-    content=content
+    content=body
+    host="example.com"
+    site="example.com"
+
+디렉터리를 재귀적으로 처리하기
+-------------------------------
+
+파라미터:
+
+::
+
+    directories=/var/data/exports
+    recursive=true
+    max_depth=3
+    include_pattern=.*\.jsonl
+    file_encoding=UTF-8
 
 문제 해결
 =========
 
 파일을 찾을 수 없음
--------------------
+--------------------
 
-**증상**: 로그에 ``... is not found.`` 또는 ``Source file ... does not exist.`` 가 출력됩니다
+**증상**: 로그에 ``... does not exist.`` , ``... is not a file.`` ,
+``... is skipped because its suffix is not one of ...`` 가 출력됨
 
 **확인 사항**:
 
 1. 파일 경로가 올바른지 확인
 2. 파일이 존재하는지 확인
-3. 파일 확장자가 ``.json`` 또는 ``.jsonl`` 인지 확인
-4. 파일 읽기 권한이 있는지 확인
+3. 파일의 접미사가 ``file_suffixes`` (기본값은 ``.json`` 또는 ``.jsonl`` )에
+   일치하는지 확인
+4. |Fess| 실행 사용자에게 읽기 권한이 있는지 확인
 
 JSON 파싱 오류
---------------
+---------------
 
-**증상**: 로그에 ``Crawling Access Exception`` 과 ``JsonParseException`` 등이 출력됩니다
-
-잘못된 줄이 포함된 경우, 해당 줄만 건너뛰고 실패 URL로 기록되며,
-크롤링 자체는 다음 줄부터 계속됩니다.
+**증상**: 로그에 ``Failed to parse ...`` 나 ``Failed to read ...`` 가 출력되거나,
+실패 URL이 기록됨
 
 **확인 사항**:
 
-1. JSON 파일이 올바른 형식(한 줄에 하나의 오브젝트인 JSONL)인지 확인:
+1. 파일이 올바른 JSON인지 검증
 
    ::
 
-       # 각 줄이 유효한 JSON 오브젝트인지 검증
-       cat data.json | jq -c .
+       # JSON Lines 형식의 경우, 각 행이 유효한 JSON 오브젝트인지 검증
+       cat data.jsonl | jq -c .
+
+       # 배열이나 단일 오브젝트의 경우
+       jq . data.json
 
 2. 문자 인코딩이 올바른지 확인
-3. 하나의 오브젝트가 여러 줄에 걸쳐 있지 않은지 확인
+3. 파일이 도중에 잘리지 않았는지 확인
 4. 주석이 포함되어 있지 않은지 확인(JSON 표준에서는 주석 불가)
 
 데이터를 가져올 수 없음
------------------------
+------------------------
 
 **증상**: 크롤링은 성공하지만 건수가 0
 
 **확인 사항**:
 
-1. JSON 구조 확인
-2. 스크립트 설정이 올바른지 확인(필드 참조가 ``data.`` 접두사 없이 되어 있는지)
-3. 필드명이 올바른지 확인(대소문자 포함)
-4. 로그에서 오류 메시지 확인
+1. ``root_path`` 를 지정하고 있는 경우, 그 JSON Pointer가 문서의 구조와
+   일치하는지 확인(일치하지 않는 경우 오류가 되지 않고 0건이 됩니다)
+2. ``include_pattern`` , ``exclude_pattern`` , ``file_suffixes`` 로 대상이
+   모두 제외되지 않았는지 확인. 이 경우에는 로그에 ``No sources to process`` 가
+   출력됩니다
+3. 스크립트 설정이 올바른지 확인(필드 참조가 ``data.`` 접두사 없이 되어 있는지)
+4. 필드 이름이 올바른지 확인(대소문자 포함)
+5. ``url`` 이 구성되어 있는지 확인. ``url`` 이 비어 있는 경우 레코드마다 실패로
+   처리됩니다
 
-대용량 JSON 파일
-----------------
+문자 깨짐 발생
+---------------
+
+**증상**: 등록된 문서의 문자가 깨져 있음
+
+``file_encoding`` 에 실제로 존재하지만 잘못된 인코딩을 지정한 경우, 오류가 되지 않고
+문자가 깨진 채로 등록됩니다. 파일의 실제 인코딩을 확인하십시오.
+존재하지 않는 인코딩 이름을 지정한 경우에는 파일마다 실패 URL이 기록됩니다.
+
+대형 JSON 파일
+---------------
 
 **증상**: 메모리 부족 또는 타임아웃
 
-파일은 한 줄씩 읽어들이기 때문에 파일 전체 크기가 직접 메모리 사용량에
-영향을 주지는 않습니다. 단, 한 줄(오브젝트 하나)이 극단적으로 큰 경우나
-인덱스 등록 부하가 높은 경우 문제가 발생할 수 있습니다.
+레코드는 1건씩 읽어들이므로, 파일 전체의 크기가 직접 메모리 사용량에
+영향을 미치지는 않습니다. 다만, 하나의 레코드가 극단적으로 큰 경우나,
+인덱스 등록 부하가 높은 경우에는 문제가 발생할 수 있습니다.
 
 **해결 방법**:
 
 1. JSON 파일을 여러 개로 분할
-2. |Fess| 힙 사이즈 늘리기
-
-스크립트 고급 사용 예
-=====================
-
-조건부 처리
------------
-
-각 필드는 독립된 식으로 평가됩니다. 조건부 값에는 삼항 연산자를 사용합니다:
-
-::
-
-    url=status == "published" ? "https://example.com/product/" + id : null
-    title=status == "published" ? name : null
-    content=status == "published" ? description : null
-    price=status == "published" ? price : null
-
-배열 결합
----------
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=content
-    tags=tags ? tags.join(", ") : ""
-    categories=categories.collect { it.name }.join(", ")
-
-기본값 설정
------------
-
-::
-
-    url="https://example.com/item/" + id
-    title=title ?: "제목 없음"
-    content=description ?: (summary ?: "설명 없음")
-    price=price ?: 0
-
-날짜 포맷
----------
-
-::
-
-    url="https://example.com/post/" + id
-    title=title
-    content=body
-    created=created_at
-    last_modified=updated_at
-
-숫자 처리
----------
-
-::
-
-    url="https://example.com/product/" + id
-    title=name
-    content=description
-    price=price as Float
-    stock=stock_quantity as Integer
+2. |Fess| 의 힙 크기 증가
 
 참고 정보
 =========
@@ -366,4 +452,5 @@ JSON 파싱 오류
 - :doc:`../../admin/dataconfig-guide` - 데이터 스토어 설정 가이드
 - `JSON (JavaScript Object Notation) <https://www.json.org/>`_
 - `JSON Lines <https://jsonlines.org/>`_
+- `JSON Pointer (RFC 6901) <https://datatracker.ietf.org/doc/html/rfc6901>`_
 - `jq - JSON processor <https://stedolan.github.io/jq/>`_

--- a/zh-cn/15.9/config/datastore/ds-json.rst
+++ b/zh-cn/15.9/config/datastore/ds-json.rst
@@ -5,38 +5,58 @@ JSON连接器
 概述
 ====
 
-JSON连接器提供从本地JSONL文件（JSON Lines格式）获取数据并注册到
+JSON连接器提供从本地文件系统上的JSON文件获取数据并注册到
 |Fess| 索引的功能。
 
 此功能需要 ``fess-ds-json`` 插件。
+
+支持以下三种格式，默认情况下会根据文件内容自动判断。
+
+- JSON Lines格式（每行一个JSON对象）
+- JSON对象数组（无论是格式化后的还是压缩为一行的均可）
+- 单个JSON对象
+
+由于记录是逐条读取的，因此即使是较大的数组，也不会将文件全部内容
+保留在内存中。
+
+.. note::
+
+   此连接器仅面向本地文件系统上的JSON文件。不支持HTTP等远程获取方式，
+   若指定了 ``urls`` 参数，不会被忽略，而是会导致报错。
 
 前提条件
 ========
 
 1. 需要安装插件
-2. 需要对JSON文件的访问权限
-3. 需要理解JSON的结构
+2. 需要具有JSON文件的访问权限
+3. 需要了解JSON的结构
 
 插件安装
 ------------------------
 
-方法1: 直接放置JAR文件
-
-::
-
-    # 从Maven Central下载
-    wget https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
-
-    # 放置
-    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/lib/
-    # 或者
-    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/lib/
-
-方法2: 从管理界面安装
+方法1: 从管理界面安装
 
 1. 打开「系统」→「插件」
 2. 上传JAR文件
 3. 重启 |Fess|
+
+方法2: 直接放置JAR文件
+
+::
+
+    # 从CodeLibs仓库下载
+    wget https://maven.codelibs.org/org/codelibs/fess/fess-ds-json/X.X.X/fess-ds-json-X.X.X.jar
+
+    # 放置
+    cp fess-ds-json-X.X.X.jar $FESS_HOME/app/WEB-INF/plugin/
+    # 或者
+    cp fess-ds-json-X.X.X.jar /usr/share/fess/app/WEB-INF/plugin/
+
+.. note::
+
+   15.8.0及以后版本的JAR文件发布在 `CodeLibs仓库 <https://maven.codelibs.org/release/org/codelibs/fess/fess-ds-json/>`_
+   ，15.7.0及以前版本位于
+   `Maven Central <https://repo1.maven.org/maven2/org/codelibs/fess/fess-ds-json/>`_ 。
 
 配置方法
 ========
@@ -66,81 +86,163 @@ JSON连接器提供从本地JSONL文件（JSON Lines格式）获取数据并注�
 
 ::
 
-    files=/path/to/data.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
 多个文件:
 
 ::
 
-    files=/path/to/data1.json,/path/to/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/data1.json,/var/data/data2.json
+    file_encoding=UTF-8
 
 目录指定:
 
 ::
 
-    directories=/path/to/json_dir/
-    fileEncoding=UTF-8
+    directories=/var/data/json_dir/
+    file_encoding=UTF-8
 
 参数列表
 ~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 10 70
+   :widths: 22 12 66
 
    * - 参数
-     - 必需
+     - 默认值
      - 说明
    * - ``files``
-     - 否
-     - 要处理的JSON文件路径（可指定多个：逗号分隔）。仅处理扩展名为 ``.json`` 或 ``.jsonl`` 的文件。
+     -
+     - 要处理的JSON文件路径（可指定多个：逗号分隔）。将按指定的顺序处理。
    * - ``directories``
-     - 否
-     - 包含JSON文件的目录路径（可指定多个：逗号分隔）
-   * - ``fileEncoding``
-     - 否
-     - 字符编码（默认: UTF-8）
+     -
+     - 包含JSON文件的目录路径（可指定多个：逗号分隔）。
+   * - ``recursive``
+     - ``false``
+     - 是否对 ``directories`` 递归扫描子目录。
+   * - ``max_depth``
+     - ``10``
+     - ``recursive=true`` 时，从各目录向下扫描的层数。指定 ``0`` 时的行为与 ``recursive=false`` 相同。
+   * - ``include_pattern``
+     -
+     - 文件的绝对路径必须完全匹配的正则表达式。
+   * - ``exclude_pattern``
+     -
+     - 文件的绝对路径不得匹配的正则表达式。
+   * - ``file_suffixes``
+     - ``.json,.jsonl``
+     - 作为处理对象的文件后缀（可指定多个：逗号分隔）。不区分大小写。
+   * - ``file_encoding``
+     - ``UTF-8``
+     - 文件的字符编码。
+   * - ``format``
+     - ``auto``
+     - 文档的格式。可选 ``auto``、``jsonl``、``json`` 之一。
+   * - ``root_path``
+     -
+     - 指定读取记录位置的JSON Pointer（例: ``/data/items`` ）。
+
+.. note::
+
+   参数名以蛇形命名法（snake_case）书写，但驼峰命名法的拼写
+   （如对应 ``file_encoding`` 的 ``fileEncoding`` 等）同样可以正常使用。
+
+.. note::
+
+   请至少指定 ``files`` 和 ``directories`` 中的一个。
+   两者均为空时将报错。
+   两者并非互斥关系，若同时指定则两者都会被处理。
+   即使同一个文件通过两者都能到达，也只会被读取一次。
+
+文件搜索顺序
+~~~~~~~~~~~~~~~~~~
+
+- 通过 ``files`` 指定的文件将按指定的顺序处理。
+- 在 ``directories`` 下找到的文件将按更新时间从旧到新的顺序处理。
+- 通过 ``files`` 指定的文件会先于 ``directories`` 下的文件被处理。
+
+通过 ``file_suffixes`` 进行的筛选也适用于通过 ``files`` 直接指定的文件。
+后缀不匹配的文件会在日志中输出原因后被跳过。
+
+不存在的路径、在 ``files`` 中指定的目录、在 ``directories`` 中指定的文件，
+均会作为警告记录到日志中，爬取本身会继续进行。
+
+``format``
+----------
+
+``auto`` 会读取文档开头，并根据其语法判断格式。无论是三种格式中的哪一种，
+只要文件书写正确，就能通过这种方式判断出来。
+
+需要明确指定 ``format=jsonl`` 的情况，是文件为JSON Lines格式，且开头附近的行
+可能已损坏时（例如横幅行、进度日志、传输中途中断的记录等）。
+这是因为自动判别需要跳过这类行才能做出判断。
+
+此设置还决定了错误记录的影响范围。
+
+- **JSON Lines格式**: 由于每行都是独立解析的，因此错误行的代价仅限于该行本身。
+  失败会以 ``<文件的绝对路径>@<行号>`` 为键记录到失败URL中，
+  之后会从下一行继续处理。
+- **其他格式**: 由于是作为令牌流读取的，一次失败可能会连累后续的记录。
+  在对象中途中断的文档无法恢复，若连续失败达到一定次数，
+  该文件会输出警告并被中止处理。
+
+``root_path``
+-------------
+
+若指定指向嵌套数组的JSON Pointer，则该元素会被注册为记录。
+
+::
+
+    root_path=/data/items
+
+.. code-block:: json
+
+    { "meta": { "count": 2 }, "data": { "items": [ { "id": "1" }, { "id": "2" } ] } }
+
+- 若指向数组，则每个元素对应一条记录。
+- 若指向对象，则该对象即为一条记录。
+- 若未匹配到任何位置，则不会报错，记录数为0。
+- 可以使用JSON Pointer的转义（ ``~1`` 表示 ``/`` 、 ``~0`` 表示 ``~`` ）。
+
+``root_path`` 的优先级高于 ``format`` 。这是因为通过JSON Pointer到达的文档
+不会按行读取，若与 ``format=jsonl`` 同时指定，日志中会输出相应的警告。
 
 .. warning::
-   必须指定 ``files`` 或 ``directories`` 其中之一。
-   如果两者都未指定（为空），将会发生 ``DataStoreException``\ 。
-   如果两者都指定了，``files`` 优先，``directories`` 将被忽略。
+
+   ``root_path`` 必须以 ``/`` 开头。如果像 ``data/items`` 那样遗漏了开头的 ``/`` ，
+   将无法作为JSON Pointer解析，导致整个数据存储配置报错。
+   此时失败URL记录的不是参数名而是数据存储配置本身，
+   因此需要根据日志中的
+   ``JSON Pointer expression must start with '/'`` 来判断是哪个参数导致的问题。
 
 .. note::
-   参数名使用驼峰命名法 ``fileEncoding``\ （而非蛇形命名法 ``file_encoding``）。
 
-目录指定时的行为
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-指定 ``directories`` 时，各目录直接下的文件将按以下规则处理。
-
-- **不会遍历子目录**\ （不进行递归搜索）。
-- 仅处理扩展名为 ``.json`` 或 ``.jsonl`` 的文件（不区分大小写）。
-- 文件按修改时间（最后修改时刻）升序处理。
-
-.. note::
-   此连接器仅支持本地文件系统上的JSON文件，不支持HTTP访问或API认证功能。
+   如果不指定 ``root_path`` ，而直接读取记录跨多行格式化的文档
+   （即包含元信息和数组的所谓包装器格式），系统会尝试按行解析，
+   导致无法获取预期的记录并记录失败。
+   对于此类文档，请务必指定 ``root_path`` 。
 
 脚本设置
 --------------
 
-各字段的值通过引用JSON对象各字段的值来组装。
-JSON对象顶层字段在脚本中可作为 **无前缀的变量** 直接引用
-（不带 ``data.`` 之类的前缀）。
+各字段的值通过引用JSON对象各字段的值来构建。
+JSON对象的顶层字段在脚本中可作为 **无前缀的变量**
+直接引用（不加 ``data.`` 等前缀）。
 
-简单JSON对象:
+简单的JSON对象:
 
 ::
 
-    url="https://example.com/product/" + id
+    url="https://shop.example.com/product/" + id
     title=name
     content=description
-    price=price
-    category=category
+    digest=description
+    host="shop.example.com"
+    site="shop.example.com"
 
-嵌套JSON对象（嵌套对象以映射形式引用）:
+嵌套的对象可作为map引用，嵌套的数组可作为list引用:
 
 ::
 
@@ -148,17 +250,7 @@ JSON对象顶层字段在脚本中可作为 **无前缀的变量** 直接引用
     title=product.name
     content=product.description
     price=product.pricing.amount
-    author=product.author.name
-
-数组元素处理:
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=body
-    tags=tags.join(", ")
-    categories=categories[0].name
+    first_tag=tags[0]
 
 可用字段
 ~~~~~~~~~~~~~~~~~~~~
@@ -166,48 +258,65 @@ JSON对象顶层字段在脚本中可作为 **无前缀的变量** 直接引用
 - ``<字段名>`` - 通过名称直接引用JSON对象的顶层字段
 - ``<父>.<子>`` - 嵌套对象的字段
 - ``<数组>[<索引>]`` - 数组元素
-- ``<数组>.<方法>`` - 数组的方法（``join``、``collect``、``size`` 等）
 
 .. note::
 
-   如果字段名包含空格或连字符等Groovy标识符中无效的字符，
-   则无法直接将该字段作为变量名引用。
-
-JSON格式详情
-==============
-
-JSON文件格式
-----------------
-
-JSON连接器读取JSONL（JSON Lines）格式的文件。
-这是一种每行记录一个JSON对象的格式。文件逐行读取，
-每行作为独立的JSON对象进行解析。
+   若字段的值为 ``null`` ，则该字段不会被注册到文档中。
 
 .. note::
-   扩展名为 ``.json`` 的文件也在处理范围内，但内容必须为JSONL格式
-   （每行一个对象）。
-   数组格式的JSON文件（``[{...}, {...}]``）或经过多行格式化
-   （pretty-print）的JSON无法直接读取，请转换为JSONL格式。
 
-JSONL格式的文件:
+   在 |Fess| 15.9 中，内置脚本引擎变为JavaScript。
+   Groovy作为 ``fess-script-groovy`` 插件提供。
+   要使用的引擎通过数据存储的参数 ``script_type`` 指定
+   （如 ``script_type=javascript`` ）。省略时使用 ``groovy`` 。
+   上述示例中简单的引用和字符串拼接在两种引擎中的行为相同，
+   但除此之外的写法因引擎而异。
 
-::
+注意事项
+========
 
-    {"id": 1, "name": "Product A", "description": "Description A"}
-    {"id": 2, "name": "Product B", "description": "Description B"}
+名称与 ``app.encrypt.property.pattern`` 匹配的参数（默认情况下以 ``password`` 、
+``key`` 、 ``token`` 、 ``secret`` 结尾的参数），从脚本中引用时会得到 ``null`` 。
+这是为了防止写在数据存储参数中的凭据被复制到索引的
+字段中。
+
+若记录一侧存在同名字段，则与其他参数一样，以记录一侧的值
+优先。
+
+.. note::
+
+   匹配判定是对参数名区分大小写的完全匹配。
+   ``access_token`` 属于匹配对象，但驼峰命名法的 ``accessToken``
+   不属于匹配对象。若需要在参数中记述凭据，请使用蛇形命名法
+   （snake_case）书写。
+
+参数错误与报错
+==========================
+
+若为 ``format`` 、 ``include_pattern`` 、 ``exclude_pattern`` 、 ``urls`` 指定了无法使用的值，
+则会在读取文件之前结束爬取，并记录包含该参数名的
+失败URL（例: ``JsonDataStore:format`` ）。
+
+若为 ``max_depth`` 指定了非数值，则会在记录到日志后使用默认值。
+
+.. note::
+
+   数据存储的爬取即使一个对象都未能获取到，作为任务也会
+   正常结束。若获取件数与预期不符，请确认索引的件数、失败URL，
+   以及 ``fess-crawler.log`` 。
 
 使用示例
 ========
 
 产品目录
---------------
+------------
 
 参数:
 
 ::
 
-    files=/var/data/products.json
-    fileEncoding=UTF-8
+    files=/var/data/products.jsonl
+    file_encoding=UTF-8
 
 脚本:
 
@@ -215,19 +324,20 @@ JSONL格式的文件:
 
     url="https://shop.example.com/product/" + product_id
     title=name
-    content=description + " 价格: " + price + " 日元"
+    content=description
     digest=category
-    price=price
+    host="shop.example.com"
+    site="shop.example.com"
 
-多JSON文件整合
----------------------
+保存API响应的文件
+--------------------------------
 
 参数:
 
 ::
 
-    files=/var/data/data1.json,/var/data/data2.json
-    fileEncoding=UTF-8
+    files=/var/data/response.json
+    root_path=/data/items
 
 脚本:
 
@@ -235,7 +345,22 @@ JSONL格式的文件:
 
     url="https://example.com/item/" + id
     title=title
-    content=content
+    content=body
+    host="example.com"
+    site="example.com"
+
+递归处理目录
+------------------------------
+
+参数:
+
+::
+
+    directories=/var/data/exports
+    recursive=true
+    max_depth=3
+    include_pattern=.*\.jsonl
+    file_encoding=UTF-8
 
 故障排除
 ======================
@@ -243,119 +368,76 @@ JSONL格式的文件:
 找不到文件
 ----------------------
 
-**症状**: 日志中输出 ``... is not found.`` 或 ``Source file ... does not exist.``
+**症状**: 日志中输出 ``... does not exist.`` 、 ``... is not a file.`` 、
+``... is skipped because its suffix is not one of ...``
 
 **确认事项**:
 
 1. 确认文件路径是否正确
 2. 确认文件是否存在
-3. 确认文件扩展名是否为 ``.json`` 或 ``.jsonl``
-4. 确认是否有文件读取权限
+3. 确认文件后缀是否与 ``file_suffixes`` （默认为 ``.json`` 或 ``.jsonl`` ）
+   相匹配
+4. 确认 |Fess| 的运行用户是否具有读取权限
 
 JSON解析错误
 --------------
 
-**症状**: 日志中输出 ``Crawling Access Exception`` 和 ``JsonParseException`` 等信息
-
-如果包含非法行，仅该行被跳过并记录为失败URL，
-爬取本身从下一行继续进行。
+**症状**: 日志中输出 ``Failed to parse ...`` 或 ``Failed to read ...`` ，
+或记录了失败URL
 
 **确认事项**:
 
-1. 确认JSON文件格式是否正确（每行一个对象的JSONL格式）:
+1. 验证文件是否为有效的JSON
 
    ::
 
-       # 验证各行是否为有效的JSON对象
-       cat data.json | jq -c .
+       # 若为JSON Lines格式，验证每行是否为有效的JSON对象
+       cat data.jsonl | jq -c .
+
+       # 若为数组或单个对象
+       jq . data.json
 
 2. 确认字符编码是否正确
-3. 确认是否有单个对象跨多行的情况
+3. 确认文件是否中途被截断
 4. 确认是否包含注释（JSON标准不允许注释）
 
 无法获取数据
 --------------------
 
-**症状**: 爬取成功但数量为0
+**症状**: 爬取成功但件数为0
 
 **确认事项**:
 
-1. 确认JSON结构
-2. 确认脚本设置是否正确（字段引用是否不带 ``data.`` 前缀）
-3. 确认字段名是否正确（包括大小写）
-4. 在日志中确认错误信息
+1. 若指定了 ``root_path`` ，请确认该JSON Pointer是否与文档结构
+   相符（不相符时不会报错，而是件数为0）
+2. 确认是否因 ``include_pattern`` 、 ``exclude_pattern`` 、 ``file_suffixes`` 而将对象
+   全部排除在外。此时日志中会输出 ``No sources to process``
+3. 确认脚本设置是否正确（字段引用是否未带 ``data.`` 前缀）
+4. 确认字段名是否正确（含大小写）
+5. 确认 ``url`` 是否已构建成功。若 ``url`` 为空，则每条记录都会失败
+
+出现乱码
+------------
+
+**症状**: 注册的文档中字符出现乱码
+
+若在 ``file_encoding`` 中指定了实际存在但错误的编码，不会报错，而是会
+以乱码状态注册。请确认文件的实际编码。
+若指定了不存在的编码名称，则会按文件记录失败URL。
 
 大型JSON文件
 ------------------
 
 **症状**: 内存不足或超时
 
-由于文件逐行读取，文件整体大小不会直接影响内存使用量。
-但如果单行（单个对象）极大，或索引注册负载较高，
-则可能出现问题。
+由于记录是逐条读取的，文件的整体大小不会直接影响内存使用量。
+但是，当单条记录极大，或索引注册的负荷较高时，
+可能会出现问题。
 
 **解决方法**:
 
 1. 将JSON文件分割成多个
 2. 增加 |Fess| 的堆大小
-
-脚本的高级使用示例
-========================
-
-条件处理
-------------
-
-各字段作为独立的表达式进行求值。条件值使用三元运算符:
-
-::
-
-    url=status == "published" ? "https://example.com/product/" + id : null
-    title=status == "published" ? name : null
-    content=status == "published" ? description : null
-    price=status == "published" ? price : null
-
-数组合并
-----------
-
-::
-
-    url="https://example.com/article/" + id
-    title=title
-    content=content
-    tags=tags ? tags.join(", ") : ""
-    categories=categories.collect { it.name }.join(", ")
-
-设置默认值
-------------------
-
-::
-
-    url="https://example.com/item/" + id
-    title=title ?: "无标题"
-    content=description ?: (summary ?: "无描述")
-    price=price ?: 0
-
-日期格式化
-------------------
-
-::
-
-    url="https://example.com/post/" + id
-    title=title
-    content=body
-    created=created_at
-    last_modified=updated_at
-
-数值处理
-----------
-
-::
-
-    url="https://example.com/product/" + id
-    title=name
-    content=description
-    price=price as Float
-    stock=stock_quantity as Integer
 
 参考信息
 ========
@@ -366,4 +448,5 @@ JSON解析错误
 - :doc:`../../admin/dataconfig-guide` - 数据存储配置指南
 - `JSON (JavaScript Object Notation) <https://www.json.org/>`_
 - `JSON Lines <https://jsonlines.org/>`_
+- `JSON Pointer (RFC 6901) <https://datatracker.ietf.org/doc/html/rfc6901>`_
 - `jq - JSON processor <https://stedolan.github.io/jq/>`_


### PR DESCRIPTION
The 15.9 JSON connector page still described a much older connector. Seven
parameters were missing entirely, and several statements the page did make are
no longer true. This rewrites it in all seven languages.

The page content was checked against the current `fess-ds-json` master by
running real data store crawls on a live Fess 15.9.0-SNAPSHOT, rather than by
reading the source alone.

## Corrected

| The page said | Actually |
| --- | --- |
| JSON Lines only; an array or a pretty-printed document "cannot be read directly, convert it to JSON Lines" | Three shapes are supported — JSON Lines, an array of objects, and a single object — and the shape is detected from the document by default |
| "If both are given, `files` takes priority and `directories` is ignored" | They are not exclusive. Both are processed, and a file reachable through both is read once |
| "The parameter name is the camelCase `fileEncoding`, not the snake_case `file_encoding`" | Both spellings resolve, for every parameter |
| Install to `app/WEB-INF/lib` | `app/WEB-INF/plugin` — where the admin UI installs plugins, and what the plugin README documents. (`WEB-INF/lib` also happens to be on the crawler child classpath, so it did work; it is just not the managed location.) |
| Download from Maven Central | Maven Central carries 15.7.0 and earlier. 15.8.0 onwards is published to the CodeLibs repository |
| Script examples in Groovy-only syntax (`?:`, `as Float`, `collect {}`) | Fess 15.9 replaced the built-in engine with JavaScript and moved Groovy out to `fess-script-groovy`, so those no longer run under the default engine |

## Added

None of this was documented anywhere on the page before.

- The full parameter table: `recursive`, `max_depth`, `include_pattern`,
  `exclude_pattern`, `file_suffixes`, `format` and `root_path` in addition to
  the three that were already there.
- **File discovery order** — `files` in the order given, directory contents
  oldest first, `files` before directory contents; the suffix filter applies to
  `files` too.
- **`format`** — what `auto` decides, when `jsonl` is worth setting explicitly,
  and how the choice decides what a malformed record costs: one line in JSON
  Lines, potentially the rest of the source in the other shapes.
- **`root_path`** — array to N records, object to one, no match to none, the
  `~0`/`~1` escapes, and its precedence over `format`. A leading `/` is
  required; omitting it fails the whole data config without naming the
  parameter, so that gets a `warning` directive.
- **Error routing** — which parameter errors abort the crawl with a failure URL
  named after the parameter, and which are logged and defaulted.
- A note that a data store crawl finishes normally even when it indexed
  nothing, so the index count and the failure URLs are what to judge by.
- A note that the `app.encrypt.property.pattern` masking is a case-sensitive
  full match on the parameter name, so `access_token` is masked but
  `accessToken` is not.

## Notes

- Only the 15.9 (development) tree is touched; earlier versions are left as
  they are.
- Every page parses cleanly under docutils.
- The Japanese page is the source; the other six follow it section for section
  and reuse each language's existing `ds-csv.rst` terminology.
