### PR TITLE
docs(15.9): the Playwright crawler moved to a plugin

### DIFF
--- a/de/15.9/install/upgrade.rst
+++ b/de/15.9/install/upgrade.rst
@@ -503,19 +503,21 @@ hängt eine solche Anfrage, statt fehlzuschlagen.
    Sicherungsseite im Administrationsbereich und crawlen Sie erneut. Die Sicherung umfasst
    Crawl-Einstellungen, Benutzer und Protokolle, **nicht** die gecrawlten Dokumente.
 
-Node.js für Playwright wird nicht mehr mitgeliefert
----------------------------------------------------
+Playwright-Crawler wird als Plugin ausgeliefert
+-----------------------------------------------
 
-Die Node.js-Programmdateien, die der Playwright-Crawler ausführt, sind nicht mehr Teil der
-Distribution. Das ZIP schrumpft dadurch von 438,5 MiB auf 204,7 MiB.
+Der Playwright-Crawler und die Node.js-Programmdateien, die er ausführt, sind nicht mehr Teil
+der Distribution. Das ZIP schrumpft dadurch von 438,5 MiB auf 204,7 MiB.
 
 Wenn eine Crawl-Konfiguration den Playwright-Client benennt, etwa mit
 ``client.crawlerClients=playwright:http://.*`` in ihren Konfigurationsparametern, installieren
-Sie Node.js mit dem folgenden Befehl. ``bin/fess.in.sh`` findet es und setzt
-``PLAYWRIGHT_NODEJS_PATH``.
+Sie sowohl das Plugin als auch Node.js. Das Plugin lässt sich auch über die Seite
+**System > Plugin** im Administrationsbereich installieren. ``bin/fess.in.sh`` findet Node.js
+und setzt ``PLAYWRIGHT_NODEJS_PATH``.
 
 ::
 
+    $ bin/fess-setup install plugin fess-crawler-playwright
     $ bin/fess-setup install nodejs
 
 Ohne den Playwright-Crawler ist nichts zu tun.

--- a/en/15.9/install/upgrade.rst
+++ b/en/15.9/install/upgrade.rst
@@ -496,18 +496,20 @@ relies on, and over HTTP such a request hangs rather than failing.
    OpenSearch server, move the settings with the admin Backup page, and re-crawl. The backup
    covers crawl settings, users and logs; it does **not** contain the crawled documents.
 
-Node.js for Playwright is no longer bundled
--------------------------------------------
+Playwright Crawler Moved to a Plugin
+------------------------------------
 
-The Node.js executables that the Playwright crawler runs are no longer part of the
+The Playwright crawler, and the Node.js executables it runs, are no longer part of the
 distribution. The ZIP drops from 438.5 MiB to 204.7 MiB as a result.
 
 If a crawl configuration names the Playwright client, for example with
-``client.crawlerClients=playwright:http://.*`` in its configuration parameters, install Node.js
-with the command below. ``bin/fess.in.sh`` discovers it and sets ``PLAYWRIGHT_NODEJS_PATH``.
+``client.crawlerClients=playwright:http://.*`` in its configuration parameters, install both the
+plugin and Node.js. The plugin is also available from the System > Plugin page in the
+administration screen. ``bin/fess.in.sh`` discovers Node.js and sets ``PLAYWRIGHT_NODEJS_PATH``.
 
 ::
 
+    $ bin/fess-setup install plugin fess-crawler-playwright
     $ bin/fess-setup install nodejs
 
 Nothing is needed if you do not use the Playwright crawler.

--- a/es/15.9/install/upgrade.rst
+++ b/es/15.9/install/upgrade.rst
@@ -503,19 +503,21 @@ queda colgada en lugar de fallar.
    la administración y vuelva a rastrear. La copia de seguridad incluye la configuración de
    rastreo, los usuarios y los registros; **no** contiene los documentos rastreados.
 
-Node.js para Playwright ya no se incluye
-----------------------------------------
+El rastreador de Playwright pasa a un plugin
+--------------------------------------------
 
-Los ejecutables de Node.js que utiliza el rastreador de Playwright ya no forman parte de la
+El rastreador de Playwright, y los ejecutables de Node.js que utiliza, ya no forman parte de la
 distribución. Como consecuencia, el ZIP pasa de 438,5 MiB a 204,7 MiB.
 
 Si alguna configuración de rastreo indica el cliente de Playwright, por ejemplo con
-``client.crawlerClients=playwright:http://.*`` en sus parámetros de configuración, instale
-Node.js con la orden siguiente. ``bin/fess.in.sh`` lo detecta y establece
-``PLAYWRIGHT_NODEJS_PATH``.
+``client.crawlerClients=playwright:http://.*`` en sus parámetros de configuración, instale tanto
+el plugin como Node.js. El plugin también puede instalarse desde la página
+**Sistema > Plugin** de la pantalla de administración. ``bin/fess.in.sh`` detecta Node.js y
+establece ``PLAYWRIGHT_NODEJS_PATH``.
 
 ::
 
+    $ bin/fess-setup install plugin fess-crawler-playwright
     $ bin/fess-setup install nodejs
 
 Si no utiliza el rastreador de Playwright, no hay nada que hacer.

--- a/fr/15.9/install/upgrade.rst
+++ b/fr/15.9/install/upgrade.rst
@@ -508,18 +508,20 @@ HTTP une telle requête reste bloquée au lieu d'échouer.
    d'exploration, les utilisateurs et les journaux ; elle ne contient **pas** les documents
    explorés.
 
-Node.js pour Playwright n’est plus fourni
------------------------------------------
+Le robot Playwright passe dans un plugin
+----------------------------------------
 
-Les exécutables Node.js utilisés par le robot Playwright ne font plus partie de la distribution.
-L'archive ZIP passe ainsi de 438,5 Mio à 204,7 Mio.
+Le robot Playwright, ainsi que les exécutables Node.js qu'il utilise, ne font plus partie de la
+distribution. L'archive ZIP passe ainsi de 438,5 Mio à 204,7 Mio.
 
 Si une configuration d'exploration désigne le client Playwright, par exemple avec
-``client.crawlerClients=playwright:http://.*`` dans ses paramètres, installez Node.js avec la
-commande ci-dessous. ``bin/fess.in.sh`` le détecte et définit ``PLAYWRIGHT_NODEJS_PATH``.
+``client.crawlerClients=playwright:http://.*`` dans ses paramètres, installez à la fois le
+plugin et Node.js. Le plugin s'installe également depuis la page **Système > Plugin** de l'écran
+d'administration. ``bin/fess.in.sh`` détecte Node.js et définit ``PLAYWRIGHT_NODEJS_PATH``.
 
 ::
 
+    $ bin/fess-setup install plugin fess-crawler-playwright
     $ bin/fess-setup install nodejs
 
 Rien à faire si vous n'utilisez pas le robot Playwright.

--- a/ja/15.9/install/upgrade.rst
+++ b/ja/15.9/install/upgrade.rst
@@ -493,18 +493,20 @@ Docker を使用してください）。
    再クロールしてください。バックアップに含まれるのはクロール設定・ユーザー・ログで、
    **クロール済みの文書は含まれません**。
 
-Playwright 用 Node.js の同梱を終了
-----------------------------------
+Playwright クローラをプラグインへ移動
+-------------------------------------
 
-Playwright クローラが使用する Node.js の実行ファイルは、配布物に含まれなくなりました。
-これにより ZIP は 438.5 MiB から 204.7 MiB になっています。
+Playwright クローラと、それが使用する Node.js の実行ファイルは、配布物に含まれなく
+なりました。これにより ZIP は 438.5 MiB から 204.7 MiB になっています。
 
 クロール設定の設定パラメータで ``client.crawlerClients=playwright:http://.*`` のように
-Playwright クライアントを指定している場合は、次のコマンドで Node.js を導入してください。
-``bin/fess.in.sh`` が導入先を検出し、 ``PLAYWRIGHT_NODEJS_PATH`` を設定します。
+Playwright クライアントを指定している場合は、プラグインと Node.js の両方を導入してください。
+プラグインは管理画面の「システム > プラグイン」ページからも導入できます。 ``bin/fess.in.sh``
+が Node.js の導入先を検出し、 ``PLAYWRIGHT_NODEJS_PATH`` を設定します。
 
 ::
 
+    $ bin/fess-setup install plugin fess-crawler-playwright
     $ bin/fess-setup install nodejs
 
 Playwright クローラを使用していない場合、対応は不要です。

--- a/ko/15.9/install/upgrade.rst
+++ b/ko/15.9/install/upgrade.rst
@@ -492,18 +492,20 @@ Homebrew 또는 Docker 를 사용하십시오).
    새로 구축하고 관리 화면의 「백업」에서 설정을 옮긴 뒤 다시 크롤링하십시오. 백업에 포함되는
    것은 크롤링 설정, 사용자, 로그이며 **크롤링한 문서는 포함되지 않습니다**.
 
-Playwright 용 Node.js 동봉 종료
--------------------------------
+Playwright 크롤러를 플러그인으로 이동
+-------------------------------------
 
-Playwright 크롤러가 사용하는 Node.js 실행 파일은 더 이상 배포물에 포함되지 않습니다.
-이에 따라 ZIP 은 438.5 MiB 에서 204.7 MiB 가 되었습니다.
+Playwright 크롤러와 그것이 사용하는 Node.js 실행 파일은 더 이상 배포물에 포함되지
+않습니다. 이에 따라 ZIP 은 438.5 MiB 에서 204.7 MiB 가 되었습니다.
 
 크롤링 설정의 설정 파라미터에서 ``client.crawlerClients=playwright:http://.*`` 와 같이
-Playwright 클라이언트를 지정한 경우에는 아래 명령으로 Node.js 를 설치하십시오.
-``bin/fess.in.sh`` 가 설치 위치를 찾아 ``PLAYWRIGHT_NODEJS_PATH`` 를 설정합니다.
+Playwright 클라이언트를 지정한 경우에는 플러그인과 Node.js 를 모두 설치하십시오.
+플러그인은 관리 화면의 「시스템 > 플러그인」 페이지에서도 설치할 수 있습니다.
+``bin/fess.in.sh`` 가 Node.js 설치 위치를 찾아 ``PLAYWRIGHT_NODEJS_PATH`` 를 설정합니다.
 
 ::
 
+    $ bin/fess-setup install plugin fess-crawler-playwright
     $ bin/fess-setup install nodejs
 
 Playwright 크롤러를 사용하지 않는 경우에는 대응이 필요 없습니다.

--- a/zh-cn/15.9/install/upgrade.rst
+++ b/zh-cn/15.9/install/upgrade.rst
@@ -486,18 +486,20 @@ Docker）。
    使用内嵌 OpenSearch 运行时的索引数据无法继承。请新建外部 OpenSearch 服务器，通过管理界面的
    「备份」迁移配置后重新爬取。备份包含爬取配置、用户和日志，**不包含已爬取的文档**。
 
-不再随附 Playwright 所需的 Node.js
-----------------------------------
+Playwright 爬虫移至插件
+-----------------------
 
-Playwright 爬虫使用的 Node.js 可执行文件不再包含在发行包中。
+Playwright 爬虫及其使用的 Node.js 可执行文件不再包含在发行包中。
 因此 ZIP 从 438.5 MiB 减少到 204.7 MiB。
 
 如果爬取配置的设置参数中指定了 Playwright 客户端（例如
-``client.crawlerClients=playwright:http://.*``\ ），请使用以下命令安装 Node.js。
-``bin/fess.in.sh`` 会检测安装位置并设置 ``PLAYWRIGHT_NODEJS_PATH``\ 。
+``client.crawlerClients=playwright:http://.*``\ ），请同时安装插件与 Node.js。
+插件也可以从管理界面的「系统 > 插件」页面安装。 ``bin/fess.in.sh`` 会检测 Node.js
+的安装位置并设置 ``PLAYWRIGHT_NODEJS_PATH``\ 。
 
 ::
 
+    $ bin/fess-setup install plugin fess-crawler-playwright
     $ bin/fess-setup install nodejs
 
 如果不使用 Playwright 爬虫，则无需处理。


### PR DESCRIPTION
The 15.9 upgrade note says only the Node.js binaries left the distribution. With codelibs/fess#3437 shipping the Playwright crawler as a plugin, the crawler itself has left too, so a Playwright crawl now needs two steps rather than one.

The section is retitled and rewritten in all seven languages (ja, en, de, es, fr, ko, zh-cn):

- both `bin/fess-setup install plugin fess-crawler-playwright` and `bin/fess-setup install nodejs`
- the plugin half is also available from the System > Plugin page, the way the Google Cloud Storage section below it already describes

Everything else in the section is unchanged, including the ZIP size figures and the closing sentence that nothing is needed if the Playwright crawler is not used.

Only the `development` tree (15.9) is touched.

Verification: `tools/check_headings.py` passes on all seven files, and docutils reports no title-underline problems.
